### PR TITLE
Add probes to example auth service, cleans up docs

### DIFF
--- a/docs/user-guide/auth-tutorial.md
+++ b/docs/user-guide/auth-tutorial.md
@@ -73,19 +73,13 @@ kubectl apply -f https://www.getambassador.io/yaml/demo/demo-auth.yaml
 
 to spin everything up. (Of course, you can also use a local file, if you prefer.)
 
-Wait for the pod to be running before continuing. The best test here is to use `kubectl port-forward` to make port 3000 available, then actually try talking to the auth service. In one window:
-
-```shell
-kubectl port-forward $example-auth-pod-name 3000
+Wait for the pod to be running before continuing. The output of `kubectl get pods` should look something like -
+```console
+$ kubectl get pods
+NAME                            READY     STATUS    RESTARTS   AGE
+example-auth-6c5855b98d-24clp   1/1       Running   0          4m
 ```
-
-then in another
-
-```shell
-$ curl http://localhost:3000/ready
-```
-
-You should see output like `OK (not /qotm/quote)` when the service is running.
+Note that the `READY` field says `1/1` which means the pod is up and running.
 
 ## 2. Configure Ambassador authentication
 

--- a/templates/demo/demo-auth.yaml
+++ b/templates/demo/demo-auth.yaml
@@ -28,6 +28,18 @@ spec:
       containers:
       - name: example-auth
         image: datawire/ambassador-auth-service:1.1.1
+        livenessProbe:
+          httpGet:
+            path: /ready
+            port: 3000
+          initialDelaySeconds: 15
+          periodSeconds: 4
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 3000
+          initialDelaySeconds: 15
+          periodSeconds: 4
         ports:
         - name: http-api
           containerPort: 3000


### PR DESCRIPTION
Prior to this commit, the user was expected to do a port forward
of the example auth service per the authentication docs, and then
connect to the auth service to make sure it was up and running.
This is an extra step just to verify the health of the service.

This commit adds probes to the example auth service which make
sure the service is running, and the docs are updated to tell the
user to only check the output of `kubectl get pods` to see if the
service is up and running, instead of doing a port forward and
trying to connect.