### PR TITLE
Allow running ambassador as a non-privileged user

### DIFF
--- a/ambassador/Dockerfile
+++ b/ambassador/Dockerfile
@@ -21,18 +21,18 @@ LABEL PROJECT_REPO_URL         = "git@github.com:datawire/ambassador.git" \
       VENDOR_URL               = "https://datawire.io/"
 
 # This Dockerfile is set up to install all the application-specific stuff into
-# /application.
+# /ambassador.
 #
 # NOTE: If you don't know what you're doing, it's probably a mistake to
 # blindly hack up this file.
 
 RUN apk --no-cache add curl python3
 
-# Set WORKDIR to /application which is the root of all our apps then COPY
+# Set WORKDIR to /ambassador which is the root of all our apps then COPY
 # only requirements.txt to avoid screwing up Docker caching and causing a
 # full reinstall of all dependencies when dependencies are not changed.
-
-WORKDIR /application
+ENV AMBASSADOR_ROOT=/ambassador
+WORKDIR ${AMBASSADOR_ROOT}
 COPY requirements.txt .
 
 # Install application dependencies
@@ -43,12 +43,18 @@ COPY ./ ambassador
 RUN cd ambassador && python3 setup.py --quiet install
 RUN rm -rf ./ambassador
 
-# MKDIR an empty /etc/ambassador-config. You can dump a configmap over this with no
-# trouble, or you can let annotations do the right thing.
-RUN mkdir /etc/ambassador-config
+# MKDIR an empty /ambassador/ambassador-config. You can dump a
+# configmap over this with no trouble, or you can let
+# annotations do the right thing
+RUN mkdir ambassador-config
 
 # COPY in a default config for use with --demo.
-COPY default-config/ /etc/ambassador-demo-config
+COPY default-config/ ambassador-demo-config
+
+# Fix permissions to allow running as a non root user
+RUN chgrp -R 0 ${AMBASSADOR_ROOT} && \
+    chmod -R u+x ${AMBASSADOR_ROOT} && \
+    chmod -R g=u ${AMBASSADOR_ROOT} /etc/passwd
 
 # COPY the entrypoint script and make it runnable.
 COPY kubewatch.py .

--- a/ambassador/ambassador/config.py
+++ b/ambassador/ambassador/config.py
@@ -904,7 +904,7 @@ class Config (object):
         # default values now.
 
         self.ambassador_module = SourcedDict(
-            service_port = 80,
+            service_port = 8080,
             admin_port = 8001,
             diag_port = 8877,
             auth_enabled = None,

--- a/ambassador/start-envoy.sh
+++ b/ambassador/start-envoy.sh
@@ -2,6 +2,7 @@
 
 DRAIN_TIME=${AMBASSADOR_DRAIN_TIME:-5}
 SHUTDOWN_TIME=${AMBASSADOR_SHUTDOWN_TIME:-10}
+AMBASSADOR_ROOT="/ambassador"
 
-LATEST=$(ls -1v /etc/envoy*.json | tail -1)
+LATEST=$(ls -1v "$AMBASSADOR_ROOT"/envoy*.json | tail -1)
 exec /usr/local/bin/envoy -c ${LATEST} --restart-epoch $RESTART_EPOCH --drain-time-s "${DRAIN_TIME}" --parent-shutdown-time-s "${SHUTDOWN_TIME}"

--- a/ambassador/tests/000-default/gold.intermediate.json
+++ b/ambassador/tests/000-default/gold.intermediate.json
@@ -98,7 +98,7 @@
             {
                 "_source": "--internal--",
                 "require_tls": false,
-                "service_port": 80,
+                "service_port": 8080,
                 "use_proxy_proto": false
             }
         ],

