### PR TITLE
Diagnostics refactor

### DIFF
--- a/ambassador/ambassador/config.py
+++ b/ambassador/ambassador/config.py
@@ -311,8 +311,9 @@ class Config (object):
                 all_objects.append((filename, ocount, obj))
                 ocount += 1
         except Exception as e:
-            self.logger.error("%s: could not parse YAML: %s" % (filename, e))
-            self.fatal_errors += 1
+            # ALLOW THIS. No sense letting one attribute with bad YAML take 
+            # down the whole gateway.
+            self.post_error(RichStatus.fromError("%s: could not parse YAML" % filename))
 
         for filename, ocount, obj in all_objects:
             self.filename = filename

--- a/ambassador/ambassador/config.py
+++ b/ambassador/ambassador/config.py
@@ -908,8 +908,6 @@ class Config (object):
 
             for route in self.envoy_config['routes']:
                 if route['_group_id'] == group_id:
-                    self.logger.info("get_intermediate_for found route:\n%s" %
-                                     json.dumps(route, sort_keys=True, indent=4))
                     source_keys.append(route['_source'])
 
                     for reference_key in route['_referenced_by']:
@@ -935,8 +933,8 @@ class Config (object):
 
         source_keys = set(source_keys)
 
-        self.logger.info("get_intermediate_for: source_keys %s" % source_keys)
-        self.logger.info("get_intermediate_for: errors %s" % self.errors)
+        # self.logger.debug("get_intermediate_for: source_keys %s" % source_keys)
+        # self.logger.debug("get_intermediate_for: errors %s" % self.errors)
 
         sources = []
 
@@ -956,7 +954,7 @@ class Config (object):
             "sources": sources
         }
 
-        self.logger.info("get_intermediate_for: initial result %s" % result)
+        # self.logger.debug("get_intermediate_for: initial result %s" % result)
 
         for key in self.envoy_config.keys():
             result[key] = []

--- a/ambassador/ambassador_diag/diagd.py
+++ b/ambassador/ambassador_diag/diagd.py
@@ -346,15 +346,22 @@ def show_overview(reqid=None):
     app.logger.debug("headers:")
     app.logger.info(request.headers)
 
+    errors = []
+
     for source in ov['sources']:
         for obj in source['objects'].values():
             obj['target'] = ambassador_targets.get(obj['kind'].lower(), None)
+
+            if obj['errors']:
+                errors.extend([ (obj['key'], error['summary'])
+                                 for error in obj['errors'] ])
 
     tvars = dict(system=system_info(), 
                  envoy_status=envoy_status(app.estats), 
                  loginfo=app.estats.loginfo,
                  cluster_stats=cstats,
                  notices=notices,
+                 errors=errors,
                  route_info=route_info,
                  **ov)
 

--- a/ambassador/ambassador_diag/diagd.py
+++ b/ambassador/ambassador_diag/diagd.py
@@ -253,8 +253,8 @@ def route_and_cluster_info(request, overview, clusters, cstats):
                 'host': host if host else '*'
             })
 
-        app.logger.info("route_info")
-        app.logger.info(json.dumps(route_info, indent=4, sort_keys=True))
+        # app.logger.info("route_info")
+        # app.logger.info(json.dumps(route_info, indent=4, sort_keys=True))
 
         # app.logger.info("cstats")
         # app.logger.info(json.dumps(cstats, indent=4, sort_keys=True))
@@ -343,9 +343,6 @@ def show_overview(reqid=None):
 
     notices.extend(clean_notices(Config.scout_notices))
 
-    app.logger.debug("headers:")
-    app.logger.info(request.headers)
-
     errors = []
 
     for source in ov['sources']:
@@ -381,7 +378,7 @@ def show_intermediate(source=None, reqid=None):
 
     result = aconf(app).get_intermediate_for(source)
 
-    app.logger.debug("result\n%s" % json.dumps(result, indent=4, sort_keys=True))
+    # app.logger.debug("result\n%s" % json.dumps(result, indent=4, sort_keys=True))
 
     method = request.args.get('method', None)
     resource = request.args.get('resource', None)
