### PR TITLE
Use host_rewrite for SNI as well if TLS is enabled.

### DIFF
--- a/ambassador/tests/001-broader-v0/gold.intermediate.json
+++ b/ambassador/tests/001-broader-v0/gold.intermediate.json
@@ -107,8 +107,13 @@
                 "_service": "google.com",
                 "_source": "mapping-google.yaml.1",
                 "lb_type": "round_robin",
-                "name": "cluster_https___google_com_otls",
-                "tls_array": [],
+                "name": "cluster_https___google_com_otls_hr_google_com",
+                "tls_array": [
+                    {
+                        "key": "sni",
+                        "value": "google.com"
+                    }
+                ],
                 "tls_context": {
                     "_ambassador_enabled": true
                 },
@@ -293,8 +298,13 @@
                 "_service": "myservice.org/",
                 "_source": "mapping-httpbin-shadow.yaml.1",
                 "lb_type": "round_robin",
-                "name": "cluster_shadow_https___myservice_org__otls",
-                "tls_array": [],
+                "name": "cluster_shadow_https___myservice_org__otls_hr_httpbin_org",
+                "tls_array": [
+                    {
+                        "key": "sni",
+                        "value": "httpbin.org"
+                    }
+                ],
                 "tls_context": {
                     "_ambassador_enabled": true
                 },
@@ -428,7 +438,7 @@
                 "prefix": "/httpbin/",
                 "prefix_rewrite": "/",
                 "shadow": {
-                    "name": "cluster_shadow_https___myservice_org__otls"
+                    "name": "cluster_shadow_https___myservice_org__otls_hr_httpbin_org"
                 },
                 "timeout_ms": 50
             },
@@ -912,7 +922,7 @@
                 "_source": "mapping-google.yaml.1",
                 "clusters": [
                     {
-                        "name": "cluster_https___google_com_otls",
+                        "name": "cluster_https___google_com_otls_hr_google_com",
                         "weight": 100.0
                     }
                 ],

--- a/ambassador/tests/001-broader-v0/gold.json
+++ b/ambassador/tests/001-broader-v0/gold.json
@@ -141,7 +141,7 @@
                             ]
                         },
                         "shadow": {
-                          "cluster": "cluster_shadow_https___myservice_org__otls"
+                          "cluster": "cluster_shadow_https___myservice_org__otls_hr_httpbin_org"
                         }
 
                       
@@ -167,7 +167,7 @@
                         "weighted_clusters": {
                             "clusters": [
                                 
-                                  { "name": "cluster_https___google_com_otls", "weight": 100.0 }
+                                  { "name": "cluster_https___google_com_otls_hr_google_com", "weight": 100.0 }
                                 
                             ]
                         }
@@ -409,7 +409,7 @@
           
         ]},
       {
-        "name": "cluster_https___google_com_otls",
+        "name": "cluster_https___google_com_otls_hr_google_com",
         "connect_timeout_ms": 3000,
         "type": "strict_dns",
         "lb_type": "round_robin",        
@@ -420,6 +420,8 @@
           
         ],
         "ssl_context": {
+          
+          "sni": "google.com"
           
         }},
       {
@@ -573,7 +575,7 @@
           
         ]},
       {
-        "name": "cluster_shadow_https___myservice_org__otls",
+        "name": "cluster_shadow_https___myservice_org__otls_hr_httpbin_org",
         "connect_timeout_ms": 3000,
         "type": "strict_dns",
         "lb_type": "round_robin",        
@@ -584,6 +586,8 @@
           
         ],
         "ssl_context": {
+          
+          "sni": "httpbin.org"
           
         }},
       {

--- a/end-to-end/000-no-base/diag-1.json
+++ b/end-to-end/000-no-base/diag-1.json
@@ -118,5 +118,30 @@
         ],
         "prefix": "/qotm/",
         "prefix_rewrite": "/"
+    },
+    {
+        "__saved": [
+            0,
+            4,
+            0,
+            "/hb/",
+            "GET"
+        ],
+        "_group_id": "b8d9f34208af81a8514a2d2697636a2feccf5611",
+        "_method": "GET",
+        "_precedence": 0,
+        "_referenced_by": [
+            "ambassador-default.yaml.2"
+        ],
+        "_source": "ambassador-default.yaml.2",
+        "clusters": [
+            {
+                "name": "cluster_https___httpbin_org_otls_hr_httpbin_org",
+                "weight": 100.0
+            }
+        ],
+        "host_rewrite": "httpbin.org",
+        "prefix": "/hb/",
+        "prefix_rewrite": "/"
     }
 ]

--- a/end-to-end/000-no-base/k8s/ambassador.yaml
+++ b/end-to-end/000-no-base/k8s/ambassador.yaml
@@ -12,6 +12,13 @@ metadata:
       prefix: /ambassador/
       rewrite: /ambassador/
       service: 127.0.0.1:8877
+      ---
+      apiVersion: ambassador/v0
+      kind:  Mapping
+      name:  httpbin2_mapping
+      prefix: /hb/
+      service: https://httpbin.org
+      host_rewrite: httpbin.org      
 spec:
   selector:
     app: ambassador


### PR DESCRIPTION
If you set `host_rewrite` in a `Mapping` configured to use TLS upstream, we now use the `host_rewrite` value as the SNI name going upstream as well. 

Without explicitly configuring SNI, Envoy sends nothing at all upstream. For some servers, this works great, but for others (e.g. httpbin.org) it results in the connection being instantly closed.

Fixes #396.