### PR TITLE
Return --internal-- stuff to diag overview and tests.

### DIFF
--- a/ambassador/ambassador/config.py
+++ b/ambassador/ambassador/config.py
@@ -206,6 +206,7 @@ class Config (object):
 
         self.sources = {
             "--internal--": {
+                "_source": "--internal--",
                 "kind": "Internal",
                 "version": "v0",
                 "name": "Ambassador Internals",
@@ -214,6 +215,7 @@ class Config (object):
                 "description": "The '--internal--' source marks objects created by Ambassador's internal logic."
             },
             "--diagnostics--": {
+                "_source": "--diagnostics--",
                 "kind": "diagnostics",
                 "version": "v0",
                 "name": "Ambassador Diagnostics",
@@ -1302,9 +1304,9 @@ class Config (object):
             # self.logger.debug("overview -- filename %s, source_keys %d" %
             #                   (filename, len(source_keys)))
 
-            # Skip '--internal--' etc.
-            if filename.startswith('--'):
-                continue
+            # # Skip '--internal--' etc.
+            # if filename.startswith('--'):
+            #     continue
 
             source_dict = source_files.setdefault(
                 filename,

--- a/ambassador/tests/000-default/gold.intermediate.json
+++ b/ambassador/tests/000-default/gold.intermediate.json
@@ -3,6 +3,7 @@
         "clusters": [
             {
                 "_referenced_by": [
+                    "--internal--",
                     "mapping-diag.yaml.1"
                 ],
                 "_service": "127.0.0.1:8877",
@@ -58,6 +59,11 @@
         ],
         "filters": [
             {
+                "_source": "--internal--",
+                "config": {},
+                "name": "cors"
+            },
+            {
                 "_source": "auth.yaml.1",
                 "config": {
                     "allowed_headers": [
@@ -70,6 +76,12 @@
                     "timeout_ms": 5000
                 },
                 "name": "extauth",
+                "type": "decoder"
+            },
+            {
+                "_source": "--internal--",
+                "config": {},
+                "name": "router",
                 "type": "decoder"
             }
         ],
@@ -99,6 +111,22 @@
                 "prefix_rewrite": "/"
             },
             {
+                "_group_id": "0a42187b7b3d283e0079ddab01825e1c71fad9f6",
+                "_method": "GET",
+                "_referenced_by": [
+                    "--internal--"
+                ],
+                "_source": "--internal--",
+                "clusters": [
+                    {
+                        "name": "cluster_127_0_0_1_8877",
+                        "weight": 100.0
+                    }
+                ],
+                "prefix": "/ambassador/v0/check_ready",
+                "prefix_rewrite": "/ambassador/v0/check_ready"
+            },
+            {
                 "_group_id": "3e935e6af2ad12df1441fee5d2cf17a69303b2ad",
                 "_method": "GET",
                 "_referenced_by": [
@@ -120,6 +148,22 @@
                 ],
                 "prefix": "/cqrs/",
                 "prefix_rewrite": "/qotm/quote/"
+            },
+            {
+                "_group_id": "6151893fbc2f1f730a1bb946b2eefac391f0d2ec",
+                "_method": "GET",
+                "_referenced_by": [
+                    "--internal--"
+                ],
+                "_source": "--internal--",
+                "clusters": [
+                    {
+                        "name": "cluster_127_0_0_1_8877",
+                        "weight": 100.0
+                    }
+                ],
+                "prefix": "/ambassador/v0/check_alive",
+                "prefix_rewrite": "/ambassador/v0/check_alive"
             },
             {
                 "_group_id": "688e9f91e06f33c943c0c6373a5bdd32e647f7c4",
@@ -152,6 +196,22 @@
                 ],
                 "prefix": "/qotm/",
                 "prefix_rewrite": "/qotm/"
+            },
+            {
+                "_group_id": "b69eeb747b38f5e5fd3955d044ea7797d67d024f",
+                "_method": "GET",
+                "_referenced_by": [
+                    "--internal--"
+                ],
+                "_source": "--internal--",
+                "clusters": [
+                    {
+                        "name": "cluster_127_0_0_1_8877",
+                        "weight": 100.0
+                    }
+                ],
+                "prefix": "/ambassador/v0/",
+                "prefix_rewrite": "/ambassador/v0/"
             },
             {
                 "_group_id": "c78d3e3dc6c4a44ace22414fd99b17305dd29a37",
@@ -201,6 +261,7 @@
     },
     "sources": {
         "--diagnostics--": {
+            "_source": "--diagnostics--",
             "description": "The '--diagnostics--' source marks objects created by Ambassador to assist with diagnostic output.",
             "filename": "--diagnostics--",
             "index": 0,
@@ -209,6 +270,7 @@
             "version": "v0"
         },
         "--internal--": {
+            "_source": "--internal--",
             "description": "The '--internal--' source marks objects created by Ambassador's internal logic.",
             "filename": "--internal--",
             "index": 0,

--- a/ambassador/tests/001-broader-v0/gold.intermediate.json
+++ b/ambassador/tests/001-broader-v0/gold.intermediate.json
@@ -206,6 +206,11 @@
         ],
         "filters": [
             {
+                "_source": "--internal--",
+                "config": {},
+                "name": "cors"
+            },
+            {
                 "_source": "auth.yaml.1",
                 "config": {
                     "allowed_headers": [
@@ -216,6 +221,12 @@
                     "timeout_ms": 5000
                 },
                 "name": "extauth",
+                "type": "decoder"
+            },
+            {
+                "_source": "--internal--",
+                "config": {},
+                "name": "router",
                 "type": "decoder"
             }
         ],
@@ -568,6 +579,7 @@
     },
     "sources": {
         "--diagnostics--": {
+            "_source": "--diagnostics--",
             "description": "The '--diagnostics--' source marks objects created by Ambassador to assist with diagnostic output.",
             "filename": "--diagnostics--",
             "index": 0,
@@ -576,6 +588,7 @@
             "version": "v0"
         },
         "--internal--": {
+            "_source": "--internal--",
             "description": "The '--internal--' source marks objects created by Ambassador's internal logic.",
             "filename": "--internal--",
             "index": 0,

--- a/ambassador/tests/002-tls-module-1/gold.intermediate.json
+++ b/ambassador/tests/002-tls-module-1/gold.intermediate.json
@@ -28,7 +28,19 @@
                 ]
             }
         ],
-        "filters": [],
+        "filters": [
+            {
+                "_source": "--internal--",
+                "config": {},
+                "name": "cors"
+            },
+            {
+                "_source": "--internal--",
+                "config": {},
+                "name": "router",
+                "type": "decoder"
+            }
+        ],
         "listeners": [
             {
                 "_source": "ambassador.yaml.1",
@@ -112,6 +124,7 @@
     },
     "sources": {
         "--diagnostics--": {
+            "_source": "--diagnostics--",
             "description": "The '--diagnostics--' source marks objects created by Ambassador to assist with diagnostic output.",
             "filename": "--diagnostics--",
             "index": 0,
@@ -120,6 +133,7 @@
             "version": "v0"
         },
         "--internal--": {
+            "_source": "--internal--",
             "description": "The '--internal--' source marks objects created by Ambassador's internal logic.",
             "filename": "--internal--",
             "index": 0,

--- a/ambassador/tests/003-tls-module-2/gold.intermediate.json
+++ b/ambassador/tests/003-tls-module-2/gold.intermediate.json
@@ -28,7 +28,19 @@
                 ]
             }
         ],
-        "filters": [],
+        "filters": [
+            {
+                "_source": "--internal--",
+                "config": {},
+                "name": "cors"
+            },
+            {
+                "_source": "--internal--",
+                "config": {},
+                "name": "router",
+                "type": "decoder"
+            }
+        ],
         "listeners": [
             {
                 "_source": "ambassador.yaml.1",
@@ -112,6 +124,7 @@
     },
     "sources": {
         "--diagnostics--": {
+            "_source": "--diagnostics--",
             "description": "The '--diagnostics--' source marks objects created by Ambassador to assist with diagnostic output.",
             "filename": "--diagnostics--",
             "index": 0,
@@ -120,6 +133,7 @@
             "version": "v0"
         },
         "--internal--": {
+            "_source": "--internal--",
             "description": "The '--internal--' source marks objects created by Ambassador's internal logic.",
             "filename": "--internal--",
             "index": 0,

--- a/ambassador/tests/004-tls-without-ambassador-module/gold.intermediate.json
+++ b/ambassador/tests/004-tls-without-ambassador-module/gold.intermediate.json
@@ -28,7 +28,19 @@
                 ]
             }
         ],
-        "filters": [],
+        "filters": [
+            {
+                "_source": "--internal--",
+                "config": {},
+                "name": "cors"
+            },
+            {
+                "_source": "--internal--",
+                "config": {},
+                "name": "router",
+                "type": "decoder"
+            }
+        ],
         "listeners": [
             {
                 "_source": "tls.yaml.1",
@@ -125,6 +137,7 @@
     },
     "sources": {
         "--diagnostics--": {
+            "_source": "--diagnostics--",
             "description": "The '--diagnostics--' source marks objects created by Ambassador to assist with diagnostic output.",
             "filename": "--diagnostics--",
             "index": 0,
@@ -133,6 +146,7 @@
             "version": "v0"
         },
         "--internal--": {
+            "_source": "--internal--",
             "description": "The '--internal--' source marks objects created by Ambassador's internal logic.",
             "filename": "--internal--",
             "index": 0,

--- a/ambassador/tests/005-canary/gold.intermediate.json
+++ b/ambassador/tests/005-canary/gold.intermediate.json
@@ -3,6 +3,7 @@
         "clusters": [
             {
                 "_referenced_by": [
+                    "--internal--",
                     "ambassador.yaml.1"
                 ],
                 "_service": "127.0.0.1:8877",
@@ -41,7 +42,19 @@
                 ]
             }
         ],
-        "filters": [],
+        "filters": [
+            {
+                "_source": "--internal--",
+                "config": {},
+                "name": "cors"
+            },
+            {
+                "_source": "--internal--",
+                "config": {},
+                "name": "router",
+                "type": "decoder"
+            }
+        ],
         "listeners": [
             {
                 "_source": "--internal--",
@@ -50,6 +63,22 @@
             }
         ],
         "routes": [
+            {
+                "_group_id": "0a42187b7b3d283e0079ddab01825e1c71fad9f6",
+                "_method": "GET",
+                "_referenced_by": [
+                    "--internal--"
+                ],
+                "_source": "--internal--",
+                "clusters": [
+                    {
+                        "name": "cluster_127_0_0_1_8877",
+                        "weight": 100.0
+                    }
+                ],
+                "prefix": "/ambassador/v0/check_ready",
+                "prefix_rewrite": "/ambassador/v0/check_ready"
+            },
             {
                 "_group_id": "16fb9d91fbd83c170f865b77420a902000b27841",
                 "_method": "GET",
@@ -72,6 +101,22 @@
                 "prefix_rewrite": "/"
             },
             {
+                "_group_id": "6151893fbc2f1f730a1bb946b2eefac391f0d2ec",
+                "_method": "GET",
+                "_referenced_by": [
+                    "--internal--"
+                ],
+                "_source": "--internal--",
+                "clusters": [
+                    {
+                        "name": "cluster_127_0_0_1_8877",
+                        "weight": 100.0
+                    }
+                ],
+                "prefix": "/ambassador/v0/check_alive",
+                "prefix_rewrite": "/ambassador/v0/check_alive"
+            },
+            {
                 "_group_id": "688e9f91e06f33c943c0c6373a5bdd32e647f7c4",
                 "_method": "GET",
                 "_referenced_by": [
@@ -86,6 +131,22 @@
                 ],
                 "prefix": "/ambassador/",
                 "prefix_rewrite": "/ambassador/"
+            },
+            {
+                "_group_id": "b69eeb747b38f5e5fd3955d044ea7797d67d024f",
+                "_method": "GET",
+                "_referenced_by": [
+                    "--internal--"
+                ],
+                "_source": "--internal--",
+                "clusters": [
+                    {
+                        "name": "cluster_127_0_0_1_8877",
+                        "weight": 100.0
+                    }
+                ],
+                "prefix": "/ambassador/v0/",
+                "prefix_rewrite": "/ambassador/v0/"
             }
         ]
     },
@@ -105,6 +166,7 @@
     },
     "sources": {
         "--diagnostics--": {
+            "_source": "--diagnostics--",
             "description": "The '--diagnostics--' source marks objects created by Ambassador to assist with diagnostic output.",
             "filename": "--diagnostics--",
             "index": 0,
@@ -113,6 +175,7 @@
             "version": "v0"
         },
         "--internal--": {
+            "_source": "--internal--",
             "description": "The '--internal--' source marks objects created by Ambassador's internal logic.",
             "filename": "--internal--",
             "index": 0,

--- a/ambassador/tests/006-headers-and-host/gold.intermediate.json
+++ b/ambassador/tests/006-headers-and-host/gold.intermediate.json
@@ -3,6 +3,7 @@
         "clusters": [
             {
                 "_referenced_by": [
+                    "--internal--",
                     "mapping-diag.yaml.1"
                 ],
                 "_service": "127.0.0.1:8877",
@@ -84,6 +85,11 @@
         ],
         "filters": [
             {
+                "_source": "--internal--",
+                "config": {},
+                "name": "cors"
+            },
+            {
                 "_source": "auth.yaml.1",
                 "config": {
                     "allowed_headers": [
@@ -97,6 +103,12 @@
                 },
                 "name": "extauth",
                 "type": "decoder"
+            },
+            {
+                "_source": "--internal--",
+                "config": {},
+                "name": "router",
+                "type": "decoder"
             }
         ],
         "listeners": [
@@ -107,6 +119,22 @@
             }
         ],
         "routes": [
+            {
+                "_group_id": "0a42187b7b3d283e0079ddab01825e1c71fad9f6",
+                "_method": "GET",
+                "_referenced_by": [
+                    "--internal--"
+                ],
+                "_source": "--internal--",
+                "clusters": [
+                    {
+                        "name": "cluster_127_0_0_1_8877",
+                        "weight": 100.0
+                    }
+                ],
+                "prefix": "/ambassador/v0/check_ready",
+                "prefix_rewrite": "/ambassador/v0/check_ready"
+            },
             {
                 "_group_id": "3d6174456a466eb4f342d4aa4165bd8c2b99ce1e",
                 "_method": "GET",
@@ -129,6 +157,22 @@
                 ],
                 "prefix": "/qotm/",
                 "prefix_rewrite": "/qotm/"
+            },
+            {
+                "_group_id": "6151893fbc2f1f730a1bb946b2eefac391f0d2ec",
+                "_method": "GET",
+                "_referenced_by": [
+                    "--internal--"
+                ],
+                "_source": "--internal--",
+                "clusters": [
+                    {
+                        "name": "cluster_127_0_0_1_8877",
+                        "weight": 100.0
+                    }
+                ],
+                "prefix": "/ambassador/v0/check_alive",
+                "prefix_rewrite": "/ambassador/v0/check_alive"
             },
             {
                 "_group_id": "688e9f91e06f33c943c0c6373a5bdd32e647f7c4",
@@ -160,16 +204,35 @@
                     }
                 ],
                 "cors": {
-                    "expose_headers": "X-Custom-Header",
-                    "allow_headers": "Content-Type",
-                    "max_age": "86400",
-                    "allow_methods": "POST, GET, OPTIONS",
-                    "allow_origin": ["http://foo.example", "http://bar.example"],
                     "allow_credentials": true,
-                    "enabled": true
+                    "allow_headers": "Content-Type",
+                    "allow_methods": "POST, GET, OPTIONS",
+                    "allow_origin": [
+                        "http://foo.example",
+                        "http://bar.example"
+                    ],
+                    "enabled": true,
+                    "expose_headers": "X-Custom-Header",
+                    "max_age": "86400"
                 },
                 "prefix": "/cors-creds/",
                 "prefix_rewrite": "/"
+            },
+            {
+                "_group_id": "b69eeb747b38f5e5fd3955d044ea7797d67d024f",
+                "_method": "GET",
+                "_referenced_by": [
+                    "--internal--"
+                ],
+                "_source": "--internal--",
+                "clusters": [
+                    {
+                        "name": "cluster_127_0_0_1_8877",
+                        "weight": 100.0
+                    }
+                ],
+                "prefix": "/ambassador/v0/",
+                "prefix_rewrite": "/ambassador/v0/"
             },
             {
                 "_group_id": "c208ab7e4e146b9a8bbdebadc7b33f99bc635ab7",
@@ -275,7 +338,9 @@
                     }
                 ],
                 "cors": {
-                    "allow_origin": ["*"],
+                    "allow_origin": [
+                        "*"
+                    ],
                     "enabled": true
                 },
                 "prefix": "/cors-all/",
@@ -308,6 +373,7 @@
     },
     "sources": {
         "--diagnostics--": {
+            "_source": "--diagnostics--",
             "description": "The '--diagnostics--' source marks objects created by Ambassador to assist with diagnostic output.",
             "filename": "--diagnostics--",
             "index": 0,
@@ -316,6 +382,7 @@
             "version": "v0"
         },
         "--internal--": {
+            "_source": "--internal--",
             "description": "The '--internal--' source marks objects created by Ambassador's internal logic.",
             "filename": "--internal--",
             "index": 0,

--- a/ambassador/tests/007-originating-tls/gold.intermediate.json
+++ b/ambassador/tests/007-originating-tls/gold.intermediate.json
@@ -46,7 +46,19 @@
                 ]
             }
         ],
-        "filters": [],
+        "filters": [
+            {
+                "_source": "--internal--",
+                "config": {},
+                "name": "cors"
+            },
+            {
+                "_source": "--internal--",
+                "config": {},
+                "name": "router",
+                "type": "decoder"
+            }
+        ],
         "listeners": [
             {
                 "_source": "ambassador.yaml.1",
@@ -128,6 +140,7 @@
     },
     "sources": {
         "--diagnostics--": {
+            "_source": "--diagnostics--",
             "description": "The '--diagnostics--' source marks objects created by Ambassador to assist with diagnostic output.",
             "filename": "--diagnostics--",
             "index": 0,
@@ -136,6 +149,7 @@
             "version": "v0"
         },
         "--internal--": {
+            "_source": "--internal--",
             "description": "The '--internal--' source marks objects created by Ambassador's internal logic.",
             "filename": "--internal--",
             "index": 0,

--- a/ambassador/tests/ambassador_test.py
+++ b/ambassador/tests/ambassador_test.py
@@ -186,5 +186,9 @@ def test_diag(testname, dirpath, configdir):
     if errors:
         print("---- ERRORS")
         print("%s" % "\n".join(errors))
-
+        print("---- OVERVIEW ----")
+        print("%s" % results['overview'])
+        print("---- RECONSTITUTED ----")
+        print("%s" % results['reconstituted'])
+    
     assert errorcount == 0, ("failing, errors: %d" % errorcount)


### PR DESCRIPTION
We used to filter `--internal--` elements out of the diag stuff, because of issues around stability of the diagnostic overview between running on (say) my Mac vs Travis. Those issues should be fixed now, so I'm returning `--internal--` elements to the test to make me feel better about some of the multiple-listener stuff in flight right now.