### PR TITLE
Version and hostname in monospace on diag

### DIFF
--- a/ambassador/templates/overview.html
+++ b/ambassador/templates/overview.html
@@ -23,9 +23,9 @@
 
       <div class="row">
         <div class="col-7">
-          Ambassador version {{ system.version }}
+          Ambassador version <samp>{{ system.version }}</samp>
           <br/>
-          Hostname {{ system.hostname }}
+          Hostname <samp>{{ system.hostname }}</samp>
           <br/>
           Configuration from {{ system.boot_time }} &mdash; {{ system.hr_uptime }} ago
           <br/>


### PR DESCRIPTION
Making the diag view more developer friendly, fixing the display of some characters, such as `l` in my example.

Before:
<img width="349" alt="screen shot 2018-02-07 at 10 43 04" src="https://user-images.githubusercontent.com/188509/36042813-186ee25e-0d9b-11e8-90a0-88ca074bf8a3.png">


After:
<img width="364" alt="screen shot 2018-02-07 at 10 46 49" src="https://user-images.githubusercontent.com/188509/36042814-19f8d92c-0d9b-11e8-9ef7-b05a1398bafb.png">
