### PR TITLE
Update GKE section to use inline gcloud command

### DIFF
--- a/docs/user-guide/getting-started.md
+++ b/docs/user-guide/getting-started.md
@@ -121,9 +121,7 @@ When Ambassador starts, it will notice the `getambassador.io/config` annotation 
 Note: If you're using Google Kubernetes Engine with RBAC, you'll need to grant permissions to the account that will be setting up Ambassador. To do this, get your official GKE username, and then grant `cluster-admin` Role privileges to that username:
 
 ```
-$ gcloud info | grep Account
-Account: [username@example.org]
-$ kubectl create clusterrolebinding my-cluster-admin-binding --clusterrole=cluster-admin --user=username@example.org
+$ kubectl create clusterrolebinding my-cluster-admin-binding --clusterrole=cluster-admin --user=$(gcloud info --format="value(config.account)")
 ```
 
 ### 5.3 Testing the Mapping


### PR DESCRIPTION
the `gcloud` tool has a rich query and value extraction mechanism which means we should not need to resort to using `grep` which is brittle because it is parsing the human consumable format that can change any time Google wants.