### PR TITLE
Support TLS origination for auth-service

### DIFF
--- a/ambassador/ambassador/config.py
+++ b/ambassador/ambassador/config.py
@@ -1422,7 +1422,6 @@ class Config (object):
                 cluster_hosts = { '127.0.0.1:5000': 100 }
 
             urls = []
-            use_tls = False
             protocols = {}
 
             for svc in sorted(cluster_hosts.keys()):
@@ -1431,10 +1430,13 @@ class Config (object):
                 (svc, url, originate_tls, otls_name) = self.service_tls_check(svc, tls_context)
 
                 if originate_tls:
-                    use_tls = True
                     protocols['https'] = True
                 else:
                     protocols['http'] = True
+
+                if otls_name:
+                    filter_config['cluster'] = cluster_name + "_" + otls_name
+                    cluster_name = filter_config['cluster']
 
                 urls.append(url)
 
@@ -1444,7 +1446,7 @@ class Config (object):
             self.add_intermediate_cluster(first_source, cluster_name,
                                           'extauth', urls,
                                           type="strict_dns", lb_type="round_robin",
-                                          originate_tls=use_tls)
+                                          originate_tls=originate_tls)
 
         for source in sources:
             filter._mark_referenced_by(source)

--- a/ambassador/schemas/v0/AuthService.schema
+++ b/ambassador/schemas/v0/AuthService.schema
@@ -9,7 +9,8 @@
         "name": { "type": "string" },
         "auth_service": { "type": "string" },
         "path_prefix": { "type": "string" },