@@ -461,6 +458,8 @@ def _main(config_dir_path:Parameter.REQUIRED, *, no_checks=False, no_debugging=F
     if app.debugging or verbose:
         app.logger.setLevel(logging.DEBUG)
         logging.getLogger().setLevel(logging.DEBUG)
+    else:
+        logging.getLogger("ambassador.config").setLevel(logging.INFO)
 
     if not no_checks:
         app.health_checks = True

--- a/ambassador/ambassador_diag/diagd.py
+++ b/ambassador/ambassador_diag/diagd.py
@@ -374,15 +374,18 @@ def show_intermediate(source=None, reqid=None):
 
     result = aconf(app).get_intermediate_for(source)
 
-    clusters = result['clusters']
-    cstats = cluster_stats(clusters)
-
-    route_info, cluster_info = route_and_cluster_info(request, result, clusters, cstats)
+    app.logger.debug("result\n%s" % json.dumps(result, indent=4, sort_keys=True))
 
     method = request.args.get('method', None)
     resource = request.args.get('resource', None)
+    route_info = None
 
     if "error" not in result:
+        clusters = result['clusters']
+        cstats = cluster_stats(clusters)
+
+        route_info, cluster_info = route_and_cluster_info(request, result, clusters, cstats)
+
         result['cluster_stats'] = cstats
         result['sources'] = sorted_sources(result['sources'])
 

--- a/ambassador/ambassador_diag/diagd.py
+++ b/ambassador/ambassador_diag/diagd.py
@@ -386,6 +386,7 @@ def show_intermediate(source=None, reqid=None):
     method = request.args.get('method', None)
     resource = request.args.get('resource', None)
     route_info = None
+    errors = []
 
     if "error" not in result:
         clusters = result['clusters']
@@ -399,11 +400,16 @@ def show_intermediate(source=None, reqid=None):
         for source in result['sources']:
             source['target'] = ambassador_targets.get(source['kind'].lower(), None)
 
+            if source['errors']:
+                errors.extend([ (source['filename'], error['summary'])
+                                 for error in source['errors'] ])
+
     tvars = dict(system=system_info(),
                  envoy_status=envoy_status(app.estats),
                  loginfo=app.estats.loginfo,
                  method=method, resource=resource,
                  route_info=route_info,
+                 errors=errors,
                  notices=clean_notices(Config.scout_notices),
                  **result)
 

--- a/ambassador/ambassador_diag/diagd.py
+++ b/ambassador/ambassador_diag/diagd.py
@@ -185,12 +185,11 @@ def route_and_cluster_info(request, overview, clusters, cstats):
     for cluster_name, cstat in cstats.items():
         c_info = cluster_info.setdefault(cluster_name, {
             '_service': 'unknown service!',
-            '_health': 'unknown service!',
-            '_hmetric': 'unknown service!'
         })
 
         c_info['_health'] = cstat['health']
         c_info['_hmetric'] = cstat['hmetric']
+        c_info['_hcolor'] = cstat['hcolor']
 
     route_info = []
 
@@ -207,17 +206,20 @@ def route_and_cluster_info(request, overview, clusters, cstats):
                 c_name = cluster['name']
                 c_info = cluster_info.get(c_name, {
                     '_service': 'unknown cluster!',
-                    '_health': 'bad'
+                    '_health': 'unknown cluster!',
+                    '_hmetric': 'unknown',
+                    '_hcolor': 'orange'
                 })
 
                 c_service = c_info.get('_service', 'unknown service!')
                 c_health = c_info.get('_hmetric', 'unknown')
-
+                c_color = c_info.get('_hcolor', 'orange')
                 c_weight = cluster['weight']
 
                 route_clusters[c_name] = {
                     'weight': c_weight,
                     '_health': c_health,
+                    '_hcolor': c_color,
                     'service': c_service
                 }
 

--- a/ambassador/ambassador_diag/envoy.py
+++ b/ambassador/ambassador_diag/envoy.py
@@ -79,7 +79,8 @@ class EnvoyStats (object):
                 'valid': False,
                 'reason': "No stats updates have succeeded",
                 'health': "no stats yet",
-                'hmetric': 'startup'
+                'hmetric': 'startup',
+                'hcolor': 'grey'
             }
 
         # OK, we should be OK.
@@ -91,7 +92,8 @@ class EnvoyStats (object):
                 'valid': False,
                 'reason': "Cluster %s is not defined" % name,
                 'health': "undefined cluster",
-                'hmetric': 'undefined cluster'
+                'hmetric': 'undefined cluster',
+                'hcolor': 'orange',
             }
 
         cstat = dict(**cstat[name])
@@ -103,14 +105,23 @@ class EnvoyStats (object):
         pct = cstat.get('healthy_percent', None)
 
         if pct != None:
+            color = 'green'
+
+            if pct < 70:
+                color = 'red'
+            elif pct < 90:
+                color = 'yellow'
+
             cstat.update({
                 'health': "%d%% healthy" % pct,
-                'hmetric': int(pct)
+                'hmetric': int(pct),
+                'hcolor': color
             })
         else:
             cstat.update({
                 'health': "no requests yet",
-                'hmetric': 'waiting'
+                'hmetric': 'waiting',
+                'hcolor': 'grey'
             })
 
         return cstat

