### PR TITLE
Added support for circuit breaker `max_requests`

### DIFF
--- a/ambassador/schemas/v0/CircuitBreaker.schema
+++ b/ambassador/schemas/v0/CircuitBreaker.schema
@@ -8,6 +8,7 @@
         "kind": { "type": "string" },
         "name": { "type": "string" },
         "max_connections": { "type": "integer" },
+        "max_requests": { "type": "integer" },
         "max_pending": { "type": "integer" },
         "max_retries": { "type": "integer" }
     },

--- a/ambassador/templates/envoy.j2
+++ b/ambassador/templates/envoy.j2
@@ -103,8 +103,9 @@
         ]{%- if cluster.circuit_breakers -%},
         "circuit_breakers": {
           "default": {
-            "max_connections": {{ cluster.circuit_breakers.max_connections or 1 }},
-            "max_pending_requests": {{ cluster.circuit_breakers.max_pending or 1 }},
+            "max_connections": {{ cluster.circuit_breakers.max_connections or 1024 }},
+            "max_pending_requests": {{ cluster.circuit_breakers.max_pending or 1024 }},
+            "max_requests": {{ cluster.circuit_breakers.max_requests or 1024 }},
             "max_retries": {{ cluster.circuit_breakers.max_retries or 3 }}
           }
         }{%- endif -%}{%- if cluster.outlier_detection -%},

--- a/ambassador/tests/001-broader-v0/config/custom-breaker.yaml
+++ b/ambassador/tests/001-broader-v0/config/custom-breaker.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: ambassador/v0
+kind: CircuitBreaker
+name: custom
+max_connections: 1
+max_requests: 2
+max_pending: 3
+max_retries: 4

--- a/ambassador/tests/001-broader-v0/config/default-breaker.yaml
+++ b/ambassador/tests/001-broader-v0/config/default-breaker.yaml
@@ -1,7 +1,8 @@
 ---
 apiVersion: ambassador/v0
-kind:  CircuitBreaker
-name:  default
-# max_connections: 1
-# max_pending: 1
+kind: CircuitBreaker
+name: default
+# max_connections: 1024
+# max_requests: 1024
+# max_pending: 1024
 # max_retries: 3

--- a/ambassador/tests/001-broader-v0/config/mapping-qotm.yaml
+++ b/ambassador/tests/001-broader-v0/config/mapping-qotm.yaml
@@ -4,7 +4,7 @@ kind:  Mapping
 name:  qotm_mapping
 prefix: /qotm/
 service: qotm
-# circuit_breaker: default
+circuit_breaker: custom
 ---
 apiVersion: ambassador/v0.12
 kind:  Mapping

