### PR TITLE
Expose envoy tls alpn_protocol to fix grpc over tls

### DIFF
--- a/ambassador/templates/envoy.j2
+++ b/ambassador/templates/envoy.j2
@@ -8,7 +8,10 @@
       "ssl_context": {
         {%- if listener.tls.cert_chain_file -%}
           "cert_chain_file": "{{ listener.tls.cert_chain_file }}",
-          "private_key_file": "{{ listener.tls.private_key_file }}"{{ "," if listener.tls.cacert_chain_file }}
+          "private_key_file": "{{ listener.tls.private_key_file }}"{{ "," if listener.tls.alpn_protocols }}
+          {%- if listener.tls.alpn_protocols -%}
+          "alpn_protocols": "{{ listener.tls.alpn_protocols }}"
+          {%- endif -%}{{ "," if listener.tls.cacert_chain_file }}
         {%- endif -%}
         {%- if listener.tls.cacert_chain_file -%}
           "ca_cert_file": "{{ listener.tls.cacert_chain_file }}"{{ "," if listener.tls.cert_required }}

--- a/ambassador/tests/002-tls-module-1/config/tls.yaml
+++ b/ambassador/tests/002-tls-module-1/config/tls.yaml
@@ -8,6 +8,7 @@ config:
     # These are optional.
     cert_chain_file: /etc/ambassador-config/certs/tls.crt
     private_key_file: /etc/ambassador-config/certs/tls.key
+    alpn_protocols: h2
 
   client:
     enabled: True,

--- a/ambassador/tests/002-tls-module-1/gold.intermediate.json
+++ b/ambassador/tests/002-tls-module-1/gold.intermediate.json
@@ -54,6 +54,7 @@
                 "service_port": 443,
                 "tls": {
                     "_source": "tls.yaml.1",
+                    "alpn_protocols": "h2",
                     "cacert_chain_file": "/etc/ambassador-config/ca_cert_chain/tls.crt",
                     "cert_chain_file": "/etc/ambassador-config/certs/tls.crt",
                     "cert_required": true,
@@ -172,7 +173,7 @@
             "kind": "Module",
             "name": "tls",
             "version": "ambassador/v0",
-            "yaml": "apiVersion: ambassador/v0\nconfig:\n  client:\n    cacert_chain_file: /etc/ambassador-config/ca_cert_chain/tls.crt\n    cert_required: true\n    enabled: True,\n  server:\n    cert_chain_file: /etc/ambassador-config/certs/tls.crt\n    enabled: true\n    private_key_file: /etc/ambassador-config/certs/tls.key\nkind: Module\nname: tls\n"
+            "yaml": "apiVersion: ambassador/v0\nconfig:\n  client:\n    cacert_chain_file: /etc/ambassador-config/ca_cert_chain/tls.crt\n    cert_required: true\n    enabled: True,\n  server:\n    alpn_protocols: h2\n    cert_chain_file: /etc/ambassador-config/certs/tls.crt\n    enabled: true\n    private_key_file: /etc/ambassador-config/certs/tls.key\nkind: Module\nname: tls\n"
         }
     }
 }

--- a/ambassador/tests/002-tls-module-1/gold.json
+++ b/ambassador/tests/002-tls-module-1/gold.json
@@ -5,7 +5,7 @@
       "address": "tcp://0.0.0.0:443",
       
       "ssl_context": {"cert_chain_file": "/etc/ambassador-config/certs/tls.crt",
-          "private_key_file": "/etc/ambassador-config/certs/tls.key","ca_cert_file": "/etc/ambassador-config/ca_cert_chain/tls.crt","require_client_certificate": true
+          "private_key_file": "/etc/ambassador-config/certs/tls.key","alpn_protocols": "h2","ca_cert_file": "/etc/ambassador-config/ca_cert_chain/tls.crt","require_client_certificate": true
       },"filters": [
         {
           "type": "read",

--- a/docs/user-guide/grpc.md
+++ b/docs/user-guide/grpc.md
@@ -126,6 +126,10 @@ To test `Hello World`, we can use the Docker image `enm10k/grpc-hello-world`:
 docker run -e ADDRESS=${AMBASSADORHOST}:${AMBASSADORPORT} enm10k/grpc-hello-world greeter_client
 ```
 
+## Using over TLS
+
+To enable grpc over TLS, ALPN protocol http2 `alpn_protocols: h2` must be added to the TLS module configuration. Refer to [TLS termination guide](/user-guide/tls-termination.html) for more information.
+
 ## Note
 
 Some [Kubernetes ingress controllers](https://kubernetes.io/docs/concepts/services-networking/ingress/) do not support HTTP/2 fully. As a result, if you are running Ambassador with an ingress controller in front, you may find that gRPC requests fail even with correct Ambassador configuration.

--- a/docs/user-guide/tls-termination.md
+++ b/docs/user-guide/tls-termination.md
@@ -66,6 +66,11 @@ config:
     # cert_chain_file: /etc/certs/tls.crt
     # private_key_file: /etc/certs/tls.key
 
+    # Enable TLS ALPN protocol, typically HTTP2 to negotiate it with 
+    # HTTP2 clients over TLS.
+    # This must be set to be able to use grpc over TLS.
+    # alpn_protocols: h2
+
   # The 'client' block configures TLS client-certificate authentication.
   # 'enabled' is the only required element.
   client:


### PR DESCRIPTION
This PR exposes the ability to set Envoy `alpn_protocol` for the `ssl_context` listeners to enable ALPN protocol requested protocols.

Since gRPC clients use HTTP2, this option must be set to `h2` for it to work over TLS.

[Envoy TLS context reference](https://www.envoyproxy.io/docs/envoy/latest/api-v1/cluster_manager/cluster_ssl.html).