### PR TITLE
Don't log socat notice messages as it is flooding the logs

### DIFF
--- a/statsd/Dockerfile
+++ b/statsd/Dockerfile
@@ -2,4 +2,4 @@ FROM alpine:3.7
 
 RUN apk --update add socat
 
-CMD ["socat", "-d", "-d", "UDP-RECVFROM:8125,fork", "UDP-SENDTO:statsd-sink:8125"]
+CMD ["socat", "-d", "UDP-RECVFROM:8125,fork", "UDP-SENDTO:statsd-sink:8125"]


### PR DESCRIPTION
Reducing `socat` log level to prevent flooding notice messages to elasticsearch (or whatever log backend)