### PR TITLE
Fixing regex escaping issues and mismatch between enjoy.json and diag

### DIFF
--- a/ambassador/ambassador/config.py
+++ b/ambassador/ambassador/config.py
@@ -1549,7 +1549,7 @@ class Config (object):
         for route in self.envoy_config['routes']:
             if route['_source'] != "--diagnostics--":
                 route['_group_id'] = Mapping.group_id(route.get('method', 'GET'),
-                                                      route['prefix'],
+                                                      route['prefix'] if 'prefix' in route else route['regex'],
                                                       route.get('headers', []))
 
                 routes.append(route)

--- a/ambassador/ambassador_diag/diagd.py
+++ b/ambassador/ambassador_diag/diagd.py
@@ -244,7 +244,7 @@ def route_and_cluster_info(request, overview, clusters, cstats):
 
     if 'routes' in overview:
         for route in overview['routes']:
-            prefix = route['prefix']
+            prefix = route['prefix'] if 'prefix' in route else route['regex']
             rewrite = route.get('prefix_rewrite', "/")
             method = '*'
             host = None

--- a/ambassador/templates/envoy.j2
+++ b/ambassador/templates/envoy.j2
@@ -47,7 +47,8 @@
                     {% for route in routes %}
                     {
                       "timeout_ms": {{ route.timeout_ms or 3000 }},
-                      {%- if route.prefix -%}{%- if route.prefix_regex -%}"regex"{%- else %}"prefix"{% endif %}: "{{ route.prefix }}",{% endif %}
+                      {%- if route.prefix -%}"prefix": "{{ route.prefix }}",{% endif %}
+                      {%- if route.regex -%}"regex": {{ route.regex | tojson }},{% endif %}
                       {%- if route.case_sensitive -%}"case_sensitive": {{ route.case_sensitive | tojson }},{% endif %}
                       {%- if route.cors -%}"cors": {{ route.cors | tojson }},{% endif %}
                       {%- if route.rate_limits -%}"rate_limits": {{ route.rate_limits | tojson }},{% endif %}

--- a/ambassador/tests/008-regex-prefix/config/mapping-regex.yaml
+++ b/ambassador/tests/008-regex-prefix/config/mapping-regex.yaml
@@ -7,3 +7,12 @@ prefix_regex: true
 service: http://httpbin.org
 host_rewrite: httpbin.org
 host: test.datawire.io
+---
+apiVersion: ambassador/v0
+kind:  Mapping
+name:  regex_escaping_mapping
+prefix: ^\/users\/(\S)+\/profile$
+prefix_regex: true
+service: http://httpbin.org
+host_rewrite: httpbin.org
+host: test.datawire.io

--- a/ambassador/tests/008-regex-prefix/gold.intermediate.json
+++ b/ambassador/tests/008-regex-prefix/gold.intermediate.json
@@ -22,10 +22,11 @@
             },
             {
                 "_referenced_by": [
-                    "mapping-regex.yaml.1"
+                    "mapping-regex.yaml.1",
+                    "mapping-regex.yaml.2"
                 ],
                 "_service": "httpbin.org",
-                "_source": "mapping-regex.yaml.1",
+                "_source": "mapping-regex.yaml.2",
                 "lb_type": "round_robin",
                 "name": "cluster_http___httpbin_org",
                 "type": "strict_dns",
@@ -110,9 +111,41 @@
                     }
                 ],
                 "host_rewrite": "httpbin.org",
-                "prefix": "^\\/http(bin)\\/$",
-                "prefix_regex": true,
-                "prefix_rewrite": "/"
+                "prefix_rewrite": "/",
+                "regex": "^\\/http(bin)\\/$"
+            },
+            {
+                "__saved": [
+                    0,
+                    25,
+                    26,
+                    "^\\/users\\/(\\S)+\\/profile$",
+                    "GET",
+                    ":authority-test.datawire.io"
+                ],
+                "_group_id": "46d4c65de8385b0037059a5230371c822f43b189",
+                "_method": "GET",
+                "_precedence": 0,
+                "_referenced_by": [
+                    "mapping-regex.yaml.2"
+                ],
+                "_source": "mapping-regex.yaml.2",
+                "clusters": [
+                    {
+                        "name": "cluster_http___httpbin_org",
+                        "weight": 100.0
+                    }
+                ],
+                "headers": [
+                    {
+                        "name": ":authority",
+                        "regex": false,
+                        "value": "test.datawire.io"
+                    }
+                ],
+                "host_rewrite": "httpbin.org",
+                "prefix_rewrite": "/",
+                "regex": "^\\/users\\/(\\S)+\\/profile$"
             },
             {
                 "__saved": [
@@ -170,7 +203,8 @@
             "--internal--": true
         },
         "mapping-regex.yaml": {
-            "mapping-regex.yaml.1": true
+            "mapping-regex.yaml.1": true,
+            "mapping-regex.yaml.2": true
         }
     },
     "sources": {
@@ -200,6 +234,15 @@
             "name": "regex_mapping",
             "version": "ambassador/v0",
             "yaml": "apiVersion: ambassador/v0\nhost: test.datawire.io\nhost_rewrite: httpbin.org\nkind: Mapping\nname: regex_mapping\nprefix: ^\\/http(bin)\\/$\nprefix_regex: true\nservice: http://httpbin.org\n"
+        },
+        "mapping-regex.yaml.2": {
+            "_source": "mapping-regex.yaml",
+            "filename": "mapping-regex.yaml",
+            "index": 2,
+            "kind": "Mapping",
+            "name": "regex_escaping_mapping",
+            "version": "ambassador/v0",
+            "yaml": "apiVersion: ambassador/v0\nhost: test.datawire.io\nhost_rewrite: httpbin.org\nkind: Mapping\nname: regex_escaping_mapping\nprefix: ^\\/users\\/(\\S)+\\/profile$\nprefix_regex: true\nservice: http://httpbin.org\n"
         }
     }
 }

