### PR TITLE
Mapping objects support for Envoy request_headers_to_add

### DIFF
--- a/ambassador/ambassador/mapping.py
+++ b/ambassador/ambassador/mapping.py
@@ -39,6 +39,7 @@ class Mapping (object):
         "use_websocket": True,
         "timeout_ms": True,
         "priority": True,
+        "request_headers_to_add": True,
     }
 
     def __init__(self, _source="--internal--", _from=None, **kwargs):

--- a/ambassador/schemas/v0/Mapping.schema
+++ b/ambassador/schemas/v0/Mapping.schema
@@ -20,6 +20,18 @@
         "outlier_detection": { "type": "string" },
         "path_redirect": { "type": "string" },
         "priority": { "type": "string" },
+        "request_headers_to_add": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "key":  { "type": "string" },
+                    "value":  { "type": "string" }
+                },
+                "required": [ "key", "value" ],
+                "additionalProperties": false
+            }
+        },
         "rewrite": { "type": "string" },
         "timeout_ms": { "type": "string" },
         "tls": { "type": [ "string", "boolean" ] },

--- a/ambassador/templates/envoy.j2
+++ b/ambassador/templates/envoy.j2
@@ -47,6 +47,12 @@
                       {%- if route.timeout_ms -%}"timeout_ms": "{{ route.timeout_ms }}",{% endif %}
                       {%- if route.use_websocket -%}"use_websocket": {{ route.use_websocket | tojson }},{% endif %}
                       {%- if route.headers -%}"headers": {{ route.headers | tojson }},{% endif %}
+                      {% if route.request_headers_to_add %}
+                      "request_headers_to_add": [
+                        {% for header in route.request_headers_to_add %}
+                        { "key": "{{header.key}}", "value": "{{header.value}}" }{{ "," if not loop.last }}
+                        {% endfor %}
+                      ],{% endif %}
                       "weighted_clusters": {
                           "clusters": [
                               {% for wc in route.clusters %}

--- a/ambassador/tests/006-headers-and-host/config/mapping-qotm.yaml
+++ b/ambassador/tests/006-headers-and-host/config/mapping-qotm.yaml
@@ -27,3 +27,10 @@ headers:
   x-demo-mode: host
 host: httpbin.org
 host_rewrite: httpbin.org
+request_headers_to_add:
+- key: x-test-proto
+  value: "%PROTOCOL%"
+- key: x-test-ip
+  value: "%CLIENT_IP%"
+- key: x-test-static
+  value: testing

--- a/ambassador/tests/006-headers-and-host/gold.intermediate.json
+++ b/ambassador/tests/006-headers-and-host/gold.intermediate.json
@@ -182,7 +182,21 @@
                 ],
                 "host_rewrite": "httpbin.org",
                 "prefix": "/qotm/",
-                "prefix_rewrite": "/"
+                "prefix_rewrite": "/",
+                "request_headers_to_add": [
+                    {
+                        "key": "x-test-proto",
+                        "value": "%PROTOCOL%"
+                    },
+                    {
+                        "key": "x-test-ip",
+                        "value": "%CLIENT_IP%"
+                    },
+                    {
+                        "key": "x-test-static",
+                        "value": "testing"
+                    }
+                ]
             },
             {
                 "_group_id": "dc5d22df356f9df8439ed418ef194c061e57c68f",
@@ -298,7 +312,7 @@
             "kind": "Mapping",
             "name": "qotm_host_mapping",
             "version": "ambassador/v0",
-            "yaml": "apiVersion: ambassador/v0\nheaders:\n  x-demo-mode: host\nhost: httpbin.org\nhost_rewrite: httpbin.org\nkind: Mapping\nname: qotm_host_mapping\nprefix: /qotm/\nrewrite: /\nservice: httpbin.org:80\n"
+            "yaml": "apiVersion: ambassador/v0\nheaders:\n  x-demo-mode: host\nhost: httpbin.org\nhost_rewrite: httpbin.org\nkind: Mapping\nname: qotm_host_mapping\nprefix: /qotm/\nrequest_headers_to_add:\n- key: x-test-proto\n  value: '%PROTOCOL%'\n- key: x-test-ip\n  value: '%CLIENT_IP%'\n- key: x-test-static\n  value: testing\nrewrite: /\nservice: httpbin.org:80\n"
         }
     }
 }

--- a/ambassador/tests/006-headers-and-host/gold.json
+++ b/ambassador/tests/006-headers-and-host/gold.json
@@ -89,6 +89,7 @@
                     
                     {
                       "timeout_ms": 10000,"prefix": "/qotm/","prefix_rewrite": "/","host_rewrite": "httpbin.org","headers": [{"name": "x-demo-mode", "regex": false, "value": "host"}, {"name": ":authority", "regex": false, "value": "httpbin.org"}],
+                      "request_headers_to_add": [{"key": "x-test-proto", "value": "%PROTOCOL%"}, {"key": "x-test-ip", "value": "%CLIENT_IP%"}, {"key": "x-test-static", "value": "testing"}],
                       "weighted_clusters": {
                           "clusters": [
                               

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -230,10 +230,11 @@ Common optional attributes for mappings:
 
 Less-common optional attributes for mappings:
 
-- `auto_host_rewrite`: if present with a true value, forces the HTTP `Host` header to the `service` to which we will route
-- `case_sensitive`: determines whether `prefix` matching is case-sensitive; defaults to True
-- `host_redirect`: if set, this `Mapping` performs an HTTP 301 `Redirect`, with the host portion of the URL replaced with the `host_redirect` value
-- `path_redirect`: if set, this `Mapping` performs an HTTP 301 `Redirect`, with the path portion of the URL replaced with the `path_redirect` value
+- `auto_host_rewrite`: if present with a true value, forces the HTTP `Host` header to the `service` to which we will route.
+- `case_sensitive`: determines whether `prefix` matching is case-sensitive; defaults to True.
+- `host_redirect`: if set, this `Mapping` performs an HTTP 301 `Redirect`, with the host portion of the URL replaced with the `host_redirect` value.
+- `path_redirect`: if set, this `Mapping` performs an HTTP 301 `Redirect`, with the path portion of the URL replaced with the `path_redirect` value.
+- `request_headers_to_add`: if present, specifies a list of HTTP headers (`key` and `value` objects) that should be added to each request when talking to the service. Envoy dynamic `value`s `%CLIENT_IP%` and `%PROTOCOL%` are supported, in addition to static `value`s.
 - `timeout_ms`: the timeout, in milliseconds, for requests through this `Mapping`. Defaults to 3000.
 - `use_websocket`: if present with a true value, tells Ambassador that this service will used for websockets
 - `envoy_override`: supplies raw configuration data to be included with the generated Envoy route entry.


### PR DESCRIPTION
Added support for `request_headers_to_add`, https://github.com/datawire/ambassador/issues/217

``` 
apiVersion: ambassador/v0
kind:  Mapping
name:  default
prefix: /default
service: echo-svc:8080
request_headers_to_add:
- key: x-test-proto
  value: "%PROTOCOL%"
- key: x-test-ip
  value: "%CLIENT_IP%"
- key: x-test-static
  value: This is a test header
```