### PR TITLE
Move YAML strings to YAML arrays for CORS configuration

### DIFF
--- a/ambassador/ambassador/mapping.py
+++ b/ambassador/ambassador/mapping.py
@@ -122,6 +122,54 @@ class Mapping (object):
         else:
             return self.attrs.get(key)
 
+    def save_cors_element(self, cors_key, route_key, route):
+        """If self.get('cors')[cors_key] exists, and
+        - is a list, e.g. ["1","2","3"], then route[route_key] is set as "1, 2, 3"
+        - is something else, then set route[route_key] as it is
+
+        :param cors_key: key to exist in self.get('cors'), i.e. Ambassador's config
+        :param route_key: key to save to in envoy's cors configuration
+        :param route: envoy's cors configuration
+        """
+        cors = self.get('cors')
+        if cors.get(cors_key) is not None:
+            if type(cors.get(cors_key)) is list:
+                route[route_key] = ", ".join(cors.get(cors_key))
+            else:
+                route[route_key] = cors.get(cors_key)
+
+    def generate_route_cors(self):
+        """Generates envoy's cors configuration from ambassador's cors configuration
+
+        :return generated envoy cors configuration
+        :rtype: dict
+        """
+
+        cors = self.get('cors')
+        if cors is None:
+            return
+
+        route_cors = {'enabled': True}
+        # cors['origins'] cannot be treated like other keys, because if it's a
+        # list, then it remains as is, but if it's a string, then it's
+        # converted to a list
+        origins = cors.get('origins')
+        if origins is not None:
+            if type(origins) is list:
+                route_cors['allow_origin'] = origins
+            elif type(origins) is str:
+                route_cors['allow_origin'] = origins.split(',')
+            else:
+                print("invalid cors configuration supplied - {}".format(origins))
+                return
+
+        self.save_cors_element('max_age', 'max_age', route_cors)
+        self.save_cors_element('credentials', 'allow_credentials', route_cors)
+        self.save_cors_element('methods', 'allow_methods', route_cors)
+        self.save_cors_element('headers', 'allow_headers', route_cors)
+        self.save_cors_element('exposed_headers', 'expose_headers', route_cors)
+        return route_cors
+
     def new_route(self, svc, cluster_name):
         route = SourcedDict(
             _source=self['_source'],
@@ -165,17 +213,9 @@ class Mapping (object):
             for key, value in add_request_headers.items():
                 route['request_headers_to_add'].append({"key": key, "value": value})
 
-        cors = self.get('cors')
-        if cors:
-            route['cors'] = {key: value for key, value in {
-                "allow_origin": cors['origins'].split(',') if cors['origins'] else None,
-                "allow_methods": cors.get('methods'),
-                "allow_headers": cors.get('headers'),
-                "expose_headers": cors.get('exposed_headers'),
-                "allow_credentials": cors.get('credentials'),
-                "max_age": cors.get('max_age'),
-                "enabled": True
-            }.items() if value}
+        envoy_cors = self.generate_route_cors()
+        if envoy_cors:
+            route['cors'] = envoy_cors
 
         rate_limits = self.get('rate_limits')
         if rate_limits != None:

--- a/ambassador/schemas/v0/Mapping.schema
+++ b/ambassador/schemas/v0/Mapping.schema
@@ -25,11 +25,31 @@
         "cors": {
             "type": "object",
             "properties": {
-                "origins":  { "type": "string" },
-                "methods": { "type": "string" },
-                "headers": { "type": "string" },
+                "origins":  {
+                    "anyOf": [
+                        { "type": "string" },
+                        { "type": "array", "items": { "type": "string" } }
+                    ],
+                },
+                "methods": {
+                    "anyOf": [
+                        { "type": "string" },
+                        { "type": "array", "items": { "type": "string" } }
+                    ],
+                },
+                "headers": {
+                    "anyOf": [
+                        { "type": "string" },
+                        { "type": "array", "items": { "type": "string" } }
+                    ],
+                },
                 "credentials": { "type": "boolean" },
-                "exposed_headers": { "type": "string" },
+                "exposed_headers": {
+                    "anyOf": [
+                        { "type": "string" },
+                        { "type": "array", "items": { "type": "string" } }
+                    ],
+                },
                 "max_age": { "type": "string" }
             },
             "additionalProperties": false

--- a/ambassador/tests/006-headers-and-host/config/mapping-cors-array.yaml
+++ b/ambassador/tests/006-headers-and-host/config/mapping-cors-array.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: ambassador/v0
+kind:  Mapping
+name:  cors_creds_mapping_array
+prefix: /cors-creds-array/
+service: cors-array:8080
+cors:
+  origins:
+  - http://foo.example
+  - http://bar.example
+  methods:
+  - POST
+  - GET
+  - OPTIONS
+  headers:
+  - Content-Type
+  credentials: true
+  exposed_headers:
+  - X-Custom-Header
+  max_age: "86400"
+---
+apiVersion: ambassador/v0
+kind:  Mapping
+name:  cors_all_mapping_array
+prefix: /cors-all-array/
+service: cors-array:8080
+cors:
+  origins:
+  - "*"

--- a/ambassador/tests/006-headers-and-host/gold.intermediate.json
+++ b/ambassador/tests/006-headers-and-host/gold.intermediate.json
@@ -37,6 +37,20 @@
             },
             {
                 "_referenced_by": [
+                    "mapping-cors-array.yaml.1",
+                    "mapping-cors-array.yaml.2"
+                ],
+                "_service": "cors-array:8080",
+                "_source": "mapping-cors-array.yaml.2",
+                "lb_type": "round_robin",
+                "name": "cluster_cors_array_8080",
+                "type": "strict_dns",
+                "urls": [
+                    "tcp://cors-array:8080"
+                ]
+            },
+            {
+                "_referenced_by": [
                     "mapping-qotm.yaml.1"
                 ],
                 "_service": "demo.getambassador.io",
@@ -235,22 +249,88 @@
             },
             {
                 "__saved": [
-                    0,
-                    12,
-                    0,
-                    "/cors-creds/",
-                    "GET"
+                  0,
+                  16,
+                  0,
+                  "/cors-all-array/",
+                  "GET"
                 ],
-                "_group_id": "ac37c2861c386e18591032460dad7c77ce4fc8ac",
+                "_group_id": "7328eb7f069e2e2a15ce940330fe33dcdaffd105",
                 "_method": "GET",
                 "_precedence": 0,
                 "_referenced_by": [
-                    "mapping-cors.yaml.1"
+                  "mapping-cors-array.yaml.2"
                 ],
-                "_source": "mapping-cors.yaml.1",
+                "_source": "mapping-cors-array.yaml.2",
+                "clusters": [
+                  {
+                    "name": "cluster_cors_array_8080",
+                    "weight": 100.0
+                  }
+                ],
+                "cors": {
+                  "allow_origin": [
+                      "*"
+                    ],
+                  "enabled": true
+                },
+                "prefix": "/cors-all-array/",
+              "prefix_rewrite": "/"
+          },
+          {
+            "__saved": [
+              0,
+              12,
+              0,
+              "/cors-creds/",
+              "GET"
+            ],
+            "_group_id": "ac37c2861c386e18591032460dad7c77ce4fc8ac",
+            "_method": "GET",
+            "_precedence": 0,
+            "_referenced_by": [
+              "mapping-cors.yaml.1"
+            ],
+            "_source": "mapping-cors.yaml.1",
+            "clusters": [
+              {
+                "name": "cluster_cors_8080",
+                "weight": 100.0
+              }
+            ],
+            "cors": {
+              "allow_credentials": true,
+              "allow_headers": "Content-Type",
+              "allow_methods": "POST, GET, OPTIONS",
+              "allow_origin": [
+                  "http://foo.example",
+                  "http://bar.example"
+                ],
+              "enabled": true,
+              "expose_headers": "X-Custom-Header",
+              "max_age": "86400"
+            },
+            "prefix": "/cors-creds/",
+            "prefix_rewrite": "/"
+          },
+            {
+                "__saved": [
+                    0,
+                    18,
+                    0,
+                    "/cors-creds-array/",
+                    "GET"
+                ],
+                "_group_id": "b2ccffefb7924fc9b6336a3930d0ac0edecc5f51",
+                "_method": "GET",
+                "_precedence": 0,
+                "_referenced_by": [
+                    "mapping-cors-array.yaml.1"
+                ],
+                "_source": "mapping-cors-array.yaml.1",
                 "clusters": [
                     {
-                        "name": "cluster_cors_8080",
+                        "name": "cluster_cors_array_8080",
                         "weight": 100.0
                     }
                 ],
@@ -261,12 +341,12 @@
                     "allow_origin": [
                         "http://foo.example",
                         "http://bar.example"
-                    ],
+                      ],
                     "enabled": true,
                     "expose_headers": "X-Custom-Header",
                     "max_age": "86400"
                 },
