### PR TITLE
Travis CI: echo "$encrypted_95ce0d75e6f7_iv"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,7 @@ env:
 before_install:
   - mkdir -p ~/bin
   - mkdir -p ~/.config/kubernaut
+  - echo "encrypted_95ce0d75e6f7_iv is \"$encrypted_95ce0d75e6f7_iv\" <-- (must not be blank)"
   - |-
     openssl aes-256-cbc \
       -K $encrypted_95ce0d75e6f7_key \


### PR DESCRIPTION
Travis CI builds are failing because [__$encrypted_95ce0d75e6f7_iv__ is not set](https://travis-ci.org/datawire/ambassador/builds/390370879#L473).

* $ __openssl list-cipher-commands__
* $ __openssl aes-256-cbc --help__