### PR TITLE
[MINOR] Ambassador 0.29

### DIFF
--- a/ambassador/ambassador/mapping.py
+++ b/ambassador/ambassador/mapping.py
@@ -42,6 +42,7 @@ class Mapping (object):
     TransparentRouteKeys = {
         "auto_host_rewrite": True,
         "case_sensitive": True,
+        "envoy_override": True,
         "host_redirect": True,
         "host_rewrite": True,
         "path_redirect": True,

--- a/ambassador/entrypoint.sh
+++ b/ambassador/entrypoint.sh
@@ -9,7 +9,7 @@ if [ "$1" == "--demo" ]; then
     CONFIG_DIR="/etc/ambassador-demo-config"
 fi
 
-DELAY=${AMBASSADOR_RESTART_TIME:-5}
+DELAY=${AMBASSADOR_RESTART_TIME:-15}
 
 APPDIR=${APPDIR:-/application}
 

--- a/ambassador/start-envoy.sh
+++ b/ambassador/start-envoy.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
-DRAIN_TIME=${AMBASSADOR_DRAIN_TIME:-2}
-SHUTDOWN_TIME=${AMBASSADOR_SHUTDOWN_TIME:-3}
+DRAIN_TIME=${AMBASSADOR_DRAIN_TIME:-5}
+SHUTDOWN_TIME=${AMBASSADOR_SHUTDOWN_TIME:-10}
 
 LATEST=$(ls -1v /etc/envoy*.json | tail -1)
 exec /usr/local/bin/envoy -c ${LATEST} --restart-epoch $RESTART_EPOCH --drain-time-s "${DRAIN_TIME}" --parent-shutdown-time-s "${SHUTDOWN_TIME}"

--- a/ambassador/tests/001-broader-v0/gold.intermediate.json
+++ b/ambassador/tests/001-broader-v0/gold.intermediate.json
@@ -845,6 +845,18 @@
                         "weight": 100.0
                     }
                 ],
+                "envoy_override": {
+                    "request_headers_to_add": [
+                        {
+                            "key": "test",
+                            "value": "%PROTOCOL%"
+                        },
+                        {
+                            "key": "test-2",
+                            "value": "testing"
+                        }
+                    ]
+                },
                 "host_rewrite": "google.com",
                 "prefix": "/google/",
                 "prefix_rewrite": "/"

--- a/ambassador/tests/001-broader-v0/gold.json
+++ b/ambassador/tests/001-broader-v0/gold.json
@@ -149,7 +149,11 @@
                                  { "name": "cluster_https___google_com_otls", "weight": 100.0 }
                               
                           ]
-                      }
+                      },
+                      
+                        
+                        "request_headers_to_add": [{"key": "test", "value": "%PROTOCOL%"}, {"key": "test-2", "value": "testing"}]
+                        
                       
                     }
                     ,

--- a/docs/about/features-and-benefits.md
+++ b/docs/about/features-and-benefits.md
@@ -5,6 +5,7 @@ Key features in Ambassador include:
 * Self-service mapping of public URLs to services running inside a Kubernetes cluster
 * Flexible canary deployments
 * Kubernetes-native architecture (also, no need for a dedicated Kubernetes ingress controller)
+* Load balancing
 * First class gRPC and HTTP/2 support
 * Istio integration
 * Authentication
@@ -13,7 +14,6 @@ Key features in Ambassador include:
 * Simple setup and configuration
 * Integrated monitoring
 * Open source
-
 
 ## Self-Service via Kubernetes Annotations
 

--- a/docs/about/why-ambassador.md
+++ b/docs/about/why-ambassador.md
@@ -1,6 +1,6 @@
 # Why Ambassador?
 
