### PR TITLE
Diagnostic tweaks

### DIFF
--- a/ambassador/ambassador_diag/diagd.py
+++ b/ambassador/ambassador_diag/diagd.py
@@ -237,7 +237,7 @@ def show_overview(reqid=None):
 
     ov = aconf(app).diagnostic_overview()
     cstats = cluster_stats(ov['clusters'])
-    del(ov['clusters'])
+    # del(ov['clusters'])
 
     for source in ov['sources']:
         for obj in source['objects'].values():

--- a/ambassador/ambassador_diag/envoy.py
+++ b/ambassador/ambassador_diag/envoy.py
@@ -168,7 +168,7 @@ class EnvoyStats (object):
 
                     upstream_4xx = cluster.get('upstream_rq_4xx', 0)
                     upstream_5xx = cluster.get('upstream_rq_5xx', 0)
-                    upstream_bad = upstream_4xx + upstream_5xx
+                    upstream_bad = upstream_5xx # used to include 4XX here, but that seems wrong.
 
                     upstream_ok = upstream_total - upstream_bad
 

--- a/ambassador/ambassador_diag/envoy.py
+++ b/ambassador/ambassador_diag/envoy.py
@@ -152,7 +152,7 @@ class EnvoyStats (object):
                     # mapping_name = active_cluster_map[cluster_name]
                     # active_mappings[mapping_name] = {}
 
-                    # logging.info("SVC %s has cluster" % mapping_name)
+                    # logging.info("cluster %s stats: %s" % (cluster_name, cluster))
 
                     healthy_members = cluster['membership_healthy']
                     total_members = cluster['membership_total']
@@ -162,12 +162,24 @@ class EnvoyStats (object):
                     update_successes = cluster['update_success']
                     update_percent = percentage(update_successes, update_attempts)
 
-                    upstream_ok = cluster.get('upstream_rq_2xx', 0)
+                    # Weird.
+                    # upstream_ok = cluster.get('upstream_rq_2xx', 0)
+                    upstream_total = cluster.get('upstream_rq_pending_total', 0)
+
                     upstream_4xx = cluster.get('upstream_rq_4xx', 0)
                     upstream_5xx = cluster.get('upstream_rq_5xx', 0)
                     upstream_bad = upstream_4xx + upstream_5xx
 
