### PR TITLE
Extend default restart times and initial liveness/readiness check delays.

### DIFF
--- a/ambassador/entrypoint.sh
+++ b/ambassador/entrypoint.sh
@@ -9,7 +9,7 @@ if [ "$1" == "--demo" ]; then
     CONFIG_DIR="/etc/ambassador-demo-config"
 fi
 
-DELAY=${AMBASSADOR_RESTART_TIME:-5}
+DELAY=${AMBASSADOR_RESTART_TIME:-15}
 
 APPDIR=${APPDIR:-/application}
 

--- a/ambassador/start-envoy.sh
+++ b/ambassador/start-envoy.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
-DRAIN_TIME=${AMBASSADOR_DRAIN_TIME:-2}
-SHUTDOWN_TIME=${AMBASSADOR_SHUTDOWN_TIME:-3}
+DRAIN_TIME=${AMBASSADOR_DRAIN_TIME:-5}
+SHUTDOWN_TIME=${AMBASSADOR_SHUTDOWN_TIME:-10}
 
 LATEST=$(ls -1v /etc/envoy*.json | tail -1)
 exec /usr/local/bin/envoy -c ${LATEST} --restart-epoch $RESTART_EPOCH --drain-time-s "${DRAIN_TIME}" --parent-shutdown-time-s "${SHUTDOWN_TIME}"

--- a/templates/ambassador/ambassador-no-rbac.yaml
+++ b/templates/ambassador/ambassador-no-rbac.yaml
@@ -44,13 +44,13 @@ spec:
           httpGet:
             path: /ambassador/v0/check_alive
             port: 8877
-          initialDelaySeconds: 3
+          initialDelaySeconds: 30
           periodSeconds: 3
         readinessProbe:
           httpGet:
             path: /ambassador/v0/check_ready
             port: 8877
-          initialDelaySeconds: 3
+          initialDelaySeconds: 30
           periodSeconds: 3
       - name: statsd
         image: {STREG}statsd:{VERSION}

--- a/templates/ambassador/ambassador-rbac-prometheus.yaml
+++ b/templates/ambassador/ambassador-rbac-prometheus.yaml
@@ -81,13 +81,13 @@ spec:
           httpGet:
             path: /ambassador/v0/check_alive
             port: 8877
-          initialDelaySeconds: 3
+          initialDelaySeconds: 30
           periodSeconds: 3
         readinessProbe:
           httpGet:
             path: /ambassador/v0/check_ready
             port: 8877
-          initialDelaySeconds: 3
+          initialDelaySeconds: 30
           periodSeconds: 3
       - name: statsd-sink
         image: datawire/prom-statsd-exporter:0.6.0

--- a/templates/ambassador/ambassador-rbac.yaml
+++ b/templates/ambassador/ambassador-rbac.yaml
@@ -81,13 +81,13 @@ spec:
           httpGet:
             path: /ambassador/v0/check_alive
             port: 8877
-          initialDelaySeconds: 3
+          initialDelaySeconds: 30
           periodSeconds: 3
         readinessProbe:
           httpGet:
             path: /ambassador/v0/check_ready
             port: 8877
-          initialDelaySeconds: 3
+          initialDelaySeconds: 30
           periodSeconds: 3
       - name: statsd
         image: {STREG}statsd:{VERSION}


### PR DESCRIPTION
`AMBASSADOR_RESTART_TIME`: 5 => 15s
`AMBASSADOR_DRAIN_TIME`: 2 => 5s
`AMBASSADOR_SHUTDOWN_TIME`: 3 => 10s

and default the readiness and liveness initial wait time to 30s as well.

