### PR TITLE
Add command in docs to check for RBAC

### DIFF
--- a/docs/reference/upgrading.md
+++ b/docs/reference/upgrading.md
@@ -1,17 +1,21 @@
 ## Upgrading Ambassador
 
-Since Ambassador's configuration is entirely stored in annotations or a `ConfigMap`, no special process is necessary to upgrade Ambassador. If you're using the YAML files supplied by Datawire, you'll be able to upgrade simply by repeating
+Since Ambassador's configuration is entirely stored in annotations or a `ConfigMap`, no special process is necessary to upgrade Ambassador. If you're using the YAML files supplied by Datawire, you'll be able to upgrade simply by repeating the following `kubectl apply` commands. First determine if Kubernetes has RBAC enabled, run:
+```shell
+kubectl cluster-info dump --namespace kube-system | grep authorization-mode
+```
+If you see something like `--authorization-mode=Node,RBAC` in the output, then RBAC is enabled.
 
+If RBAC is enabled:
 ```shell
 kubectl apply -f https://www.getambassador.io/yaml/ambassador/ambassador-rbac.yaml
 ```
 
-or
-
+If RBAC is not enabled:
 ```shell
 kubectl apply -f https://www.getambassador.io/yaml/ambassador/ambassador-no-rbac.yaml
 ```
 
-as appropriate for your cluster. This will trigger a rolling upgrade of Ambassador.
+This will trigger a rolling upgrade of Ambassador.
 
 If you're using your own YAML, check the Datawire YAML to be sure of other changes, but at minimum, you'll need to change the pulled `image` for the Ambassador container and redeploy.

--- a/docs/reference/upgrading.md
+++ b/docs/reference/upgrading.md
@@ -1,9 +1,13 @@
 ## Upgrading Ambassador
 
-Since Ambassador's configuration is entirely stored in annotations or a `ConfigMap`, no special process is necessary to upgrade Ambassador. If you're using the YAML files supplied by Datawire, you'll be able to upgrade simply by repeating the following `kubectl apply` commands. First determine if Kubernetes has RBAC enabled, run:
+Since Ambassador's configuration is entirely stored in annotations or a `ConfigMap`, no special process is necessary to upgrade Ambassador. If you're using the YAML files supplied by Datawire, you'll be able to upgrade simply by repeating the following `kubectl apply` commands.
+
+First determine if Kubernetes has RBAC enabled:
+
 ```shell
 kubectl cluster-info dump --namespace kube-system | grep authorization-mode
 ```
+
 If you see something like `--authorization-mode=Node,RBAC` in the output, then RBAC is enabled.
 
 If RBAC is enabled:

--- a/docs/user-guide/getting-started.md
+++ b/docs/user-guide/getting-started.md
@@ -6,7 +6,15 @@ Ambassador is designed to allow service authors to control how their service is 
 
 ## 1. Deploying Ambassador
 
-To deploy Ambassador in your default namespace, run this command if you're running in a cluster with RBAC enabled:
+To deploy Ambassador in your default namespace, first you need to check if Kubernetes has RBAC enabled, run:
+
+```shell
+kubectl cluster-info dump --namespace kube-system | grep authorization-mode
+```
+
+If you see something like `--authorization-mode=Node,RBAC` in the output, then RBAC is enabled.
+
+If RBAC is enabled:
 
 ```shell
 kubectl apply -f https://getambassador.io/yaml/ambassador/ambassador-rbac.yaml

--- a/docs/user-guide/getting-started.md
+++ b/docs/user-guide/getting-started.md
@@ -6,7 +6,7 @@ Ambassador is designed to allow service authors to control how their service is 
 
 ## 1. Deploying Ambassador
 
-To deploy Ambassador in your default namespace, first you need to check if Kubernetes has RBAC enabled, run:
+To deploy Ambassador in your default namespace, first you need to check if Kubernetes has RBAC enabled:
 
 ```shell
 kubectl cluster-info dump --namespace kube-system | grep authorization-mode

--- a/docs/user-guide/with-istio.md
+++ b/docs/user-guide/with-istio.md
@@ -22,7 +22,16 @@ By default, the Bookinfo application uses the Istio ingress. To use Ambassador, 
 
 First you will need to deploy the Ambassador ambassador-admin service to your cluster:
 
-It's simplest to use the YAML files we have online for this (though of course you can download them and use them locally if you prefer!). If you're using a cluster with RBAC enabled, you'll need to use:
+It's simplest to use the YAML files we have online for this (though of course you can download them and use them locally if you prefer!).
+
+First, you need to check if Kubernetes has RBAC enabled, run:
+```shell
+kubectl cluster-info dump --namespace kube-system | grep authorization-mode
+```
+If you see something like `--authorization-mode=Node,RBAC` in the output, then RBAC is enabled.
+
+If RBAC is enabled, you'll need to use:
+
 
 ```shell
 kubectl apply -f https://getambassador.io/yaml/ambassador/ambassador-rbac.yaml
@@ -33,6 +42,7 @@ Without RBAC, you can use:
 ```shell
 kubectl apply -f https://getambassador.io/yaml/ambassador/ambassador-no-rbac.yaml
 ```
+
 (Note that if you are planning to use mutual TLS for communication between Ambassador and Istio/services in the future, then the order in which you deploy the ambassador-admin service and the ambassador LoadBalancer service below may need to be swapped)
 
 Next you will deploy an ambassador service that acts as a point of ingress into the cluster via the LoadBalancer type. Create the following YAML and put it in a file called `ambassador-service.yaml`.

--- a/docs/user-guide/with-istio.md
+++ b/docs/user-guide/with-istio.md
@@ -24,7 +24,8 @@ First you will need to deploy the Ambassador ambassador-admin service to your cl
 
 It's simplest to use the YAML files we have online for this (though of course you can download them and use them locally if you prefer!).
 
-First, you need to check if Kubernetes has RBAC enabled, run:
+First, you need to check if Kubernetes has RBAC enabled:
+
 ```shell
 kubectl cluster-info dump --namespace kube-system | grep authorization-mode
 ```


### PR DESCRIPTION
This commit updates the docs for users to verify is their
Kubernetes installations have RBAC enabled or not. Maybe not the
perfect solution, but a step towards it.