### PR TITLE
Make sure composite YAML gets generated

### DIFF
--- a/scripts/build-yaml.sh
+++ b/scripts/build-yaml.sh
@@ -24,3 +24,6 @@ for tdir in *; do
         python "$HERE/template.py" < $tfile > "$ODIR/$tfile"
     done
 done
+
+ADIR="$ODIR/ambassador"
+cat "$ADIR/ambassador-store.yaml" "$ADIR/ambassador-rest.yaml" > "$ADIR/ambassador.yaml"


### PR DESCRIPTION
Make sure that the composite `ambassadar.yaml` is correctly generated (from `ambassador-store.yaml` and `ambassador-rest.yaml`). Sigh.

Fixes #84.
