### PR TITLE
unicode() is an undefined name in Python 3

### DIFF
--- a/scripts/versioner.py
+++ b/scripts/versioner.py
@@ -100,7 +100,10 @@ class VersionedBranch (object):
                  self.version, str(self.versioned_commit)[0:8]))
 
     def __str__(self):
-        return unicode(self)
+        try:
+            return unicode(self)
+        except NameError:
+            return self.__unicode__()
 
     def recent_commits(self, since_tag=None):
         if not since_tag:


### PR DESCRIPTION
flake8 testing of https://github.com/datawire/ambassador on Python 3.6.3

2.28s$ time flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./ambassador/ambassador_diag/envoy.py:223:45: F821 undefined name 'active_cluster_map'
                if True or (cluster_name in active_cluster_map):
                                            ^
./scripts/versioner.py:103:16: F821 undefined name 'unicode'
        return unicode(self)
               ^
2     F821 undefined name 'active_cluster_map'
2
```