--- a/ambassador/tests/008-regex-prefix/gold.json
+++ b/ambassador/tests/008-regex-prefix/gold.json
@@ -49,7 +49,20 @@
                     ,
                     
                     {
-                      "timeout_ms": 3000,"regex": "^\/http(bin)\/$","prefix_rewrite": "/","host_rewrite": "httpbin.org","headers": [{"name": ":authority", "regex": false, "value": "test.datawire.io"}],
+                      "timeout_ms": 3000,"regex": "^\\/users\\/(\\S)+\\/profile$","prefix_rewrite": "/","host_rewrite": "httpbin.org","headers": [{"name": ":authority", "regex": false, "value": "test.datawire.io"}],
+                      "weighted_clusters": {
+                          "clusters": [
+                              
+                                 { "name": "cluster_http___httpbin_org", "weight": 100.0 }
+                              
+                          ]
+                      }
+                      
+                    }
+                    ,
+                    
+                    {
+                      "timeout_ms": 3000,"regex": "^\\/http(bin)\\/$","prefix_rewrite": "/","host_rewrite": "httpbin.org","headers": [{"name": ":authority", "regex": false, "value": "test.datawire.io"}],
                       "weighted_clusters": {
                           "clusters": [
                               

--- a/ambassador/tests/010-rewrite/gold.intermediate.json
+++ b/ambassador/tests/010-rewrite/gold.intermediate.json
@@ -134,8 +134,7 @@
                     }
                 ],
                 "host_rewrite": "httpbin.org",
-                "prefix": "^\\/http(.*)\\/$",
-                "prefix_regex": true,
+                "regex": "^\\/http(.*)\\/$",
                 "prefix_rewrite": ""
             },
             {

--- a/ambassador/tests/010-rewrite/gold.json
+++ b/ambassador/tests/010-rewrite/gold.json
@@ -61,7 +61,7 @@
                     }
                     ,
                     {
-                      "timeout_ms": 3000,"regex": "^\/http(.*)\/$","host_rewrite": "httpbin.org","headers": [{"name": ":authority", "regex": false, "value": "test.datawire.io"}],
+                      "timeout_ms": 3000,"regex": "^\\/http(.*)\\/$","host_rewrite": "httpbin.org","headers": [{"name": ":authority", "regex": false, "value": "test.datawire.io"}],
                       "weighted_clusters": {
                           "clusters": [
                               


### PR DESCRIPTION
Fixes https://github.com/datawire/ambassador/issues/528

Now, the generated `envoy.json` is valid and matches the diagnostic view.
Given the following Mapping:
<img width="285" alt="528-mapping" src="https://user-images.githubusercontent.com/188509/41469922-0f65025c-707d-11e8-9dd0-54aefad3901a.png">

The diag view generates the following envoy route:
<img width="358" alt="528-route" src="https://user-images.githubusercontent.com/188509/41469948-1df50f74-707d-11e8-87f1-7fbdd4491f3e.png">

Which matches the generated `envoy.json` config:
```
{
  "timeout_ms": 3000,"regex": "^\\/users\\/(\\S)+\\/profile$","prefix_rewrite": "/",
    "weighted_clusters": {
        "clusters": [
              { "name": "cluster_void_666", "weight": 100.0 }
        ]
    }
}
```

Notice the correct regex escaping in both diag and `envoy.json`.

Testing the regex matching:
```
~$ curl -v http://192.168.99.100:32569/users/1/profile
*   Trying 192.168.99.100...
* Connected to 192.168.99.100 (192.168.99.100) port 32569 (#0)
> GET /users/1/profile HTTP/1.1
> Host: 192.168.99.100:32569
> User-Agent: curl/7.43.0
> Accept: */*
>
< HTTP/1.1 503 Service Unavailable
< content-length: 19
< content-type: text/plain
< date: Fri, 15 Jun 2018 13:08:19 GMT
< server: envoy
<
* Connection #0 to host 192.168.99.100 left intact
no healthy upstream

~$ curl -v http://192.168.99.100:32569/users/profile
*   Trying 192.168.99.100...
* Connected to 192.168.99.100 (192.168.99.100) port 32569 (#0)
> GET /users/profile HTTP/1.1
> Host: 192.168.99.100:32569
> User-Agent: curl/7.43.0
> Accept: */*
>
< HTTP/1.1 404 Not Found
< date: Fri, 15 Jun 2018 13:08:35 GMT
< server: envoy
< content-length: 0
<
* Connection #0 to host 192.168.99.100 left intact
```