-                    # logging.debug("cluster %s is %d%% healthy" % (cluster_name, healthy_percent))
+                    upstream_ok = upstream_total - upstream_bad
+
+                    # logging.info("%s total %s bad %s ok %s" % (cluster_name, upstream_total, upstream_bad, upstream_ok))
+
+                    if upstream_total > 0:
+                        healthy_percent = percentage(upstream_ok, upstream_total)
+                        logging.debug("cluster %s is %d%% healthy" % (cluster_name, healthy_percent))
+                    else:
+                        healthy_percent = None
+                        logging.debug("cluster %s has had no requests" % cluster_name)
 
                     # active_mappings[mapping_name] = {
                     active_clusters[cluster_name] = {

--- a/ambassador/templates/diag.html
+++ b/ambassador/templates/diag.html
@@ -5,15 +5,15 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <meta name="description" content="">
     <meta name="author" content="">
-    <!-- <link rel="icon" href="http://getbootstrap.com/favicon.ico"> -->
+    <!-- <link rel="icon" href="//getbootstrap.com/favicon.ico"> -->
 
     <title>Ambassador Diagnostics</title>
 
     <!-- Bootstrap core CSS -->
-    <link href="http://getbootstrap.com/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="//getbootstrap.com/dist/css/bootstrap.min.css" rel="stylesheet">
 
     <!-- Custom styles for this template -->
-    <link href="http://getbootstrap.com/docs/4.0/examples/grid/grid.css" rel="stylesheet">
+    <link href="//getbootstrap.com/docs/4.0/examples/grid/grid.css" rel="stylesheet">
   </head>
 
   <body>
@@ -225,6 +225,6 @@
     ================================================== -->
     <!-- Placed at the end of the document so the pages load faster -->
     <!-- IE10 viewport hack for Surface/desktop Windows 8 bug -->
-    <script src="http://getbootstrap.com/assets/js/ie10-viewport-bug-workaround.js"></script>
+    <script src="//getbootstrap.com/assets/js/ie10-viewport-bug-workaround.js"></script>
   </body>
 </html>

--- a/ambassador/templates/diag.html
+++ b/ambassador/templates/diag.html
@@ -147,7 +147,11 @@
             <div class="col-7">
               <code>{{ cluster['name'] }}</code> -- 
               {% if cluster_stats[cluster.name].valid %}
-                {{ cluster_stats[cluster.name].healthy_percent }}% healthy
+                {% if cluster_stats[cluster.name].healthy_percent != None %}
+                  {{ cluster_stats[cluster.name].healthy_percent }}% healthy
+                {% else %}
+                  no requests yet
+                {% endif %}
               {% else %}
                 unknown health ({{ cluster_stats[cluster.name].reason }})
               {% endif %}

--- a/ambassador/templates/overview.html
+++ b/ambassador/templates/overview.html
@@ -139,7 +139,11 @@
             </div>
             <div class="col-5">
               {% if cluster_stats[cluster.name].valid %}
-                {{ cluster_stats[cluster.name].healthy_percent }}% healthy
+                {% if cluster_stats[cluster.name].healthy_percent != None %}
+                  {{ cluster_stats[cluster.name].healthy_percent }}% healthy
+                {% else %}
+                  no requests yet
+                {% endif %}
               {% else %}
                 unknown health ({{ cluster_stats[cluster.name].reason }})
               {% endif %}

--- a/ambassador/templates/overview.html
+++ b/ambassador/templates/overview.html
@@ -5,15 +5,15 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <meta name="description" content="">
     <meta name="author" content="">
-    <!-- <link rel="icon" href="http://getbootstrap.com/favicon.ico"> -->
+    <!-- <link rel="icon" href="//getbootstrap.com/favicon.ico"> -->
 
     <title>Ambassador Diagnostic Overview</title>
 
     <!-- Bootstrap core CSS -->
-    <link href="http://getbootstrap.com/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="//getbootstrap.com/dist/css/bootstrap.min.css" rel="stylesheet">
 
     <!-- Custom styles for this template -->
-    <link href="http://getbootstrap.com/docs/4.0/examples/grid/grid.css" rel="stylesheet">
+    <link href="//getbootstrap.com/docs/4.0/examples/grid/grid.css" rel="stylesheet">
   </head>
 
   <body>
@@ -202,6 +202,6 @@
     ================================================== -->
     <!-- Placed at the end of the document so the pages load faster -->
     <!-- IE10 viewport hack for Surface/desktop Windows 8 bug -->
-    <script src="http://getbootstrap.com/assets/js/ie10-viewport-bug-workaround.js"></script>
+    <script src="//getbootstrap.com/assets/js/ie10-viewport-bug-workaround.js"></script>
   </body>
 </html>

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -4,3 +4,5 @@ docopt
 awscli
 pytest
 pytest-cov
+dpath
+kubernaut

--- a/end-to-end/000-no-base/diag-1.json
+++ b/end-to-end/000-no-base/diag-1.json
@@ -1,6 +1,9 @@
 [
     {
         "_method": "GET",
+        "_referenced_by": [
+            "--internal--"
+        ],
         "_source": "--internal--",
         "clusters": [
             {
@@ -14,6 +17,9 @@
     },
     {
         "_method": "GET",
+        "_referenced_by": [
+            "--internal--"
+        ],
         "_source": "--internal--",
         "clusters": [
             {
@@ -27,6 +33,9 @@
     },
     {
         "_method": "GET",
+        "_referenced_by": [
+            "--internal--"
+        ],
         "_source": "--internal--",
         "clusters": [
             {
@@ -40,6 +49,9 @@
     },
     {
         "_method": "GET",
+        "_referenced_by": [
+            "ambassador.yaml.1"
+        ],
         "_source": "ambassador.yaml.1",
         "clusters": [
             {
@@ -53,6 +65,9 @@
     },
     {
         "_method": "GET",
+        "_referenced_by": [
+            "qotm.yaml.1"
+        ],
         "_source": "qotm.yaml.1",
         "clusters": [
             {

--- a/end-to-end/001-simple/diag-1.json
+++ b/end-to-end/001-simple/diag-1.json
@@ -1,6 +1,9 @@
 [
     {
         "_method": "GET",
+        "_referenced_by": [
+            "--internal--"
+        ],
         "_source": "--internal--",
         "clusters": [
             {
@@ -14,6 +17,9 @@
     },
     {
         "_method": "GET",
+        "_referenced_by": [
+            "--internal--"
+        ],
         "_source": "--internal--",
         "clusters": [
             {
@@ -27,6 +33,9 @@
     },
     {
         "_method": "GET",
+        "_referenced_by": [
+            "--internal--"
+        ],
         "_source": "--internal--",
         "clusters": [
             {
@@ -40,6 +49,9 @@
     },
     {
         "_method": "GET",
+        "_referenced_by": [
+            "base-config.yaml.1"
+        ],
         "_source": "base-config.yaml.1",
         "clusters": [
             {

--- a/end-to-end/001-simple/diag-2.json
+++ b/end-to-end/001-simple/diag-2.json
@@ -1,6 +1,9 @@
 [
     {
         "_method": "GET",
+        "_referenced_by": [
+            "--internal--"
+        ],
         "_source": "--internal--",
         "clusters": [
             {
@@ -14,6 +17,9 @@
     },
     {
         "_method": "GET",
+        "_referenced_by": [
+            "--internal--"
+        ],
         "_source": "--internal--",
         "clusters": [
             {
@@ -27,6 +33,9 @@
     },
     {
         "_method": "GET",
+        "_referenced_by": [
+            "--internal--"
+        ],
         "_source": "--internal--",
         "clusters": [
             {
@@ -40,6 +49,9 @@
     },
     {
         "_method": "GET",
+        "_referenced_by": [
+            "base-config.yaml.1"
+        ],
         "_source": "base-config.yaml.1",
         "clusters": [
             {
@@ -53,6 +65,9 @@
     },
     {
         "_method": "GET",
+        "_referenced_by": [
+            "qotm.yaml.1"
+        ],
         "_source": "qotm.yaml.1",
         "clusters": [
             {

--- a/end-to-end/001-simple/diag-3.json
+++ b/end-to-end/001-simple/diag-3.json
@@ -1,6 +1,9 @@
 [
     {
         "_method": "GET",
+        "_referenced_by": [
+            "--internal--"
+        ],
         "_source": "--internal--",
         "clusters": [
             {
@@ -14,6 +17,9 @@
     },
     {
         "_method": "GET",
+        "_referenced_by": [
+            "--internal--"
+        ],
         "_source": "--internal--",
         "clusters": [
             {
@@ -27,6 +33,9 @@
     },
     {
         "_method": "GET",
+        "_referenced_by": [
+            "--internal--"
+        ],
         "_source": "--internal--",
         "clusters": [
             {
@@ -40,6 +49,9 @@
     },
     {
         "_method": "GET",
+        "_referenced_by": [
+            "example-auth.yaml.1"
+        ],
         "_source": "example-auth.yaml.1",
         "clusters": [
             {
@@ -53,6 +65,9 @@
     },
     {
         "_method": "GET",
+        "_referenced_by": [
+            "base-config.yaml.1"
+        ],
         "_source": "base-config.yaml.1",
         "clusters": [
             {
@@ -66,6 +81,9 @@
     },
     {
         "_method": "GET",
+        "_referenced_by": [
+            "qotm.yaml.1"
+        ],
         "_source": "qotm.yaml.1",
         "clusters": [
             {

--- a/end-to-end/002-canary/diag-1.json
+++ b/end-to-end/002-canary/diag-1.json
@@ -1,6 +1,9 @@
 [
     {
         "_method": "GET",
+        "_referenced_by": [
+            "--internal--"
+        ],
         "_source": "--internal--",
         "clusters": [
             {
@@ -14,6 +17,9 @@
     },
     {
         "_method": "GET",
+        "_referenced_by": [
+            "--internal--"
+        ],
         "_source": "--internal--",
         "clusters": [
             {
@@ -27,6 +33,9 @@
     },
     {
         "_method": "GET",
+        "_referenced_by": [
+            "--internal--"
+        ],
         "_source": "--internal--",
         "clusters": [
             {
@@ -40,6 +49,9 @@
     },
     {
         "_method": "GET",
+        "_referenced_by": [
+            "ambassador.yaml.1"
+        ],
         "_source": "ambassador.yaml.1",
         "clusters": [
             {

--- a/end-to-end/002-canary/diag-2.json
+++ b/end-to-end/002-canary/diag-2.json
@@ -1,6 +1,9 @@
 [
     {
         "_method": "GET",
+        "_referenced_by": [
+            "--internal--"
+        ],
         "_source": "--internal--",
         "clusters": [
             {
@@ -14,6 +17,9 @@
     },
     {
         "_method": "GET",
+        "_referenced_by": [
+            "--internal--"
+        ],
         "_source": "--internal--",
         "clusters": [
             {
@@ -27,6 +33,9 @@
     },
     {
         "_method": "GET",
+        "_referenced_by": [
+            "--internal--"
+        ],
         "_source": "--internal--",
         "clusters": [
             {
@@ -40,6 +49,9 @@
     },
     {
         "_method": "GET",
+        "_referenced_by": [
+            "ambassador.yaml.1"
+        ],
         "_source": "ambassador.yaml.1",
         "clusters": [
             {
@@ -53,6 +65,9 @@
     },
     {
         "_method": "GET",
+        "_referenced_by": [
+            "demo1.yaml.1"
+        ],
         "_source": "demo1.yaml.1",
         "clusters": [
             {

--- a/end-to-end/003-headers-and-host/diag-1.json
+++ b/end-to-end/003-headers-and-host/diag-1.json
@@ -1,6 +1,9 @@
 [
     {
         "_method": "GET",
+        "_referenced_by": [
+            "--internal--"
+        ],
         "_source": "--internal--",
         "clusters": [
             {
@@ -14,6 +17,9 @@
     },
     {
         "_method": "GET",
+        "_referenced_by": [
+            "--internal--"
+        ],
         "_source": "--internal--",
         "clusters": [
             {
@@ -27,6 +33,9 @@
     },
     {
         "_method": "GET",
+        "_referenced_by": [
+            "--internal--"
+        ],
         "_source": "--internal--",
         "clusters": [
             {
@@ -40,6 +49,9 @@
     },
     {
         "_method": "GET",
+        "_referenced_by": [
+            "ambassador.yaml.1"
+        ],
         "_source": "ambassador.yaml.1",
         "clusters": [
             {
@@ -53,6 +65,9 @@
     },
     {
         "_method": "GET",
+        "_referenced_by": [
+            "demo1.yaml.2"
+        ],
         "_source": "demo1.yaml.2",
         "clusters": [
             {
@@ -73,6 +88,9 @@
     },
     {
         "_method": "GET",
+        "_referenced_by": [
+            "demo2.yaml.1"
+        ],
         "_source": "demo2.yaml.1",
         "clusters": [
             {
@@ -93,6 +111,9 @@
     },
     {
         "_method": "GET",
+        "_referenced_by": [
+            "demo1.yaml.1"
+        ],
         "_source": "demo1.yaml.1",
         "clusters": [
             {

--- a/end-to-end/testall.sh
+++ b/end-to-end/testall.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 
 set -e
+set -o pipefail
 
 HERE=$(cd $(dirname $0); pwd)
 

--- a/end-to-end/utils.sh
+++ b/end-to-end/utils.sh
@@ -148,6 +148,11 @@ check_diag () {
 
     if ! cmp -s check-$index.json diag-$index.json; then
         echo "check_diag $index: mismatch for $desc"
+
+        if diag-diff.sh $index; then
+            diag-fix.sh $index
+            rc=0
+        fi
     else
         echo "check_diag $index: OK"
         rc=0


### PR DESCRIPTION
- Allow the diag service to look good (well, OK, not too horrible anyway) when Ambassador is running with TLS termination
- Show clusters on the overview page again
- The diag service now shows you the "health" of a cluster by computing it from the number of requests to a given service that didn't involve a 5xx status code, rather than just forwarding Envoy's stat, since we don't configure Envoy's stat in a meaningful way yet
- Make sure that the tests correctly reported failures (sigh).
- Allow updating out-of-date diagnostic reports without requiring multiple test runs.