### PR TITLE
Change unicode() to str()

### DIFF
--- a/scripts/versioner.py
+++ b/scripts/versioner.py
@@ -100,7 +100,7 @@ class VersionedBranch (object):
                  self.version, str(self.versioned_commit)[0:8]))
 
     def __str__(self):
-        return unicode(self)
+        return str(self)
 
     def recent_commits(self, since_tag=None):
         if not since_tag:


### PR DESCRIPTION
Python 3 dropped support for unicode() and renamed it to str()
This commit accomodates that change.

Read more at -
https://docs.python.org/dev/howto/pyporting.html#text-versus-binary-data

Fix #460