--- a/ambassador/tests/000-default/gold.json
+++ b/ambassador/tests/000-default/gold.json
@@ -2,7 +2,7 @@
   "listeners": [
     
     {
-      "address": "tcp://0.0.0.0:80",
+      "address": "tcp://0.0.0.0:8080",
       
       "filters": [
         {

--- a/ambassador/tests/005-canary/gold.intermediate.json
+++ b/ambassador/tests/005-canary/gold.intermediate.json
@@ -65,7 +65,7 @@
             {
                 "_source": "--internal--",
                 "require_tls": false,
-                "service_port": 80,
+                "service_port": 8080,
                 "use_proxy_proto": false
             }
         ],

--- a/ambassador/tests/005-canary/gold.json
+++ b/ambassador/tests/005-canary/gold.json
@@ -2,7 +2,7 @@
   "listeners": [
     
     {
-      "address": "tcp://0.0.0.0:80",
+      "address": "tcp://0.0.0.0:8080",
       
       "filters": [
         {

--- a/ambassador/tests/006-headers-and-host/gold.intermediate.json
+++ b/ambassador/tests/006-headers-and-host/gold.intermediate.json
@@ -124,7 +124,7 @@
             {
                 "_source": "--internal--",
                 "require_tls": false,
-                "service_port": 80,
+                "service_port": 8080,
                 "use_proxy_proto": false
             }
         ],

--- a/ambassador/tests/006-headers-and-host/gold.json
+++ b/ambassador/tests/006-headers-and-host/gold.json
@@ -2,7 +2,7 @@
   "listeners": [
     
     {
-      "address": "tcp://0.0.0.0:80",
+      "address": "tcp://0.0.0.0:8080",
       
       "filters": [
         {

--- a/ambassador/tests/008-regex-prefix/gold.intermediate.json
+++ b/ambassador/tests/008-regex-prefix/gold.intermediate.json
@@ -52,7 +52,7 @@
             {
                 "_source": "--internal--",
                 "require_tls": false,
-                "service_port": 80,
+                "service_port": 8080,
                 "use_proxy_proto": false
             }
         ],

--- a/ambassador/tests/008-regex-prefix/gold.json
+++ b/ambassador/tests/008-regex-prefix/gold.json
@@ -2,7 +2,7 @@
   "listeners": [
     
     {
-      "address": "tcp://0.0.0.0:80",
+      "address": "tcp://0.0.0.0:8080",
       
       "filters": [
         {

--- a/ambassador/tests/009-rate-limit/gold.intermediate.json
+++ b/ambassador/tests/009-rate-limit/gold.intermediate.json
@@ -84,7 +84,7 @@
             {
                 "_source": "--internal--",
                 "require_tls": false,
-                "service_port": 80,
+                "service_port": 8080,
                 "use_proxy_proto": false
             }
         ],

--- a/ambassador/tests/009-rate-limit/gold.json
+++ b/ambassador/tests/009-rate-limit/gold.json
@@ -2,7 +2,7 @@
   "listeners": [
 
     {
-      "address": "tcp://0.0.0.0:80",
+      "address": "tcp://0.0.0.0:8080",
 
       "filters": [
         {

--- a/ambassador/tests/010-rewrite/gold.intermediate.json
+++ b/ambassador/tests/010-rewrite/gold.intermediate.json
@@ -51,7 +51,7 @@
             {
                 "_source": "--internal--",
                 "require_tls": false,
-                "service_port": 80,
+                "service_port": 8080,
                 "use_proxy_proto": false
             }
         ],

--- a/ambassador/tests/010-rewrite/gold.json
+++ b/ambassador/tests/010-rewrite/gold.json
@@ -2,7 +2,7 @@
   "listeners": [
     
     {
-      "address": "tcp://0.0.0.0:80",
+      "address": "tcp://0.0.0.0:8080",
       
       "filters": [
         {

--- a/docs/reference/ambassador-with-aws.md
+++ b/docs/reference/ambassador-with-aws.md
@@ -28,7 +28,7 @@ spec:
   ports:
   - name: ambassador
     port: 443
-    targetPort: 80
+    targetPort: 8080
   selector:
     service: ambassador-{{ build.profile.name }}
 ```

--- a/docs/user-guide/with-istio.md
+++ b/docs/user-guide/with-istio.md
@@ -59,7 +59,7 @@ spec:
   ports:
   - name: ambassador
     port: 80
-    targetPort: 80
+    targetPort: 8080
   selector:
     service: ambassador
 ```
@@ -258,7 +258,7 @@ spec:
   ports:
   - name: ambassador
     port: 80
-    targetPort: 80
+    targetPort: 8080
   selector:
     service: ambassador
 ```

--- a/end-to-end/000-no-base/k8s/ambassador.yaml
+++ b/end-to-end/000-no-base/k8s/ambassador.yaml
@@ -27,5 +27,5 @@ spec:
     - name: http
       protocol: TCP
       port: 80
-      targetPort: 80
+      targetPort: 8080
   type: NodePort

--- a/end-to-end/001-simple/k8s/ambassador.yaml
+++ b/end-to-end/001-simple/k8s/ambassador.yaml
@@ -10,5 +10,5 @@ spec:
     - name: http
       protocol: TCP
       port: 80
-      targetPort: 80
+      targetPort: 8080
   type: NodePort

--- a/end-to-end/001-simple/k8s/authenable.yaml
+++ b/end-to-end/001-simple/k8s/authenable.yaml
@@ -23,5 +23,5 @@ spec:
     - name: http
       protocol: TCP
       port: 80
-      targetPort: 80
+      targetPort: 8080
   type: NodePort

--- a/end-to-end/002-canary/k8s/ambassador.yaml
+++ b/end-to-end/002-canary/k8s/ambassador.yaml
@@ -19,5 +19,5 @@ spec:
     - name: http
       protocol: TCP
       port: 80
-      targetPort: 80
+      targetPort: 8080
   type: NodePort

--- a/end-to-end/003-headers-and-host/k8s/ambassador.yaml
+++ b/end-to-end/003-headers-and-host/k8s/ambassador.yaml
@@ -19,5 +19,5 @@ spec:
     - name: http
       protocol: TCP
       port: 80
-      targetPort: 80
+      targetPort: 8080
   type: NodePort

--- a/end-to-end/004-tls-1/k8s/ambassador.yaml
+++ b/end-to-end/004-tls-1/k8s/ambassador.yaml
@@ -19,7 +19,7 @@ metadata:
       config:
         server:
           enabled: True
-          redirect_cleartext_from: 80
+          redirect_cleartext_from: 8080
           # These are optional.
           cert_chain_file: /etc/certs/tls.crt
           private_key_file: /etc/certs/tls.key
@@ -54,5 +54,5 @@ spec:
     - name: http
       protocol: TCP
       port: 80
-      targetPort: 80
+      targetPort: 8080
   type: NodePort

--- a/end-to-end/005-single-namespace/k8s/ambassador.yaml
+++ b/end-to-end/005-single-namespace/k8s/ambassador.yaml
@@ -19,5 +19,5 @@ spec:
     - name: http
       protocol: TCP
       port: 80
-      targetPort: 80
+      targetPort: 8080
   type: NodePort

--- a/end-to-end/006-auth-canary/k8s/ambassador.yaml
+++ b/end-to-end/006-auth-canary/k8s/ambassador.yaml
@@ -19,5 +19,5 @@ spec:
     - name: http
       protocol: TCP
       port: 80
-      targetPort: 80
+      targetPort: 8080
   type: NodePort

--- a/end-to-end/007-rate-limit/k8s/ambassador.yaml
+++ b/end-to-end/007-rate-limit/k8s/ambassador.yaml
@@ -17,5 +17,5 @@ spec:
     - name: http
       protocol: TCP
       port: 80
-      targetPort: 80
+      targetPort: 8080
   type: NodePort

--- a/end-to-end/009-grpc/k8s/ambassador.yaml
+++ b/end-to-end/009-grpc/k8s/ambassador.yaml
@@ -11,5 +11,5 @@ spec:
     - name: http
       protocol: TCP
       port: 80
-      targetPort: 80
+      targetPort: 8080
   type: NodePort

--- a/end-to-end/010-multiple-ambassadors/k8s/ambassador-1.yaml
+++ b/end-to-end/010-multiple-ambassadors/k8s/ambassador-1.yaml
@@ -11,5 +11,5 @@ spec:
     - name: http
       protocol: TCP
       port: 80
-      targetPort: 80
+      targetPort: 8080
   type: NodePort

--- a/end-to-end/010-multiple-ambassadors/k8s/ambassador-2.yaml
+++ b/end-to-end/010-multiple-ambassadors/k8s/ambassador-2.yaml
@@ -11,5 +11,5 @@ spec:
     - name: http
       protocol: TCP
       port: 80
-      targetPort: 80
+      targetPort: 8080
   type: NodePort

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -18,7 +18,7 @@ spec:
     - name: http
       protocol: TCP
       port: 80
-      targetPort: 80
+      targetPort: 8080
   type: LoadBalancer
 ---
 apiVersion: v1

--- a/templates/ambassador/ambassador-http.yaml
+++ b/templates/ambassador/ambassador-http.yaml
@@ -11,6 +11,6 @@ spec:
   ports:
   - name: ambassador
     port: 80
-    targetPort: 80
+    targetPort: 8080
   selector:
     service: ambassador

--- a/templates/istio/ambassador.yaml
+++ b/templates/istio/ambassador.yaml
@@ -26,7 +26,7 @@ spec:
   ports:
   - name: http-ambassador
     port: 80
-    targetPort: 80
+    targetPort: 8080
   selector:
     service: ambassador
 ---


### PR DESCRIPTION
This commit lets ambassador to be run as a non-root user and
moves all ambassador related configurations to /ambassador
inside the container.

Fix #457