### PR TITLE
Don’t require the port when a user maps a resource; it’s not needed.

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ will get a list of all the  Ambassador knows how to map;
 
 ```
 curl -XPOST -H "Content-Type: application/json" \
-      -d '{ "prefix": "/url/prefix/here", "port": 80 }' \
+      -d '{ "prefix": "/url/prefix/here/" }' \
       $AMBASSADORURL/ambassador/service/$servicename
 ```
 

--- a/ambassador/envoy.py
+++ b/ambassador/envoy.py
@@ -77,10 +77,9 @@ class EnvoyConfig (object):
         self.services = {}
         self.base_config = base_config
 
-    def add_service(self, name, prefix, port):
+    def add_service(self, name, prefix):
         self.services[name] = {
             'prefix': prefix,
-            'port': port
         }
 
     def write_config(self, path):


### PR DESCRIPTION
Fixes #15.