### PR TITLE
Annotation attribution

### DIFF
--- a/ambassador/ambassador/config.py
+++ b/ambassador/ambassador/config.py
@@ -417,6 +417,9 @@ class Config (object):
             'yaml': yaml.safe_dump(obj, default_flow_style=False)
         }
 
+        if 'source' in obj:
+            self.sources[source_key]['source'] = obj['source']
+
         source_map = self.source_map.setdefault(self.filename, {})
         source_map[source_key] = True
 
@@ -947,6 +950,7 @@ class Config (object):
                 }
                 for error in self.errors.get(key, [])
             ]
+            source_dict['source_key'] = key
 
             sources.append(source_dict)
 
@@ -1138,6 +1142,10 @@ class Config (object):
                 # self.logger.debug("overview --- source_key %s" % source_key)
 
                 source = self.sources[source_key]
+
+                if ('source' in source) and not ('source' in source_dict):
+                    source_dict['source'] = source['source']
+
                 raw_errors = self.errors.get(source_key, [])
 
                 errors = []

--- a/ambassador/kubewatch.py
+++ b/ambassador/kubewatch.py
@@ -39,6 +39,9 @@ def is_annotated(svc):
 def get_annotation(svc):
     return svc.metadata.annotations[KEY] if is_annotated(svc) else None
 
+def get_source(svc):
+    return "service %s, namespace %s" % (svc.metadata.name, svc.metadata.namespace)
+
 def get_filename(svc):
     return "%s.yaml" % svc.metadata.name
 
@@ -66,7 +69,6 @@ class Restarter(threading.Thread):
         self.read_fs(self.ambassador_config_dir)
 
         # ...then pull in anything updated by the restarter logic.
-
         while True:
             if not os.path.exists("%s-%s" % (self.ambassador_config_dir, self.restart_count + 1)):
                 break
@@ -82,10 +84,12 @@ class Restarter(threading.Thread):
 
             for name in os.listdir(path):
                 if name.endswith(".yaml"):
-                    with open(os.path.join(path, name)) as fd:
-                        self.configs[name] = fd.read()
+                    filepath = os.path.join(path, name)
 
-                    logger.info("Loaded %s" % os.path.join(path, name))
+                    with open(filepath) as fd:
+                        self.configs[name] = self.read_yaml(fd.read(), "file %s" % filepath)
+
+                    logger.info("Loaded %s" % filepath)
 
     def changes(self):
         with self.mutex:
@@ -111,9 +115,11 @@ class Restarter(threading.Thread):
         self.restart_count += 1
         output = "%s-%s" % (self.ambassador_config_dir, self.restart_count)
         config = self.generate_config(output)
+
         base, ext = os.path.splitext(self.envoy_config_file)
         target = "%s-%s%s" % (base, self.restart_count, ext)
         os.rename(config, target)
+
         logger.info("Moved valid configuration %s to %s" % (config, target))
         if self.pid:
             os.kill(self.pid, signal.SIGHUP)
@@ -157,12 +163,35 @@ class Restarter(threading.Thread):
         raise ValueError("Unable to generate config")
 
     def update_from_service(self, svc):
+        key = get_filename(svc)
+        source = get_source(svc)
         config = get_annotation(svc)
+
         if config is None:
             self.delete(svc)
         else:
-            key = get_filename(svc)
-            self.update(key, config)
+            self.update(key, self.read_yaml(config, source))
+
+    def read_yaml(self, raw_yaml, source):
+        all_objects = []
+        yaml_to_return = raw_yaml
+
+        try:
+            # XXX This is a bit of a hack -- yaml.safe_load_all returns a
+            # generator, and if we don't use list() here, any exception
+            # dealing with the actual object gets deferred             
+            for obj in yaml.safe_load_all(raw_yaml):
+                if 'source' not in obj:
+                    obj['source'] = source
+
+                all_objects.append(obj)
+
+            yaml_to_return = "---\n" + yaml.safe_dump_all(all_objects)
+        except Exception as e:
+            # Ooops.
+            logger.error("could not parse YAML from %s: %s" % (source, e))
+
+        return yaml_to_return
 
     def update(self, key, config):
         logger.info("update: including key %s" % key)

