### PR TITLE
Disable Istio automatic sidecar injection

### DIFF
--- a/docs/user-guide/with-istio.md
+++ b/docs/user-guide/with-istio.md
@@ -156,7 +156,7 @@ kubectl apply -f <(istioctl kube-inject -f samples/bookinfo/kube/bookinfo.yaml)
 
 ## Automatic Sidecar Injection
 
-Newer versions of Istio support Kubernetes initializers to [automatically inject the Istio sidecar](https://istio.io/docs/setup/kubernetes/sidecar-injection.html#automatic-sidecar-injection). With Ambassador, you don't need to inject the Istio sidecar -- Ambassador's Envoy instance will automatically route to the appropriate service(s). If you're using automatic sidecar injection, you'll need to configure Istio to not inject the sidecar automatically for Ambassador pods. There are several approaches to doing this that are [explained in the documentation](https://istio.io/docs/setup/kubernetes/sidecar-injection.html#configuration-options).
+Newer versions of Istio support Kubernetes initializers to [automatically inject the Istio sidecar](https://istio.io/docs/setup/kubernetes/sidecar-injection.html#automatic-sidecar-injection). You don't need to inject the Istio sidecar into Ambassador's pods -- Ambassador's Envoy instance will automatically route to the appropriate service(s). Ambassador's pods are configured to skip sidecar injection, using an annotation as [explained in the documentation](https://istio.io/docs/setup/kubernetes/sidecar-injection.html#policy).
 
 ## Roadmap
 

--- a/templates/ambassador/ambassador-no-rbac.yaml
+++ b/templates/ambassador/ambassador-no-rbac.yaml
@@ -22,6 +22,8 @@ spec:
   replicas: 3
   template:
     metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
       labels:
         service: ambassador
     spec:

--- a/templates/ambassador/ambassador-rbac-prometheus.yaml
+++ b/templates/ambassador/ambassador-rbac-prometheus.yaml
@@ -58,6 +58,8 @@ spec:
   replicas: 1
   template:
     metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
       labels:
         service: ambassador
     spec:

--- a/templates/ambassador/ambassador-rbac.yaml
+++ b/templates/ambassador/ambassador-rbac.yaml
@@ -58,6 +58,8 @@ spec:
   replicas: 3
   template:
     metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
       labels:
         service: ambassador
     spec:


### PR DESCRIPTION
This adds an annotation to the Ambassador deployments to skip automatic sidecar injection for istio as described [here](https://istio.io/docs/setup/kubernetes/sidecar-injection.html#policy). It also updates the docs to say this is taken care of for you.