### PR TITLE
Basic TLS client certification authentication

### DIFF
--- a/ambassador/templates/envoy.j2
+++ b/ambassador/templates/envoy.j2
@@ -9,7 +9,8 @@
           "private_key_file": "{{ tls.private_key_file }}"{{ "," if tls.cacert_chain_file }}
         {%- endif -%}
         {%- if tls.cacert_chain_file -%}
-          "ca_cert_file": "{{ tls.cacert_chain_file }}"
+          "ca_cert_file": "{{ tls.cacert_chain_file }}"{{ "," if tls.cert_required }}
+          {%- if tls.cert_required -%}"require_client_certificate": true{%- endif %}
         {%- endif %}
       },
       {%- endif -%}

--- a/docs/how-to/auth-tls-certs.md
+++ b/docs/how-to/auth-tls-certs.md
@@ -1,23 +1,46 @@
-# Auth with TLS Client Certs
+# Auth with TLS Client Certificates
 
-If you want to use TLS client-certificate authentication, you'll need to tell Ambassador about the CA certificate chain to use to validate client certificates. This is also best done before starting Ambassador. Get the CA certificate chain - including all necessary intermediate certificates - and create a Kubernetes secret with it:
+If you want to use TLS client-certificate authentication, you'll need to tell Ambassador about the CA certificate chain to use to validate client certificates. Get the CA certificate chain - including all necessary intermediate certificates - and create a Kubernetes secret with it:
 
 ```shell
 kubectl create secret generic ambassador-cacert --from-file=fullchain.pem=$CACERT_PATH
 ```
 
-After starting Ambassador, you **must** tell Ambassador about which certificates are allowed, using the `/ambassador/principal/` REST API of Ambassador's [admin interface](admin-port.md):
+Once that's done, you can tell Ambassador to pay attention to client certs using the `client` block of the `ambassador` module. Note that it is necessary to enable [TLS termination](../how-to/tls-termination.md) as well, or client certificates cannot be checked -- the simplest useful way to enable client certificate authentication is therefore something like:
 
-```shell
-curl -X POST -H "Content-Type: application/json" \
-      -d '{ "fingerprint": "$FINGERPRINT" }' \
-      http://localhost:8888/ambassador/principal/flynn
+```yaml
+---
+apiVersion: ambassador/v0
+kind:  Module
+name:  ambassador
+config:
+  tls:
+    # The 'server' block configures TLS termination. 'enabled' is the only required element.
+    server:
+      enabled: True
+    client:
+      enabled: True
+      cert_required: True
 ```
 
-`$FINGERPRINT` here is the SHA256 fingerprint of the TLS client cert. The easiest way to get it is with the `openssl` command:
+where the `cert_required` line tells Ambassador to _require_ a client certificate with a valid signature in order to proceed.
 
-```shell
-openssl x509 -fingerprint -sha256 -in $CERTPATH -noout | cut -d= -f2 | tr -d ':' | tr '[A-Z]' '[a-z]'
+If desired, you can override the path to the certificate chain as well:
+
+```yaml
+---
+apiVersion: ambassador/v0
+kind:  Module
+name:  ambassador
+config:
+  tls:
+    # The 'server' block configures TLS termination. 'enabled' is the only required element.
+    server:
+      enabled: True
+    client:
+      enabled: True
+      cert_required: True
+      cacert_chain_file: /etc/cacert/fullchain.pem
 ```
 
-**NOTE WELL** that the presence of the CA cert chain makes a valid client certificate **mandatory**. If you don't define some valid certificates, Ambassador won't allow any access. We'll be improving on this in a later release.
+The default is `/etc/cacert/fullchain.pem`, which is how the `ConfigMap` mounts are defined in the `ambassador-proxy.yaml` which Datawire provides. If you choose to move it, you'll need to edit the maps!

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -54,7 +54,7 @@ Modules let you enable and configure special behaviors for Ambassador, in ways t
 
 ### The `ambassador` Module
 
-If present, the `ambassador` module defines system-wide configuration. **You will not normally need this file.**
+If present, the `ambassador` module defines system-wide configuration. **You will not normally need this file.** The defaults in the `ambassador` module are, roughly:
 
 ```yaml
 ---
@@ -78,14 +78,35 @@ config:
   # readiness_probe:
   #   enabled: false
 
-  # TLS setup
+  # TLS defaults to unconfigured. See below for more.
   # tls:
-  #   cert_chain_file: ...
-  #   private_key_file: ...
-  #   cacert_chain_file: ...
+  #   ...
 ```
 
-Everything in this file has a sane default; you should need to supply it _only_ to override defaults in highly-custom situations.
+Everything in this file except for TLS has a default that should cover most situations; it should only be necessary to include them to override the defaults in highly-custom situations.
+
+TLS, on the other hand, must be explicitly enabled in order to be used. The simplest configurations that make sense are
+
+```yaml
+  tls:
+    server:
+      enabled: True
+```
+
+to enable TLS termination only, and 
+
+```yaml
+  tls:
+    server:
+      enabled: True
+    client:
+      enabled: True
+      cert_required: True
+```
+
+to enable TLS termination and mandatory use of TLS client certificates.
+
+For more discussion of TLS configuration, see the documentation on [TLS termination](../how-to/tls-termination.md) and [TLS client certificate authentication](../how-to/auth-tls-certs.md).
 
 ### Probes
 


### PR DESCRIPTION
Support simple TLS client-cert authentication using Envoy's ability to require a TLS client cert with a valid signature. Support for the `client_ssl_auth` filter coming soon.