### PR TITLE
Remove extra close paren from website-yaml

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -232,7 +232,7 @@ website-yaml:
 		-type f \
 		-exec sed \
 			-i''\
-			-e 's|{{AMBASSADOR_DOCKER_IMAGE}}|$(AMBASSADOR_DOCKER_REPO):$(VERSION)|g;s|{{STATSD_DOCKER_IMAGE}}|$(STATSD_DOCKER_REPO):$(VERSION))|g' \
+			-e 's|{{AMBASSADOR_DOCKER_IMAGE}}|$(AMBASSADOR_DOCKER_REPO):$(VERSION)|g;s|{{STATSD_DOCKER_IMAGE}}|$(STATSD_DOCKER_REPO):$(VERSION)|g' \
 			{} \;
 
 website: website-yaml


### PR DESCRIPTION
There was an extra close parentheses in the website-yaml that caused erroneous configuration to be pushed.