### PR TITLE
Mixin the diagnostics section from module definition

### DIFF
--- a/ambassador/ambassador/config.py
+++ b/ambassador/ambassador/config.py
@@ -1216,7 +1216,7 @@ class Config (object):
         # as we find them.
         for key in [ 'service_port', 'admin_port', 'diag_port',
                      'liveness_probe', 'readiness_probe', 'auth_enabled',
-                     'use_proxy_proto', 'use_remote_address' ]:
+                     'use_proxy_proto', 'use_remote_address', 'diagnostics' ]:
             if amod and (key in amod):
                 # Yes. It overrides the default.
                 self.set_config_ambassador(amod, key, amod[key])

--- a/docs/reference/modules.md
+++ b/docs/reference/modules.md
@@ -34,6 +34,10 @@ config:
   # readiness_probe:
   #   enabled: false
 
+  # diagnostics routes defaults on, but you can disable it.
+  # diagnostics:
+  #   enabled: false
+
   # use_proxy_protocol controls whether Envoy will honor the PROXY
   # protocol on incoming requests.
   # use_proxy_proto: false


### PR DESCRIPTION
So I'm trying to disable the diagnostics route mappings (from #354) and I think that if the module would allow one to mixin the `diagnostics` section I can use an annotation to disable them. This is my (bad) attempt to try and implement this change. I am still struggling to get `make DOCKER_REGISTRY=-` to run (just keep getting `error: [Errno 2] No such file or directory: 'requirements.txt'`) and I'm not really used to Python so any pointers I would love to get it going and add some tests, even, assuming I'm going down the right path 👍 