### PR TITLE
Renamed request_headers_to_add to add_request_headers

### DIFF
--- a/ambassador/ambassador/mapping.py
+++ b/ambassador/ambassador/mapping.py
@@ -31,15 +31,14 @@ class Mapping (object):
         return tuple(weight)
 
     TransparentRouteKeys = {
-        "host_redirect": True,
-        "path_redirect": True,
-        "host_rewrite": True,
         "auto_host_rewrite": True,
         "case_sensitive": True,
-        "use_websocket": True,
-        "timeout_ms": True,
+        "host_redirect": True,
+        "host_rewrite": True,
+        "path_redirect": True,
         "priority": True,
-        "request_headers_to_add": True,
+        "timeout_ms": True,
+        "use_websocket": True,
     }
 
     def __init__(self, _source="--internal--", _from=None, **kwargs):
@@ -108,6 +107,12 @@ class Mapping (object):
 
         if self.headers:
             route['headers'] = self.headers
+
+        add_request_headers = self.get('add_request_headers')
+        if add_request_headers:
+            route['request_headers_to_add'] = []
+            for key, value in add_request_headers.items():
+              route['request_headers_to_add'].append({"key": key, "value": value})
 
         # Even though we don't use it for generating the Envoy config, go ahead
         # and make sure that any ':method' header match gets saved under the

--- a/ambassador/schemas/v0/Mapping.schema
+++ b/ambassador/schemas/v0/Mapping.schema
@@ -10,6 +10,7 @@
         "prefix": { "type": "string" },
         "service": { "type": "string" },
 
+        "add_request_headers": { "$ref": "#/definitions/mapStrStr" },
         "auto_host_rewrite": { "type": "boolean" },
         "case_sensitive": { "type": "boolean" },
         "circuit_breaker": { "type": "string" },
@@ -20,18 +21,6 @@
         "outlier_detection": { "type": "string" },
         "path_redirect": { "type": "string" },
         "priority": { "type": "string" },
-        "request_headers_to_add": {
-            "type": "array",
-            "items": {
-                "type": "object",
-                "properties": {
-                    "key":  { "type": "string" },
-                    "value":  { "type": "string" }
-                },
-                "required": [ "key", "value" ],
-                "additionalProperties": false
-            }
-        },
         "rewrite": { "type": "string" },
         "timeout_ms": { "type": "string" },
         "tls": { "type": [ "string", "boolean" ] },

--- a/ambassador/templates/envoy.j2
+++ b/ambassador/templates/envoy.j2
@@ -47,12 +47,7 @@
                       {%- if route.timeout_ms -%}"timeout_ms": "{{ route.timeout_ms }}",{% endif %}
                       {%- if route.use_websocket -%}"use_websocket": {{ route.use_websocket | tojson }},{% endif %}
                       {%- if route.headers -%}"headers": {{ route.headers | tojson }},{% endif %}
-                      {% if route.request_headers_to_add %}
-                      "request_headers_to_add": [
-                        {% for header in route.request_headers_to_add %}
-                        { "key": "{{header.key}}", "value": "{{header.value}}" }{{ "," if not loop.last }}
-                        {% endfor %}
-                      ],{% endif %}
+                      {%- if route.request_headers_to_add -%}"request_headers_to_add": {{ route.request_headers_to_add | tojson }},{% endif %}
                       "weighted_clusters": {
                           "clusters": [
                               {% for wc in route.clusters %}

--- a/ambassador/tests/006-headers-and-host/config/mapping-qotm.yaml
+++ b/ambassador/tests/006-headers-and-host/config/mapping-qotm.yaml
@@ -27,10 +27,7 @@ headers:
   x-demo-mode: host
 host: httpbin.org
 host_rewrite: httpbin.org
-request_headers_to_add:
-- key: x-test-proto
-  value: "%PROTOCOL%"
-- key: x-test-ip
-  value: "%CLIENT_IP%"
-- key: x-test-static
-  value: testing
+add_request_headers:
+  x-test-proto: "%PROTOCOL%"
+  x-test-ip: "%CLIENT_IP%"
+  x-test-static: testing

--- a/ambassador/tests/006-headers-and-host/gold.intermediate.json
+++ b/ambassador/tests/006-headers-and-host/gold.intermediate.json
@@ -312,7 +312,7 @@
             "kind": "Mapping",
             "name": "qotm_host_mapping",
             "version": "ambassador/v0",
-            "yaml": "apiVersion: ambassador/v0\nheaders:\n  x-demo-mode: host\nhost: httpbin.org\nhost_rewrite: httpbin.org\nkind: Mapping\nname: qotm_host_mapping\nprefix: /qotm/\nrequest_headers_to_add:\n- key: x-test-proto\n  value: '%PROTOCOL%'\n- key: x-test-ip\n  value: '%CLIENT_IP%'\n- key: x-test-static\n  value: testing\nrewrite: /\nservice: httpbin.org:80\n"
+            "yaml": "add_request_headers:\n  x-test-ip: '%CLIENT_IP%'\n  x-test-proto: '%PROTOCOL%'\n  x-test-static: testing\napiVersion: ambassador/v0\nheaders:\n  x-demo-mode: host\nhost: httpbin.org\nhost_rewrite: httpbin.org\nkind: Mapping\nname: qotm_host_mapping\nprefix: /qotm/\nrewrite: /\nservice: httpbin.org:80\n"
         }
     }
 }

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -230,11 +230,11 @@ Common optional attributes for mappings:
 
 Less-common optional attributes for mappings:
 
+- `add_request_headers`: if present, specifies a dictionary of other HTTP headers that should be added to each request when talking to the service. Envoy dynamic `value`s `%CLIENT_IP%` and `%PROTOCOL%` are supported, in addition to static `value`s.
 - `auto_host_rewrite`: if present with a true value, forces the HTTP `Host` header to the `service` to which we will route.
 - `case_sensitive`: determines whether `prefix` matching is case-sensitive; defaults to True.
 - `host_redirect`: if set, this `Mapping` performs an HTTP 301 `Redirect`, with the host portion of the URL replaced with the `host_redirect` value.
 - `path_redirect`: if set, this `Mapping` performs an HTTP 301 `Redirect`, with the path portion of the URL replaced with the `path_redirect` value.
-- `request_headers_to_add`: if present, specifies a list of HTTP headers (`key` and `value` objects) that should be added to each request when talking to the service. Envoy dynamic `value`s `%CLIENT_IP%` and `%PROTOCOL%` are supported, in addition to static `value`s.
 - `timeout_ms`: the timeout, in milliseconds, for requests through this `Mapping`. Defaults to 3000.
 - `use_websocket`: if present with a true value, tells Ambassador that this service will used for websockets
 - `envoy_override`: supplies raw configuration data to be included with the generated Envoy route entry.


### PR DESCRIPTION
Follow-up to https://github.com/datawire/ambassador/pull/221
Renamed `request_headers_to_add` to `add_request_headers` and struct is now a dict.

```
apiVersion: ambassador/v0
kind:  Mapping
name:  default
prefix: /default
service: echo-svc:8080
request_headers_to_add:
    x-test-proto: "%PROTOCOL%"
    x-test-ip: "%CLIENT_IP%"
    x-test-static: This is a test header
```