### PR TITLE
Easier dev

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -3,6 +3,10 @@ current_version = 0.9.0
 commit = False
 tag = False
 tag_name = v{new_version}
+parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<commit>\d+\-g[a-f0-9]+))?
+serialize = 
+	{major}.{minor}.{patch}-{commit}
+	{major}.{minor}.{patch}
 
 [bumpversion:file:ambassador-rest.yaml]
 search = 'image: .*:{current_version}'

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -31,9 +31,13 @@ Normal Workflow
 
    Hopefully this step is clear.
 
-2. `make new-$level`
+2. `make new-commit`
 
-   This will correctly set the version number everywhere, then build (and probably push) Docker images, then build YAML files for you. IT WILL NOT COMMIT OR TAG.
+   This will compute a temporary version number based on the current version and the git commit ID (`git describe --tags`), then update version numbers everywhere to that version number. Then it will build (and probably push) Docker images, then build YAML files for you. IT WILL NOT COMMIT OR TAG. With new version numbers everywhere, you can easily `kubectl apply` the updated YAML files and see your changes in your Kubernetes cluster.
+
+3. `make new-$level`
+
+   This will correctly set the version number everywhere by incrementing the specified level and removing any commit ID information, then build (and probably push) Docker images, then build YAML files for you. IT WILL NOT COMMIT OR TAG.
 
    `$level` must be one of "major", "minor", or "patch", using [semantic versioning](http://semver.org/):
 
@@ -41,9 +45,7 @@ Normal Workflow
    "minor" is for new functionality that's still backward compatible.
    "patch" is for bug fixes.
 
-   (You can do "make artifacts" if you want to rebuild artifacts but not change the version, even though that's likely to not be a great idea.)
-
-3. `make tag`
+4. `make tag`
 
    Do this once you're happy with everything. It will commit (if need be) and then create a Git tag for your version.
 

--- a/Makefile
+++ b/Makefile
@@ -22,20 +22,31 @@ VERSIONED = \
 
 artifacts: docker-images ambassador.yaml istio/ambassador.yaml
 
-bump:
-	@if [ -z "$$LEVEL" ]; then \
-	    echo "LEVEL must be set" >&2 ;\
+reg-check:
+	@if [ -z "$$DOCKER_REGISTRY" ]; then \
+	    echo "DOCKER_REGISTRY must be set" >&2 ;\
 	    exit 1 ;\
 	fi
 
-	@if [ -z "$$DOCKER_REGISTRY" ]; then \
-	    echo "DOCKER_REGISTRY must be set" >&2 ;\
+bump: reg-check
+	@if [ -z "$$LEVEL" ]; then \
+	    echo "LEVEL must be set" >&2 ;\
 	    exit 1 ;\
 	fi
 
 	@echo "Bumping to new $$LEVEL version..."
 	bump2version --no-tag --no-commit "$$LEVEL"
 	@echo "Building version $$(python ambassador/VERSION.py)"
+
+dev-bump: reg-check
+	@echo "Bumping for development..."
+	bump2version --allow-dirty --no-tag --no-commit \
+	    --new-version `git describe --tags | sed s/^v//` commit
+	@echo "Building version $$(python ambassador/VERSION.py)"
+
+new-commit:
+	$(MAKE) dev-bump
+	$(MAKE) artifacts
 
 new-patch:
 	$(MAKE) bump LEVEL=patch

--- a/scripts/travis-build.sh
+++ b/scripts/travis-build.sh
@@ -7,7 +7,7 @@ env | grep TRAVIS | sort
 # Do we have any non-doc changes?
 change_count=$(git diff --name-only "$TRAVIS_COMMIT_RANGE" | grep -v '^docs/' | wc -l)
 
-if [ $change_count -eq 0 ]; then
+if [ -n "$TRAVIS_COMMIT_RANGE" ] && [ $change_count -eq 0 ]; then
     echo "No non-doc changes"
     exit 0
 fi


### PR DESCRIPTION
Add a `new-commit` target to the `Makefile` that creates a temporary version number and pushes everything. This makes it easier to try out incremental development steps.