### PR TITLE
Added interactive check of the kubectl context before launching individual e2e tests

### DIFF
--- a/end-to-end/testall.sh
+++ b/end-to-end/testall.sh
@@ -19,6 +19,7 @@ fi
 
 # For linify
 export MACHINE_READABLE=yes
+export SKIP_CHECK_CONTEXT=yes
 
 for dir in 0*; do
     attempt=0

--- a/end-to-end/utils.sh
+++ b/end-to-end/utils.sh
@@ -14,6 +14,10 @@ step () {
 }
 
 initialize_cluster () {
+    if [ -z "$SKIP_CHECK_CONTEXT" ]; then
+        interactive_check_context
+    fi
+
     for namespace in $(kubectl get namespaces | egrep -v '^(NAME|kube-)' | awk ' { print $1 }'); do
         echo "Deleting everything in $namespace..."
 
@@ -200,6 +204,22 @@ istio_running () {
 
 ambassador_pod () {
     kubectl get pod -l app=ambassador -o jsonpath='{.items[0].metadata.name}'
+}
+
+kubectl_context () {
+    kubectl config current-context
+}
+
+interactive_check_context () {
+    CONTEXT=$(kubectl_context)
+    while true; do
+        read -p "You are about to delete everything running in '$CONTEXT' context. Proceed? [yes, no] " yn
+        case $yn in
+            [Yy]* ) return;;
+            [Nn]* ) exit;;
+            * ) echo "Please answer yes or no.";;
+        esac
+    done
 }
 
 # ISTIOHOME=${ISTIOHOME:-${HERE}/istio-0.1.6}


### PR DESCRIPTION
When running individual end-to-end test cases, such as
```
cd end-to-end/001-simple/
sh test.sh
```
the kubernaut cluster is not claimed and defaulting to whatever is the current kubectl context.

Unfortunately, when I triggered a test run locally, my kubectl context was targeting a production cluster and it started deleting pods without warning :/
So, I added an interactive check Y/N check before performing any destructive action :)