### PR TITLE
Fix TLS name-conflict bug

### DIFF
--- a/ambassador/ambassador/config.py
+++ b/ambassador/ambassador/config.py
@@ -683,8 +683,7 @@ class Config (object):
                 name_fields = [ 'otls', context ]
                 originate_tls = context
             else:
-                self.logger.error("Originate-TLS context %s is not defined (mapping %s)" %
-                                  (context, mapping_name))
+                self.logger.error("Originate-TLS context %s is not defined" % context)
 
         port = 443 if originate_tls else 80
         context_name = "_".join(name_fields) if name_fields else None
@@ -742,6 +741,9 @@ class Config (object):
         # ...most notably the 'ambassador' and 'tls' modules, which are handled first.
         amod = modules.get('ambassador', None)
         tmod = modules.get('tls', None)
+
+        if not tmod:
+            tmod = modules.get('tls-from-ambassador-certs',)
 
         if amod or tmod:
             self.module_config_ambassador("ambassador", amod, tmod)

--- a/ambassador/kubewatch.py
+++ b/ambassador/kubewatch.py
@@ -332,7 +332,7 @@ def sync(restarter):
                 tls_mod = {
                     "apiVersion": "ambassador/v0",
                     "kind": "Module",
-                    "name": "tls",
+                    "name": "tls-from-ambassador-certs",
                     "config": {
                         "server": {
                             "enabled": True,

--- a/end-to-end/004-tls-1/k8s/ambassador.yaml
+++ b/end-to-end/004-tls-1/k8s/ambassador.yaml
@@ -21,8 +21,8 @@ metadata:
           enabled: True
           redirect_cleartext_from: 80
           # These are optional.
-          cert_chain_file: /etc/certs/termination/tls.crt
-          private_key_file: /etc/certs/termination/tls.key
+          cert_chain_file: /etc/certs/tls.crt
+          private_key_file: /etc/certs/tls.key
 
         # client:
         #   enabled: True,

--- a/end-to-end/004-tls-1/k8s/canary-100.yaml
+++ b/end-to-end/004-tls-1/k8s/canary-100.yaml
@@ -10,7 +10,7 @@ metadata:
       kind:  Mapping
       name:  demo_default_mapping
       prefix: /demo/
-      tls: upstream     
+      tls: True     
       service: demo1
 spec:
   selector:
@@ -32,7 +32,7 @@ metadata:
       name:  demo_with_host_mapping
       prefix: /demo/
       host: demo2.datawire.io
-      tls: upstream     
+      tls: True     
       service: demo2:443
       ---
       apiVersion: ambassador/v0
@@ -41,7 +41,7 @@ metadata:
       prefix: /good/
       headers:
         "x-hurkle": true
-      tls: upstream     
+      tls: True     
       service: demo2:443
       ---
       apiVersion: ambassador/v0
@@ -50,7 +50,7 @@ metadata:
       prefix: /demo/
       headers:
         x-demo-mode: canary
-      tls: upstream    
+      tls: True    
       service: demo2
 spec:
   selector:
@@ -73,28 +73,6 @@ metadata:
       prefix: /ambassador/
       rewrite: /ambassador/
       service: 127.0.0.1:8877
-      ---
-      apiVersion: ambassador/v0
-      kind:  Module
-      name:  tls
-      config:
-        server:
-          enabled: True
-          # These are optional.
-          cert_chain_file: /etc/certs/termination/tls.crt
-          private_key_file: /etc/certs/termination/tls.key
-
-        # client:
-        #   enabled: True,
-        #   # These are optional.
-        #   cert_required: True
-        #   cacert_chain_file: /etc/ca_cert_chain/tls.crt
-
-        # This is an upstream context. Use tls: upstream in a 
-        # mapping to reference it.
-        upstream:
-          cert_chain_file: /etc/certs/upstream/tls.crt
-          private_key_file: /etc/certs/upstream/tls.key
       ---
       apiVersion: ambassador/v0
       kind: Module

--- a/end-to-end/004-tls-1/test.sh
+++ b/end-to-end/004-tls-1/test.sh
@@ -15,7 +15,7 @@ initialize_cluster
 
 kubectl cluster-info
 
-kubectl create secret tls ambassador-certs-termination --cert=certs/termination.crt --key=certs/termination.key
+kubectl create secret tls ambassador-certs --cert=certs/termination.crt --key=certs/termination.key
 kubectl create secret tls ambassador-certs-upstream --cert=certs/upstream.crt --key=certs/upstream.key
 
 kubectl apply -f k8s/authsvc.yaml
@@ -73,6 +73,7 @@ if ! kubectl exec -i $DEMOTEST_POD -- python3 demotest.py "$BASEURL" /dev/fd/0 <
     exit 1
 fi
 
+echo "kubectl apply -f k8s/canary-50.yaml"
 kubectl apply -f k8s/canary-50.yaml
 wait_for_pods
 wait_for_demo_weights "$BASEURL" x-demo-mode=canary 50 50
@@ -86,8 +87,12 @@ if ! kubectl exec -i $DEMOTEST_POD -- python3 demotest.py "$BASEURL" /dev/fd/0 <
     exit 1
 fi
 
+echo "kubectl apply -f k8s/canary-100.yaml"
 kubectl apply -f k8s/canary-100.yaml
 wait_for_pods
+
+sleep 10
+
 wait_for_demo_weights "$BASEURL" x-demo-mode=canary 100
 
 # This needs sorting crap before it'll work. :P

--- a/end-to-end/ambassador-with-mounts.yaml
+++ b/end-to-end/ambassador-with-mounts.yaml
@@ -92,8 +92,8 @@ spec:
             fieldRef:
               fieldPath: metadata.namespace          
         volumeMounts:
-        - name: termination-certs
-          mountPath: /etc/certs/termination
+        # - name: termination-certs
+        #   mountPath: /etc/certs/termination
         - name: upstream-certs
           mountPath: /etc/certs/upstream
         terminationMessagePath: /dev/termination-log
@@ -101,9 +101,9 @@ spec:
         image: {STREG}statsd:{VERSION}
         imagePullPolicy: Always
       volumes:
-      - name: termination-certs
-        secret:
-          secretName: ambassador-certs-termination
+      # - name: termination-certs
+      #   secret:
+      #     secretName: ambassador-certs-termination
       - name: upstream-certs
         secret:
           secretName: ambassador-certs-upstream


### PR DESCRIPTION
Allow the `tls` module that is autogenerated when we see the presence of the `ambassador-certs` secret to be overrideable.
