### PR TITLE
Remove magical ConfigMap uuid stuff because it usually doesn't work.

### DIFF
--- a/ambassador/ambassador/config.py
+++ b/ambassador/ambassador/config.py
@@ -68,17 +68,15 @@ class Config (object):
 
     runtime = "kubernetes" if os.environ.get('KUBERNETES_SERVICE_HOST', None) else "docker"
     namespace = os.environ.get('AMBASSADOR_NAMESPACE', 'default')
-    scout_install_id = os.environ.get('AMBASSADOR_SCOUT_ID', None)
+
+    # Default to using the Nil UUID unless the environment variable is set explicitly
+    scout_install_id = os.environ.get('AMBASSADOR_SCOUT_ID', "00000000-0000-0000-0000-000000000000")
 
     _scout_args = dict(
         app="ambassador", version=scout_version,
     )
 
-    if scout_install_id:
-        _scout_args['install_id'] = scout_install_id
-    else:
-        _scout_args['id_plugin'] = Scout.configmap_install_id_plugin
-        _scout_args['id_plugin_args'] = { "namespace": namespace }
+    _scout_args['install_id'] = scout_install_id
 
     try:
         scout = Scout(**_scout_args)

--- a/ambassador/ambassador/config.py
+++ b/ambassador/ambassador/config.py
@@ -72,14 +72,8 @@ class Config (object):
     # Default to using the Nil UUID unless the environment variable is set explicitly
     scout_install_id = os.environ.get('AMBASSADOR_SCOUT_ID', "00000000-0000-0000-0000-000000000000")
 
-    _scout_args = dict(
-        app="ambassador", version=scout_version,
-    )
-
-    _scout_args['install_id'] = scout_install_id
-
     try:
-        scout = Scout(**_scout_args)
+        scout = Scout(app="ambassador", version=scout_version, install_id=scout_install_id)
         scout_error = None
     except OSError as e:
         scout_error = e


### PR DESCRIPTION
Defaults to the "Nil" UUID which we will filter out in the future from
scout queries.

I scanned around for some tests but I didn't see any. @kflynn do we test scout initialization at all in Ambassador?

Are we OK with the Nil UUID implementation?