-                "prefix": "/cors-creds/",
+                "prefix": "/cors-creds-array/",
                 "prefix_rewrite": "/"
             },
             {
@@ -435,7 +515,7 @@
                 "cors": {
                     "allow_origin": [
                         "*"
-                    ],
+                      ],
                     "enabled": true
                 },
                 "prefix": "/cors-all/",
@@ -454,6 +534,10 @@
         "mapping-cors.yaml": {
             "mapping-cors.yaml.1": true,
             "mapping-cors.yaml.2": true
+        },
+        "mapping-cors-array.yaml": {
+            "mapping-cors-array.yaml.1": true,
+            "mapping-cors-array.yaml.2": true
         },
         "mapping-diag.yaml": {
             "mapping-diag.yaml.1": true
@@ -512,6 +596,24 @@
             "name": "cors_all_mapping",
             "version": "ambassador/v0",
             "yaml": "apiVersion: ambassador/v0\ncors:\n  origins: '*'\nkind: Mapping\nname: cors_all_mapping\nprefix: /cors-all/\nservice: cors:8080\n"
+        },
+        "mapping-cors-array.yaml.1": {
+            "_source": "mapping-cors-array.yaml",
+            "filename": "mapping-cors-array.yaml",
+            "index": 1,
+            "kind": "Mapping",
+            "name": "cors_creds_mapping_array",
+            "version": "ambassador/v0",
+            "yaml": "apiVersion: ambassador/v0\ncors:\n  credentials: true\n  exposed_headers:\n  - X-Custom-Header\n  headers:\n  - Content-Type\n  max_age: '86400'\n  methods:\n  - POST\n  - GET\n  - OPTIONS\n  origins:\n  - http://foo.example\n  - http://bar.example\nkind: Mapping\nname: cors_creds_mapping_array\nprefix: /cors-creds-array/\nservice: cors-array:8080\n"
+        },
+        "mapping-cors-array.yaml.2": {
+            "_source": "mapping-cors-array.yaml",
+            "filename": "mapping-cors-array.yaml",
+            "index": 2,
+            "kind": "Mapping",
+            "name": "cors_all_mapping_array",
+            "version": "ambassador/v0",
+            "yaml": "apiVersion: ambassador/v0\ncors:\n  origins:\n  - '*'\nkind: Mapping\nname: cors_all_mapping_array\nprefix: /cors-all-array/\nservice: cors-array:8080\n"
         },
         "mapping-diag.yaml.1": {
             "_source": "mapping-diag.yaml",

--- a/ambassador/tests/006-headers-and-host/gold.json
+++ b/ambassador/tests/006-headers-and-host/gold.json
@@ -31,23 +31,65 @@
                               
                           ]
                       }