--- a/ambassador/tests/001-broader-v0/gold.intermediate.json
+++ b/ambassador/tests/001-broader-v0/gold.intermediate.json
@@ -3,6 +3,19 @@
         "breakers": [
             {
                 "_referenced_by": [
+                    "mapping-qotm.yaml.1"
+                ],
+                "_source": "custom-breaker.yaml.1",
+                "apiVersion": "ambassador/v0",
+                "kind": "CircuitBreaker",
+                "max_connections": 1,
+                "max_pending": 3,
+                "max_requests": 2,
+                "max_retries": 4,
+                "name": "custom"
+            },
+            {
+                "_referenced_by": [
                     "mapping-qotm.yaml.2",
                     "mapping-qotm.yaml.3"
                 ],
@@ -98,13 +111,34 @@
             },
             {
                 "_referenced_by": [
-                    "mapping-evil.yaml.1",
-                    "mapping-qotm.yaml.1"
+                    "mapping-evil.yaml.1"
                 ],
                 "_service": "qotm",
                 "_source": "mapping-evil.yaml.1",
                 "lb_type": "round_robin",
                 "name": "cluster_qotm",
+                "type": "strict_dns",
+                "urls": [
+                    "tcp://qotm:80"
+                ]
+            },
+            {
+                "_referenced_by": [
+                    "mapping-qotm.yaml.1"
+                ],
+                "_service": "qotm",
+                "_source": "mapping-qotm.yaml.1",
+                "circuit_breakers": {
+                    "apiVersion": "ambassador/v0",
+                    "kind": "CircuitBreaker",
+                    "max_connections": 1,
+                    "max_pending": 3,
+                    "max_requests": 2,
+                    "max_retries": 4,
+                    "name": "custom"
+                },
+                "lb_type": "round_robin",
+                "name": "cluster_qotm_cb_custom",
                 "type": "strict_dns",
                 "urls": [
                     "tcp://qotm:80"
@@ -398,7 +432,7 @@
                 "_source": "mapping-qotm.yaml.1",
                 "clusters": [
                     {
-                        "name": "cluster_qotm",
+                        "name": "cluster_qotm_cb_custom",
                         "weight": 100.0
                     }
                 ],
@@ -531,6 +565,9 @@
         "auth.yaml": {
             "auth.yaml.1": true
         },
+        "custom-breaker.yaml": {
+            "custom-breaker.yaml.1": true
+        },
         "default-breaker.yaml": {
             "default-breaker.yaml.1": true
         },
@@ -600,6 +637,15 @@
             "name": "authentication",
             "version": "ambassador/v0",
             "yaml": "apiVersion: ambassador/v0\nconfig:\n  allowed_headers:\n  - x-qotm-session\n  auth_service: http://example-auth:3000\n  path_prefix: /extauth\nkind: Module\nname: authentication\n"
+        },
+        "custom-breaker.yaml.1": {
+            "_source": "custom-breaker.yaml",
+            "filename": "custom-breaker.yaml",
+            "index": 1,
+            "kind": "CircuitBreaker",
+            "name": "custom",
+            "version": "ambassador/v0",
+            "yaml": "apiVersion: ambassador/v0\nkind: CircuitBreaker\nmax_connections: 1\nmax_pending: 3\nmax_requests: 2\nmax_retries: 4\nname: custom\n"
         },
         "default-breaker.yaml.1": {
             "_source": "default-breaker.yaml",
@@ -689,7 +735,7 @@
             "kind": "Mapping",
             "name": "qotm_mapping",
             "version": "ambassador/v0",
-            "yaml": "apiVersion: ambassador/v0\nkind: Mapping\nname: qotm_mapping\nprefix: /qotm/\nservice: qotm\n"
+            "yaml": "apiVersion: ambassador/v0\ncircuit_breaker: custom\nkind: Mapping\nname: qotm_mapping\nprefix: /qotm/\nservice: qotm\n"
         },
         "mapping-qotm.yaml.2": {
             "_source": "mapping-qotm.yaml",

--- a/ambassador/tests/001-broader-v0/gold.json
+++ b/ambassador/tests/001-broader-v0/gold.json
@@ -198,7 +198,7 @@
                       "weighted_clusters": {
                           "clusters": [
                               
-                                 { "name": "cluster_qotm", "weight": 100.0 }
+                                 { "name": "cluster_qotm_cb_custom", "weight": 100.0 }
                               
                           ]
                       }
@@ -327,6 +327,25 @@
           
         ]},
       {
+        "circuit_breakers": {
+          "default": {
+            "max_connections": 1,
+            "max_pending_requests": 3,
+            "max_requests": 2,
+            "max_retries": 4
+          }
+        },
+        "connect_timeout_ms": 3000,
+        "hosts": [
+          {
+            "url": "tcp://qotm:80"
+          }
+        ],
+        "lb_type": "round_robin",
+        "name": "cluster_qotm_cb_custom",
+        "type": "strict_dns"
+      },
+      {
         "name": "cluster_qotm_cb_default",
         "connect_timeout_ms": 3000,
         "type": "strict_dns",
@@ -339,8 +358,9 @@
         ],
         "circuit_breakers": {
           "default": {
-            "max_connections": 1,
-            "max_pending_requests": 1,
+            "max_connections": 1024,
+            "max_pending_requests": 1024,
+            "max_requests": 1024,
             "max_retries": 3
           }
         }},
@@ -357,8 +377,9 @@
         ],
         "circuit_breakers": {
           "default": {
-            "max_connections": 1,
-            "max_pending_requests": 1,
+            "max_connections": 1024,
+            "max_pending_requests": 1024,
+            "max_requests": 1024,
             "max_retries": 3
           }
         },


### PR DESCRIPTION
* Added support for circuit breaker `max_requests`.
* Using the same default value as Envoy (https://www.envoyproxy.io/docs/envoy/v1.5.0/api-v1/cluster_manager/cluster_circuit_breakers#per-priority-settings)
* Added unit tests

Documentation to follow?