--- a/ambassador/templates/diag.html
+++ b/ambassador/templates/diag.html
@@ -106,7 +106,10 @@
             <span style="color:red">CONFIGURATION ERRORS</span>
             <br/>
             {% for error in errors | sort %}
-              <span style="color:red">{{ error[0] }}: {{ error[1] }}</span><br/>
+              <a href="/ambassador/v0/diag/{{ error[0] }}">
+                <span style="color:red">{{ error[0] }}: {{ error[1] }}</span>
+              </a>
+              <br/>
             {% endfor %}
           </div>
         </div>

--- a/ambassador/templates/diag.html
+++ b/ambassador/templates/diag.html
@@ -99,6 +99,19 @@
           </div>
         </div>
       {% else %}
+
+      {% if errors %}
+        <div class="row">
+          <div class="col-12">
+            <span style="color:red">CONFIGURATION ERRORS</span>
+            <br/>
+            {% for error in errors | sort %}
+              <span style="color:red">{{ error[0] }}: {{ error[1] }}</span><br/>
+            {% endfor %}
+          </div>
+        </div>
+      {% endif %}
+
       <div class="row">
         <div class="col-12">
           Currently active Envoy <a href="https://envoyproxy.github.io/envoy/configuration/http_conn_man/route_config/route.html">Routes</a>
@@ -256,7 +269,7 @@
 
                 {% if source.errors %}
                   {% for error in source.errors %}
-                  <br/>ERROR: {{ error.summary }}
+                  <br/><span style="color:red">ERROR:</span> {{ error.text }}
                   {% endfor %}
                 {% endif %}
               {% endif %}

--- a/ambassador/templates/diag.html
+++ b/ambassador/templates/diag.html
@@ -19,13 +19,13 @@
   <body>
     <div class="container">
 
-      <h1>Ambassador Diagnostics 
+      <h1><a href="/ambassador/v0/diag/">Ambassador Diagnostics
         {% if method or resource %} for <code>
           {% if method %}{{ method }}{% endif %}
           {% if resource %}{{ resource }}{% endif %}
           </code>
         {% endif %}
-      </h1>
+      </a></h1>
 
       <div class="row">
         <div class="col-7">
@@ -104,13 +104,15 @@
         <div class="row">
           <div class="col-12">
             <span style="color:red">CONFIGURATION ERRORS</span>
-            <br/>
+            <ul>
             {% for error in errors | sort %}
-              <a href="/ambassador/v0/diag/{{ error[0] }}">
-                <span style="color:red">{{ error[0] }}: {{ error[1] }}</span>
-              </a>
-              <br/>
+              <li>
+                <a href="/ambassador/v0/diag/{{ error[0] }}">
+                  <span style="color:red">{{ error[0] }}: {{ error[1] }}</span>
+                </a>
+              </li>
             {% endfor %}
+            </ul>
           </div>
         </div>
       {% endif %}
@@ -271,9 +273,13 @@
                 {% if source['target'] %}</a>{% endif %}
 
                 {% if source.errors %}
-                  {% for error in source.errors %}
-                  <br/><span style="color:red">ERROR:</span> {{ error.text }}
-                  {% endfor %}
+                  <ul>
+                    {% for error in source.errors %}
+                    <li>
+                      <span style="color:red">ERROR:</span> {{ error.text }}
+                    </li>
+                    {% endfor %}
+                  </ul>
                 {% endif %}
               {% endif %}
             </div>

--- a/ambassador/templates/diag.html
+++ b/ambassador/templates/diag.html
@@ -145,17 +145,32 @@
               <a href="/ambassador/v0/diag/{{ cluster['_source'] }}">
                 <code>{{ cluster['name'] }}</code>
               </a>
-              <br/> 
-              {% if cluster_stats[cluster.name].valid %}
-                {% if cluster_stats[cluster.name].healthy_percent != None %}
-                  {{ cluster_stats[cluster.name].healthy_percent }}% healthy
+              <br/><br/>
+              <span style=" 
+                {% if cluster._hmetric == 'bad' %}
+                  color:red;
+                {% elif cluster._hmetric == 'unknown' %}
+                  color:red;
+                {% elif cluster._hmetric == 'waiting' %}
+                  color:grey;
+                {% elif cluster._hmetric == 'startup' %}
+                  color:grey;
+                {% elif cluster._hmetric < 70 %}
+                  color:red;
+                {% elif cluster._hmetric < 90 %}
+                  color:yellow;
                 {% else %}
