### PR TITLE
Allow running ambassador as a non-privileged user

### DIFF
--- a/ambassador/Dockerfile
+++ b/ambassador/Dockerfile
@@ -21,18 +21,18 @@ LABEL PROJECT_REPO_URL         = "git@github.com:datawire/ambassador.git" \
       VENDOR_URL               = "https://datawire.io/"
 
 # This Dockerfile is set up to install all the application-specific stuff into
-# /application.
+# /ambassador.
 #
 # NOTE: If you don't know what you're doing, it's probably a mistake to
 # blindly hack up this file.
 
 RUN apk --no-cache add curl python3
 
-# Set WORKDIR to /application which is the root of all our apps then COPY
+# Set WORKDIR to /ambassador which is the root of all our apps then COPY
 # only requirements.txt to avoid screwing up Docker caching and causing a
 # full reinstall of all dependencies when dependencies are not changed.
-
-WORKDIR /application
+ENV AMBASSADOR_ROOT=/ambassador
+WORKDIR ${AMBASSADOR_ROOT}
 COPY requirements.txt .
 
 # Install application dependencies
@@ -43,12 +43,18 @@ COPY ./ ambassador
 RUN cd ambassador && python3 setup.py --quiet install
 RUN rm -rf ./ambassador
 
-# MKDIR an empty /etc/ambassador-config. You can dump a configmap over this with no
-# trouble, or you can let annotations do the right thing.
-RUN mkdir /etc/ambassador-config
+# MKDIR an empty /ambassador/ambassador-config. You can dump a
+# configmap over this with no trouble, or you can let
+# annotations do the right thing
+RUN mkdir ambassador-config
 
 # COPY in a default config for use with --demo.
-COPY default-config/ /etc/ambassador-demo-config
+COPY default-config/ ambassador-demo-config
+
+# Fix permissions to allow running as a non root user
+RUN chgrp -R 0 ${AMBASSADOR_ROOT} && \
+    chmod -R u+x ${AMBASSADOR_ROOT} && \
+    chmod -R g=u ${AMBASSADOR_ROOT} /etc/passwd
 
 # COPY the entrypoint script and make it runnable.
 COPY kubewatch.py .

--- a/ambassador/ambassador/config.py
+++ b/ambassador/ambassador/config.py
@@ -884,7 +884,7 @@ class Config (object):
         # default values now.
 
         self.ambassador_module = SourcedDict(
-            service_port = 80,
+            service_port = 8080,
             admin_port = 8001,
             diag_port = 8877,
             auth_enabled = None,

--- a/ambassador/entrypoint.sh
+++ b/ambassador/entrypoint.sh
@@ -3,15 +3,21 @@
 export LC_ALL=C.UTF-8
 export LANG=C.UTF-8
 
-CONFIG_DIR="/etc/ambassador-config"
+AMBASSADOR_ROOT="/ambassador"
+CONFIG_DIR="$AMBASSADOR_ROOT/ambassador-config"
+ENVOY_CONFIG_FILE="$AMBASSADOR_ROOT/envoy.json"
 
 if [ "$1" == "--demo" ]; then
-    CONFIG_DIR="/etc/ambassador-demo-config"
+    CONFIG_DIR="$AMBASSADOR_ROOT/ambassador-demo-config"
 fi
 
 DELAY=${AMBASSADOR_RESTART_TIME:-15}
 
-APPDIR=${APPDIR:-/application}
+APPDIR=${APPDIR:-"$AMBASSADOR_ROOT"}
+
+# If we don't set PYTHON_EGG_CACHE explicitly, /.cache is set by default, which fails when running as a non-privileged
+# user
+export PYTHON_EGG_CACHE=${APPDIR/.cache}
 
 pids=""
 
@@ -26,7 +32,7 @@ diediedie() {
     fi
 
     echo "Here's the envoy.json we were trying to run with:"
-    LATEST="$(ls -v /etc/envoy*.json | tail -1)"
+    LATEST="$(ls -v $AMBASSADOR_ROOT/envoy*.json | tail -1)"
     if [ -e "$LATEST" ]; then
         cat "$LATEST"
     else
@@ -66,7 +72,7 @@ handle_int() {
 trap "handle_chld" CHLD
 trap "handle_int" INT
 
-/usr/bin/python3 "$APPDIR/kubewatch.py" sync "$CONFIG_DIR" /etc/envoy.json
+/usr/bin/python3 "$APPDIR/kubewatch.py" sync "$CONFIG_DIR" "$ENVOY_CONFIG_FILE"
 
 STATUS=$?
 
@@ -85,7 +91,7 @@ echo "AMBASSADOR: starting Envoy"
 RESTARTER_PID="$!"
 pids="${pids:+${pids} }${RESTARTER_PID}:envoy"
 
-/usr/bin/python3 "$APPDIR/kubewatch.py" watch "$CONFIG_DIR" /etc/envoy.json -p "${RESTARTER_PID}" --delay "${DELAY}" &
+/usr/bin/python3 "$APPDIR/kubewatch.py" watch "$CONFIG_DIR" "$ENVOY_CONFIG_FILE" -p "${RESTARTER_PID}" --delay "${DELAY}" &
 pids="${pids:+${pids} }$!:kubewatch"
 
 echo "AMBASSADOR: waiting"

--- a/ambassador/start-envoy.sh
+++ b/ambassador/start-envoy.sh
@@ -2,6 +2,7 @@
 
 DRAIN_TIME=${AMBASSADOR_DRAIN_TIME:-5}
 SHUTDOWN_TIME=${AMBASSADOR_SHUTDOWN_TIME:-10}
+AMBASSADOR_ROOT="/ambassador"
 
-LATEST=$(ls -1v /etc/envoy*.json | tail -1)
+LATEST=$(ls -1v "$AMBASSADOR_ROOT"/envoy*.json | tail -1)
 exec /usr/local/bin/envoy -c ${LATEST} --restart-epoch $RESTART_EPOCH --drain-time-s "${DRAIN_TIME}" --parent-shutdown-time-s "${SHUTDOWN_TIME}"


### PR DESCRIPTION
This commit lets ambassador to be run as a non-root user and
moves all ambassador related configurations to /ambassador
inside the container.