-                      
                     }
                     ,
-                    
                     {
                       "timeout_ms": 3000,"prefix": "/ambassador/v0/check_alive","prefix_rewrite": "/ambassador/v0/check_alive",
                       "weighted_clusters": {
                           "clusters": [
-                              
+
                                  { "name": "cluster_127_0_0_1_8877", "weight": 100.0 }
-                              
+
                           ]
                       }
-                      
                     }
                     ,
-                    
+                    {
+                      "timeout_ms": 3000,
+                      "prefix": "/cors-creds-array/",
+                      "prefix_rewrite": "/",
+                      "cors": {
+                        "allow_credentials": true,
+                        "allow_headers": "Content-Type",
+                        "allow_methods": "POST, GET, OPTIONS",
+                        "allow_origin": [
+                          "http://foo.example",
+                          "http://bar.example"
+                        ],
+                        "enabled": true,
+                        "expose_headers": "X-Custom-Header",
+                        "max_age": "86400"
+                      },
+                      "weighted_clusters": {
+                        "clusters": [
+                          {
+                            "name": "cluster_cors_array_8080",
+                            "weight": 100.0
+                          }
+                        ]
+                      }
+                    }
+                    ,
+                    {
+                      "cors": {
+                        "allow_origin": [
+                          "*"
+                        ],
+                        "enabled": true
+                      },
+                      "prefix": "/cors-all-array/",
+                      "prefix_rewrite": "/",
+                      "timeout_ms": 3000,
+                      "weighted_clusters": {
+                        "clusters": [
+                          {
+                            "name": "cluster_cors_array_8080",
+                            "weight": 100.0
+                          }
+                        ]
+                      }
+                    }
+                    ,
                     {
                       "timeout_ms": 3000,"prefix": "/ambassador/v0/","prefix_rewrite": "/ambassador/v0/",
                       "weighted_clusters": {
@@ -60,7 +102,6 @@
                       
                     }
                     ,
-                    
                     {
                       "timeout_ms": 3000,"prefix": "/cors-creds/","prefix_rewrite": "/","cors": {"allow_credentials": true, "allow_headers": "Content-Type", "allow_methods": "POST, GET, OPTIONS", "allow_origin": ["http://foo.example", "http://bar.example"], "enabled": true, "expose_headers": "X-Custom-Header", "max_age": "86400"},
                       "weighted_clusters": {
@@ -86,17 +127,16 @@
                       
                     }
                     ,
-                    
                     {
                       "timeout_ms": 3000,"prefix": "/cors-all/","prefix_rewrite": "/","cors": {"allow_origin": ["*"], "enabled": true},
                       "weighted_clusters": {
                           "clusters": [
-                              
+
                                  { "name": "cluster_cors_8080", "weight": 100.0 }
-                              
+
                           ]
                       }
-                      
+
                     }
                     ,
                     
@@ -200,6 +240,17 @@
             "url": "tcp://cors:8080"
           }
           
+        ]},
+      {
+        "name": "cluster_cors_array_8080",
+        "connect_timeout_ms": 3000,
+        "type": "strict_dns",
+        "lb_type": "round_robin",
+        "hosts": [
+          {
+            "url": "tcp://cors-array:8080"
+          }
+
         ]},
       {
         "name": "cluster_demo_getambassador_io",

--- a/docs/reference/cors.md
+++ b/docs/reference/cors.md
@@ -6,11 +6,50 @@ Cross-Origin resource sharing lets users request resources (e.g., images, fonts,
 
 The `cors` attribute enables the CORS filter. The following settings are supported:
 
-- `origins`: Specifies a comma-separated list of allowed domains for the `Access-Control-Allow-Origin` header. To allow all origins, use the wildcard `"*"` value.
-- `methods`: if present, specifies a comma-separated list of allowed methods for the `Access-Control-Allow-Methods` header.
-- `headers`: if present, specifies a comma-separated list of allowed headers for the `Access-Control-Allow-Headers` header.
+- `origins`: Specifies a list of allowed domains for the `Access-Control-Allow-Origin` header. To allow all origins, use the wildcard `"*"` value. Format can be either of:
+    - comma-separated list, e.g.
+    ```yaml
+    origins: http://foo.example,http://bar.example
+    ```
+    - YAML array, e.g.
+    ```yaml
+    origins:
+    - http://foo.example
+    - http://bar.example
+    ```
+- `methods`: if present, specifies a list of allowed methods for the `Access-Control-Allow-Methods` header. Format can be either of:
+    - comma-separated list, e.g.
+    ```yaml
+    methods: POST, GET, OPTIONS
+    ```
+    - YAML array, e.g.
+    ```yaml
+    methods:
+    - GET
+    - POST
+    - OPTIONS
+    ```
+- `headers`: if present, specifies a list of allowed headers for the `Access-Control-Allow-Headers` header. Format can be either of:
+    - comma-separated list, e.g.
+    ```yaml
+    headers: Content-Type
+    ```
+    - YAML array, e.g.
+    ```yaml
+    header:
+    - Content-Type
+    ```
 - `credentials`: if present with a true value (boolean), will send a `true` value for the `Access-Control-Allow-Credentials` header.
-- `exposed_headers`: if present, specifies a comma-separated list of allowed headers for the `Access-Control-Expose-Headers` header.
+- `exposed_headers`: if present, specifies a list of allowed headers for the `Access-Control-Expose-Headers` header. Format can be either of:
+    - comma-separated list, e.g.
+    ```yaml
+    exposed_headers: X-Custom-Header
+    ```
+    - YAML array, e.g.
+    ```yaml
+    exposed_headers:
+    - X-Custom-Header
+    ```
 - `max_age`: if present, indicated how long the results of the preflight request can be cached, in seconds. This value must be a string.
 
 ## Example


### PR DESCRIPTION
This commit makes defining CORS configuration in ambassador more
readable by moving comma separated strings, which envoy supports,
to YAML arrays.

The previous format looks like -
```yaml
cors:
  origins: http://foo.example,http://bar.example
  methods: POST, GET, OPTIONS
  headers: Content-Type,Accept,Authorization
  credentials: true
  exposed_headers: X-Custom-Header
  max_age: "86400"
```

The new format looks like -
```yaml
cors:
  origins:
  - http://foo.example
  - http://bar.example
  methods:
  - POST
  - GET
  - OPTIONS
  headers:
  - Content-Type
  - Accept
  - Authorization
  credentials: true
  exposed_headers:
  - X-Custom-Header
  max_age: "86400"
```

Fix #466