-                  no requests yet
+                  color:green;
                 {% endif %}
-              {% else %}
-                unknown health ({{ cluster_stats[cluster.name].reason }})
-              {% endif %}
-              <br/>
+              ">
+                {% if cluster_stats[cluster.name].valid %}
+                  {{ 'Unknown health: ' if cluster._hmetric is not number }}
+                  {{ cluster._health }}
+                {% else %}
+                  Unknown health: {{ cluster_stats[cluster.name].reason }}
+                {% endif %}
+              </span>
+              <br/><br/>
               sources:
               <ul>
                 {% for ref in cluster._referenced_by | sort %}
@@ -181,12 +196,16 @@
           {% for breaker in breakers | sort(attribute = 'name') %}
           <div class="row">
             <div class="col-5">
-              <code>{{ breaker['name'] }}</code>
-              <br/>
-              referenced by
-                {% for ref in breaker['_referenced_by'] | sort %}
-                  <a href="/ambassador/v0/diag/{{ ref }}"><code>{{ ref }}</code></a>{{ "," if not loop.last }}
+              <a href="/ambassador/v0/diag/{{ breaker['_source'] }}">
+                <code>{{ breaker['name'] }}</code>
+              </a>
+              <br/><br/>
+              sources:
+              <ul>
+                {% for ref in breaker._referenced_by | sort %}
+                  <li><a href="/ambassador/v0/diag/{{ ref }}"><code>{{ ref }}</code></a></li>
                 {% endfor %}
+              </ul>
             </div>
             <div class="col-7">
               <div class="row">
@@ -207,12 +226,16 @@
           {% for outlier in outliers | sort(attribute = 'name') %}
           <div class="row">
             <div class="col-5">
-              <code>{{ outlier['name'] }}</code>
-              <br/>
-              referenced by
-                {% for ref in outlier['_referenced_by'] | sort %}
-                  <a href="/ambassador/v0/diag/{{ ref }}"><code>{{ ref }}</code></a>{{ "," if not loop.last }}
+              <a href="/ambassador/v0/diag/{{ outlier['_source'] }}">
+                <code>{{ outlier['name'] }}</code>
+              </a>
+              <br/><br/>
+              sources:
+              <ul>
+                {% for ref in outlier._referenced_by | sort %}
+                  <li><a href="/ambassador/v0/diag/{{ ref }}"><code>{{ ref }}</code></a></li>
                 {% endfor %}
+              </ul>
             </div>
             <div class="col-7">
               <div class="row">
@@ -232,10 +255,16 @@
           {% for source in sources %}
           <div class="row">
             <div class="col-5">
-              <code>{{ source['filename'] }}{%- if not source.description -%}.{{ source['index'] }}{%- endif -%}</code>
+              <a href="/ambassador/v0/diag/{{ source.filename }}">
+                <code>{{ source['filename'] }}{%- if not source.description -%}.{{ source['index'] }}{%- endif -%}</code>
+              </a>
               {% if not source.description %}
-                -- object {{ source.index }} in <a href="/ambassador/v0/diag/{{ source.filename }}"><code>{{ source.filename }}</code></a>
                 <br/>
+                (object {{ source.index }} in 
+                <a href="/ambassador/v0/diag/{{ source.filename }}">
+                  <code>{{ source.filename }}</code>
+                </a>
+                )<br/>
                 Ambassador 
                 {% if source['target'] %}<a href={{ source['target'] }}>{% endif %}
                 {{ source['kind'] }}

--- a/ambassador/templates/diag.html
+++ b/ambassador/templates/diag.html
@@ -33,7 +33,7 @@
           <br/>
           Hostname {{ system.hostname }}
           <br/>
-          Configuration from {{ system.boot_time }} -- {{ system.hr_uptime }} ago
+          Configuration from {{ system.boot_time }} &mdash; {{ system.hr_uptime }} ago
           <br/>
           {% if envoy_status.ready %}
           Envoy ready, last status report {{ envoy_status.since_update }}
@@ -252,7 +252,7 @@
 
       <div class="row">
         <div class="col-12">
-          YAML input documents -- these are what Ambassador is currently using for its configuration.
+          YAML input documents &mdash; these are what Ambassador is currently reading for its configuration.
 
           {% for source in sources %}
           <div class="row">

--- a/ambassador/templates/diag.html
+++ b/ambassador/templates/diag.html
@@ -146,23 +146,7 @@
                 <code>{{ cluster['name'] }}</code>
               </a>
               <br/><br/>
