### PR TITLE
use soct to forward statsd udp 

### DIFF
--- a/socat/Dockerfile
+++ b/socat/Dockerfile
@@ -1,0 +1,5 @@
+FROM alpine:3.7
+
+RUN apk --update add socat
+
+CMD ["socat", "-d", "-d", "UDP-RECVFROM:8125,fork", "UDP-SENDTO:statsd-sink:8125"]


### PR DESCRIPTION
This is a possible fix for #315. We switch to socat for UDP forwarding. When I tested this in a cluster without `statsd-sink` I see a bunch of this in the logs:

```
2018/03/22 19:26:14 socat[1] N receiving on AF=2 0.0.0.0:8125
2018/03/22 19:26:14 socat[1] N receiving packet from AF=2 127.0.0.1:45989
2018/03/22 19:26:14 socat[1] N forked off child process 15942
2018/03/22 19:26:14 socat[15942] E getaddrinfo("statsd-sink", "NULL", {1,0,2,17}, {}): Name does not resolve
2018/03/22 19:26:14 socat[15942] N exit(1)
2018/03/22 19:26:14 socat[1] N receiving on AF=2 0.0.0.0:8125
2018/03/22 19:26:14 socat[1] N receiving packet from AF=2 127.0.0.1:45989
2018/03/22 19:26:14 socat[1] N forked off child process 15943
2018/03/22 19:26:14 socat[15943] E getaddrinfo("statsd-sink", "NULL", {1,0,2,17}, {}): Name does not resolve
2018/03/22 19:26:14 socat[15943] N exit(1)
2018/03/22 19:26:14 socat[1] N receiving on AF=2 0.0.0.0:8125
2018/03/22 19:26:14 socat[1] N receiving packet from AF=2 127.0.0.1:45989
2018/03/22 19:26:14 socat[1] N forked off child process 15944
2018/03/22 19:26:14 socat[15944] E getaddrinfo("statsd-sink", "NULL", {1,0,2,17}, {}): Name does not resolve
2018/03/22 19:26:14 socat[15944] N exit(1)
2018/03/22 19:26:14 socat[1] N receiving on AF=2 0.0.0.0:8125
2018/03/22 19:26:14 socat[1] N receiving packet from AF=2 127.0.0.1:45989
2018/03/22 19:26:14 socat[1] N forked off child process 15945
```

I'm going to let this run overnight to see if the `socat` process grows (currently it's 14MB).