### PR TITLE
Make Travis builds work on the first commit on a branch

### DIFF
--- a/scripts/travis-build.sh
+++ b/scripts/travis-build.sh
@@ -46,9 +46,8 @@ onmaster () {
 
 # Do we have any non-doc changes?
 DIFF_RANGE=${TRAVIS_COMMIT_RANGE:-HEAD^}
-# echo "DIFF_RANGE ${DIFF_RANGE}"
 
-echo "======== Diff summary"
+echo "======== Diff summary ($DIFF_RANGE)"
 git diff --stat "$DIFF_RANGE"
 
 nondoc_changes=$(git diff --name-only "$DIFF_RANGE" | grep -v '^docs/' | wc -l | tr -d ' ')

--- a/scripts/travis-build.sh
+++ b/scripts/travis-build.sh
@@ -45,11 +45,14 @@ onmaster () {
 }
 
 # Do we have any non-doc changes?
-echo "======== Diff summary"
-git diff --stat "$TRAVIS_COMMIT_RANGE"
+DIFF_RANGE=${TRAVIS_COMMIT_RANGE:-HEAD^}
+echo "DIFF_RANGE ${DIFF_RANGE}"
 
-nondoc_changes=$(git diff --name-only "$TRAVIS_COMMIT_RANGE" | grep -v '^docs/' | wc -l | tr -d ' ')
-doc_changes=$(git diff --name-only "$TRAVIS_COMMIT_RANGE" | grep -e '^docs/' | wc -l | tr -d ' ')
+echo "======== Diff summary"
+git diff --stat "$DIFF_RANGE"
+
+nondoc_changes=$(git diff --name-only "$DIFF_RANGE" | grep -v '^docs/' | wc -l | tr -d ' ')
+doc_changes=$(git diff --name-only "$DIFF_RANGE" | grep -e '^docs/' | wc -l | tr -d ' ')
 
 # Default VERSION to _the current version of Ambassador._
 VERSION=$(python scripts/versioner.py)

--- a/scripts/travis-build.sh
+++ b/scripts/travis-build.sh
@@ -46,7 +46,7 @@ onmaster () {
 
 # Do we have any non-doc changes?
 DIFF_RANGE=${TRAVIS_COMMIT_RANGE:-HEAD^}
-echo "DIFF_RANGE ${DIFF_RANGE}"
+# echo "DIFF_RANGE ${DIFF_RANGE}"
 
 echo "======== Diff summary"
 git diff --stat "$DIFF_RANGE"


### PR DESCRIPTION
Travis just mishandles `TRAVIS_COMMIT_RANGE`, full stop, IMNSHO. On the first commit into a branch, `TRAVIS_COMMIT_RANGE` is empty, which breaks the stats output. We deal with that here by swapping in `HEAD^` for an empty range.