-              <span style=" 
-                {% if cluster._hmetric == 'bad' %}
-                  color:red;
-                {% elif cluster._hmetric == 'unknown' %}
-                  color:red;
-                {% elif cluster._hmetric == 'waiting' %}
-                  color:grey;
-                {% elif cluster._hmetric == 'startup' %}
-                  color:grey;
-                {% elif cluster._hmetric < 70 %}
-                  color:red;
-                {% elif cluster._hmetric < 90 %}
-                  color:yellow;
-                {% else %}
-                  color:green;
-                {% endif %}
-              ">
+              <span style="color:{{ cluster._hcolor }}">
                 {% if cluster_stats[cluster.name].valid %}
                   {{ 'Unknown health: ' if cluster._hmetric is not number }}
                   {{ cluster._health }}

--- a/ambassador/templates/overview.html
+++ b/ambassador/templates/overview.html
@@ -96,7 +96,10 @@
             <span style="color:red">CONFIGURATION ERRORS</span>
             <br/>
             {% for error in errors | sort %}
-              <span style="color:red">{{ error[0] }}: {{ error[1] }}</span><br/>
+              <a href="/ambassador/v0/diag/{{ error[0] }}">
+                <span style="color:red">{{ error[0] }}: {{ error[1] }}</span>
+              </a>
+              <br/>
             {% endfor %}
           </div>
         </div>

--- a/ambassador/templates/overview.html
+++ b/ambassador/templates/overview.html
@@ -94,13 +94,15 @@
         <div class="row">
           <div class="col-12">
             <span style="color:red">CONFIGURATION ERRORS</span>
-            <br/>
+            <ul>
             {% for error in errors | sort %}
-              <a href="/ambassador/v0/diag/{{ error[0] }}">
-                <span style="color:red">{{ error[0] }}: {{ error[1] }}</span>
-              </a>
-              <br/>
+              <li>
+                <a href="/ambassador/v0/diag/{{ error[0] }}">
+                  <span style="color:red">{{ error[0] }}: {{ error[1] }}</span>
+                </a>
+              </li>
             {% endfor %}
+            </ul>
           </div>
         </div>
       {% endif %}

--- a/ambassador/templates/overview.html
+++ b/ambassador/templates/overview.html
@@ -90,6 +90,18 @@
         </div>
       {% endif %}
 
+      {% if errors %}
+        <div class="row">
+          <div class="col-12">
+            <span style="color:red">CONFIGURATION ERRORS</span>
+            <br/>
+            {% for error in errors | sort %}
+              <span style="color:red">{{ error[0] }}: {{ error[1] }}</span><br/>
+            {% endfor %}
+          </div>
+        </div>
+      {% endif %}
+
       <div class="row">
         <div class="col-12">
           Ambassador Route Table

--- a/ambassador/templates/overview.html
+++ b/ambassador/templates/overview.html
@@ -124,23 +124,9 @@
                       <td>
                         {% for cluster in route.clusters| sort_clusters_by_service %}
                           <a href="/ambassador/v0/diag/{{ route['_source'] }}">
-                            <code><span style=" 
-                              {% if cluster._health == 'bad' %}
-                                color:red;
-                              {% elif cluster._health == 'unknown' %}
-                                color:red;
-                              {% elif cluster._health == 'waiting' %}
-                                color:grey;
-                              {% elif cluster._health == 'startup' %}
-                                color:grey;
-                              {% elif cluster._health < 70 %}
-                                color:red;
-                              {% elif cluster._health < 90 %}
-                                color:yellow;
-                              {% else %}
-                                color:green;
-                              {% endif %}
-                            ">{{ cluster.service }}</span></code>
+                            <code><span style="color:{{ cluster._hcolor }}">
+                              {{ cluster.service }}
+                            </span></code>
                           </a>
                           {% if not loop.last %}
                           <br/>

--- a/ambassador/templates/overview.html
+++ b/ambassador/templates/overview.html
@@ -27,7 +27,7 @@
           <br/>
           Hostname {{ system.hostname }}
           <br/>
-          Configuration from {{ system.boot_time }} -- {{ system.hr_uptime }} ago
+          Configuration from {{ system.boot_time }} &mdash; {{ system.hr_uptime }} ago
           <br/>
           {% if envoy_status.ready %}
           Envoy ready, last status reported {{ envoy_status.since_update }}


### PR DESCRIPTION
Too many diagnostics refactors to list. Notably:

- switch to URL-style display of route table entries
- surface errors better
- have a way to switch Envoy debug logging on and off
- first level of drilldown from a route takes you to the group for that route, not just its single source file
