### PR TITLE
Fix Scout/Kubernaut errors on build.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,9 @@ tags
 no-such-file
 envoy.json
 intermediate.json
+check-*.json
 end-to-end/ambassador-deployment-mounts.yaml
 end-to-end/ambassador-deployment.yaml
+end-to-end/005-single-namespace/k8s/ambassador-deployment.yaml
+end-to-end/kubernaut
 end-to-end/*.log

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -5,4 +5,3 @@ awscli
 pytest
 pytest-cov
 dpath
-kubernaut

--- a/end-to-end/README.md
+++ b/end-to-end/README.md
@@ -2,6 +2,7 @@ Run `testall.sh` in this directory to descend into each 0* directory and run the
 
 TESTS REQUIRE:
 
-kubernaut
 Python 3
 everything in dev-requirements.txt
+
+Note that running the end-to-end tests will install [kubernaut](kubernaut.io) as `end-to-end/kubernaut`.

--- a/end-to-end/README.md
+++ b/end-to-end/README.md
@@ -1,10 +1,8 @@
 Run `testall.sh` in this directory to descend into each 0* directory and run the tests.
 
-#### Requires:
+- You will need to use Python 3 to run the tests.
+- The tests use [`kubernaut`](https://kubernaut.io/). If needed, they will install `kubernaut` for you and walk you through getting a `kubernaut` token.
+- The tests will not work unless you've pushed your build to a public `DOCKER_REGISTRY`. See [building instructions](../BUILDING.md).
 
-* Python 3
-* [kubernaut](https://github.com/datawire/kubernaut#installation)
-* kubernaut token from https://kubernaut.io/token
-* A build pushed to a public DOCKER_REGISTRY. See [building instructions](../BUILDING.md).
+If you're working with this stuff, we'd love to see you in our [Gitter channel](https://gitter.im/datawire/ambassador)!
 
-Note that running the end-to-end tests will install [kubernaut](kubernaut.io) as `end-to-end/kubernaut`.

--- a/end-to-end/utils.sh
+++ b/end-to-end/utils.sh
@@ -84,6 +84,7 @@ wait_for_ready () {
 
     if [ -z "$ready" ]; then
         echo 'Ambassador not yet ready?' >&2
+        kubectl get pods >&2
         exit 1
     fi
 }

--- a/end-to-end/utils.sh
+++ b/end-to-end/utils.sh
@@ -1,3 +1,8 @@
+if [ -z "$ROOT" ]; then
+    echo "ROOT must be set to the root of the end-to-end tests" >&2
+    exit 1
+fi
+
 if [ -n "$MACHINE_READABLE" ]; then
     LINE_END="\n"
 else
@@ -9,11 +14,19 @@ step () {
 }
 
 shred_and_reclaim () {
+    KUBERNAUT="$ROOT/kubernaut"
+
+    if [ ! -x "$KUBERNAUT" ]; then
+        echo "Fetching Kubernaut..."
+        curl -q -L -o "$KUBERNAUT" https://s3.amazonaws.com/datawire-static-files/kubernaut/$(curl -s https://s3.amazonaws.com/datawire-static-files/kubernaut/stable.txt)/kubernaut
+        chmod +x "$KUBERNAUT"
+    fi
+
     step "Dropping old cluster"
-    kubernaut discard
+    "$KUBERNAUT" discard
 
     step "Claiming new cluster"
-    kubernaut claim
+    "$KUBERNAUT" claim
     export KUBECONFIG=${HOME}/.kube/kubernaut
 }
 


### PR DESCRIPTION
Embarrassingly enough, we had a disagreement between some internal versioning going on. This cleans that up by acknowledging two realities:

1. `kubernaut` is not a build requirement; it's a test requirement.
2. If we use `curl` to grab `kubernaut`, we sidestep annoyances with `pip` fighting over `scout` versions.

Fixes #225.