### PR TITLE
Fixing links in docs

### DIFF
--- a/docs/about/features-and-benefits.md
+++ b/docs/about/features-and-benefits.md
@@ -25,7 +25,7 @@ For more information, check out the [concepts](concepts.md) section of the Ambas
 
 ## TLS
 
-Ambassador supports inbound TLS and inbound TLS client-certificate authentication. We **strongly** recommend using TLS with Ambassador, and encourage you to carefully read the [TLS](../reference/tls-auth.md) section of the Ambassador documentation for more.
+Ambassador supports inbound TLS and inbound TLS client-certificate authentication. We **strongly** recommend using TLS with Ambassador, and encourage you to carefully read the [TLS](../how-to/tls-termination.md) section of the Ambassador documentation for more.
 
 At present, a resource can be mapped to only one service, but the same service can be used behind as many different resources as you want. There's no hard limit to the number of mappings Ambassador can handle (though eventually you'll run out of memory).
 

--- a/docs/how-to/auth-external.md
+++ b/docs/how-to/auth-external.md
@@ -39,4 +39,4 @@ Additionally, Ambassador can be configured to allow headers from the auth servic
 
 ## Example
 
-See [the Ambassador Authentication Tutorial](#../user-guide/auth-tutorial.md) for an example.
+See [the Ambassador Authentication Tutorial](../user-guide/auth-tutorial.md) for an example.

--- a/docs/user-guide/running.md
+++ b/docs/user-guide/running.md
@@ -1,6 +1,6 @@
 # Running Ambassador
 
-The simplest way to run Ambassador is **not** to build it! Instead, just use the YAML files published at https://www.getambassador.io, and start by deciding whether you want to use TLS or not. (If you want more information on TLS, check out our [TLS Overview](../reference/tls-auth.md).) It's possible to switch this later, but it's a pain, and may well involve mucking about with your DNS and such to do it, so it's better to decide up front.
+The simplest way to run Ambassador is **not** to build it! Instead, just use the YAML files published at https://www.getambassador.io, and start by deciding whether you want to use TLS or not. (If you want more information on TLS, check out our [TLS Overview](../how-to/tls-termination.md).) It's possible to switch this later, but it's a pain, and may well involve mucking about with your DNS and such to do it, so it's better to decide up front.
 
 ### Creating the Ambassador Service With TLS
 

--- a/docs/user-guide/with-istio.md
+++ b/docs/user-guide/with-istio.md
@@ -17,7 +17,7 @@ Getting Ambassador working with Istio is straightforward. In this example, we'll
 
 By default, the Bookinfo application uses the Istio ingress. To use Ambassador, we need to:
 
-1. Install Ambassador. See the [quickstart](https://www.getambassador.io/user-guide/getting-started) guide.
+1. Install Ambassador. See the [quickstart](getting-started.md) guide.
 
 2. Update the `bookinfo.yaml` manifest to include the necessary Ambassador annotations. See below.
 


### PR DESCRIPTION
Fixing some bad links that I noticed while reading the docs.

One thing - reference/tls-auth.md is referenced twice, but the file doesn't exist. I updated it to the how-to/tls-termination.md file, but it wasn't clear to me what the here intent was.