### PR TITLE
Let both "make" at the command line and the CI pipeline work

### DIFF
--- a/scripts/docker_build_maybe_push
+++ b/scripts/docker_build_maybe_push
@@ -10,7 +10,7 @@ TARGET="$3"
 HERE=$(dirname $0)
 eval $(sh $HERE/get_registries.sh)
 
-docker build -q -t "${DOCKER_REGISTRY}${NAME}:${VERSION}" "${TARGET}"
+docker build $EXTRA_DOCKER_ARGS -t "${DOCKER_REGISTRY}${NAME}:${VERSION}" "${TARGET}"
 
 if [ -n "$DOCKER_REGISTRY" ]; then
     docker push "${DOCKER_REGISTRY}${NAME}:${VERSION}"

--- a/scripts/travis-build.sh
+++ b/scripts/travis-build.sh
@@ -28,7 +28,7 @@ nondoc_changes=$(git diff --name-only "$TRAVIS_COMMIT_RANGE" | grep -v '^docs/' 
 doc_changes=$(git diff --name-only "$TRAVIS_COMMIT_RANGE" | grep -e '^docs/' | wc -l | tr -d ' ')
 
 # Default a VERSION
-VERSION=$(python scripts/versioner.py --verbose)
+VERSION=$(python scripts/versioner.py --verbose --only-if-changes)
 
 if [ \( -z "$TRAVIS_COMMIT_RANGE" \) -o \( $nondoc_changes -gt 0 \) ]; then
     if onmaster; then
@@ -44,7 +44,7 @@ if [ \( -z "$TRAVIS_COMMIT_RANGE" \) -o \( $nondoc_changes -gt 0 \) ]; then
         DOCKER_REGISTRY=-
 
         # Override the VERSION for a non-master build.
-        VERSION=$(python scripts/versioner.py --verbose --magic-pre)
+        VERSION=$(python scripts/versioner.py --verbose --only-if-changes --magic-pre)
     fi
 
     echo "==== BUILDING IMAGES FOR $VERSION"

--- a/scripts/travis-build.sh
+++ b/scripts/travis-build.sh
@@ -28,7 +28,7 @@ nondoc_changes=$(git diff --name-only "$TRAVIS_COMMIT_RANGE" | grep -v '^docs/' 
 doc_changes=$(git diff --name-only "$TRAVIS_COMMIT_RANGE" | grep -e '^docs/' | wc -l | tr -d ' ')
 
 # Default a VERSION
-VERSION=$(python scripts/versioner.py --verbose --only-if-changes)
+VERSION=$(python scripts/versioner.py --only-if-changes)
 
 if [ \( -z "$TRAVIS_COMMIT_RANGE" \) -o \( $nondoc_changes -gt 0 \) ]; then
     if onmaster; then
@@ -44,7 +44,7 @@ if [ \( -z "$TRAVIS_COMMIT_RANGE" \) -o \( $nondoc_changes -gt 0 \) ]; then
         DOCKER_REGISTRY=-
 
         # Override the VERSION for a non-master build.
-        VERSION=$(python scripts/versioner.py --verbose --only-if-changes --magic-pre)
+        VERSION=$(python scripts/versioner.py --only-if-changes --magic-pre)
     fi
 
     echo "==== BUILDING IMAGES FOR $VERSION"

--- a/scripts/travis-build.sh
+++ b/scripts/travis-build.sh
@@ -49,7 +49,7 @@ if [ \( -z "$TRAVIS_COMMIT_RANGE" \) -o \( $nondoc_changes -gt 0 \) ]; then
 
     echo "==== BUILDING IMAGES FOR $VERSION"
 
-    make VERSION=${VERSION} travis-images
+    make VERSION=${VERSION} EXTRA_DOCKER_ARGS=-q travis-images
 
     if [ $doc_changes -eq 0 ]; then
         doc_changes=1


### PR DESCRIPTION
Arrange for "make" at the command line to pretty much always build, while allowing the CI pipeline to short-circuit if there's nothing to be done.

Fixes #86.