### PR TITLE
[MINOR] Smaller image, `add_request_headers`, et al

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,6 @@ build
 dist
 
 *.out
-envoy.json
 
 docs/yaml
 docs/_book
@@ -30,3 +29,11 @@ forge.yaml
 .idea
 *.iml
 tags
+
+# Test outputs
+no-such-file
+envoy.json
+intermediate.json
+end-to-end/ambassador-deployment-mounts.yaml
+end-to-end/ambassador-deployment.yaml
+end-to-end/*.log

--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,9 @@ tags
 no-such-file
 envoy.json
 intermediate.json
+check-*.json
 end-to-end/ambassador-deployment-mounts.yaml
 end-to-end/ambassador-deployment.yaml
+end-to-end/005-single-namespace/k8s/ambassador-deployment.yaml
+end-to-end/kubernaut
 end-to-end/*.log

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -9,7 +9,7 @@ TL;DR
 ```
 git clone https://github.com/datawire/ambassador
 cd ambassador
-# best to activate a virtualenv here!
+# best to activate a Python 3 virtualenv here!
 pip install -r dev-requirements.txt
 DOCKER_REGISTRY=- make
 ```

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -8,6 +8,9 @@ TL;DR
 
 ```
 git clone https://github.com/datawire/ambassador
+# Development should be on branches based on the `develop` branch
+git checkout develop
+git checkout -b dev/my-branch-here
 cd ambassador
 # best to activate a Python 3 virtualenv here!
 pip install -r dev-requirements.txt
@@ -17,6 +20,17 @@ DOCKER_REGISTRY=- make
 That will build an Ambassador Docker image for you but not push it anywhere. To actually push the image into a registry so that you can use it for Kubernetes, set `DOCKER_REGISTRY` to a registry that you have permissions to push to.
 
 **It is important to use `make` rather than trying to just do a `docker build`.** Actually assembling a Docker image for Ambassador involves quite a few steps before the image can be built.
+
+Branching
+---------
+
+1. `master` is the branch from which Ambassador releases are cut. There should be no other activity on `master`.
+
+2. `develop` is the default branch for the repo, and is the base from which all development should happen. 
+
+3. **All development should be on branches cut from `develop`.** When you have things working and tested, submit a pull request back to `develop`.
+
+This implies that `master` must _always_ be shippable and tagged, and `develop` _should_ always be shippable.
 
 Unit Tests
 ----------
@@ -57,9 +71,9 @@ Normal Workflow
 
    You can separately tweak the registry from which images will be _pulled_ using `AMBASSADOR_REGISTRY` and `STATSD_REGISTRY`. See the files in `templates` for more here.
 
-1. Be on a branch that isn't `master`.
+1. Use a private branch cut from `develop` for your work.
 
-   At Datawire, committing to `master` triggers the CI pipeline to do an actual release. Even if you're not at Datawire, it's better to do you Ambassador development on a feature branch.
+   Committing to `master` triggers the CI pipeline to do an actual release. The base branch for development work is `develop` -- and you should always create a new branch from `develop` for your changes.
 
 2. Hack away, then `make`. This will:
 
@@ -75,9 +89,9 @@ Normal Workflow
 
 3. Commit to your feature branch.
 
-   Remember: _not to `master`_.
+   Remember: _not to `develop` or `master`_.
 
-4. Open a pull request against `master` when you're ready to ship.
+4. Open a pull request against `develop` when you're ready to ship.
 
 What if I Don't Want to Push My Images?
 ---------------------------------------

--- a/ambassador/Dockerfile
+++ b/ambassador/Dockerfile
@@ -1,5 +1,5 @@
 # Our base image was built from https://github.com/datawire/envoy, commit
-# 7ccb25882, on the flynn/feature/extauth branch. We need this instead of
+# 6557e9ea7, on the flynn/feature/extauth branch. We need this instead of
 # the official Envoy image so that we can support Ambassador's ability to
 # use an external authentication service.
 #
@@ -11,7 +11,7 @@
 # 
 # and then read DATAWIRE/README.md.
 
-FROM datawire/ambassador-envoy-alpine:v1.5.0-116-g7ccb25882
+FROM datawire/ambassador-envoy-alpine-stripped:v1.5.0-232-g6557e9ea7
 
 MAINTAINER Datawire <flynn@datawire.io>
 LABEL PROJECT_REPO_URL         = "git@github.com:datawire/ambassador.git" \

--- a/ambassador/ambassador/mapping.py
+++ b/ambassador/ambassador/mapping.py
@@ -31,15 +31,14 @@ class Mapping (object):
         return tuple(weight)
 
     TransparentRouteKeys = {
-        "host_redirect": True,
-        "path_redirect": True,
-        "host_rewrite": True,
         "auto_host_rewrite": True,
         "case_sensitive": True,
-        "use_websocket": True,
-        "timeout_ms": True,
+        "host_redirect": True,
+        "host_rewrite": True,
+        "path_redirect": True,
         "priority": True,
-        "request_headers_to_add": True,
+        "timeout_ms": True,
+        "use_websocket": True,
     }
 
     def __init__(self, _source="--internal--", _from=None, **kwargs):
@@ -108,6 +107,12 @@ class Mapping (object):
 
         if self.headers:
             route['headers'] = self.headers
+
+        add_request_headers = self.get('add_request_headers')
+        if add_request_headers:
+            route['request_headers_to_add'] = []
+            for key, value in add_request_headers.items():
+              route['request_headers_to_add'].append({"key": key, "value": value})
 
         # Even though we don't use it for generating the Envoy config, go ahead
         # and make sure that any ':method' header match gets saved under the

--- a/ambassador/ambassador/mapping.py
+++ b/ambassador/ambassador/mapping.py
@@ -39,6 +39,7 @@ class Mapping (object):
         "use_websocket": True,
         "timeout_ms": True,
         "priority": True,
+        "request_headers_to_add": True,
     }
 
     def __init__(self, _source="--internal--", _from=None, **kwargs):

--- a/ambassador/schemas/v0/Mapping.schema
+++ b/ambassador/schemas/v0/Mapping.schema
@@ -10,6 +10,7 @@
         "prefix": { "type": "string" },
         "service": { "type": "string" },
 
+        "add_request_headers": { "$ref": "#/definitions/mapStrStr" },
         "auto_host_rewrite": { "type": "boolean" },
         "case_sensitive": { "type": "boolean" },
         "circuit_breaker": { "type": "string" },
@@ -20,18 +21,6 @@
         "outlier_detection": { "type": "string" },
         "path_redirect": { "type": "string" },
         "priority": { "type": "string" },
-        "request_headers_to_add": {
-            "type": "array",
-            "items": {
-                "type": "object",
-                "properties": {
-                    "key":  { "type": "string" },
-                    "value":  { "type": "string" }
-                },
-                "required": [ "key", "value" ],
-                "additionalProperties": false
-            }
-        },
         "rewrite": { "type": "string" },
         "timeout_ms": { "type": "string" },
         "tls": { "type": [ "string", "boolean" ] },

--- a/ambassador/schemas/v0/Mapping.schema
+++ b/ambassador/schemas/v0/Mapping.schema
@@ -20,6 +20,18 @@
         "outlier_detection": { "type": "string" },
         "path_redirect": { "type": "string" },
         "priority": { "type": "string" },
+        "request_headers_to_add": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "key":  { "type": "string" },
+                    "value":  { "type": "string" }
+                },
+                "required": [ "key", "value" ],
+                "additionalProperties": false
+            }
+        },
         "rewrite": { "type": "string" },
         "timeout_ms": { "type": "string" },
         "tls": { "type": [ "string", "boolean" ] },

--- a/ambassador/templates/diag.html
+++ b/ambassador/templates/diag.html
@@ -119,7 +119,7 @@
 
       <div class="row">
         <div class="col-12">
-          Currently active Envoy <a href="https://envoyproxy.github.io/envoy/configuration/http_conn_man/route_config/route.html">Routes</a>
+          Currently active Envoy <a href="https://www.envoyproxy.io/docs/envoy/v1.5.0/api-v1/route_config/route.html">Routes</a>
 
           {% for route in route_info %}
           <div class="row">
@@ -155,7 +155,7 @@
 
       <div class="row">
         <div class="col-12">
-          Currently active Envoy <a href="https://envoyproxy.github.io/envoy/configuration/cluster_manager/cluster.html">Clusters</a>
+          Currently active Envoy <a href="https://www.envoyproxy.io/docs/envoy/v1.5.0/api-v1/cluster_manager/cluster.html">Clusters</a>
 
           {% for cluster in clusters | sort(attribute = 'name') %}
           <div class="row">
@@ -193,7 +193,7 @@
       {% if breakers %}
       <div class="row">
         <div class="col-12">
-          Currently active Envoy <a href="https://envoyproxy.github.io/envoy/configuration/cluster_manager/cluster_circuit_breakers.html">Circuit Breakers</a>
+          Currently active Envoy <a href="https://www.envoyproxy.io/docs/envoy/v1.5.0/api-v1/cluster_manager/cluster_circuit_breakers">Circuit Breakers</a>
 
           {% for breaker in breakers | sort(attribute = 'name') %}
           <div class="row">
@@ -223,7 +223,7 @@
       {% if outliers %}
       <div class="row">
         <div class="col-12">
-          Currently active Envoy <a href="https://envoyproxy.github.io/envoy/configuration/cluster_manager/cluster_outlier_detection.html">Outlier Detection</a> configuration
+          Currently active Envoy <a href="https://www.envoyproxy.io/docs/envoy/v1.5.0/api-v1/cluster_manager/outlier">Outlier Detection</a> configuration
 
           {% for outlier in outliers | sort(attribute = 'name') %}
           <div class="row">

--- a/ambassador/templates/envoy.j2
+++ b/ambassador/templates/envoy.j2
@@ -47,6 +47,12 @@
                       {%- if route.timeout_ms -%}"timeout_ms": "{{ route.timeout_ms }}",{% endif %}
                       {%- if route.use_websocket -%}"use_websocket": {{ route.use_websocket | tojson }},{% endif %}
                       {%- if route.headers -%}"headers": {{ route.headers | tojson }},{% endif %}
+                      {% if route.request_headers_to_add %}
+                      "request_headers_to_add": [
+                        {% for header in route.request_headers_to_add %}
+                        { "key": "{{header.key}}", "value": "{{header.value}}" }{{ "," if not loop.last }}
+                        {% endfor %}
+                      ],{% endif %}
                       "weighted_clusters": {
                           "clusters": [
                               {% for wc in route.clusters %}

--- a/ambassador/templates/envoy.j2
+++ b/ambassador/templates/envoy.j2
@@ -47,12 +47,7 @@
                       {%- if route.timeout_ms -%}"timeout_ms": "{{ route.timeout_ms }}",{% endif %}
                       {%- if route.use_websocket -%}"use_websocket": {{ route.use_websocket | tojson }},{% endif %}
                       {%- if route.headers -%}"headers": {{ route.headers | tojson }},{% endif %}
-                      {% if route.request_headers_to_add %}
-                      "request_headers_to_add": [
-                        {% for header in route.request_headers_to_add %}
-                        { "key": "{{header.key}}", "value": "{{header.value}}" }{{ "," if not loop.last }}
-                        {% endfor %}
-                      ],{% endif %}
+                      {%- if route.request_headers_to_add -%}"request_headers_to_add": {{ route.request_headers_to_add | tojson }},{% endif %}
                       "weighted_clusters": {
                           "clusters": [
                               {% for wc in route.clusters %}

--- a/ambassador/tests/006-headers-and-host/config/mapping-qotm.yaml
+++ b/ambassador/tests/006-headers-and-host/config/mapping-qotm.yaml
@@ -27,10 +27,7 @@ headers:
   x-demo-mode: host
 host: httpbin.org
 host_rewrite: httpbin.org
-request_headers_to_add:
-- key: x-test-proto
-  value: "%PROTOCOL%"
-- key: x-test-ip
-  value: "%CLIENT_IP%"
-- key: x-test-static
-  value: testing
+add_request_headers:
+  x-test-proto: "%PROTOCOL%"
+  x-test-ip: "%CLIENT_IP%"
+  x-test-static: testing

--- a/ambassador/tests/006-headers-and-host/config/mapping-qotm.yaml
+++ b/ambassador/tests/006-headers-and-host/config/mapping-qotm.yaml
@@ -27,3 +27,10 @@ headers:
   x-demo-mode: host
 host: httpbin.org
 host_rewrite: httpbin.org
+request_headers_to_add:
+- key: x-test-proto
+  value: "%PROTOCOL%"
+- key: x-test-ip
+  value: "%CLIENT_IP%"
+- key: x-test-static
+  value: testing

--- a/ambassador/tests/006-headers-and-host/gold.intermediate.json
+++ b/ambassador/tests/006-headers-and-host/gold.intermediate.json
@@ -312,7 +312,7 @@
             "kind": "Mapping",
             "name": "qotm_host_mapping",
             "version": "ambassador/v0",
-            "yaml": "apiVersion: ambassador/v0\nheaders:\n  x-demo-mode: host\nhost: httpbin.org\nhost_rewrite: httpbin.org\nkind: Mapping\nname: qotm_host_mapping\nprefix: /qotm/\nrequest_headers_to_add:\n- key: x-test-proto\n  value: '%PROTOCOL%'\n- key: x-test-ip\n  value: '%CLIENT_IP%'\n- key: x-test-static\n  value: testing\nrewrite: /\nservice: httpbin.org:80\n"
+            "yaml": "add_request_headers:\n  x-test-ip: '%CLIENT_IP%'\n  x-test-proto: '%PROTOCOL%'\n  x-test-static: testing\napiVersion: ambassador/v0\nheaders:\n  x-demo-mode: host\nhost: httpbin.org\nhost_rewrite: httpbin.org\nkind: Mapping\nname: qotm_host_mapping\nprefix: /qotm/\nrewrite: /\nservice: httpbin.org:80\n"
         }
     }
 }

--- a/ambassador/tests/006-headers-and-host/gold.intermediate.json
+++ b/ambassador/tests/006-headers-and-host/gold.intermediate.json
@@ -182,7 +182,21 @@
                 ],
                 "host_rewrite": "httpbin.org",
                 "prefix": "/qotm/",
-                "prefix_rewrite": "/"
+                "prefix_rewrite": "/",
+                "request_headers_to_add": [
+                    {
+                        "key": "x-test-proto",
+                        "value": "%PROTOCOL%"
+                    },
+                    {
+                        "key": "x-test-ip",
+                        "value": "%CLIENT_IP%"
+                    },
+                    {
+                        "key": "x-test-static",
+                        "value": "testing"
+                    }
+                ]
             },
             {
                 "_group_id": "dc5d22df356f9df8439ed418ef194c061e57c68f",
@@ -298,7 +312,7 @@
             "kind": "Mapping",
             "name": "qotm_host_mapping",
             "version": "ambassador/v0",
-            "yaml": "apiVersion: ambassador/v0\nheaders:\n  x-demo-mode: host\nhost: httpbin.org\nhost_rewrite: httpbin.org\nkind: Mapping\nname: qotm_host_mapping\nprefix: /qotm/\nrewrite: /\nservice: httpbin.org:80\n"
+            "yaml": "apiVersion: ambassador/v0\nheaders:\n  x-demo-mode: host\nhost: httpbin.org\nhost_rewrite: httpbin.org\nkind: Mapping\nname: qotm_host_mapping\nprefix: /qotm/\nrequest_headers_to_add:\n- key: x-test-proto\n  value: '%PROTOCOL%'\n- key: x-test-ip\n  value: '%CLIENT_IP%'\n- key: x-test-static\n  value: testing\nrewrite: /\nservice: httpbin.org:80\n"
         }
     }
 }

--- a/ambassador/tests/006-headers-and-host/gold.json
+++ b/ambassador/tests/006-headers-and-host/gold.json
@@ -89,6 +89,7 @@
                     
                     {
                       "timeout_ms": 10000,"prefix": "/qotm/","prefix_rewrite": "/","host_rewrite": "httpbin.org","headers": [{"name": "x-demo-mode", "regex": false, "value": "host"}, {"name": ":authority", "regex": false, "value": "httpbin.org"}],
+                      "request_headers_to_add": [{"key": "x-test-proto", "value": "%PROTOCOL%"}, {"key": "x-test-ip", "value": "%CLIENT_IP%"}, {"key": "x-test-static", "value": "testing"}],
                       "weighted_clusters": {
                           "clusters": [
                               

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -5,4 +5,3 @@ awscli
 pytest
 pytest-cov
 dpath
-kubernaut

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -230,10 +230,11 @@ Common optional attributes for mappings:
 
 Less-common optional attributes for mappings:
 
-- `auto_host_rewrite`: if present with a true value, forces the HTTP `Host` header to the `service` to which we will route
-- `case_sensitive`: determines whether `prefix` matching is case-sensitive; defaults to True
-- `host_redirect`: if set, this `Mapping` performs an HTTP 301 `Redirect`, with the host portion of the URL replaced with the `host_redirect` value
-- `path_redirect`: if set, this `Mapping` performs an HTTP 301 `Redirect`, with the path portion of the URL replaced with the `path_redirect` value
+- `auto_host_rewrite`: if present with a true value, forces the HTTP `Host` header to the `service` to which we will route.
+- `case_sensitive`: determines whether `prefix` matching is case-sensitive; defaults to True.
+- `host_redirect`: if set, this `Mapping` performs an HTTP 301 `Redirect`, with the host portion of the URL replaced with the `host_redirect` value.
+- `path_redirect`: if set, this `Mapping` performs an HTTP 301 `Redirect`, with the path portion of the URL replaced with the `path_redirect` value.
+- `request_headers_to_add`: if present, specifies a list of HTTP headers (`key` and `value` objects) that should be added to each request when talking to the service. Envoy dynamic `value`s `%CLIENT_IP%` and `%PROTOCOL%` are supported, in addition to static `value`s.
 - `timeout_ms`: the timeout, in milliseconds, for requests through this `Mapping`. Defaults to 3000.
 - `use_websocket`: if present with a true value, tells Ambassador that this service will used for websockets
 - `envoy_override`: supplies raw configuration data to be included with the generated Envoy route entry.

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -230,11 +230,11 @@ Common optional attributes for mappings:
 
 Less-common optional attributes for mappings:
 
+- `add_request_headers`: if present, specifies a dictionary of other HTTP headers that should be added to each request when talking to the service. Envoy dynamic `value`s `%CLIENT_IP%` and `%PROTOCOL%` are supported, in addition to static `value`s.
 - `auto_host_rewrite`: if present with a true value, forces the HTTP `Host` header to the `service` to which we will route.
 - `case_sensitive`: determines whether `prefix` matching is case-sensitive; defaults to True.
 - `host_redirect`: if set, this `Mapping` performs an HTTP 301 `Redirect`, with the host portion of the URL replaced with the `host_redirect` value.
 - `path_redirect`: if set, this `Mapping` performs an HTTP 301 `Redirect`, with the path portion of the URL replaced with the `path_redirect` value.
-- `request_headers_to_add`: if present, specifies a list of HTTP headers (`key` and `value` objects) that should be added to each request when talking to the service. Envoy dynamic `value`s `%CLIENT_IP%` and `%PROTOCOL%` are supported, in addition to static `value`s.
 - `timeout_ms`: the timeout, in milliseconds, for requests through this `Mapping`. Defaults to 3000.
 - `use_websocket`: if present with a true value, tells Ambassador that this service will use websockets.
 - `envoy_override`: supplies raw configuration data to be included with the generated Envoy route entry.

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -236,7 +236,7 @@ Less-common optional attributes for mappings:
 - `path_redirect`: if set, this `Mapping` performs an HTTP 301 `Redirect`, with the path portion of the URL replaced with the `path_redirect` value.
 - `request_headers_to_add`: if present, specifies a list of HTTP headers (`key` and `value` objects) that should be added to each request when talking to the service. Envoy dynamic `value`s `%CLIENT_IP%` and `%PROTOCOL%` are supported, in addition to static `value`s.
 - `timeout_ms`: the timeout, in milliseconds, for requests through this `Mapping`. Defaults to 3000.
-- `use_websocket`: if present with a true value, tells Ambassador that this service will used for websockets
+- `use_websocket`: if present with a true value, tells Ambassador that this service will use websockets.
 - `envoy_override`: supplies raw configuration data to be included with the generated Envoy route entry.
 
 The name of the mapping must be unique. If no `method` is given, all methods will be proxied.

--- a/docs/user-guide/auth-tutorial.md
+++ b/docs/user-guide/auth-tutorial.md
@@ -130,7 +130,7 @@ or, again, apply it from a local file if you prefer.
 
 Ambassador will see the annotations and reconfigure itself within a few seconds.
 
-## 4. Test authentication
+## 3. Test authentication
 
 If we `curl` to a protected URL:
 

--- a/end-to-end/README.md
+++ b/end-to-end/README.md
@@ -1,7 +1,7 @@
 Run `testall.sh` in this directory to descend into each 0* directory and run the tests.
 
-TESTS REQUIRE:
-
-kubernaut
-Python 3
-everything in dev-requirements.txt
+#### Requires:
+* Python 3
+* [kubernaut](https://github.com/datawire/kubernaut#installation)
+* kubernaut token from https://kubernaut.io/token
+* A build pushed to a public DOCKER_REGISTRY. See [building instructions](../BUILDING.md).

--- a/end-to-end/README.md
+++ b/end-to-end/README.md
@@ -1,7 +1,8 @@
 Run `testall.sh` in this directory to descend into each 0* directory and run the tests.
 
-#### Requires:
-* Python 3
-* [kubernaut](https://github.com/datawire/kubernaut#installation)
-* kubernaut token from https://kubernaut.io/token
-* A build pushed to a public DOCKER_REGISTRY. See [building instructions](../BUILDING.md).
+- You will need to use Python 3 to run the tests.
+- The tests use [`kubernaut`](https://kubernaut.io/). If needed, they will install `kubernaut` for you and walk you through getting a `kubernaut` token.
+- The tests will not work unless you've pushed your build to a public `DOCKER_REGISTRY`. See [building instructions](../BUILDING.md).
+
+If you're working with this stuff, we'd love to see you in our [Gitter channel](https://gitter.im/datawire/ambassador)!
+

--- a/end-to-end/save-token.sh
+++ b/end-to-end/save-token.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+set -e
+set -o pipefail
+
+ROOT=$(cd $(dirname $0); pwd)
+
+source ${ROOT}/utils.sh
+
+KUBERNAUT="$ROOT/kubernaut"
+
+get_kubernaut
+
+"$KUBERNAUT" set-token "$1"

--- a/end-to-end/testall.sh
+++ b/end-to-end/testall.sh
@@ -4,10 +4,13 @@ set -e
 set -o pipefail
 
 HERE=$(cd $(dirname $0); pwd)
+BUILD_ALL=${BUILD_ALL:-false}
 
 cd "$HERE"
 
-sh buildall.sh
+if [ "$BUILD_ALL" = true ]; then
+  sh buildall.sh
+fi
 
 # For linify
 export MACHINE_READABLE=yes

--- a/end-to-end/utils.sh
+++ b/end-to-end/utils.sh
@@ -14,20 +14,15 @@ step () {
 }
 
 get_kubernaut () {
-    KUBERNAUT="$ROOT/kubernaut"
-
     if [ ! -x "$KUBERNAUT" ]; then
-        echo "Fetching Kubernaut..."
-        curl -q -L -o "$KUBERNAUT" https://s3.amazonaws.com/datawire-static-files/kubernaut/$(curl -s https://s3.amazonaws.com/datawire-static-files/kubernaut/stable.txt)/kubernaut
+        echo "Fetching kubernaut..."
+        # curl -s -L -o "$KUBERNAUT" https://s3.amazonaws.com/datawire-static-files/kubernaut/$(curl -s https://s3.amazonaws.com/datawire-static-files/kubernaut/stable.txt)/kubernaut
+        curl -s -L -o "$KUBERNAUT" https://s3.amazonaws.com/datawire-static-files/kubernaut/0.1.39/kubernaut
         chmod +x "$KUBERNAUT"
     fi
-
-    echo "$KUBERNAUT"
 }
 
 check_kubernaut_token () {
-    KUBERNAUT="$1"
-    
     if [ $("$KUBERNAUT" kubeconfig | grep -c 'Token not found') -gt 0 ]; then
         echo "You need a Kubernaut token. Go to"
         echo ""
@@ -35,22 +30,19 @@ check_kubernaut_token () {
         echo ""
         echo "to get one, then run"
         echo ""
-        echo "sh $ROOT/save-token \"\$token\""
+        echo "sh $ROOT/save-token.sh \"\$token\""
         echo ""
         echo "to save it before trying again."
 
-        return 1
+        exit 1
     fi
-
-    return 0
 }
 
 shred_and_reclaim () {
-    KUBERNAUT=$(get_kubernaut)
+    KUBERNAUT="$ROOT/kubernaut"
 
-    if ! check_kubernaut_token "$KUBERNAUT"; then
-        exit 1
-    fi
+    get_kubernaut
+    check_kubernaut_token
 
     step "Dropping old cluster"
     "$KUBERNAUT" discard

--- a/scripts/travis-build.sh
+++ b/scripts/travis-build.sh
@@ -45,11 +45,13 @@ onmaster () {
 }
 
 # Do we have any non-doc changes?
-echo "======== Diff summary"
-git diff --stat "$TRAVIS_COMMIT_RANGE"
+DIFF_RANGE=${TRAVIS_COMMIT_RANGE:-HEAD^}
 
-nondoc_changes=$(git diff --name-only "$TRAVIS_COMMIT_RANGE" | grep -v '^docs/' | wc -l | tr -d ' ')
-doc_changes=$(git diff --name-only "$TRAVIS_COMMIT_RANGE" | grep -e '^docs/' | wc -l | tr -d ' ')
+echo "======== Diff summary ($DIFF_RANGE)"
+git diff --stat "$DIFF_RANGE"
+
+nondoc_changes=$(git diff --name-only "$DIFF_RANGE" | grep -v '^docs/' | wc -l | tr -d ' ')
+doc_changes=$(git diff --name-only "$DIFF_RANGE" | grep -e '^docs/' | wc -l | tr -d ' ')
 
 # Default VERSION to _the current version of Ambassador._
 VERSION=$(python scripts/versioner.py)

--- a/templates/ambassador/ambassador-no-rbac.yaml
+++ b/templates/ambassador/ambassador-no-rbac.yaml
@@ -28,7 +28,6 @@ spec:
       containers:
       - name: ambassador
         image: {AMREG}ambassador:{VERSION}
-        imagePullPolicy: Always
         resources:
           limits:
             cpu: 1

--- a/templates/ambassador/ambassador-rbac.yaml
+++ b/templates/ambassador/ambassador-rbac.yaml
@@ -65,7 +65,6 @@ spec:
       containers:
       - name: ambassador
         image: {AMREG}ambassador:{VERSION}
-        imagePullPolicy: Always
         resources:
           limits:
             cpu: 1


### PR DESCRIPTION
- Clean up build docs (thanks @alexgervais!)
- Support `add_request_headers` for, uh, adding requests headers (thanks @alexgervais!)
- Make end-to-end tests and Travis build process a bit more robust
- Pin to Kubernaut 0.1.39
- Document the use of the `develop` branch
- Don't default to `imagePullAlways`
- Switch to Alpine base with a stripped Envoy image (which, horrifyingly, saves 180MB(!!))