-Ambassador is an open source, Kubernetes-native [microservices API gateway](microservices-api-gateways) built on the [Envoy Proxy](https://www.envoyproxy.io). Ambassador is built from the ground up to support multiple, independent teams that need to rapidly publish, monitor, and update services for end users. Ambassador can also be used to handle the functions of a Kubernetes ingress controller (for more, see [this blog post](https://blog.getambassador.io/kubernetes-ingress-nodeport-load-balancers-and-ingress-controllers-6e29f1c44f2d)).
+Ambassador is an open source, Kubernetes-native [microservices API gateway](microservices-api-gateways) built on the [Envoy Proxy](https://www.envoyproxy.io). Ambassador is built from the ground up to support multiple, independent teams that need to rapidly publish, monitor, and update services for end users. Ambassador can also be used to handle the functions of a Kubernetes ingress controller and load balancer (for more, see [this blog post](https://blog.getambassador.io/kubernetes-ingress-nodeport-load-balancers-and-ingress-controllers-6e29f1c44f2d)).
 
 Ambassador is:
 
@@ -16,7 +16,7 @@ Alternatives to Ambassador fall in three basic categories.
 
 * Hosted API gateways, such as the [Amazon API gateway](https://aws.amazon.com/api-gateway/).
 * Traditional API gateways, such as [Kong](https://getkong.org/).
-* L7 proxies, such as [Traefik](https://traefik.io/), [NGINX](http://nginx.org/), [HAProxy](http://www.haproxy.org/), or [Envoy](https://envoyproxy.github.io).
+* L7 proxies, such as [Traefik](https://traefik.io/), [NGINX](http://nginx.org/), [HAProxy](http://www.haproxy.org/), or [Envoy](https://www.envoyproxy.io), or Ingress controllers built on these proxies.
 
 Both hosted API gateways and traditional API gateways are:
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -8,7 +8,7 @@
 
     <title>Kubernetes-native microservices API gateway: Ambassador</title>
     <meta name="description" content="Ambassador, open source, Kubernetes-native API Gateway for microservices built on Envoy">
-    <meta name="keywords" content="Ambassador, Envoy, Kubernetes, microservices, open source, API Gateway, Kubernetes ingress">
+    <meta name="keywords" content="Ambassador, Envoy, Kubernetes, microservices, open source, API Gateway, Kubernetes ingress, Kubernetes load balancer">
     <meta name="author" content="Datawire.io">
 
     <link rel="shortcut icon" href="/favicon.ico">
@@ -100,7 +100,7 @@
                 </ul>
                 <div class="tab-content font-light text-white">
                     <div id="routing">
-                        <p>Map services to arbitrary URLs in a single, declarative YAML file. Configure routes with CORS support, circuit breakers, timeouts, and more. Replace your Kubernetes ingress controller. Route gRPC, WebSockets, or HTTP.</p>
+                        <p>Map services to arbitrary URLs in a single, declarative YAML file. Configure routes with CORS support, circuit breakers, timeouts, and more. Replace your Kubernetes ingress controller. Route gRPC, WebSockets, or HTTP. Load balance between your different services.</p>
                     </div>
                     <div id="authentication">
                         <p>

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -18,34 +18,6 @@ Ambassador assembles its configuration from YAML blocks that may be stored:
 
 The data contained within each YAML block is the same no matter where the blocks are stored, and multiple YAML documents are likewise supported no matter where the blocks are stored.
 
-## Namespaces
-
-Ambassador supports multiple namespaces within Kubernetes. To make this work correctly, you need to set the `AMBASSADOR_NAMESPACE` environment variable in Ambassador's container. By far the easiest way to do this is using Kubernetes' downward API (this is included in the YAML files from `getambassador.io`):
-
-```yaml
-        env:
-        - name: AMBASSADOR_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace          
-```
-
-Given that `AMBASSADOR_NAMESPACE` is set, Ambassador [mappings](#mapping) can operate within the same namespace, or across namespaces. **Note well** that mappings will have to explictly include the namespace with the service to cross namespaces; see the [mapping](#mappings) documentation for more information.
-
-If you only want Ambassador to only work within a single namespace, set `AMBASSADOR_SINGLE_NAMESPACE` as an environment variable.
-
-## Reconfiguration Timing Configuration
-
-Ambassador is constantly watching for changes to the service annotations. When changes are observed, Ambassador generates a new Envoy configuration and restarts the Envoy handling the heavy lifting of routing. Three environment variables provide control over the timing of this reconfiguration:
-
-- `AMBASSADOR_RESTART_TIME` (default 5) sets the minimum number of seconds between restarts. No matter how often services are changed, Ambassador will never restart Envoy more frequently than this.
-
-- `AMBASSADOR_DRAIN_TIME` (default 2) sets the number of seconds that the Envoy will wait for open connections to drain on a restart. Connections still open at the end of this time will be summarily dropped.
-
-- `AMBASSADOR_SHUTDOWN_TIME` (default 3) sets the number of seconds that Ambassador will wait for the old Envoy to clean up and exit on a restart. **If Envoy is not able to shut down in this time, the Ambassador pod will exit.** If this happens, it is generally indicative of issues with restarts being attempted too often.
-
-These environment variables can be set much like `AMBASSADOR_NAMESPACE`, above.
-
 ## Best Practices for Configuration
 
 Ambassador's configuration is assembled from multiple YAML blocks, to help enable self-service routing and make it easier for multiple developers to collaborate on a single larger application. This implies a few things:

--- a/docs/reference/running.md
+++ b/docs/reference/running.md
@@ -30,11 +30,11 @@ If you only want Ambassador to only work within a single namespace, set `AMBASSA
 
 Ambassador is constantly watching for changes to the service annotations. When changes are observed, Ambassador generates a new Envoy configuration and restarts the Envoy handling the heavy lifting of routing. Three environment variables provide control over the timing of this reconfiguration:
 
-- `AMBASSADOR_RESTART_TIME` (default 5) sets the minimum number of seconds between restarts. No matter how often services are changed, Ambassador will never restart Envoy more frequently than this.
+- `AMBASSADOR_RESTART_TIME` (default 15) sets the minimum number of seconds between restarts. No matter how often services are changed, Ambassador will never restart Envoy more frequently than this.
 
-- `AMBASSADOR_DRAIN_TIME` (default 2) sets the number of seconds that the Envoy will wait for open connections to drain on a restart. Connections still open at the end of this time will be summarily dropped.
+- `AMBASSADOR_DRAIN_TIME` (default 5) sets the number of seconds that the Envoy will wait for open connections to drain on a restart. Connections still open at the end of this time will be summarily dropped.
 
-- `AMBASSADOR_SHUTDOWN_TIME` (default 3) sets the number of seconds that Ambassador will wait for the old Envoy to clean up and exit on a restart. **If Envoy is not able to shut down in this time, the Ambassador pod will exit.** If this happens, it is generally indicative of issues with restarts being attempted too often.
+- `AMBASSADOR_SHUTDOWN_TIME` (default 10) sets the number of seconds that Ambassador will wait for the old Envoy to clean up and exit on a restart. **If Envoy is not able to shut down in this time, the Ambassador pod will exit.** If this happens, it is generally indicative of issues with restarts being attempted too often.
 
 These environment variables can be set much like `AMBASSADOR_NAMESPACE`, above.
 

--- a/docs/reference/running.md
+++ b/docs/reference/running.md
@@ -1,5 +1,7 @@
 # Running Ambassador
 
+This section is intended for operators running Ambassador, and covers various aspects of deploying and configuring Ambassador in production.
+
 ## Ambassador and Kubernetes
 
 Ambassador relies on Kubernetes for reliability, availability, and scalability. This means that features such as Kubernetes readiness and liveness probes, rolling updates, and the Horizontal Pod Autoscaling should be utilized to manage Ambassador.
@@ -7,6 +9,34 @@ Ambassador relies on Kubernetes for reliability, availability, and scalability. 
 ## Default configuration
 
 The default configuration of Ambassador includes default [resource limits](https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/#resource-requests-and-limits-of-pod-and-container), as well as [readiness and liveness probes](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/). These values should be adjusted for your specific environment.
+
+## Namespaces
+
+Ambassador supports multiple namespaces within Kubernetes. To make this work correctly, you need to set the `AMBASSADOR_NAMESPACE` environment variable in Ambassador's container. By far the easiest way to do this is using Kubernetes' downward API (this is included in the YAML files from `getambassador.io`):
+
+```yaml
+        env:
+        - name: AMBASSADOR_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace          
+```
+
+Given that `AMBASSADOR_NAMESPACE` is set, Ambassador [mappings](#mapping) can operate within the same namespace, or across namespaces. **Note well** that mappings will have to explictly include the namespace with the service to cross namespaces; see the [mapping](#mappings) documentation for more information.
+
+If you only want Ambassador to only work within a single namespace, set `AMBASSADOR_SINGLE_NAMESPACE` as an environment variable.
+
+## Reconfiguration Timing Configuration
+
+Ambassador is constantly watching for changes to the service annotations. When changes are observed, Ambassador generates a new Envoy configuration and restarts the Envoy handling the heavy lifting of routing. Three environment variables provide control over the timing of this reconfiguration:
+
+- `AMBASSADOR_RESTART_TIME` (default 5) sets the minimum number of seconds between restarts. No matter how often services are changed, Ambassador will never restart Envoy more frequently than this.
+
+- `AMBASSADOR_DRAIN_TIME` (default 2) sets the number of seconds that the Envoy will wait for open connections to drain on a restart. Connections still open at the end of this time will be summarily dropped.
+
+- `AMBASSADOR_SHUTDOWN_TIME` (default 3) sets the number of seconds that Ambassador will wait for the old Envoy to clean up and exit on a restart. **If Envoy is not able to shut down in this time, the Ambassador pod will exit.** If this happens, it is generally indicative of issues with restarts being attempted too often.
+
+These environment variables can be set much like `AMBASSADOR_NAMESPACE`, above.
 
 ## Diagnostics
 

--- a/docs/reference/statistics.md
+++ b/docs/reference/statistics.md
@@ -40,7 +40,7 @@ If you don't already have a Prometheus setup, the [Prometheus operator](https://
 - [`prometheus.yaml`](https://github.com/datawire/ambassador/blob/master/statsd-sink/prometheus/prometheus.yaml) creates a `Prometheus` object that collects data from the `ServiceMonitor` specified
 - [`ambassador-rbac-prometheus.yaml`](https://www.getambassador.io/yaml/ambassador/ambassador-rbac-prometheus.yaml) is an example Ambassador deployment that includes the Prometheus `statsd` exporter. The statsd exporter collects the stats data from Ambassador, translates it to Prometheus metrics, and is picked up by the Operator using the configurations above.
 
-A walk-through of the basics of configuring the Prometheus operator with Ambassador and Envoy is available [here](http://www.datawire.io/faster/ambassador-prometheus/).
+Make sure that the `ServiceMonitor` is in the same namespace as Ambassador. A walk-through of the basics of configuring the Prometheus operator with Ambassador and Envoy is available [here](http://www.datawire.io/faster/ambassador-prometheus/).
 
 ### StatsD as an Independent Deployment
 

--- a/docs/user-guide/with-istio.md
+++ b/docs/user-guide/with-istio.md
@@ -4,7 +4,7 @@
 
 Ambassador is a Kubernetes-native API gateway for microservices. Ambassador is deployed at the edge of your network, and routes incoming traffic to your internal services (aka "north-south" traffic).  [Istio](https://istio.io/) is a service mesh for microservices, and is designed to add application-level Layer (L7) observability, routing, and resilience to service-to-service traffic (aka "east-west" traffic). Both Istio and Ambassador are built using [Envoy](https://www.envoyproxy.io).
 
-Ambassador and Istio can be deployed together on Kubernetes. In this configuration, incoming traffic from outside the cluster is first routed through Ambassador, which then routes the traffic to Istio. Ambassador handles authentication, edge routing, TLS termination, and other traditional edge functions.
+Ambassador and Istio can be deployed together on Kubernetes. In this configuration, incoming traffic from outside the cluster is first routed through Ambassador, which then routes the traffic to Istio-powered services. Ambassador handles authentication, edge routing, TLS termination, and other traditional edge functions.
 
 This allows the operator to have the best of both worlds: a high performance, modern edge service (Ambassador) combined with a state-of-the-art service mesh (Istio). Istio's basic [ingress controller](https://istio.io/docs/tasks/traffic-management/ingress.html) is very limited, and has no support for authentication or many of the other features of Ambassador.
 
@@ -157,3 +157,7 @@ kubectl apply -f <(istioctl kube-inject -f samples/bookinfo/kube/bookinfo.yaml)
 ## Automatic Sidecar Injection
 
 Newer versions of Istio support Kubernetes initializers to [automatically inject the Istio sidecar](https://istio.io/docs/setup/kubernetes/sidecar-injection.html#automatic-sidecar-injection). With Ambassador, you don't need to inject the Istio sidecar -- Ambassador's Envoy instance will automatically route to the appropriate service(s). If you're using automatic sidecar injection, you'll need to configure Istio to not inject the sidecar automatically for Ambassador pods. There are several approaches to doing this that are [explained in the documentation](https://istio.io/docs/setup/kubernetes/sidecar-injection.html#configuration-options).
+
+## Roadmap
+
+There are a number of roadmap items that we'd like to tackle in improving Istio integration. This includes supporting Istio routing rules in Ambassador, mTLS for end-to-end TLS encryption, and full propagation of request headers (e.g., Zipkin tracing) between Ambassador and Istio. If you're interested in contributing, we'd welcome the help!

--- a/end-to-end/ambassador-no-mounts.yaml
+++ b/end-to-end/ambassador-no-mounts.yaml
@@ -1,4 +1,19 @@
 ---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    service: ambassador-admin
+  name: ambassador-admin
+spec:
+  type: NodePort
+  ports:
+  - name: ambassador-admin
+    port: 8877
+    targetPort: 8877
+  selector:
+    app: ambassador
+---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
@@ -12,6 +27,10 @@ rules:
   resources:
   - configmaps
   verbs: ["create", "update", "patch", "get", "list", "watch"]
+- apiGroups: [""]
+  resources:
+  - secrets
+  verbs: ["get", "list", "watch"]
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -37,37 +56,32 @@ metadata:
   name: ambassador
 spec:
   replicas: 1
-  selector:
-    matchLabels:
-      app: ambassador
-  strategy:
-    rollingUpdate:
-      maxSurge: 1
-      maxUnavailable: 0
-    type: RollingUpdate
-  revisionHistoryLimit: 1
   template:
     metadata:
       labels:
         app: ambassador
-      name: ambassador
     spec:
       serviceAccountName: ambassador
-      containers:
-      - image: {AMREG}ambassador:{VERSION}
-        imagePullPolicy: Always
-        name: ambassador
-        resources:
-          requests:
-            memory: 0.1G
-            cpu: 0.1
-          limits:
-            memory: 0.25G
-            cpu: 0.25
-        terminationMessagePath: /dev/termination-log
-      # - name: statsd-exporter
-      #   image: prom/statsd-exporter
-      restartPolicy: Always
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       terminationGracePeriodSeconds: 30
+      containers:
+      - name: ambassador
+        image: {AMREG}ambassador:{VERSION}
+        imagePullPolicy: Always
+        resources:
+          limits:
+            cpu: 1
+            memory: 400Mi
+          requests:
+            cpu: 200m
+            memory: 100Mi
+        env:
+        - name: AMBASSADOR_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace          
+        terminationMessagePath: /dev/termination-log
+      - name: statsd
+        image: {STREG}statsd:{VERSION}
+        imagePullPolicy: Always

--- a/end-to-end/ambassador-with-mounts.yaml
+++ b/end-to-end/ambassador-with-mounts.yaml
@@ -1,4 +1,19 @@
 ---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    service: ambassador-admin
+  name: ambassador-admin
+spec:
+  type: NodePort
+  ports:
+  - name: ambassador-admin
+    port: 8877
+    targetPort: 8877
+  selector:
+    app: ambassador
+---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
@@ -12,6 +27,10 @@ rules:
   resources:
   - configmaps
   verbs: ["create", "update", "patch", "get", "list", "watch"]
+- apiGroups: [""]
+  resources:
+  - secrets
+  verbs: ["get", "list", "watch"]
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -53,25 +72,34 @@ spec:
       name: ambassador
     spec:
       serviceAccountName: ambassador
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      terminationGracePeriodSeconds: 30
       containers:
-      - image: {AMREG}ambassador:{VERSION}
+      - name: ambassador
+        image: {AMREG}ambassador:{VERSION}
         imagePullPolicy: Always
-        name: ambassador
         resources:
-          requests:
-            memory: 0.1G
-            cpu: 0.1
           limits:
-            memory: 0.25G
-            cpu: 0.25
-        terminationMessagePath: /dev/termination-log
+            cpu: 1
+            memory: 400Mi
+          requests:
+            cpu: 200m
+            memory: 100Mi
+        env:
+        - name: AMBASSADOR_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace          
         volumeMounts:
         - name: termination-certs
           mountPath: /etc/certs/termination
         - name: upstream-certs
           mountPath: /etc/certs/upstream
-      # - name: statsd-exporter
-      #   image: prom/statsd-exporter
+        terminationMessagePath: /dev/termination-log
+      - name: statsd
+        image: {STREG}statsd:{VERSION}
+        imagePullPolicy: Always
       volumes:
       - name: termination-certs
         secret:
@@ -79,7 +107,3 @@ spec:
       - name: upstream-certs
         secret:
           secretName: ambassador-certs-upstream
-      restartPolicy: Always
-      dnsPolicy: ClusterFirst
-      restartPolicy: Always
-      terminationGracePeriodSeconds: 30

--- a/end-to-end/buildall.sh
+++ b/end-to-end/buildall.sh
@@ -7,6 +7,7 @@ docker build -q -t dwflynn/demo:1.0.0tls --build-arg VERSION=1.0.0 --build-arg T
 docker build -q -t dwflynn/demo:2.0.0tls --build-arg VERSION=2.0.0 --build-arg TLS=--tls demo-service
 docker build -q -t dwflynn/auth:0.0.1 auth-service
 docker build -q -t dwflynn/auth:0.0.1tls --build-arg TLS=--tls auth-service
+docker build -q -t dwflynn/stats-test:0.0.1 stats-test-service
 
 # seriously? there's no docker push --quiet???
 docker push dwflynn/demo:1.0.0 | python linify.py push.log
@@ -15,4 +16,5 @@ docker push dwflynn/demo:1.0.0tls | python linify.py push.log
 docker push dwflynn/demo:2.0.0tls | python linify.py push.log
 docker push dwflynn/auth:0.0.1 | python linify.py push.log
 docker push dwflynn/auth:0.0.1tls | python linify.py push.log
+docker push dwflynn/stats-test:0.0.1 | python linify.py push.log
 set +x

--- a/end-to-end/stats-test-service/Dockerfile
+++ b/end-to-end/stats-test-service/Dockerfile
@@ -1,0 +1,42 @@
+FROM ubuntu:14.04
+
+MAINTAINER Datawire <flynn@datawire.io>
+LABEL PROJECT_REPO_URL         = "git@github.com:datawire/ambassador.git" \
+      PROJECT_REPO_BROWSER_URL = "https://github.com/datawire/ambassador" \
+      DESCRIPTION              = "Ambassador REST Service" \
+      VENDOR                   = "Datawire" \
+      VENDOR_URL               = "https://datawire.io/"
+
+# This Dockerfile is set up to install all the application-specific stuff into
+# /application.
+#
+# NOTE: If you don't know what you're doing, it's probably a mistake to
+# blindly hack up this file.
+
+# We need curl, pip, and dnsutils (for nslookup).
+RUN apt-get update && apt-get -q install -y \
+    curl \
+    python3-pip \
+    dnsutils
+
+# Set WORKDIR to /application which is the root of all our apps then COPY
+# only requirements.txt to avoid screwing up Docker caching and causing a
+# full reinstall of all dependencies when dependencies are not changed.
+
+WORKDIR /application
+COPY requirements.txt .
+
+# Install application dependencies
+RUN pip3 install -r requirements.txt
+
+# COPY the app code and configuration into place, then perform any final
+# configuration steps.
+
+COPY stats-test.py ./
+
+# COPY the entrypoint script and make it runnable.
+COPY entrypoint.sh .
+RUN chmod 755 entrypoint.sh
+
+ENTRYPOINT ./entrypoint.sh
+

--- a/end-to-end/stats-test-service/entrypoint.sh
+++ b/end-to-end/stats-test-service/entrypoint.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+export LC_ALL=C.UTF-8
+export LANG=C.UTF-8
+
+APPDIR=${APPDIR:-/application}
+
+env | grep V
+echo "STATS-TEST: args $@"
+
+pids=()
+
+handle_chld() {
+    local tmp=()
+
+    for (( i=0; i<${#pids[@]}; ++i )); do
+        split=(${pids[$i]//;/ })    # the space after the trailing / is critical!
+        pid=${split[0]}
+        name=${split[1]}
+
+        if [ ! -d /proc/$pid ]; then
+            wait $pid
+            echo "AUTH: $name exited: $?"
+            echo "AUTH: shutting down"
+            exit 1
+        else
+            tmp+=(${pids[i]})
+        fi
+    done
+
+    pids=(${tmp[@]})
+}
+
+set -o monitor
+trap "handle_chld" CHLD
+
+ROOT=$$
+
+echo "STATS-TEST: starting stats-test service"
+/usr/bin/python3 "$APPDIR/stats-test.py" "$@" &
+pids+=("$!;stats-test")
+
+echo "STATS-TEST: waiting"
+wait
+

--- a/end-to-end/stats-test-service/requirements.txt
+++ b/end-to-end/stats-test-service/requirements.txt
@@ -1,0 +1,7 @@
+clize==4.0.1
+flask==0.11.1
+jinja2==2.9.6
+jsonschema==2.6.0
+pyyaml==3.12
+scout.py==0.3.0
+semantic-version==2.6.0

--- a/end-to-end/stats-test-service/stats-test.py
+++ b/end-to-end/stats-test-service/stats-test.py
@@ -1,0 +1,59 @@
+import sys
+
+import json
+import socket
+
+UDP_IP = "0.0.0.0"
+UDP_PORT = 8125
+
+sock = socket.socket(socket.AF_INET, # Internet
+                     socket.SOCK_DGRAM) # UDP
+sock.bind((UDP_IP, UDP_PORT))
+
+sys.stdout.write("Listening on %d\n" % UDP_PORT)
+sys.stdout.flush()
+
+interesting = {
+    'envoy.cluster.cluster_qotm.upstream_rq_time': 0,
+    'envoy.cluster.cluster_qotm.upstream_rq_total': 0,
+    'envoy.cluster.cluster_qotm.upstream_rq_2xx': 0
+}
+
+recvd = 0
+
+while True:
+    data, addr = sock.recvfrom(1024) # buffer size is 1024 bytes
+
+    data = data.decode('utf-8').strip()
+    peer_ip, peer_port = addr
+
+    if data == 'DUMP':
+        sock.sendto(json.dumps(interesting).encode("utf-8"), addr)
+    else:
+        recvd += 1
+
+        try:
+            (key, rest) = data.split(':')
+            (value, kind) = rest.split('|')
+
+            if key not in interesting:
+                continue
+            
+            interesting[key] += int(value)
+        except Exception:
+            continue
+    
+        if (recvd % 60) == 0:
+            trq = interesting['envoy.cluster.cluster_qotm.upstream_rq_total']
+            grq = interesting['envoy.cluster.cluster_qotm.upstream_rq_2xx']
+            ttm = interesting['envoy.cluster.cluster_qotm.upstream_rq_time']
+
+            if trq > 0:
+                ttm = ", %.1f ms avg" % (ttm / trq)
+            else:
+                ttm = ""
+
+            sys.stdout.write("Requests: %d (%d good)%s\n" % (trq, grq, ttm))
+            sys.stdout.flush()
+
+

--- a/end-to-end/stats-test.yaml
+++ b/end-to-end/stats-test.yaml
@@ -1,0 +1,35 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: statsd-sink
+spec:
+  selector:
+    app: stats-test
+  ports:
+    - port: 8125
+      targetPort: statsd-api
+      protocol: UDP
+  type: ClusterIP
+---
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: stats-test
+spec:
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: stats-test
+    spec:
+      containers:
+      - name: stats-test
+        image: dwflynn/stats-test:0.0.2
+        imagePullPolicy: Always
+        ports:
+        - name: statsd-api
+          containerPort: 8125
+          protocol: UDP

--- a/end-to-end/utils.sh
+++ b/end-to-end/utils.sh
@@ -173,7 +173,7 @@ check_diag () {
     index=$2
     desc=$3
 
-    sleep 5
+    sleep 20
 
     rc=1
 

--- a/statsd/Dockerfile
+++ b/statsd/Dockerfile
@@ -1,4 +1,4 @@
-FROM mhart/alpine-node:7
+FROM mhart/alpine-node:9
 
 WORKDIR /application
 RUN npm install https://api.github.com/repos/etsy/statsd/tarball/8d5363c

--- a/templates/ambassador/ambassador-no-rbac.yaml
+++ b/templates/ambassador/ambassador-no-rbac.yaml
@@ -44,13 +44,13 @@ spec:
           httpGet:
             path: /ambassador/v0/check_alive
             port: 8877
-          initialDelaySeconds: 3
+          initialDelaySeconds: 30
           periodSeconds: 3
         readinessProbe:
           httpGet:
             path: /ambassador/v0/check_ready
             port: 8877
-          initialDelaySeconds: 3
+          initialDelaySeconds: 30
           periodSeconds: 3
       - name: statsd
         image: {STREG}statsd:{VERSION}

--- a/templates/ambassador/ambassador-rbac-prometheus.yaml
+++ b/templates/ambassador/ambassador-rbac-prometheus.yaml
@@ -81,13 +81,13 @@ spec:
           httpGet:
             path: /ambassador/v0/check_alive
             port: 8877
-          initialDelaySeconds: 3
+          initialDelaySeconds: 30
           periodSeconds: 3
         readinessProbe:
           httpGet:
             path: /ambassador/v0/check_ready
             port: 8877
-          initialDelaySeconds: 3
+          initialDelaySeconds: 30
           periodSeconds: 3
       - name: statsd-sink
         image: datawire/prom-statsd-exporter:0.6.0

--- a/templates/ambassador/ambassador-rbac.yaml
+++ b/templates/ambassador/ambassador-rbac.yaml
@@ -81,13 +81,13 @@ spec:
           httpGet:
             path: /ambassador/v0/check_alive
             port: 8877
-          initialDelaySeconds: 3
+          initialDelaySeconds: 30
           periodSeconds: 3
         readinessProbe:
           httpGet:
             path: /ambassador/v0/check_ready
             port: 8877
-          initialDelaySeconds: 3
+          initialDelaySeconds: 30
           periodSeconds: 3
       - name: statsd
         image: {STREG}statsd:{VERSION}


### PR DESCRIPTION
- Default restart timings have been increased. **This will cause Ambassador to response to service changes less quickly**; by default, you'll see changes appear within 15 seconds.
- LIveness and readiness checks are enabled after 30 seconds, rather than 3 seconds, if you use our published YAML.
- The `statsd` container is now based on `mhart/alpine-node:9` rather than `:7`. **Note well** that the `statsd` container will probably be dropped from our published YAML soon; consider switching now to local YAML if you use it.
- `envoy_override` has been reenabled.