### PR TITLE
Added support for service annotations.

### DIFF
--- a/helm/ambassador/Chart.yaml
+++ b/helm/ambassador/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: "0.30.2"
+appVersion: "0.32.2"
 description: A Helm chart for Datawire Ambassador
 name: ambassador
-version: 0.30.2
+version: 0.32.2
 sources:
 - https://github.com/datawire/ambassador
 maintainers:

--- a/helm/ambassador/templates/service.yaml
+++ b/helm/ambassador/templates/service.yaml
@@ -7,6 +7,10 @@ metadata:
     chart: {{ template "ambassador.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+{{- with .Values.service.annotations }}
+  annotations:
+{{ toYaml . | indent 6 }}
+{{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/helm/ambassador/values.yaml
+++ b/helm/ambassador/values.yaml
@@ -11,6 +11,7 @@ image:
 service:
   type: LoadBalancer
   port: 80
+  annotations: {}
 
 adminService:
   create: true


### PR DESCRIPTION
With this, one can configure the service with custom annotations, for
example:

```
service:
  annotations:
    cloud.google.com/load-balancer-type: "Internal"
```