### PR TITLE
update to newer alpine to fix vulns

### DIFF
--- a/statsd/Dockerfile
+++ b/statsd/Dockerfile
@@ -1,4 +1,4 @@
-FROM mhart/alpine-node:7
+FROM mhart/alpine-node:9
 
 WORKDIR /application
 RUN npm install https://api.github.com/repos/etsy/statsd/tarball/8d5363c


### PR DESCRIPTION
The quay scanner has found some medium security vulnerabilities in our base StatsD image. I've verified that upgrading to the 9 version of the alpine-node image fixes this problem.

I *don't* have e2e tests for statsd, so I haven't actually tested functionality. 