### PR TITLE
Stripped Alpine image + minor tweaks

### DIFF
--- a/ambassador/Dockerfile
+++ b/ambassador/Dockerfile
@@ -1,5 +1,5 @@
 # Our base image was built from https://github.com/datawire/envoy, commit
-# 7ccb25882, on the flynn/feature/extauth branch. We need this instead of
+# 27a506c85, on the flynn/feature/extauth branch. We need this instead of
 # the official Envoy image so that we can support Ambassador's ability to
 # use an external authentication service.
 #
@@ -11,7 +11,7 @@
 # 
 # and then read DATAWIRE/README.md.
 
-FROM datawire/ambassador-envoy-alpine:v1.5.0-116-g7ccb25882
+FROM quay.io/datawire/ambassador-envoy-alpine-stripped:v1.5.0-231-g27a506c85
 
 MAINTAINER Datawire <flynn@datawire.io>
 LABEL PROJECT_REPO_URL         = "git@github.com:datawire/ambassador.git" \

--- a/ambassador/Dockerfile
+++ b/ambassador/Dockerfile
@@ -1,5 +1,5 @@
 # Our base image was built from https://github.com/datawire/envoy, commit
-# 27a506c85, on the flynn/feature/extauth branch. We need this instead of
+# 6557e9ea7, on the flynn/feature/extauth branch. We need this instead of
 # the official Envoy image so that we can support Ambassador's ability to
 # use an external authentication service.
 #
@@ -11,7 +11,7 @@
 # 
 # and then read DATAWIRE/README.md.
 
-FROM quay.io/datawire/ambassador-envoy-alpine-stripped:v1.5.0-231-g27a506c85
+FROM datawire/ambassador-envoy-alpine-stripped:v1.5.0-232-g6557e9ea7
 
 MAINTAINER Datawire <flynn@datawire.io>
 LABEL PROJECT_REPO_URL         = "git@github.com:datawire/ambassador.git" \

--- a/ambassador/templates/diag.html
+++ b/ambassador/templates/diag.html
@@ -119,7 +119,7 @@
 
       <div class="row">
         <div class="col-12">
-          Currently active Envoy <a href="https://envoyproxy.github.io/envoy/configuration/http_conn_man/route_config/route.html">Routes</a>
+          Currently active Envoy <a href="https://www.envoyproxy.io/docs/envoy/v1.5.0/api-v1/route_config/route.html">Routes</a>
 
           {% for route in route_info %}
           <div class="row">
@@ -155,7 +155,7 @@
 
       <div class="row">
         <div class="col-12">
-          Currently active Envoy <a href="https://envoyproxy.github.io/envoy/configuration/cluster_manager/cluster.html">Clusters</a>
+          Currently active Envoy <a href="https://www.envoyproxy.io/docs/envoy/v1.5.0/api-v1/cluster_manager/cluster.html">Clusters</a>
 
           {% for cluster in clusters | sort(attribute = 'name') %}
           <div class="row">
@@ -193,7 +193,7 @@
       {% if breakers %}
       <div class="row">
         <div class="col-12">
-          Currently active Envoy <a href="https://envoyproxy.github.io/envoy/configuration/cluster_manager/cluster_circuit_breakers.html">Circuit Breakers</a>
+          Currently active Envoy <a href="https://www.envoyproxy.io/docs/envoy/v1.5.0/api-v1/cluster_manager/cluster_circuit_breakers">Circuit Breakers</a>
 
           {% for breaker in breakers | sort(attribute = 'name') %}
           <div class="row">
@@ -223,7 +223,7 @@
       {% if outliers %}
       <div class="row">
         <div class="col-12">
-          Currently active Envoy <a href="https://envoyproxy.github.io/envoy/configuration/cluster_manager/cluster_outlier_detection.html">Outlier Detection</a> configuration
+          Currently active Envoy <a href="https://www.envoyproxy.io/docs/envoy/v1.5.0/api-v1/cluster_manager/outlier">Outlier Detection</a> configuration
 
           {% for outlier in outliers | sort(attribute = 'name') %}
           <div class="row">

--- a/templates/ambassador/ambassador-no-rbac.yaml
+++ b/templates/ambassador/ambassador-no-rbac.yaml
@@ -28,7 +28,6 @@ spec:
       containers:
       - name: ambassador
         image: {AMREG}ambassador:{VERSION}
-        imagePullPolicy: Always
         resources:
           limits:
             cpu: 1

--- a/templates/ambassador/ambassador-rbac.yaml
+++ b/templates/ambassador/ambassador-rbac.yaml
@@ -65,7 +65,6 @@ spec:
       containers:
       - name: ambassador
         image: {AMREG}ambassador:{VERSION}
-        imagePullPolicy: Always
         resources:
           limits:
             cpu: 1


### PR DESCRIPTION
- Switch to Alpine with a stripped Envoy binary.
- Don't force `imagePullPolicy` to `Always`.
- Fix broken links to the Envoy docs in the diag service. Sigh.

Fixes #235 
Fixes #236 