### PR TITLE
Add instructions for trying gRPC guide with minikube

### DIFF
--- a/docs/user-guide/grpc.md
+++ b/docs/user-guide/grpc.md
@@ -126,6 +126,8 @@ To test `Hello World`, we can use the Docker image `enm10k/grpc-hello-world`:
 docker run -e ADDRESS=${AMBASSADORHOST}:${AMBASSADORPORT} enm10k/grpc-hello-world greeter_client
 ```
 
+Note: If you're trying this out using `NodePort` on minikube and running the docker command above on your host machine, make sure to pass the `--network host` parameter to the docker command.
+
 ## Using over TLS
 
 To enable grpc over TLS, ALPN protocol http2 `alpn_protocols: h2` must be added to the TLS module configuration. Refer to [TLS termination guide](/user-guide/tls-termination.html) for more information.


### PR DESCRIPTION
This commit adds the instructions to configure networking if
someone is trying out the tutorial on minikube.