### PR TITLE
Support redirecting cleartext traffic to HTTPS

### DIFF
--- a/ambassador/ambassador/config.py
+++ b/ambassador/ambassador/config.py
@@ -788,23 +788,46 @@ class Config (object):
 
             handler(module_name, modules[module_name])
 
-        # # Once modules are handled, we can set up our listeners...
-        self.envoy_config['listeners'] = SourcedDict(
+        # Once modules are handled, we can set up our admin config...
+        self.envoy_config['admin'] = SourcedDict(
             _from=self.ambassador_module,
-            service_port=self.ambassador_module["service_port"],
             admin_port=self.ambassador_module["admin_port"]
         )
+
+        # ...and our listeners.
+        primary_listener = SourcedDict(
+            _from=self.ambassador_module,
+            service_port=self.ambassador_module["service_port"],
+            require_tls=False
+        )
+
+        redirect_cleartext_from = None
+        tmod = self.ambassador_module.get('tls_config', None)
+           
+        # ...TLS config, if necessary...
+        if tmod:
+            # self.logger.debug("USING TLS")
+            primary_listener['tls'] = tmod
+            redirect_cleartext_from = tmod.get('redirect_cleartext_from')
+
+        self.envoy_config['listeners'] = [ primary_listener ]
+
+        if redirect_cleartext_from:
+            primary_listener['require_tls'] = True
+
+            self.envoy_config['listeners'].append(SourcedDict(
+                _from=self.ambassador_module,
+                service_port=redirect_cleartext_from,
+                require_tls=True
+                # Note: no TLS context here, this is a cleartext listener.
+                # We can set require_tls True because we can let the upstream
+                # tell us about that.
+            ))
 
         self.default_liveness_probe['service'] = self.diag_service()
         self.default_readiness_probe['service'] = self.diag_service()
         self.default_diagnostics['service'] = self.diag_service()
 
-        # ...TLS config, if necessary...
-        if self.ambassador_module['tls_config']:
-            # self.logger.debug("USING TLS")
-            self.envoy_config['tls'] = self.ambassador_module['tls_config']
-
-        # ...and probes, if configured.
         for name, cur, dflt in [ 
             ("liveness",    self.ambassador_module['liveness_probe'],
                             self.default_liveness_probe),

--- a/ambassador/templates/envoy.j2
+++ b/ambassador/templates/envoy.j2
@@ -1,16 +1,17 @@
 {
   "listeners": [
+    {% for listener in listeners %}
     {
-      "address": "tcp://0.0.0.0:{{ listeners.service_port }}",
-      {% if tls -%}
+      "address": "tcp://0.0.0.0:{{ listener.service_port }}",
+      {% if listener.tls -%}
       "ssl_context": {
-        {%- if tls.cert_chain_file -%}
-          "cert_chain_file": "{{ tls.cert_chain_file }}",
-          "private_key_file": "{{ tls.private_key_file }}"{{ "," if tls.cacert_chain_file }}
+        {%- if listener.tls.cert_chain_file -%}
+          "cert_chain_file": "{{ listener.tls.cert_chain_file }}",
+          "private_key_file": "{{ listener.tls.private_key_file }}"{{ "," if listener.tls.cacert_chain_file }}
         {%- endif -%}
-        {%- if tls.cacert_chain_file -%}
-          "ca_cert_file": "{{ tls.cacert_chain_file }}"{{ "," if tls.cert_required }}
-          {%- if tls.cert_required -%}"require_client_certificate": true{%- endif %}
+        {%- if listener.tls.cacert_chain_file -%}
+          "ca_cert_file": "{{ listener.tls.cacert_chain_file }}"{{ "," if listener.tls.cert_required }}
+          {%- if listener.tls.cert_required -%}"require_client_certificate": true{%- endif %}
         {%- endif %}
       },
       {%- endif -%}
@@ -32,6 +33,9 @@
                 {
                   "name": "backend",
                   "domains": ["*"],
+                  {%- if listener.require_tls -%}
+                  "require_ssl": "all",
+                  {%- endif -%}
                   "routes": [
                     {% for route in routes %}
                     {
@@ -79,10 +83,11 @@
           }
         }
       ]
-    }    
+    }{{ "," if not loop.last }}
+    {%- endfor %}
   ],
   "admin": {
-    "address": "tcp://127.0.0.1:{{ listeners.admin_port }}",
+    "address": "tcp://127.0.0.1:{{ admin.admin_port }}",
     "access_log_path": "/tmp/admin_access_log"
   },
   "cluster_manager": {

--- a/ambassador/tests/000-default/gold.intermediate.json
+++ b/ambassador/tests/000-default/gold.intermediate.json
@@ -1,5 +1,11 @@
 {
     "envoy_config": {
+        "admin": [
+            {
+                "_source": "--internal--",
+                "admin_port": 8001
+            }
+        ],
         "clusters": [
             {
                 "_referenced_by": [
@@ -88,7 +94,7 @@
         "listeners": [
             {
                 "_source": "--internal--",
-                "admin_port": 8001,
+                "require_tls": false,
                 "service_port": 80
             }
         ],

--- a/ambassador/tests/001-broader-v0/gold.intermediate.json
+++ b/ambassador/tests/001-broader-v0/gold.intermediate.json
@@ -1,5 +1,11 @@
 {
     "envoy_config": {
+        "admin": [
+            {
+                "_source": "ambassador.yaml.1",
+                "admin_port": 8001
+            }
+        ],
         "breakers": [
             {
                 "_referenced_by": [
@@ -233,8 +239,15 @@
         "listeners": [
             {
                 "_source": "ambassador.yaml.1",
-                "admin_port": 8001,
-                "service_port": 443
+                "require_tls": false,
+                "service_port": 443,
+                "tls": {
+                    "_source": "ambassador.yaml.1",
+                    "cacert_chain_file": "/etc/ambassador-config/ca_cert_chain/tls.crt",
+                    "cert_chain_file": "/etc/ambassador-config/certs/tls.crt",
+                    "cert_required": true,
+                    "private_key_file": "/etc/ambassador-config/certs/tls.key"
+                }
             }
         ],
         "outliers": [
@@ -520,15 +533,6 @@
                 ],
                 "prefix": "/evil/",
                 "prefix_rewrite": "/"
-            }
-        ],
-        "tls": [
-            {
-                "_source": "ambassador.yaml.1",
-                "cacert_chain_file": "/etc/ambassador-config/ca_cert_chain/tls.crt",
-                "cert_chain_file": "/etc/ambassador-config/certs/tls.crt",
-                "cert_required": true,
-                "private_key_file": "/etc/ambassador-config/certs/tls.key"
             }
         ]
     },

--- a/ambassador/tests/002-tls-module-1/gold.intermediate.json
+++ b/ambassador/tests/002-tls-module-1/gold.intermediate.json
@@ -1,5 +1,11 @@
 {
     "envoy_config": {
+        "admin": [
+            {
+                "_source": "ambassador.yaml.1",
+                "admin_port": 4242
+            }
+        ],
         "clusters": [
             {
                 "_referenced_by": [
@@ -44,8 +50,15 @@
         "listeners": [
             {
                 "_source": "ambassador.yaml.1",
-                "admin_port": 4242,
-                "service_port": 443
+                "require_tls": false,
+                "service_port": 443,
+                "tls": {
+                    "_source": "tls.yaml.1",
+                    "cacert_chain_file": "/etc/ambassador-config/ca_cert_chain/tls.crt",
+                    "cert_chain_file": "/etc/ambassador-config/certs/tls.crt",
+                    "cert_required": true,
+                    "private_key_file": "/etc/ambassador-config/certs/tls.key"
+                }
             }
         ],
         "routes": [
@@ -96,15 +109,6 @@
                 ],
                 "prefix": "/ambassador/v0/",
                 "prefix_rewrite": "/ambassador/v0/"
-            }
-        ],
-        "tls": [
-            {
-                "_source": "tls.yaml.1",
-                "cacert_chain_file": "/etc/ambassador-config/ca_cert_chain/tls.crt",
-                "cert_chain_file": "/etc/ambassador-config/certs/tls.crt",
-                "cert_required": true,
-                "private_key_file": "/etc/ambassador-config/certs/tls.key"
             }
         ]
     },

--- a/ambassador/tests/003-tls-module-2/gold.intermediate.json
+++ b/ambassador/tests/003-tls-module-2/gold.intermediate.json
@@ -1,5 +1,11 @@
 {
     "envoy_config": {
+        "admin": [
+            {
+                "_source": "ambassador.yaml.1",
+                "admin_port": 4242
+            }
+        ],
         "clusters": [
             {
                 "_referenced_by": [
@@ -44,8 +50,15 @@
         "listeners": [
             {
                 "_source": "ambassador.yaml.1",
-                "admin_port": 4242,
-                "service_port": 443
+                "require_tls": false,
+                "service_port": 443,
+                "tls": {
+                    "_source": "ambassador.yaml.1",
+                    "cacert_chain_file": "/etc/ambassador-config/ca_cert_chain/tls.crt",
+                    "cert_chain_file": "/etc/ambassador-config/certs/tls.crt",
+                    "cert_required": true,
+                    "private_key_file": "/etc/ambassador-config/certs/tls.key"
+                }
             }
         ],
         "routes": [
@@ -96,15 +109,6 @@
                 ],
                 "prefix": "/ambassador/v0/",
                 "prefix_rewrite": "/ambassador/v0/"
-            }
-        ],
-        "tls": [
-            {
-                "_source": "ambassador.yaml.1",
-                "cacert_chain_file": "/etc/ambassador-config/ca_cert_chain/tls.crt",
-                "cert_chain_file": "/etc/ambassador-config/certs/tls.crt",
-                "cert_required": true,
-                "private_key_file": "/etc/ambassador-config/certs/tls.key"
             }
         ]
     },

--- a/ambassador/tests/004-tls-without-ambassador-module/gold.intermediate.json
+++ b/ambassador/tests/004-tls-without-ambassador-module/gold.intermediate.json
@@ -1,5 +1,11 @@
 {
     "envoy_config": {
+        "admin": [
+            {
+                "_source": "tls.yaml.1",
+                "admin_port": 8001
+            }
+        ],
         "clusters": [
             {
                 "_referenced_by": [
@@ -44,8 +50,15 @@
         "listeners": [
             {
                 "_source": "tls.yaml.1",
-                "admin_port": 8001,
-                "service_port": 443
+                "require_tls": false,
+                "service_port": 443,
+                "tls": {
+                    "_source": "tls.yaml.1",
+                    "cacert_chain_file": "/etc/ambassador-config/ca_cert_chain/tls.crt",
+                    "cert_chain_file": "/etc/ambassador-config/certs/tls.crt",
+                    "cert_required": true,
+                    "private_key_file": "/etc/ambassador-config/certs/tls.key"
+                }
             }
         ],
         "routes": [
@@ -112,15 +125,6 @@
                 ],
                 "prefix": "/ambassador/v0/",
                 "prefix_rewrite": "/ambassador/v0/"
-            }
-        ],
-        "tls": [
-            {
-                "_source": "tls.yaml.1",
-                "cacert_chain_file": "/etc/ambassador-config/ca_cert_chain/tls.crt",
-                "cert_chain_file": "/etc/ambassador-config/certs/tls.crt",
-                "cert_required": true,
-                "private_key_file": "/etc/ambassador-config/certs/tls.key"
             }
         ]
     },

--- a/ambassador/tests/005-canary/gold.intermediate.json
+++ b/ambassador/tests/005-canary/gold.intermediate.json
@@ -1,5 +1,11 @@
 {
     "envoy_config": {
+        "admin": [
+            {
+                "_source": "--internal--",
+                "admin_port": 8001
+            }
+        ],
         "clusters": [
             {
                 "_referenced_by": [
@@ -58,7 +64,7 @@
         "listeners": [
             {
                 "_source": "--internal--",
-                "admin_port": 8001,
+                "require_tls": false,
                 "service_port": 80
             }
         ],

--- a/ambassador/tests/006-headers-and-host/gold.intermediate.json
+++ b/ambassador/tests/006-headers-and-host/gold.intermediate.json
@@ -1,5 +1,11 @@
 {
     "envoy_config": {
+        "admin": [
+            {
+                "_source": "--internal--",
+                "admin_port": 8001
+            }
+        ],
         "clusters": [
             {
                 "_referenced_by": [
@@ -114,7 +120,7 @@
         "listeners": [
             {
                 "_source": "--internal--",
-                "admin_port": 8001,
+                "require_tls": false,
                 "service_port": 80
             }
         ],

--- a/ambassador/tests/007-originating-tls/gold.intermediate.json
+++ b/ambassador/tests/007-originating-tls/gold.intermediate.json
@@ -1,5 +1,11 @@
 {
     "envoy_config": {
+        "admin": [
+            {
+                "_source": "ambassador.yaml.1",
+                "admin_port": 4242
+            }
+        ],
         "clusters": [
             {
                 "_referenced_by": [
@@ -62,8 +68,13 @@
         "listeners": [
             {
                 "_source": "ambassador.yaml.1",
-                "admin_port": 4242,
-                "service_port": 443
+                "require_tls": false,
+                "service_port": 443,
+                "tls": {
+                    "_source": "tls.yaml.1",
+                    "cert_chain_file": "/etc/ambassador-config/certs/tls.crt",
+                    "private_key_file": "/etc/ambassador-config/certs/tls.key"
+                }
             }
         ],
         "routes": [
@@ -114,13 +125,6 @@
                 ],
                 "prefix": "/ambassador/v0/",
                 "prefix_rewrite": "/ambassador/v0/"
-            }
-        ],
-        "tls": [
-            {
-                "_source": "tls.yaml.1",
-                "cert_chain_file": "/etc/ambassador-config/certs/tls.crt",
-                "private_key_file": "/etc/ambassador-config/certs/tls.key"
             }
         ]
     },

--- a/docs/how-to/tls-termination.md
+++ b/docs/how-to/tls-termination.md
@@ -1,13 +1,33 @@
 # TLS Termination
 
-You need to choose up front whether you want to use TLS or not. It's possible to switch this later, but you'll likely need to muck about with your DNS and such to do it, so it's a pain.
+To enable TLS termination for Ambassador you'll need a few things:
 
-## 1. Get a certificate, and store it in Kubernetes
+1. You'll need a TLS certificate.
+2. For any production use, you'll need a DNS record that matches your TLS certificate's `Common Name`.
+3. You'll need to store the certificate in a Kubernetes `secret`.
+4. You may need to configure other Ambassador TLS options using the `tls` module.
 
-You'll need a certificate for TLS. With the certificate:
+All these requirements mean that it's easiest to decide to enable TLS _before_ you configure Ambassador the first time. It's possible to switch after setting up Ambassador, but it's annoying.
 
-* Make sure that the `CN` matches the DNS name of your service.
-* Ambassador needs the full certificate chain, so concatenate the server certificate and any intermediate certificates into a single file.
+## 1. You'll need a TLS certificate.
+
+There are a great many ways to get a certificate; [Let's Encrypt](https://www.letsencrypt.org) is a good option if you're not already working with something else. 
+
+Note that requesting a certificate _requires_ a `Common Name` (`CN`) for your Ambassador. The `CN` becomes very important when you try to use HTTPS in practice: if the `CN` does not match the DNS name you use to reach the Ambassador, most TLS libraries will refuse to make the connection. So use a DNS name for the `CN`, and in step 2 make sure everything matches.
+
+## 2. You'll need a DNS name.
+
+As noted above, the DNS name must match the `CN` in the certificate. The simplest way to manage this is to create an `ambassador` Kubernetes service up front, before you do anything else, so that you can point DNS to whatever Kubernetes gives you for it -- then don't delete the `ambassador` service, even if you later need to update it or delete and recreate the `ambassador` deployment.
+
+```shell
+kubectl apply -f https://www.getambassador.io/yaml/ambassador/ambassador-https.yaml
+```
+
+will create a minimal `ambassador` service for this purpose; you can then use its external appearance to configure either a `CNAME` or an `A` record in DNS. Make sure that there's a matching `PTR` record, too.
+
+It's OK to include annotations on the `ambassador` service at this point, if you need to configure additional TLS options (see below for more on this).
+
+## 3. You'll need to store the certificate in a Kubernetes `secret`.
 
 Create a Kubernetes `secret` named `ambassador-certs`:
 
@@ -17,55 +37,70 @@ kubectl create secret tls ambassador-certs --cert=$FULLCHAIN_PATH --key=$PRIVKEY
 
 where `$FULLCHAIN_PATH` is the path to a single PEM file containing the certificate chain for your cert (including the certificate for your Ambassador and all relevant intermediate certs -- this is what Let's Encrypt calls `fullchain.pem`), and `$PRIVKEY_PATH` is the path to the corresponding private key.
 
-When Ambassador starts, it will notice the `ambassador-certs` secret and turn TLS on.
+## 4. You may need to configure other Ambassador TLS options.
 
-## 2. Create the Ambassador service
+When Ambassador starts, it will notice the `ambassador-certs` secret and turn TLS on. If you don't need anything else, you're good to go.
 
-1. Create the `ambassador` service in Kubernetes, and don't delete it even if you need to delete and recreate the `ambassador` deployment. This will give you a stable external appearance that you can use for DNS records.
-
-```shell
-kubectl apply -f https://www.getambassador.io/yaml/ambassador/ambassador-https.yaml
-```
-
-2. Either a `CNAME` or an `A` is fine.
-3. Make sure that there's a valid `PTR` record.
-
-## (Legacy) Configuring Using a `ConfigMap`
-
-If you're using the `ambassador-config` Kubernetes `ConfigMap` that was required in earlier versions of Ambassador, you'll need to create the `ambassador-certs` Kubernetes `secret` as above, but you'll also need to make sure that the `ambassador` [module](../about/concepts.md#modules) is configured to allow TLS:
+However, you may also configure other options using Ambassador's `tls` module:
 
 ```yaml
 ---
 apiVersion: ambassador/v0
 kind:  Module
-name:  ambassador
+name:  tls
 config:
-  tls:
-    # The 'server' block configures TLS termination. 'enabled' is the only required element.
-    server:
-      enabled: True
+  # The 'server' block configures TLS termination. 'enabled' is the only
+  # required element.
+  server:
+    # If 'enabled' is not True, TLS termination will not happen.
+    enabled: True
+
+    # If you set 'redirect_cleartext_from' to a port number, HTTP traffic 
+    # to that port will be redirected to HTTPS traffic. Typically you would
+    # use port 80, of course.
+    # redirect_cleartext_from: 80
+
+    # These are optional. They should not be present unless you are using
+    # a custom Docker build to install certificates onto the container
+    # filesystem.
+    # cert_chain_file: /etc/certs/tls.crt
+    # private_key_file: /etc/certs/tls.key
+
+  # The 'client' block configures TLS client-certificate authentication.
+  # 'enabled' is the only required element.
+  client:
+    # If 'enabled' is not True, TLS client-certificate authentication will
+    # not happen.
+    enabled: False
+
+    # If 'cert_required' is True, TLS client certificates will be required
+    # for every connection.
+    # cert_required: False
+
+    # This is optional. It should not be present unless you are using
+    # a custom Docker build to install certificates onto the container
+    # filesystem.
+    # cacert_chain_file: /etc/cacert/fullchain.pem
 ```
 
-Earlier versions of Ambassador required the `secret` to be mounted as a volume; this is **no longer required**, but should still function.
-
-## Configuring Using Files in an Image
-
-If you're building your own custom Ambassador image, you'll need to copy the certificate files into your image, and make sure your `ambassador` [module](../about/concepts.md#modules) is configured properly:
+Of these, `redirect_cleartext_from` is the most likely to be relevant: to make Ambassador redirect HTTP traffic on port 80 to HTTPS on port 443, you _must_ use the `tls` module:
 
 ```yaml
 ---
 apiVersion: ambassador/v0
 kind:  Module
-name:  ambassador
+name:  tls
 config:
-  tls:
-    # The 'server' block configures TLS termination. 'enabled' is the only required element.
-    server:
-      enabled: True
-      # These are optional: if not present, they take the values listed here,
-      # which match what's in ambassador-proxy.yaml.
-      # cert_chain_file: /etc/certs/tls.crt
-      # private_key_file: /etc/certs/tls.key
+  server:
+    enabled: True
+    redirect_cleartext_from: 80
 ```
 
-`cert_chain_file` and `private_key_file` are optional: if you copy your certificate files into `/etc/certs` as shown above, you needn't include them. If you put the certificate files somewhere else, you'll need to update the paths to match.
+is the minimal YAML to do this.
+
+If you need a `tls` module, it's simplest to include it as an `annotation` on the `ambassador` service itself. 
+
+## Legacy configuration options
+
+It's still possible - but not recommended! - to configure Ambassador using a `ConfigMap`, or with YAML files on the container filesystem. If you think you'll need to do this, please contact us on [Gitter](https://gitter.im/datawire/ambassador).
+

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -107,18 +107,9 @@ config:
   # readiness probe defaults on, but you can disable it.
   # readiness_probe:
   #   enabled: false
-
-  # TLS configuration defaults to configuration based on certificate discovery.
-  # See below for more.
-  # tls:
-  #   ...
 ```
 
 Everything in this file has a default that should cover most situations; it should only be necessary to include them to override the defaults in highly-custom situations.
-
-#### TLS
-
-When running in Kubernetes, Ambassador will look for the existence of certificate `secret`s for default configuration. When running using filesystem-based configuration, TLS must be explicitly configured. This process is examined in detail in the documentation on [TLS termination](../how-to/tls-termination.md) and [TLS client certificate authentication](../how-to/auth-tls-certs.md).
 
 #### Probes
 
@@ -134,6 +125,27 @@ readiness_probe:
 The liveness and readiness probe both support `prefix`, `rewrite`, and `service`, with the same meanings as for [mappings](#mappings). Additionally, the `enabled` boolean may be set to `false` (as an the commented-out examples above) to disable support for the probe entirely.
 
 **Note well** that configuring the probes in the `ambassador` module only means that Ambassador will respond to the probes. You must still configure Kubernetes to perform the checks, as shown in the Datawire-provided YAML files.
+
+### The `tls` Module
+
+If present, the `tls` module defines system-wide configuration for TLS. 
+
+When running in Kubernetes, Ambassador will enable TLS termination whenever it finds valid TLS certificates stored in the `ambassador-certs` Kubernetes secret, so many Kubernetes installations of Ambassador will not need a `tls` module at all.
+
+The most common case requiring a `tls` module is redirecting cleartext traffic on port 80 to HTTPS on port 443, which can be done with the following `tls` module:
+
+```
+---
+apiVersion: ambassador/v0
+kind:  Module
+name:  tls
+config:
+  server:
+    enabled: True
+    redirect_cleartext_from: 80
+```
+
+TLS configuration is examined in more detail in the documentation on [TLS termination](../how-to/tls-termination.md) and [TLS client certificate authenticationHey, ](../how-to/auth-tls-certs.md).
 
 ### The `authentication` Module
 

--- a/end-to-end/004-tls-1/k8s/ambassador.yaml
+++ b/end-to-end/004-tls-1/k8s/ambassador.yaml
@@ -19,6 +19,7 @@ metadata:
       config:
         server:
           enabled: True
+          redirect_cleartext_from: 80
           # These are optional.
           cert_chain_file: /etc/certs/termination/tls.crt
           private_key_file: /etc/certs/termination/tls.key
@@ -46,8 +47,12 @@ spec:
   selector:
     app: ambassador
   ports:
-    - name: http
+    - name: https
       protocol: TCP
       port: 443
       targetPort: 443
+    - name: http
+      protocol: TCP
+      port: 80
+      targetPort: 80
   type: NodePort

--- a/end-to-end/utils.sh
+++ b/end-to-end/utils.sh
@@ -18,7 +18,7 @@ initialize_cluster () {
         echo "Deleting everything in $namespace..."
 
         if [ "$namespace" = "default" ]; then
-            kubectl delete pods,services,deployments,configmaps --all
+            kubectl delete pods,secrets,services,deployments,configmaps --all
         else
             kubectl delete namespace "$namespace"
         fi
@@ -36,7 +36,9 @@ cluster_ip () {
 }
 
 service_port() {
-    kubectl get services "$1" -ojsonpath={.spec.ports[0].nodePort}
+    instance=${2:-0}
+
+    kubectl get services "$1" -ojsonpath="{.spec.ports[$instance].nodePort}"
 }
 
 demotest_pod() {


### PR DESCRIPTION
In the `server` configuration for TLS, you can now specify `redirect_cleartext_from` with a port number (usually 80) to cause cleartext traffic to that port to be redirected to HTTPS on port 443. A common setup would be

```
---
apiVersion: ambassador/v0
kind:  Module
name:  tls
config:
  server:
    enabled: True
    redirect_cleartext_from: 80
```

The default is no redirection of cleartext.