-        "allowed_headers": { 
+        "tls": { "type": [ "string", "boolean" ] },
+        "allowed_headers": {
             "type": "array",
             "items": { "type": "string" }
         }

--- a/ambassador/tests/007-originating-tls/config/auth-tls.yaml
+++ b/ambassador/tests/007-originating-tls/config/auth-tls.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: ambassador/v0
+kind: AuthService
+name: authentication
+tls: upstream
+auth_service: "https://example-auth:3000"
+path_prefix: "/extauth"
+allowed_headers:
+- "x-qotm-session"

--- a/ambassador/tests/007-originating-tls/gold.intermediate.json
+++ b/ambassador/tests/007-originating-tls/gold.intermediate.json
@@ -22,6 +22,38 @@
             },
             {
                 "_referenced_by": [
+                    "auth-tls.yaml.1"
+                ],
+                "_service": "extauth",
+                "_source": "auth-tls.yaml.1",
+                "lb_type": "round_robin",
+                "name": "cluster_ext_auth_otls_upstream",
+                "tls_array": [
+                    {
+                        "key": "cert_chain_file",
+                        "value": "/etc/ambassador-config/certs/outbound.crt"
+                    },
+                    {
+                        "key": "private_key_file",
+                        "value": "/etc/ambassador-config/certs/outbound.key"
+                    }
+                ],
+                "tls_context": {
+                    "_referenced_by": [
+                        "auth-tls.yaml.1",
+                        "mapping-qotm.yaml.1"
+                    ],
+                    "_source": "tls.yaml.1",
+                    "cert_chain_file": "/etc/ambassador-config/certs/outbound.crt",
+                    "private_key_file": "/etc/ambassador-config/certs/outbound.key"
+                },
+                "type": "strict_dns",
+                "urls": [
+                    "tcp://example-auth:3000"
+                ]
+            },
+            {
+                "_referenced_by": [
                     "mapping-qotm.yaml.1"
                 ],
                 "_service": "qotm",
@@ -40,6 +72,7 @@
                 ],
                 "tls_context": {
                     "_referenced_by": [
+                        "auth-tls.yaml.1",
                         "mapping-qotm.yaml.1"
                     ],
                     "_source": "tls.yaml.1",
@@ -57,6 +90,22 @@
                 "_source": "--internal--",
                 "config": {},
                 "name": "cors"
+            },
+            {
+                "_services": [
+                    "https://example-auth:3000"
+                ],
+                "_source": "auth-tls.yaml.1",
+                "config": {
+                    "allowed_headers": [
+                        "x-qotm-session"
+                    ],
+                    "cluster": "cluster_ext_auth_otls_upstream",
+                    "path_prefix": "/extauth",
+                    "timeout_ms": 5000
+                },
+                "name": "extauth",
+                "type": "decoder"
             },
             {
                 "_source": "--internal--",
@@ -160,6 +209,9 @@
         "ambassador.yaml": {
             "ambassador.yaml.1": true
         },
+        "auth-tls.yaml": {
+            "auth-tls.yaml.1": true
+        },
         "mapping-qotm.yaml": {
             "mapping-qotm.yaml.1": true
         },
@@ -194,6 +246,15 @@
             "name": "ambassador",
             "version": "ambassador/v0",
             "yaml": "apiVersion: ambassador/v0\nconfig:\n  admin_port: 4242\n  liveness_probe:\n    enabled: false\nkind: Module\nname: ambassador\n"
+        },
+        "auth-tls.yaml.1": {
+            "_source": "auth-tls.yaml",
+            "filename": "auth-tls.yaml",
+            "index": 1,
+            "kind": "AuthService",
+            "name": "authentication",
+            "version": "ambassador/v0",
+            "yaml": "allowed_headers:\n- x-qotm-session\napiVersion: ambassador/v0\nauth_service: https://example-auth:3000\nkind: AuthService\nname: authentication\npath_prefix: /extauth\ntls: upstream\n"
         },
         "mapping-qotm.yaml.1": {
             "_source": "mapping-qotm.yaml",

--- a/ambassador/tests/007-originating-tls/gold.json
+++ b/ambassador/tests/007-originating-tls/gold.json
@@ -1,9 +1,9 @@
 {
   "listeners": [
-    
+
     {
       "address": "tcp://0.0.0.0:443",
-      
+
       "ssl_context": {"cert_chain_file": "/etc/ambassador-config/certs/tls.crt",
           "private_key_file": "/etc/ambassador-config/certs/tls.key"
       },"filters": [
@@ -23,52 +23,55 @@
                 {
                   "name": "backend",
                   "domains": ["*"],"routes": [
-                    
+
                     {
                       "timeout_ms": 3000,"prefix": "/ambassador/v0/check_ready","prefix_rewrite": "/ambassador/v0/check_ready",
                       "weighted_clusters": {
                           "clusters": [
-                              
+
                                  { "name": "cluster_127_0_0_1_8877", "weight": 100.0 }
-                              
+
                           ]
                       }
-                      
+
                     }
                     ,
-                    
+
                     {
                       "timeout_ms": 3000,"prefix": "/ambassador/v0/","prefix_rewrite": "/ambassador/v0/",
                       "weighted_clusters": {
                           "clusters": [
-                              
+
                                  { "name": "cluster_127_0_0_1_8877", "weight": 100.0 }
-                              
+
                           ]
                       }
-                      
+
                     }
                     ,
-                    
+
                     {
                       "timeout_ms": 3000,"prefix": "/qotm/","prefix_rewrite": "/",
                       "weighted_clusters": {
                           "clusters": [
-                              
+
                                  { "name": "cluster_qotm_otls_upstream", "weight": 100.0 }
-                              
+
                           ]
                       }
-                      
+
                     }
-                    
-                    
+
+
                   ]
                 }
               ]
             },
             "filters": [
-              {
+              {"type": "decoder",
+                "name": "extauth",
+                "config": {"allowed_headers": ["x-qotm-session"], "cluster": "cluster_ext_auth_otls_upstream", "path_prefix": "/extauth", "timeout_ms": 5000}
+              },{
                 "name": "cors",
                 "config": {}
               },{"type": "decoder",
@@ -91,32 +94,50 @@
         "name": "cluster_127_0_0_1_8877",
         "connect_timeout_ms": 3000,
         "type": "strict_dns",
-        "lb_type": "round_robin",        
+        "lb_type": "round_robin",
         "hosts": [
           {
             "url": "tcp://127.0.0.1:8877"
           }
-          
+
         ]},
+      {
+        "name": "cluster_ext_auth_otls_upstream",
+        "connect_timeout_ms": 3000,
+        "type": "strict_dns",
+        "lb_type": "round_robin",
+        "hosts": [
+          {
+            "url": "tcp://example-auth:3000"
+          }
+
+        ],
+        "ssl_context": {
+
+          "cert_chain_file": "/etc/ambassador-config/certs/outbound.crt",
+
+          "private_key_file": "/etc/ambassador-config/certs/outbound.key"
+
+	}},
       {
         "name": "cluster_qotm_otls_upstream",
         "connect_timeout_ms": 3000,
         "type": "strict_dns",
-        "lb_type": "round_robin",        
+        "lb_type": "round_robin",
         "hosts": [
           {
             "url": "tcp://qotm:443"
           }
-          
+
         ],
         "ssl_context": {
-          
+
           "cert_chain_file": "/etc/ambassador-config/certs/outbound.crt",
-          
+
           "private_key_file": "/etc/ambassador-config/certs/outbound.key"
-          
+
         }}
-      
+
     ]
   },
   "statsd_udp_ip_address": "127.0.0.1:8125",


### PR DESCRIPTION
Add support to offer certificates to external auth-service. Adds a new field `tls: <Boolean|String>` similar to `Mapping`