--- a/ambassador/schemas/v0/CircuitBreaker.schema
+++ b/ambassador/schemas/v0/CircuitBreaker.schema
@@ -6,6 +6,7 @@
     "properties": {
         "apiVersion": { "enum": ["ambassador/v0"] },
         "kind": { "type": "string" },
+        "source": { "type": "string" },
         "name": { "type": "string" },
         "max_connections": { "type": "integer" },
         "max_pending": { "type": "integer" },

--- a/ambassador/schemas/v0/Mapping.schema
+++ b/ambassador/schemas/v0/Mapping.schema
@@ -6,6 +6,7 @@
     "properties": {
         "apiVersion": { "enum": ["ambassador/v0"] },
         "kind": { "type": "string" },
+        "source": { "type": "string" },
         "name": { "type": "string" },
         "prefix": { "type": "string" },
         "rewrite": { "type": "string" },

--- a/ambassador/schemas/v0/Module.schema
+++ b/ambassador/schemas/v0/Module.schema
@@ -6,6 +6,7 @@
     "properties": {
         "apiVersion": { "enum": ["ambassador/v0"] },
         "kind": { "type": "string" },
+        "source": { "type": "string" },
         "name": { "type": "string" },
         "config": { "type": "object" }
     },

--- a/ambassador/schemas/v0/OutlierDetection.schema
+++ b/ambassador/schemas/v0/OutlierDetection.schema
@@ -6,6 +6,7 @@
     "properties": {
         "apiVersion": { "enum": ["ambassador/v0"] },
         "kind": { "type": "string" },
+        "source": { "type": "string" },
         "name": { "type": "string" },
         "consecutive_5xx": { "type": "integer" },
         "max_ejection": { "type": "integer" },

--- a/ambassador/templates/diag.html
+++ b/ambassador/templates/diag.html
@@ -139,7 +139,7 @@
               sources:
               <ul>
                 {% for ref in route._route._referenced_by | sort %}
-                  <li><a href="/ambassador/v0/diag/{{ ref }}"><code>{{ ref }}</code></a></li>
+                  <li><a href="/ambassador/v0/diag/{{ ref }}"><code>{{ ref | source_lookup(source_dict) }}</code></a></li>
                 {% endfor %}
               </ul>
             </div>
@@ -176,7 +176,7 @@
               sources:
               <ul>
                 {% for ref in cluster._referenced_by | sort %}
-                  <li><a href="/ambassador/v0/diag/{{ ref }}"><code>{{ ref }}</code></a></li>
+                  <li><a href="/ambassador/v0/diag/{{ ref }}"><code>{{ ref | source_lookup(source_dict) }}</code></a></li>
                 {% endfor %}
               </ul>
             </div>
@@ -205,7 +205,7 @@
               sources:
               <ul>
                 {% for ref in breaker._referenced_by | sort %}
-                  <li><a href="/ambassador/v0/diag/{{ ref }}"><code>{{ ref }}</code></a></li>
+                  <li><a href="/ambassador/v0/diag/{{ ref }}"><code>{{ ref | source_lookup(source_dict) }}</code></a></li>
                 {% endfor %}
               </ul>
             </div>
@@ -235,7 +235,7 @@
               sources:
               <ul>
                 {% for ref in outlier._referenced_by | sort %}
-                  <li><a href="/ambassador/v0/diag/{{ ref }}"><code>{{ ref }}</code></a></li>
+                  <li><a href="/ambassador/v0/diag/{{ ref }}"><code>{{ ref | source_lookup(source_dict) }}</code></a></li>
                 {% endfor %}
               </ul>
             </div>
@@ -264,7 +264,7 @@
                 <br/>
                 (object {{ source.index }} in 
                 <a href="/ambassador/v0/diag/{{ source.filename }}">
-                  <code>{{ source.filename }}</code>
+                  <code>{{ source.source_key | source_lookup(source_dict) }}</code>
                 </a>
                 )<br/>
                 Ambassador 


### PR DESCRIPTION
When a YAML file comes from an annotation, tell the user which service it was on instead of just giving an internal filename.

We need better test coverage for this.
