### PR TITLE
Disable job control and unbuffer Python output

### DIFF
--- a/ambassador/entrypoint.sh
+++ b/ambassador/entrypoint.sh
@@ -74,6 +74,8 @@ if [ $STATUS -ne 0 ]; then
     diediedie "kubewatch sync" "$STATUS"
 fi
 
+export PYTHON_UNBUFFERED=true
+
 echo "AMBASSADOR: starting diagd"
 diagd --no-debugging "$CONFIG_DIR" &
 pids="${pids:+${pids} }$!:diagd"

--- a/ambassador/entrypoint.sh
+++ b/ambassador/entrypoint.sh
@@ -62,7 +62,7 @@ handle_int() {
     echo "Exiting due to Control-C"
 }
 
-set -o monitor
+# set -o monitor
 trap "handle_chld" CHLD
 trap "handle_int" INT
 


### PR DESCRIPTION
We've seen some issues where log messages weren't making it out to the k8s logs. Switching to unbuffered output seems to help with this. Disabling job control just shuts up an error message.

(partial for #437)