### PR TITLE
Ambassador Helm chart

### DIFF
--- a/helm/ambassador/.helmignore
+++ b/helm/ambassador/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/helm/ambassador/Chart.yaml
+++ b/helm/ambassador/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "0.28.2"
+appVersion: "0.29.0"
 description: A Helm chart for Datawire Ambassador
 name: ambassador
 version: 0.1.0

--- a/helm/ambassador/Chart.yaml
+++ b/helm/ambassador/Chart.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+appVersion: "0.28.2"
+description: A Helm chart for Datawire Ambassador
+name: ambassador
+version: 0.1.0
+sources:
+- https://github.com/datawire/ambassador
+maintainers:
+  - name: stefanprodan
+    email: stefanprodan@users.noreply.github.com
+engine: gotpl

--- a/helm/ambassador/README.md
+++ b/helm/ambassador/README.md
@@ -1,0 +1,73 @@
+# Ambassador
+
+Ambassador is an open source, Kubernetes-native [microservices API gateway](https://www.getambassador.io/about/microservices-api-gateways) built on the [Envoy Proxy](https://www.envoyproxy.io/). 
+
+## TL;DR;
+
+```console
+$ helm repo add datawire https://www.getambassador.io
+$ helm install datawire/ambassador
+```
+
+## Introduction
+
+This chart bootstraps an [Ambassador](https://www.getambassador.io) deployment on 
+a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+
+## Prerequisites
+
+- Kubernetes 1.7+
+
+## Installing the Chart
+
+To install the chart with the release name `my-release`:
+
+```console
+$ helm install --name my-release datawire/ambassador
+```
+
+The command deploys Ambassador API gateway on the Kubernetes cluster in the default configuration. 
+The [configuration](#configuration) section lists the parameters that can be configured during installation.
+
+## Uninstalling the Chart
+
+To uninstall/delete the `my-release` deployment:
+
+```console
+$ helm delete --purge my-release
+```
+
+The command removes all the Kubernetes components associated with the chart and deletes the release.
+
+## Configuration
+
+The following tables lists the configurable parameters of the Ambassador chart and their default values.
+
+| Parameter                       | Description                                | Default                                                    |
+| ------------------------------- | ------------------------------------------ | ---------------------------------------------------------- |
+| `image` | Image | `quay.io/datawire/ambassador` 
+| `imageTag` | Image tag | `0.28.0` 
+| `imagePullPolicy` | Image pull policy | `IfNotPresent` 
+| `replicaCount`  | Number of Ambassador replicas  | `1` 
+| `resources` | CPU/memory resource requests/limits | None 
+| `rbac.create` | If `true`, create and use RBAC resources | `true`
+| `serviceAccount.create` | If `true`, create a new service account | `true`
+| `serviceAccount.name` | Service account to be used | `ambassador`
+| `service.type` | Service type to be used | `LoadBalancer`
+| `adminService.create` | If `true`, create a service for Ambassador's admin UI | `true`
+| `adminService.type` | Ambassador's admin service type to be used | `ClusterIP`
+| `exporter.image` | Prometheus exporter image | `datawire/prom-statsd-exporter:0.6.0`
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
+
+```console
+$ helm upgrade --install --wait --name my-release \
+    --set adminService.type=NodePort \
+    datawire/ambassador
+```
+
+Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,
+
+```console
+$ helm upgrade --install --wait --name my-release -f values.yaml datawire/ambassador
+```

--- a/helm/ambassador/README.md
+++ b/helm/ambassador/README.md
@@ -46,7 +46,7 @@ The following tables lists the configurable parameters of the Ambassador chart a
 | Parameter                       | Description                                | Default                                                    |
 | ------------------------------- | ------------------------------------------ | ---------------------------------------------------------- |
 | `image` | Image | `quay.io/datawire/ambassador` 
-| `imageTag` | Image tag | `0.28.0` 
+| `imageTag` | Image tag | `0.29.0` 
 | `imagePullPolicy` | Image pull policy | `IfNotPresent` 
 | `replicaCount`  | Number of Ambassador replicas  | `1` 
 | `resources` | CPU/memory resource requests/limits | None 
@@ -57,11 +57,14 @@ The following tables lists the configurable parameters of the Ambassador chart a
 | `adminService.create` | If `true`, create a service for Ambassador's admin UI | `true`
 | `adminService.type` | Ambassador's admin service type to be used | `ClusterIP`
 | `exporter.image` | Prometheus exporter image | `datawire/prom-statsd-exporter:0.6.0`
+| `timing.restart` | The minimum number of seconds between Envoy restarts | `15`
+| `timing.drain` | The number of seconds that the Envoy will wait for open connections to drain on a restart | `5`
+| `timing.shutdown` | The number of seconds that Ambassador will wait for the old Envoy to clean up and exit on a restart | `10`
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 
 ```console
-$ helm upgrade --install --wait --name my-release \
+$ helm upgrade --install --wait my-release \
     --set adminService.type=NodePort \
     datawire/ambassador
 ```
@@ -69,5 +72,5 @@ $ helm upgrade --install --wait --name my-release \
 Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,
 
 ```console
-$ helm upgrade --install --wait --name my-release -f values.yaml datawire/ambassador
+$ helm upgrade --install --wait my-release -f values.yaml datawire/ambassador
 ```

--- a/helm/ambassador/templates/NOTES.txt
+++ b/helm/ambassador/templates/NOTES.txt
@@ -1,0 +1,15 @@
+1. Get the application URL by running these commands:
+{{- if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "ambassador.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get svc -w {{ template "ambassador.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "ambassador.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "ambassador.name" . }},release={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl port-forward $POD_NAME 8080:80
+{{- end }}

--- a/helm/ambassador/templates/_helpers.tpl
+++ b/helm/ambassador/templates/_helpers.tpl
@@ -1,0 +1,43 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "ambassador.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "ambassador.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "ambassador.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "ambassador.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "ambassador.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}

--- a/helm/ambassador/templates/admin-service.yaml
+++ b/helm/ambassador/templates/admin-service.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.adminService.create -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "ambassador.fullname" . }}-admin
+  labels:
+    app: {{ template "ambassador.name" . }}
+    chart: {{ template "ambassador.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  type: {{ .Values.adminService.type }}
+  ports:
+    - port: 8877
+      targetPort: admin
+      protocol: TCP
+      name: admin
+  selector:
+    app: {{ template "ambassador.name" . }}
+    release: {{ .Release.Name }}
+{{- end -}}

--- a/helm/ambassador/templates/deployment.yaml
+++ b/helm/ambassador/templates/deployment.yaml
@@ -1,0 +1,72 @@
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  name: {{ template "ambassador.fullname" . }}
+  labels:
+    app: {{ template "ambassador.name" . }}
+    chart: {{ template "ambassador.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ template "ambassador.name" . }}
+      release: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "ambassador.name" . }}
+        release: {{ .Release.Name }}
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9102"
+    spec:
+      serviceAccountName: {{ template "ambassador.serviceAccountName" . }}
+      containers:
+        - name: statsd-sink
+          image: "{{ .Values.exporter.image }}"
+          ports:
+          - name: metrics
+            containerPort: 9102
+        - name: ambassador
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 80
+            - name: https
+              containerPort: 443
+            - name: admin
+              containerPort: 8877
+          env:
+          - name: AMBASSADOR_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          livenessProbe:
+            httpGet:
+              path: /ambassador/v0/check_alive
+              port: admin
+            initialDelaySeconds: 10
+            periodSeconds: 3
+          readinessProbe:
+            httpGet:
+              path: /ambassador/v0/check_ready
+              port: admin
+            initialDelaySeconds: 10
+            periodSeconds: 3
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+    {{- with .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}

--- a/helm/ambassador/templates/deployment.yaml
+++ b/helm/ambassador/templates/deployment.yaml
@@ -44,6 +44,12 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
+          - name: AMBASSADOR_RESTART_TIME
+            value: {{ .Values.timing.restart | quote }}
+          - name: AMBASSADOR_DRAIN_TIME
+            value: {{ .Values.timing.drain | quote }}
+          - name: AMBASSADOR_SHUTDOWN_TIME
+            value: {{ .Values.timing.shutdown | quote }}
           livenessProbe:
             httpGet:
               path: /ambassador/v0/check_alive

--- a/helm/ambassador/templates/deployment.yaml
+++ b/helm/ambassador/templates/deployment.yaml
@@ -48,13 +48,13 @@ spec:
             httpGet:
               path: /ambassador/v0/check_alive
               port: admin
-            initialDelaySeconds: 10
+            initialDelaySeconds: 30
             periodSeconds: 3
           readinessProbe:
             httpGet:
               path: /ambassador/v0/check_ready
               port: admin
-            initialDelaySeconds: 10
+            initialDelaySeconds: 30
             periodSeconds: 3
           resources:
 {{ toYaml .Values.resources | indent 12 }}

--- a/helm/ambassador/templates/rbac.yaml
+++ b/helm/ambassador/templates/rbac.yaml
@@ -1,0 +1,42 @@
+{{- if .Values.rbac.create -}}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: {{ template "ambassador.fullname" . }}
+  labels:
+    app: {{ template "ambassador.name" . }}
+    chart: {{ template "ambassador.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+rules:
+  - apiGroups: [""]
+    resources:
+    - services
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources:
+    - configmaps
+    verbs: ["create", "update", "patch", "get", "list", "watch"]
+  - apiGroups: [""]
+    resources:
+    - secrets
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ template "ambassador.fullname" . }}
+  labels:
+    app: {{ template "ambassador.name" . }}
+    chart: {{ template "ambassador.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "ambassador.fullname" . }}
+subjects:
+  - name: {{ template "ambassador.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace | quote }}
+    kind: ServiceAccount
+{{- end -}}

--- a/helm/ambassador/templates/service.yaml
+++ b/helm/ambassador/templates/service.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "ambassador.fullname" . }}
+  labels:
+    app: {{ template "ambassador.name" . }}
+    chart: {{ template "ambassador.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+    - port: 443
+      targetPort: https
+      protocol: TCP
+      name: https
+  selector:
+    app: {{ template "ambassador.name" . }}
+    release: {{ .Release.Name }}

--- a/helm/ambassador/templates/serviceaccount.yaml
+++ b/helm/ambassador/templates/serviceaccount.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "ambassador.serviceAccountName" . }}
+  labels:
+    app: {{ template "ambassador.name" . }}
+    chart: {{ template "ambassador.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+{{- end -}}

--- a/helm/ambassador/values.yaml
+++ b/helm/ambassador/values.yaml
@@ -46,3 +46,11 @@ affinity: {}
 
 exporter:
   image: datawire/prom-statsd-exporter:0.6.0
+
+timing:
+  # sets the minimum number of seconds between Envoy restarts
+  restart: 15
+  # sets the number of seconds that the Envoy will wait for open connections to drain on a restart
+  drain: 5
+  # sets the number of seconds that Ambassador will wait for the old Envoy to clean up and exit on a restart
+  shutdown: 10

--- a/helm/ambassador/values.yaml
+++ b/helm/ambassador/values.yaml
@@ -1,0 +1,48 @@
+# Default values for ambassador.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+image:
+  repository: quay.io/datawire/ambassador
+  tag: 0.28.0
+  pullPolicy: IfNotPresent
+
+service:
+  type: LoadBalancer
+  port: 80
+
+adminService:
+  create: true
+  type: ClusterIP
+
+rbac:
+  # Specifies whether RBAC resources should be created
+  create: true
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name:
+
+resources: {}
+  # If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #  cpu: 100m
+  #  memory: 128Mi
+  # requests:
+  #  cpu: 100m
+  #  memory: 128Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+exporter:
+  image: datawire/prom-statsd-exporter:0.6.0

--- a/helm/ambassador/values.yaml
+++ b/helm/ambassador/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: quay.io/datawire/ambassador
-  tag: 0.28.0
+  tag: 0.29.0
   pullPolicy: IfNotPresent
 
 service:


### PR DESCRIPTION
This PR adds a Helm chart to bootstrap Ambassador on Kubernetes.  Ref #65

I've tested it on GKE 1.9.3 with RBAC enabled, the default install will create the following:

* Ambassador deployment with one replica
* RBAC with a dedicated service account
* The deployment has Prometheus scraping annotations and statsd-sink runs as a sidecar
* A LoadBalancer service is used for 80 and 443 ports
* A ClusterIP service is used for port 8877 (admin UI)

In order to publish the chart on `getambassador.io` you have to run the following script in the root of the repo:

```bash
cd helm && helm package ambassador/
mv helm/ambassador-0.1.0.tgz docs/
helm repo index docs --url https://www.getambassador.io
```

This will create 2 files inside `/docs`, commit those files and publish the docs content on `getambassador.io`.

After `index.yaml` and `ambassador-0.1.0.tgz` have been published, this is how you can use the chart:

```bash
helm repo add datawire https://www.getambassador.io

helm upgrade --install --wait my-release \
 --set adminService.type=NodePort \
 datawire/ambassador
```

The chart configurable parameters are described in the readme.

| Parameter                       | Description                                | Default                                                    |
| ------------------------------- | ------------------------------------------ | ---------------------------------------------------------- |
| `image` | Image | `quay.io/datawire/ambassador` 
| `imageTag` | Image tag | `0.29.0` 
| `imagePullPolicy` | Image pull policy | `IfNotPresent` 
| `replicaCount`  | Number of Ambassador replicas  | `1` 
| `resources` | CPU/memory resource requests/limits | None 
| `rbac.create` | If `true`, create and use RBAC resources | `true`
| `serviceAccount.create` | If `true`, create a new service account | `true`
| `serviceAccount.name` | Service account to be used | `ambassador`
| `service.type` | Service type to be used | `LoadBalancer`
| `adminService.create` | If `true`, create a service for Ambassador's admin UI | `true`
| `adminService.type` | Ambassador's admin service type to be used | `ClusterIP`
| `exporter.image` | Prometheus exporter image | `datawire/prom-statsd-exporter:0.6.0`
| `timing.restart` | The minimum number of seconds between Envoy restarts | `15`
| `timing.drain` | The number of seconds that the Envoy will wait for open connections to drain on a restart | `5`
| `timing.shutdown` | The number of seconds that Ambassador will wait for the old Envoy to clean up and exit on a restart | `10`

In order to update the chart, change the `version` field inside `Chart.yaml` and run this script:

```bash
export VERSION=0.2.0
cd helm && helm package ambassador/
mv helm/ambassador-${VERSION}.tgz docs/
helm repo index docs --url https://www.getambassador.io --merge ./docs/index.yaml
```

The `merge` command will add the new version to the `index.yaml` file.

You can test the chart using my repo:

```
helm repo add sp https://stefanprodan.github.io/k8s-podinfo

helm upgrade --install --wait envoy sp/ambassador

kubectl apply -f https://raw.githubusercontent.com/stefanprodan/k8s-podinfo/master/deploy/ambassador-backends/blue-dep.yaml

kubectl apply -f https://raw.githubusercontent.com/stefanprodan/k8s-podinfo/master/deploy/ambassador-backends/blue-svc.yaml

export SERVICE_IP=$(kubectl get svc --namespace default envoy-ambassador -o jsonpath='{.status.loadBalancer.ingress[0].ip}')

curl -H "Host: podinfo.test" ${SERVICE_IP}
```