### PR TITLE
Support running as root or as non-root

### DIFF
--- a/ambassador/ambassador/config.py
+++ b/ambassador/ambassador/config.py
@@ -980,7 +980,8 @@ class Config (object):
         for module_name in modules.keys():
             if ((module_name == 'ambassador') or
                 (module_name == 'tls') or
-                (module_name == 'authentication')):
+                (module_name == 'authentication') or
+                (module_name == 'tls-from-ambassador-certs')):
                 continue
 
             handler_name = "module_config_%s" % module_name

--- a/ambassador/ambassador/config.py
+++ b/ambassador/ambassador/config.py
@@ -904,7 +904,7 @@ class Config (object):
         # default values now.
 
         self.ambassador_module = SourcedDict(
-            service_port = 8080,
+            service_port = 80,
             admin_port = 8001,
             diag_port = 8877,
             auth_enabled = None,
@@ -1306,8 +1306,8 @@ class Config (object):
                     self.logger.debug("TLS termination enabled!")
                     some_enabled = True
 
-                    # Switch to port 8443 by default...
-                    self.set_config_ambassador(amod, 'service_port', 8443)
+                    # Switch to port 443 by default...
+                    self.set_config_ambassador(amod, 'service_port', 443)
 
                     # ...and merge in the server-side defaults.
                     tmp_config.update(self.default_tls_config['server'])

--- a/ambassador/ambassador/config.py
+++ b/ambassador/ambassador/config.py
@@ -1478,7 +1478,7 @@ class Config (object):
 
         if cluster_name not in self.envoy_clusters:
             if not cluster_hosts:
-                cluster_hosts = { '127.0.0.1:5000': 100 }
+                cluster_hosts = { '127.0.0.1:5000': ( 100, None ) }
 
             urls = []
             protocols = {}

--- a/ambassador/entrypoint.sh
+++ b/ambassador/entrypoint.sh
@@ -7,6 +7,8 @@ AMBASSADOR_ROOT="/ambassador"
 CONFIG_DIR="$AMBASSADOR_ROOT/ambassador-config"
 ENVOY_CONFIG_FILE="$AMBASSADOR_ROOT/envoy.json"
 
+export PYTHON_EGG_CACHE=$(AMBASSADOR_ROOT)
+
 if [ "$1" == "--demo" ]; then
     CONFIG_DIR="$AMBASSADOR_ROOT/ambassador-demo-config"
 fi

--- a/ambassador/entrypoint.sh
+++ b/ambassador/entrypoint.sh
@@ -25,6 +25,18 @@ export PYTHONUNBUFFERED=true
 
 pids=""
 
+ambassador_exit() {
+    RC=${1:-0}
+
+    if [ -n "$AMBASSADOR_EXIT_DELAY" ]; then
+        echo "AMBASSADOR: sleeping for debug"
+        sleep $AMBASSADOR_EXIT_DELAY
+    fi
+
+    echo "AMBASSADOR: shutting down ($RC)"
+    exit $RC
+}
+
 diediedie() {
     NAME=$1
     STATUS=$2
@@ -42,9 +54,8 @@ diediedie() {
     else
         echo "No config generated."
     fi
-
-    echo "AMBASSADOR: shutting down"
-    exit 1
+    
+    ambassador_exit 1
 }
 
 handle_chld() {
@@ -99,3 +110,5 @@ pids="${pids:+${pids} }$!:kubewatch"
 echo "AMBASSADOR: waiting"
 echo "PIDS: $pids"
 wait
+
+ambassador_exit 0

--- a/ambassador/kubewatch.py
+++ b/ambassador/kubewatch.py
@@ -346,24 +346,24 @@ def sync(restarter):
                     "config": {
                         "server": {
                             "enabled": True,
-                            "cert_chain_file": "/etc/certs/tls.crt",
-                            "private_key_file": "/etc/certs/tls.key"
+                            "cert_chain_file": "/ambassador/certs/tls.crt",
+                            "private_key_file": "/ambassador/certs/tls.key"
                         }
                     }
                 }
 
-                save_cert(server_cert, server_key, "/etc/certs")
+                save_cert(server_cert, server_key, "/ambassador/certs")
 
                 if client_cert:
                     tls_mod['config']['client'] = {
                         "enabled": True,
-                        "cacert_chain_file": "/etc/cacert/tls.crt"
+                        "cacert_chain_file": "/ambassador/cacert/tls.crt"
                     }
 
                     if client_data.get('cert_required', None):
                         tls_mod['config']['client']["cert_required"] = True
 
-                    save_cert(client_cert, None, "/etc/cacert")
+                    save_cert(client_cert, None, "/ambassador/cacert")
 
                 tls_yaml = yaml.safe_dump(tls_mod)
                 logger.debug("generated TLS config %s" % tls_yaml)

--- a/ambassador/schemas/v0/Mapping.schema
+++ b/ambassador/schemas/v0/Mapping.schema
@@ -29,26 +29,26 @@
                     "anyOf": [
                         { "type": "string" },
                         { "type": "array", "items": { "type": "string" } }
-                    ],
+                    ]
                 },
                 "methods": {
                     "anyOf": [
                         { "type": "string" },
                         { "type": "array", "items": { "type": "string" } }
-                    ],
+                    ]
                 },
                 "headers": {
                     "anyOf": [
                         { "type": "string" },
                         { "type": "array", "items": { "type": "string" } }
-                    ],
+                    ]
                 },
                 "credentials": { "type": "boolean" },
                 "exposed_headers": {
                     "anyOf": [
                         { "type": "string" },
                         { "type": "array", "items": { "type": "string" } }
-                    ],
+                    ]
                 },
                 "max_age": { "type": "string" }
             },

--- a/ambassador/tests/000-default/gold.intermediate.json
+++ b/ambassador/tests/000-default/gold.intermediate.json
@@ -98,7 +98,7 @@
             {
                 "_source": "--internal--",
                 "require_tls": false,
-                "service_port": 8080,
+                "service_port": 80,
                 "use_proxy_proto": false
             }
         ],

--- a/ambassador/tests/000-default/gold.json
+++ b/ambassador/tests/000-default/gold.json
@@ -2,7 +2,7 @@
   "listeners": [
     
     {
-      "address": "tcp://0.0.0.0:8080",
+      "address": "tcp://0.0.0.0:80",
       
       "filters": [
         {
@@ -23,105 +23,105 @@
                   "domains": ["*"],"routes": [
                     
                     {
-                      "timeout_ms": 3000,"prefix": "/ambassador/v0/check_ready","prefix_rewrite": "/ambassador/v0/check_ready","weighted_clusters": {
-                              "clusters": [
-                                  
-                                    { "name": "cluster_127_0_0_1_8877", "weight": 100.0 }
-                                  
-                              ]
-                          }
-
+                      "timeout_ms": 3000,"prefix": "/ambassador/v0/check_ready","prefix_rewrite": "/ambassador/v0/check_ready",
+                      "weighted_clusters": {
+                          "clusters": [
+                              
+                                 { "name": "cluster_127_0_0_1_8877", "weight": 100.0 }
+                              
+                          ]
+                      }
                       
                     }
                     ,
                     
                     {
-                      "timeout_ms": 3000,"prefix": "/ambassador/v0/check_alive","prefix_rewrite": "/ambassador/v0/check_alive","weighted_clusters": {
-                              "clusters": [
-                                  
-                                    { "name": "cluster_127_0_0_1_8877", "weight": 100.0 }
-                                  
-                              ]
-                          }
-
+                      "timeout_ms": 3000,"prefix": "/ambassador/v0/check_alive","prefix_rewrite": "/ambassador/v0/check_alive",
+                      "weighted_clusters": {
+                          "clusters": [
+                              
+                                 { "name": "cluster_127_0_0_1_8877", "weight": 100.0 }
+                              
+                          ]
+                      }
                       
                     }
                     ,
                     
                     {
-                      "timeout_ms": 3000,"prefix": "/ambassador/v0/","prefix_rewrite": "/ambassador/v0/","weighted_clusters": {
-                              "clusters": [
-                                  
-                                    { "name": "cluster_127_0_0_1_8877", "weight": 100.0 }
-                                  
-                              ]
-                          }
-
+                      "timeout_ms": 3000,"prefix": "/ambassador/v0/","prefix_rewrite": "/ambassador/v0/",
+                      "weighted_clusters": {
+                          "clusters": [
+                              
+                                 { "name": "cluster_127_0_0_1_8877", "weight": 100.0 }
+                              
+                          ]
+                      }
                       
                     }
                     ,
                     
                     {
-                      "timeout_ms": 3000,"prefix": "/ambassador/","prefix_rewrite": "/ambassador/","weighted_clusters": {
-                              "clusters": [
-                                  
-                                    { "name": "cluster_127_0_0_1_8877", "weight": 100.0 }
-                                  
-                              ]
-                          }
-
+                      "timeout_ms": 3000,"prefix": "/ambassador/","prefix_rewrite": "/ambassador/",
+                      "weighted_clusters": {
+                          "clusters": [
+                              
+                                 { "name": "cluster_127_0_0_1_8877", "weight": 100.0 }
+                              
+                          ]
+                      }
                       
                     }
                     ,
                     
                     {
-                      "timeout_ms": 3000,"prefix": "/httpbin/","prefix_rewrite": "/","host_rewrite": "httpbin.org","weighted_clusters": {
-                              "clusters": [
-                                  
-                                    { "name": "cluster_httpbin_org_80", "weight": 100.0 }
-                                  
-                              ]
-                          }
-
+                      "timeout_ms": 3000,"prefix": "/httpbin/","prefix_rewrite": "/","host_rewrite": "httpbin.org",
+                      "weighted_clusters": {
+                          "clusters": [
+                              
+                                 { "name": "cluster_httpbin_org_80", "weight": 100.0 }
+                              
+                          ]
+                      }
                       
                     }
                     ,
                     
                     {
-                      "timeout_ms": 3000,"prefix": "/cqrs/","headers": [{"name": ":method", "regex": false, "value": "PUT"}],"prefix_rewrite": "/qotm/quote/","weighted_clusters": {
-                              "clusters": [
-                                  
-                                    { "name": "cluster_demo_getambassador_io", "weight": 100.0 }
-                                  
-                              ]
-                          }
-
+                      "timeout_ms": 3000,"prefix": "/cqrs/","prefix_rewrite": "/qotm/quote/","headers": [{"name": ":method", "regex": false, "value": "PUT"}],
+                      "weighted_clusters": {
+                          "clusters": [
+                              
+                                 { "name": "cluster_demo_getambassador_io", "weight": 100.0 }
+                              
+                          ]
+                      }
                       
                     }
                     ,
                     
                     {
-                      "timeout_ms": 3000,"prefix": "/cqrs/","headers": [{"name": ":method", "regex": false, "value": "GET"}],"prefix_rewrite": "/qotm/quote/","weighted_clusters": {
-                              "clusters": [
-                                  
-                                    { "name": "cluster_demo_getambassador_io", "weight": 100.0 }
-                                  
-                              ]
-                          }
-
+                      "timeout_ms": 3000,"prefix": "/cqrs/","prefix_rewrite": "/qotm/quote/","headers": [{"name": ":method", "regex": false, "value": "GET"}],
+                      "weighted_clusters": {
+                          "clusters": [
+                              
+                                 { "name": "cluster_demo_getambassador_io", "weight": 100.0 }
+                              
+                          ]
+                      }
                       
                     }
                     ,
                     
                     {
-                      "timeout_ms": 3000,"prefix": "/qotm/","prefix_rewrite": "/qotm/","weighted_clusters": {
-                              "clusters": [
-                                  
-                                    { "name": "cluster_demo_getambassador_io", "weight": 100.0 }
-                                  
-                              ]
-                          }
-
+                      "timeout_ms": 3000,"prefix": "/qotm/","prefix_rewrite": "/qotm/",
+                      "weighted_clusters": {
+                          "clusters": [
+                              
+                                 { "name": "cluster_demo_getambassador_io", "weight": 100.0 }
+                              
+                          ]
+                      }
                       
                     }
                     
@@ -200,7 +200,6 @@
       
     ]
   },
-  
   "statsd_udp_ip_address": "127.0.0.1:8125",
   "stats_flush_interval_ms": 1000
 }

--- a/ambassador/tests/001-broader-v0/gold.intermediate.json
+++ b/ambassador/tests/001-broader-v0/gold.intermediate.json
@@ -364,7 +364,7 @@
             {
                 "_source": "ambassador.yaml.1",
                 "require_tls": false,
-                "service_port": 8443,
+                "service_port": 443,
                 "tls": {
                     "_source": "ambassador.yaml.1",
                     "cacert_chain_file": "/etc/ambassador-config/ca_cert_chain/tls.crt",

--- a/ambassador/tests/001-broader-v0/gold.json
+++ b/ambassador/tests/001-broader-v0/gold.json
@@ -2,7 +2,7 @@
   "listeners": [
     
     {
-      "address": "tcp://0.0.0.0:8443",
+      "address": "tcp://0.0.0.0:443",
       "use_proxy_proto": true,
       "ssl_context": {"cert_chain_file": "/etc/ambassador-config/certs/tls.crt",
           "private_key_file": "/etc/ambassador-config/certs/tls.key","ca_cert_file": "/etc/ambassador-config/ca_cert_chain/tls.crt","require_client_certificate": true

--- a/ambassador/tests/002-tls-module-1/gold.intermediate.json
+++ b/ambassador/tests/002-tls-module-1/gold.intermediate.json
@@ -51,7 +51,7 @@
             {
                 "_source": "ambassador.yaml.1",
                 "require_tls": false,
-                "service_port": 8443,
+                "service_port": 443,
                 "tls": {
                     "_source": "tls.yaml.1",
                     "alpn_protocols": "h2",

--- a/ambassador/tests/002-tls-module-1/gold.json
+++ b/ambassador/tests/002-tls-module-1/gold.json
@@ -2,7 +2,7 @@
   "listeners": [
     
     {
-      "address": "tcp://0.0.0.0:8443",
+      "address": "tcp://0.0.0.0:443",
       
       "ssl_context": {"cert_chain_file": "/etc/ambassador-config/certs/tls.crt",
           "private_key_file": "/etc/ambassador-config/certs/tls.key","alpn_protocols": "h2","ca_cert_file": "/etc/ambassador-config/ca_cert_chain/tls.crt","require_client_certificate": true
@@ -25,40 +25,40 @@
                   "domains": ["*"],"routes": [
                     
                     {
-                      "timeout_ms": 3000,"prefix": "/ambassador/v0/check_ready","prefix_rewrite": "/ambassador/v0/check_ready","weighted_clusters": {
-                              "clusters": [
-                                  
-                                    { "name": "cluster_127_0_0_1_8877", "weight": 100.0 }
-                                  
-                              ]
-                          }
-
+                      "timeout_ms": 3000,"prefix": "/ambassador/v0/check_ready","prefix_rewrite": "/ambassador/v0/check_ready",
+                      "weighted_clusters": {
+                          "clusters": [
+                              
+                                 { "name": "cluster_127_0_0_1_8877", "weight": 100.0 }
+                              
+                          ]
+                      }
                       
                     }
                     ,
                     
                     {
-                      "timeout_ms": 3000,"prefix": "/ambassador/v0/","prefix_rewrite": "/ambassador/v0/","weighted_clusters": {
-                              "clusters": [
-                                  
-                                    { "name": "cluster_127_0_0_1_8877", "weight": 100.0 }
-                                  
-                              ]
-                          }
-
+                      "timeout_ms": 3000,"prefix": "/ambassador/v0/","prefix_rewrite": "/ambassador/v0/",
+                      "weighted_clusters": {
+                          "clusters": [
+                              
+                                 { "name": "cluster_127_0_0_1_8877", "weight": 100.0 }
+                              
+                          ]
+                      }
                       
                     }
                     ,
                     
                     {
-                      "timeout_ms": 3000,"prefix": "/qotm/","prefix_rewrite": "/","weighted_clusters": {
-                              "clusters": [
-                                  
-                                    { "name": "cluster_qotm", "weight": 100.0 }
-                                  
-                              ]
-                          }
-
+                      "timeout_ms": 3000,"prefix": "/qotm/","prefix_rewrite": "/",
+                      "weighted_clusters": {
+                          "clusters": [
+                              
+                                 { "name": "cluster_qotm", "weight": 100.0 }
+                              
+                          ]
+                      }
                       
                     }
                     
@@ -112,7 +112,6 @@
       
     ]
   },
-  
   "statsd_udp_ip_address": "127.0.0.1:8125",
   "stats_flush_interval_ms": 1000
 }

--- a/ambassador/tests/003-tls-module-2/gold.intermediate.json
+++ b/ambassador/tests/003-tls-module-2/gold.intermediate.json
@@ -51,7 +51,7 @@
             {
                 "_source": "ambassador.yaml.1",
                 "require_tls": false,
-                "service_port": 8443,
+                "service_port": 443,
                 "tls": {
                     "_source": "ambassador.yaml.1",
                     "cacert_chain_file": "/etc/ambassador-config/ca_cert_chain/tls.crt",

--- a/ambassador/tests/003-tls-module-2/gold.json
+++ b/ambassador/tests/003-tls-module-2/gold.json
@@ -2,7 +2,7 @@
   "listeners": [
     
     {
-      "address": "tcp://0.0.0.0:8443",
+      "address": "tcp://0.0.0.0:443",
       
       "ssl_context": {"cert_chain_file": "/etc/ambassador-config/certs/tls.crt",
           "private_key_file": "/etc/ambassador-config/certs/tls.key","ca_cert_file": "/etc/ambassador-config/ca_cert_chain/tls.crt","require_client_certificate": true
@@ -25,40 +25,40 @@
                   "domains": ["*"],"routes": [
                     
                     {
-                      "timeout_ms": 3000,"prefix": "/ambassador/v0/check_ready","prefix_rewrite": "/ambassador/v0/check_ready","weighted_clusters": {
-                              "clusters": [
-                                  
-                                    { "name": "cluster_127_0_0_1_8877", "weight": 100.0 }
-                                  
-                              ]
-                          }
-
+                      "timeout_ms": 3000,"prefix": "/ambassador/v0/check_ready","prefix_rewrite": "/ambassador/v0/check_ready",
+                      "weighted_clusters": {
+                          "clusters": [
+                              
+                                 { "name": "cluster_127_0_0_1_8877", "weight": 100.0 }
+                              
+                          ]
+                      }
                       
                     }
                     ,
                     
                     {
-                      "timeout_ms": 3000,"prefix": "/ambassador/v0/","prefix_rewrite": "/ambassador/v0/","weighted_clusters": {
-                              "clusters": [
-                                  
-                                    { "name": "cluster_127_0_0_1_8877", "weight": 100.0 }
-                                  
-                              ]
-                          }
-
+                      "timeout_ms": 3000,"prefix": "/ambassador/v0/","prefix_rewrite": "/ambassador/v0/",
+                      "weighted_clusters": {
+                          "clusters": [
+                              
+                                 { "name": "cluster_127_0_0_1_8877", "weight": 100.0 }
+                              
+                          ]
+                      }
                       
                     }
                     ,
                     
                     {
-                      "timeout_ms": 3000,"prefix": "/qotm/","prefix_rewrite": "/","weighted_clusters": {
-                              "clusters": [
-                                  
-                                    { "name": "cluster_qotm", "weight": 100.0 }
-                                  
-                              ]
-                          }
-
+                      "timeout_ms": 3000,"prefix": "/qotm/","prefix_rewrite": "/",
+                      "weighted_clusters": {
+                          "clusters": [
+                              
+                                 { "name": "cluster_qotm", "weight": 100.0 }
+                              
+                          ]
+                      }
                       
                     }
                     
@@ -112,7 +112,6 @@
       
     ]
   },
-  
   "statsd_udp_ip_address": "127.0.0.1:8125",
   "stats_flush_interval_ms": 1000
 }

--- a/ambassador/tests/004-tls-without-ambassador-module/gold.intermediate.json
+++ b/ambassador/tests/004-tls-without-ambassador-module/gold.intermediate.json
@@ -51,7 +51,7 @@
             {
                 "_source": "tls.yaml.1",
                 "require_tls": false,
-                "service_port": 8443,
+                "service_port": 443,
                 "tls": {
                     "_source": "tls.yaml.1",
                     "cacert_chain_file": "/etc/ambassador-config/ca_cert_chain/tls.crt",

--- a/ambassador/tests/004-tls-without-ambassador-module/gold.json
+++ b/ambassador/tests/004-tls-without-ambassador-module/gold.json
@@ -2,7 +2,7 @@
   "listeners": [
     
     {
-      "address": "tcp://0.0.0.0:8443",
+      "address": "tcp://0.0.0.0:443",
       
       "ssl_context": {"cert_chain_file": "/etc/ambassador-config/certs/tls.crt",
           "private_key_file": "/etc/ambassador-config/certs/tls.key","ca_cert_file": "/etc/ambassador-config/ca_cert_chain/tls.crt","require_client_certificate": true
@@ -25,53 +25,53 @@
                   "domains": ["*"],"routes": [
                     
                     {
-                      "timeout_ms": 3000,"prefix": "/ambassador/v0/check_ready","prefix_rewrite": "/ambassador/v0/check_ready","weighted_clusters": {
-                              "clusters": [
-                                  
-                                    { "name": "cluster_127_0_0_1_8877", "weight": 100.0 }
-                                  
-                              ]
-                          }
-
+                      "timeout_ms": 3000,"prefix": "/ambassador/v0/check_ready","prefix_rewrite": "/ambassador/v0/check_ready",
+                      "weighted_clusters": {
+                          "clusters": [
+                              
+                                 { "name": "cluster_127_0_0_1_8877", "weight": 100.0 }
+                              
+                          ]
+                      }
                       
                     }
                     ,
                     
                     {
-                      "timeout_ms": 3000,"prefix": "/ambassador/v0/check_alive","prefix_rewrite": "/ambassador/v0/check_alive","weighted_clusters": {
-                              "clusters": [
-                                  
-                                    { "name": "cluster_127_0_0_1_8877", "weight": 100.0 }
-                                  
-                              ]
-                          }
-
+                      "timeout_ms": 3000,"prefix": "/ambassador/v0/check_alive","prefix_rewrite": "/ambassador/v0/check_alive",
+                      "weighted_clusters": {
+                          "clusters": [
+                              
+                                 { "name": "cluster_127_0_0_1_8877", "weight": 100.0 }
+                              
+                          ]
+                      }
                       
                     }
                     ,
                     
                     {
-                      "timeout_ms": 3000,"prefix": "/ambassador/v0/","prefix_rewrite": "/ambassador/v0/","weighted_clusters": {
-                              "clusters": [
-                                  
-                                    { "name": "cluster_127_0_0_1_8877", "weight": 100.0 }
-                                  
-                              ]
-                          }
-
+                      "timeout_ms": 3000,"prefix": "/ambassador/v0/","prefix_rewrite": "/ambassador/v0/",
+                      "weighted_clusters": {
+                          "clusters": [
+                              
+                                 { "name": "cluster_127_0_0_1_8877", "weight": 100.0 }
+                              
+                          ]
+                      }
                       
                     }
                     ,
                     
                     {
-                      "timeout_ms": 3000,"prefix": "/qotm/","prefix_rewrite": "/","weighted_clusters": {
-                              "clusters": [
-                                  
-                                    { "name": "cluster_qotm", "weight": 100.0 }
-                                  
-                              ]
-                          }
-
+                      "timeout_ms": 3000,"prefix": "/qotm/","prefix_rewrite": "/",
+                      "weighted_clusters": {
+                          "clusters": [
+                              
+                                 { "name": "cluster_qotm", "weight": 100.0 }
+                              
+                          ]
+                      }
                       
                     }
                     
@@ -125,7 +125,6 @@
       
     ]
   },
-  
   "statsd_udp_ip_address": "127.0.0.1:8125",
   "stats_flush_interval_ms": 1000
 }

--- a/ambassador/tests/005-canary/gold.intermediate.json
+++ b/ambassador/tests/005-canary/gold.intermediate.json
@@ -65,7 +65,7 @@
             {
                 "_source": "--internal--",
                 "require_tls": false,
-                "service_port": 8080,
+                "service_port": 80,
                 "use_proxy_proto": false
             }
         ],

--- a/ambassador/tests/005-canary/gold.json
+++ b/ambassador/tests/005-canary/gold.json
@@ -2,7 +2,7 @@
   "listeners": [
     
     {
-      "address": "tcp://0.0.0.0:8080",
+      "address": "tcp://0.0.0.0:80",
       
       "filters": [
         {
@@ -23,68 +23,68 @@
                   "domains": ["*"],"routes": [
                     
                     {
-                      "timeout_ms": 3000,"prefix": "/ambassador/v0/check_ready","prefix_rewrite": "/ambassador/v0/check_ready","weighted_clusters": {
-                              "clusters": [
-                                  
-                                    { "name": "cluster_127_0_0_1_8877", "weight": 100.0 }
-                                  
-                              ]
-                          }
-
+                      "timeout_ms": 3000,"prefix": "/ambassador/v0/check_ready","prefix_rewrite": "/ambassador/v0/check_ready",
+                      "weighted_clusters": {
+                          "clusters": [
+                              
+                                 { "name": "cluster_127_0_0_1_8877", "weight": 100.0 }
+                              
+                          ]
+                      }
                       
                     }
                     ,
                     
                     {
-                      "timeout_ms": 3000,"prefix": "/ambassador/v0/check_alive","prefix_rewrite": "/ambassador/v0/check_alive","weighted_clusters": {
-                              "clusters": [
-                                  
-                                    { "name": "cluster_127_0_0_1_8877", "weight": 100.0 }
-                                  
-                              ]
-                          }
-
+                      "timeout_ms": 3000,"prefix": "/ambassador/v0/check_alive","prefix_rewrite": "/ambassador/v0/check_alive",
+                      "weighted_clusters": {
+                          "clusters": [
+                              
+                                 { "name": "cluster_127_0_0_1_8877", "weight": 100.0 }
+                              
+                          ]
+                      }
                       
                     }
                     ,
                     
                     {
-                      "timeout_ms": 3000,"prefix": "/ambassador/v0/","prefix_rewrite": "/ambassador/v0/","weighted_clusters": {
-                              "clusters": [
-                                  
-                                    { "name": "cluster_127_0_0_1_8877", "weight": 100.0 }
-                                  
-                              ]
-                          }
-
+                      "timeout_ms": 3000,"prefix": "/ambassador/v0/","prefix_rewrite": "/ambassador/v0/",
+                      "weighted_clusters": {
+                          "clusters": [
+                              
+                                 { "name": "cluster_127_0_0_1_8877", "weight": 100.0 }
+                              
+                          ]
+                      }
                       
                     }
                     ,
                     
                     {
-                      "timeout_ms": 3000,"prefix": "/ambassador/","prefix_rewrite": "/ambassador/","weighted_clusters": {
-                              "clusters": [
-                                  
-                                    { "name": "cluster_127_0_0_1_8877", "weight": 100.0 }
-                                  
-                              ]
-                          }
-
+                      "timeout_ms": 3000,"prefix": "/ambassador/","prefix_rewrite": "/ambassador/",
+                      "weighted_clusters": {
+                          "clusters": [
+                              
+                                 { "name": "cluster_127_0_0_1_8877", "weight": 100.0 }
+                              
+                          ]
+                      }
                       
                     }
                     ,
                     
                     {
-                      "timeout_ms": 3000,"prefix": "/demo/","prefix_rewrite": "/","weighted_clusters": {
-                              "clusters": [
-                                  
-                                    { "name": "cluster_demo1", "weight": 50.0 },
-                                  
-                                    { "name": "cluster_demo2", "weight": 50 }
-                                  
-                              ]
-                          }
-
+                      "timeout_ms": 3000,"prefix": "/demo/","prefix_rewrite": "/",
+                      "weighted_clusters": {
+                          "clusters": [
+                              
+                                 { "name": "cluster_demo1", "weight": 50.0 },
+                              
+                                 { "name": "cluster_demo2", "weight": 50 }
+                              
+                          ]
+                      }
                       
                     }
                     
@@ -149,7 +149,6 @@
       
     ]
   },
-  
   "statsd_udp_ip_address": "127.0.0.1:8125",
   "stats_flush_interval_ms": 1000
 }

--- a/ambassador/tests/006-headers-and-host/config/mapping-cors.yaml
+++ b/ambassador/tests/006-headers-and-host/config/mapping-cors.yaml
@@ -3,7 +3,7 @@ apiVersion: ambassador/v0
 kind:  Mapping
 name:  cors_creds_mapping
 prefix: /cors-creds/
-service: cors:8080
+service: cors
 cors:
   origins: http://foo.example,http://bar.example
   methods: POST, GET, OPTIONS
@@ -16,6 +16,6 @@ apiVersion: ambassador/v0
 kind:  Mapping
 name:  cors_all_mapping
 prefix: /cors-all/
-service: cors:8080
+service: cors
 cors:
   origins: "*"

--- a/ambassador/tests/006-headers-and-host/gold.intermediate.json
+++ b/ambassador/tests/006-headers-and-host/gold.intermediate.json
@@ -26,13 +26,13 @@
                     "mapping-cors.yaml.1",
                     "mapping-cors.yaml.2"
                 ],
-                "_service": "cors:8080",
+                "_service": "cors",
                 "_source": "mapping-cors.yaml.2",
                 "lb_type": "round_robin",
-                "name": "cluster_cors_8080",
+                "name": "cluster_cors",
                 "type": "strict_dns",
                 "urls": [
-                    "tcp://cors:8080"
+                    "tcp://cors:80"
                 ]
             },
             {
@@ -138,7 +138,7 @@
             {
                 "_source": "--internal--",
                 "require_tls": false,
-                "service_port": 8080,
+                "service_port": 80,
                 "use_proxy_proto": false
             }
         ],
@@ -294,7 +294,7 @@
                 "_source": "mapping-cors.yaml.1",
                 "clusters": [
                     {
-                        "name": "cluster_cors_8080",
+                        "name": "cluster_cors",
                         "weight": 100.0
                     }
                 ],
@@ -508,7 +508,7 @@
                 "_source": "mapping-cors.yaml.2",
                 "clusters": [
                     {
-                        "name": "cluster_cors_8080",
+                        "name": "cluster_cors",
                         "weight": 100.0
                     }
                 ],
@@ -604,7 +604,7 @@
             "kind": "Mapping",
             "name": "cors_creds_mapping",
             "version": "ambassador/v0",
-            "yaml": "apiVersion: ambassador/v0\ncors:\n  credentials: true\n  exposed_headers: X-Custom-Header\n  headers: Content-Type\n  max_age: '86400'\n  methods: POST, GET, OPTIONS\n  origins: http://foo.example,http://bar.example\nkind: Mapping\nname: cors_creds_mapping\nprefix: /cors-creds/\nservice: cors:8080\n"
+            "yaml": "apiVersion: ambassador/v0\ncors:\n  credentials: true\n  exposed_headers: X-Custom-Header\n  headers: Content-Type\n  max_age: '86400'\n  methods: POST, GET, OPTIONS\n  origins: http://foo.example,http://bar.example\nkind: Mapping\nname: cors_creds_mapping\nprefix: /cors-creds/\nservice: cors\n"
         },
         "mapping-cors.yaml.2": {
             "_source": "mapping-cors.yaml",
@@ -613,7 +613,7 @@
             "kind": "Mapping",
             "name": "cors_all_mapping",
             "version": "ambassador/v0",
-            "yaml": "apiVersion: ambassador/v0\ncors:\n  origins: '*'\nkind: Mapping\nname: cors_all_mapping\nprefix: /cors-all/\nservice: cors:8080\n"
+            "yaml": "apiVersion: ambassador/v0\ncors:\n  origins: '*'\nkind: Mapping\nname: cors_all_mapping\nprefix: /cors-all/\nservice: cors\n"
         },
         "mapping-diag.yaml.1": {
             "_source": "mapping-diag.yaml",

--- a/ambassador/tests/006-headers-and-host/gold.json
+++ b/ambassador/tests/006-headers-and-host/gold.json
@@ -2,7 +2,7 @@
   "listeners": [
     
     {
-      "address": "tcp://0.0.0.0:8080",
+      "address": "tcp://0.0.0.0:80",
       
       "filters": [
         {
@@ -91,7 +91,7 @@
                       "timeout_ms": 3000,"prefix": "/cors-creds/","cors": {"allow_credentials": true, "allow_headers": "Content-Type", "allow_methods": "POST, GET, OPTIONS", "allow_origin": ["http://foo.example", "http://bar.example"], "enabled": true, "expose_headers": "X-Custom-Header", "max_age": "86400"},"prefix_rewrite": "/","weighted_clusters": {
                               "clusters": [
                                   
-                                    { "name": "cluster_cors_8080", "weight": 100.0 }
+                                    { "name": "cluster_cors", "weight": 100.0 }
                                   
                               ]
                           }
@@ -117,7 +117,7 @@
                       "timeout_ms": 3000,"prefix": "/cors-all/","cors": {"allow_origin": ["*"], "enabled": true},"prefix_rewrite": "/","weighted_clusters": {
                               "clusters": [
                                   
-                                    { "name": "cluster_cors_8080", "weight": 100.0 }
+                                    { "name": "cluster_cors", "weight": 100.0 }
                                   
                               ]
                           }
@@ -217,13 +217,13 @@
           
         ]},
       {
-        "name": "cluster_cors_8080",
+        "name": "cluster_cors",
         "connect_timeout_ms": 3000,
         "type": "strict_dns",
         "lb_type": "round_robin",        
         "hosts": [
           {
-            "url": "tcp://cors:8080"
+            "url": "tcp://cors:80"
           }
           
         ]},

--- a/ambassador/tests/007-originating-tls/gold.intermediate.json
+++ b/ambassador/tests/007-originating-tls/gold.intermediate.json
@@ -118,7 +118,7 @@
             {
                 "_source": "ambassador.yaml.1",
                 "require_tls": false,
-                "service_port": 8443,
+                "service_port": 443,
                 "tls": {
                     "_source": "tls.yaml.1",
                     "cert_chain_file": "/etc/ambassador-config/certs/tls.crt",

--- a/ambassador/tests/007-originating-tls/gold.json
+++ b/ambassador/tests/007-originating-tls/gold.json
@@ -1,9 +1,9 @@
 {
   "listeners": [
-    
+
     {
-      "address": "tcp://0.0.0.0:8443",
-      
+      "address": "tcp://0.0.0.0:443",
+
       "ssl_context": {"cert_chain_file": "/etc/ambassador-config/certs/tls.crt",
           "private_key_file": "/etc/ambassador-config/certs/tls.key"
       },"filters": [
@@ -23,46 +23,46 @@
                 {
                   "name": "backend",
                   "domains": ["*"],"routes": [
-                    
-                    {
-                      "timeout_ms": 3000,"prefix": "/ambassador/v0/check_ready","prefix_rewrite": "/ambassador/v0/check_ready","weighted_clusters": {
-                              "clusters": [
-                                  
-                                    { "name": "cluster_127_0_0_1_8877", "weight": 100.0 }
-                                  
-                              ]
-                          }
 
-                      
+                    {
+                      "timeout_ms": 3000,"prefix": "/ambassador/v0/check_ready","prefix_rewrite": "/ambassador/v0/check_ready",
+                      "weighted_clusters": {
+                          "clusters": [
+
+                                 { "name": "cluster_127_0_0_1_8877", "weight": 100.0 }
+
+                          ]
+                      }
+
                     }
                     ,
-                    
-                    {
-                      "timeout_ms": 3000,"prefix": "/ambassador/v0/","prefix_rewrite": "/ambassador/v0/","weighted_clusters": {
-                              "clusters": [
-                                  
-                                    { "name": "cluster_127_0_0_1_8877", "weight": 100.0 }
-                                  
-                              ]
-                          }
 
-                      
+                    {
+                      "timeout_ms": 3000,"prefix": "/ambassador/v0/","prefix_rewrite": "/ambassador/v0/",
+                      "weighted_clusters": {
+                          "clusters": [
+
+                                 { "name": "cluster_127_0_0_1_8877", "weight": 100.0 }
+
+                          ]
+                      }
+
                     }
                     ,
-                    
-                    {
-                      "timeout_ms": 3000,"prefix": "/qotm/","prefix_rewrite": "/","weighted_clusters": {
-                              "clusters": [
-                                  
-                                    { "name": "cluster_qotm_otls_upstream", "weight": 100.0 }
-                                  
-                              ]
-                          }
 
-                      
+                    {
+                      "timeout_ms": 3000,"prefix": "/qotm/","prefix_rewrite": "/",
+                      "weighted_clusters": {
+                          "clusters": [
+
+                                 { "name": "cluster_qotm_otls_upstream", "weight": 100.0 }
+
+                          ]
+                      }
+
                     }
-                    
-                    
+
+
                   ]
                 }
               ]
@@ -94,53 +94,52 @@
         "name": "cluster_127_0_0_1_8877",
         "connect_timeout_ms": 3000,
         "type": "strict_dns",
-        "lb_type": "round_robin",        
+        "lb_type": "round_robin",
         "hosts": [
           {
             "url": "tcp://127.0.0.1:8877"
           }
-          
+
         ]},
       {
         "name": "cluster_ext_auth_otls_upstream",
         "connect_timeout_ms": 3000,
         "type": "strict_dns",
-        "lb_type": "round_robin",        
+        "lb_type": "round_robin",
         "hosts": [
           {
             "url": "tcp://example-auth:3000"
           }
-          
+
         ],
         "ssl_context": {
-          
+
           "cert_chain_file": "/etc/ambassador-config/certs/outbound.crt",
-          
+
           "private_key_file": "/etc/ambassador-config/certs/outbound.key"
-          
-        }},
+
+	}},
       {
         "name": "cluster_qotm_otls_upstream",
         "connect_timeout_ms": 3000,
         "type": "strict_dns",
-        "lb_type": "round_robin",        
+        "lb_type": "round_robin",
         "hosts": [
           {
             "url": "tcp://qotm:443"
           }
-          
+
         ],
         "ssl_context": {
-          
+
           "cert_chain_file": "/etc/ambassador-config/certs/outbound.crt",
-          
+
           "private_key_file": "/etc/ambassador-config/certs/outbound.key"
-          
+
         }}
-      
+
     ]
   },
-  
   "statsd_udp_ip_address": "127.0.0.1:8125",
   "stats_flush_interval_ms": 1000
 }

--- a/ambassador/tests/008-regex-prefix/gold.intermediate.json
+++ b/ambassador/tests/008-regex-prefix/gold.intermediate.json
@@ -52,7 +52,7 @@
             {
                 "_source": "--internal--",
                 "require_tls": false,
-                "service_port": 8080,
+                "service_port": 80,
                 "use_proxy_proto": false
             }
         ],

--- a/ambassador/tests/008-regex-prefix/gold.json
+++ b/ambassador/tests/008-regex-prefix/gold.json
@@ -2,7 +2,7 @@
   "listeners": [
     
     {
-      "address": "tcp://0.0.0.0:8080",
+      "address": "tcp://0.0.0.0:80",
       
       "filters": [
         {
@@ -23,66 +23,66 @@
                   "domains": ["*"],"routes": [
                     
                     {
-                      "timeout_ms": 3000,"prefix": "/ambassador/v0/check_ready","prefix_rewrite": "/ambassador/v0/check_ready","weighted_clusters": {
-                              "clusters": [
-                                  
-                                    { "name": "cluster_127_0_0_1_8877", "weight": 100.0 }
-                                  
-                              ]
-                          }
-
+                      "timeout_ms": 3000,"prefix": "/ambassador/v0/check_ready","prefix_rewrite": "/ambassador/v0/check_ready",
+                      "weighted_clusters": {
+                          "clusters": [
+                              
+                                 { "name": "cluster_127_0_0_1_8877", "weight": 100.0 }
+                              
+                          ]
+                      }
                       
                     }
                     ,
                     
                     {
-                      "timeout_ms": 3000,"prefix": "/ambassador/v0/check_alive","prefix_rewrite": "/ambassador/v0/check_alive","weighted_clusters": {
-                              "clusters": [
-                                  
-                                    { "name": "cluster_127_0_0_1_8877", "weight": 100.0 }
-                                  
-                              ]
-                          }
-
+                      "timeout_ms": 3000,"prefix": "/ambassador/v0/check_alive","prefix_rewrite": "/ambassador/v0/check_alive",
+                      "weighted_clusters": {
+                          "clusters": [
+                              
+                                 { "name": "cluster_127_0_0_1_8877", "weight": 100.0 }
+                              
+                          ]
+                      }
                       
                     }
                     ,
                     
                     {
-                      "timeout_ms": 3000,"regex": "^\\/users\\/(\\S)+\\/profile$","headers": [{"name": ":authority", "regex": false, "value": "test.datawire.io"}],"prefix_rewrite": "/","host_rewrite": "httpbin.org","weighted_clusters": {
-                              "clusters": [
-                                  
-                                    { "name": "cluster_http___httpbin_org", "weight": 100.0 }
-                                  
-                              ]
-                          }
-
+                      "timeout_ms": 3000,"regex": "^\\/users\\/(\\S)+\\/profile$","prefix_rewrite": "/","host_rewrite": "httpbin.org","headers": [{"name": ":authority", "regex": false, "value": "test.datawire.io"}],
+                      "weighted_clusters": {
+                          "clusters": [
+                              
+                                 { "name": "cluster_http___httpbin_org", "weight": 100.0 }
+                              
+                          ]
+                      }
                       
                     }
                     ,
                     
                     {
-                      "timeout_ms": 3000,"regex": "^\\/http(bin)\\/$","headers": [{"name": ":authority", "regex": false, "value": "test.datawire.io"}],"prefix_rewrite": "/","host_rewrite": "httpbin.org","weighted_clusters": {
-                              "clusters": [
-                                  
-                                    { "name": "cluster_http___httpbin_org", "weight": 100.0 }
-                                  
-                              ]
-                          }
-
+                      "timeout_ms": 3000,"regex": "^\\/http(bin)\\/$","prefix_rewrite": "/","host_rewrite": "httpbin.org","headers": [{"name": ":authority", "regex": false, "value": "test.datawire.io"}],
+                      "weighted_clusters": {
+                          "clusters": [
+                              
+                                 { "name": "cluster_http___httpbin_org", "weight": 100.0 }
+                              
+                          ]
+                      }
                       
                     }
                     ,
                     
                     {
-                      "timeout_ms": 3000,"prefix": "/ambassador/v0/","prefix_rewrite": "/ambassador/v0/","weighted_clusters": {
-                              "clusters": [
-                                  
-                                    { "name": "cluster_127_0_0_1_8877", "weight": 100.0 }
-                                  
-                              ]
-                          }
-
+                      "timeout_ms": 3000,"prefix": "/ambassador/v0/","prefix_rewrite": "/ambassador/v0/",
+                      "weighted_clusters": {
+                          "clusters": [
+                              
+                                 { "name": "cluster_127_0_0_1_8877", "weight": 100.0 }
+                              
+                          ]
+                      }
                       
                     }
                     
@@ -136,7 +136,6 @@
       
     ]
   },
-  
   "statsd_udp_ip_address": "127.0.0.1:8125",
   "stats_flush_interval_ms": 1000
 }

--- a/ambassador/tests/009-rate-limit/gold.intermediate.json
+++ b/ambassador/tests/009-rate-limit/gold.intermediate.json
@@ -84,7 +84,7 @@
             {
                 "_source": "--internal--",
                 "require_tls": false,
-                "service_port": 8080,
+                "service_port": 80,
                 "use_proxy_proto": false
             }
         ],

--- a/ambassador/tests/009-rate-limit/gold.json
+++ b/ambassador/tests/009-rate-limit/gold.json
@@ -1,9 +1,9 @@
 {
   "listeners": [
-    
+
     {
-      "address": "tcp://0.0.0.0:8080",
-      
+      "address": "tcp://0.0.0.0:80",
+
       "filters": [
         {
           "type": "read",
@@ -21,86 +21,86 @@
                 {
                   "name": "backend",
                   "domains": ["*"],"routes": [
-                    
-                    {
-                      "timeout_ms": 3000,"prefix": "/ambassador/v0/check_ready","prefix_rewrite": "/ambassador/v0/check_ready","weighted_clusters": {
-                              "clusters": [
-                                  
-                                    { "name": "cluster_127_0_0_1_8877", "weight": 100.0 }
-                                  
-                              ]
-                          }
 
-                      
-                    }
-                    ,
-                    
-                    {
-                      "timeout_ms": 3000,"prefix": "/ambassador/v0/check_alive","prefix_rewrite": "/ambassador/v0/check_alive","weighted_clusters": {
-                              "clusters": [
-                                  
-                                    { "name": "cluster_127_0_0_1_8877", "weight": 100.0 }
-                                  
-                              ]
-                          }
+                  {
+                    "timeout_ms": 3000,"prefix": "/ambassador/v0/check_ready","prefix_rewrite": "/ambassador/v0/check_ready",
+                    "weighted_clusters": {
+                      "clusters": [
 
-                      
-                    }
-                    ,
-                    
-                    {
-                      "timeout_ms": 3000,"prefix": "/qotm-rate-custom/","rate_limits": [{"actions": [{"type": "source_cluster"}, {"type": "destination_cluster"}, {"type": "remote_address"}]}, {"actions": [{"type": "source_cluster"}, {"type": "destination_cluster"}, {"type": "remote_address"}, {"descriptor_value": "custom-label", "type": "generic_key"}, {"descriptor_key": ":authority", "header_name": ":authority", "type": "request_headers"}]}],"prefix_rewrite": "/","weighted_clusters": {
-                              "clusters": [
-                                  
-                                    { "name": "cluster_qotm", "weight": 100.0 }
-                                  
-                              ]
-                          }
+                        { "name": "cluster_127_0_0_1_8877", "weight": 100.0 }
 
-                      
+                      ]
                     }
-                    ,
-                    
-                    {
-                      "timeout_ms": 3000,"prefix": "/ambassador/v0/","prefix_rewrite": "/ambassador/v0/","weighted_clusters": {
-                              "clusters": [
-                                  
-                                    { "name": "cluster_127_0_0_1_8877", "weight": 100.0 }
-                                  
-                              ]
-                          }
 
-                      
-                    }
-                    ,
-                    
-                    {
-                      "timeout_ms": 3000,"prefix": "/qotm-rate/","rate_limits": [{"actions": [{"type": "source_cluster"}, {"type": "destination_cluster"}, {"type": "remote_address"}]}],"prefix_rewrite": "/","weighted_clusters": {
-                              "clusters": [
-                                  
-                                    { "name": "cluster_qotm", "weight": 100.0 }
-                                  
-                              ]
-                          }
+                  }
+                ,
 
-                      
-                    }
-                    ,
-                    
-                    {
-                      "timeout_ms": 3000,"prefix": "/qotm/","prefix_rewrite": "/","weighted_clusters": {
-                              "clusters": [
-                                  
-                                    { "name": "cluster_qotm", "weight": 100.0 }
-                                  
-                              ]
-                          }
+                  {
+                    "timeout_ms": 3000,"prefix": "/ambassador/v0/check_alive","prefix_rewrite": "/ambassador/v0/check_alive",
+                    "weighted_clusters": {
+                      "clusters": [
 
-                      
+                        { "name": "cluster_127_0_0_1_8877", "weight": 100.0 }
+
+                      ]
                     }
-                    
-                    
-                  ]
+
+                  }
+                ,
+
+                  {
+                    "timeout_ms": 3000,"prefix": "/qotm-rate-custom/","prefix_rewrite": "/","rate_limits": [{"actions": [{"type": "source_cluster"}, {"type": "destination_cluster"}, {"type": "remote_address"}]}, {"actions": [{"type": "source_cluster"}, {"type": "destination_cluster"}, {"type": "remote_address"}, {"descriptor_value": "custom-label", "type": "generic_key"}, {"descriptor_key": ":authority", "header_name": ":authority", "type": "request_headers"}]}],
+                    "weighted_clusters": {
+                      "clusters": [
+
+                        { "name": "cluster_qotm", "weight": 100.0 }
+
+                      ]
+                    }
+
+                  }
+                ,
+
+                  {
+                    "timeout_ms": 3000,"prefix": "/ambassador/v0/","prefix_rewrite": "/ambassador/v0/",
+                    "weighted_clusters": {
+                      "clusters": [
+
+                        { "name": "cluster_127_0_0_1_8877", "weight": 100.0 }
+
+                      ]
+                    }
+
+                  }
+                ,
+
+                  {
+                    "timeout_ms": 3000,"prefix": "/qotm-rate/","prefix_rewrite": "/","rate_limits": [{"actions": [{"type": "source_cluster"}, {"type": "destination_cluster"}, {"type": "remote_address"}]}],
+                    "weighted_clusters": {
+                      "clusters": [
+
+                        { "name": "cluster_qotm", "weight": 100.0 }
+
+                      ]
+                    }
+
+                  }
+                ,
+
+                  {
+                    "timeout_ms": 3000,"prefix": "/qotm/","prefix_rewrite": "/",
+                    "weighted_clusters": {
+                      "clusters": [
+
+                        { "name": "cluster_qotm", "weight": 100.0 }
+
+                      ]
+                    }
+
+                  }
+
+
+                ]
                 }
               ]
             },
@@ -131,36 +131,36 @@
         "name": "cluster_127_0_0_1_8877",
         "connect_timeout_ms": 3000,
         "type": "strict_dns",
-        "lb_type": "round_robin",        
+        "lb_type": "round_robin",
         "hosts": [
           {
             "url": "tcp://127.0.0.1:8877"
           }
-          
+
         ]},
       {
         "name": "cluster_ext_ratelimit",
         "connect_timeout_ms": 3000,
         "type": "strict_dns",
-        "lb_type": "round_robin","features": "http2",        
+        "lb_type": "round_robin","features": "http2",
         "hosts": [
           {
             "url": "tcp://example-rate-limit:5000"
           }
-          
+
         ]},
       {
         "name": "cluster_qotm",
         "connect_timeout_ms": 3000,
         "type": "strict_dns",
-        "lb_type": "round_robin",        
+        "lb_type": "round_robin",
         "hosts": [
           {
             "url": "tcp://qotm:80"
           }
-          
+
         ]}
-      
+
     ]
   },
   "rate_limit_service": {
@@ -169,7 +169,7 @@
       "cluster_name": "cluster_ext_ratelimit"
     }
   },
-  
+
   "statsd_udp_ip_address": "127.0.0.1:8125",
   "stats_flush_interval_ms": 1000
 }

--- a/ambassador/tests/010-rewrite/gold.intermediate.json
+++ b/ambassador/tests/010-rewrite/gold.intermediate.json
@@ -51,7 +51,7 @@
             {
                 "_source": "--internal--",
                 "require_tls": false,
-                "service_port": 8080,
+                "service_port": 80,
                 "use_proxy_proto": false
             }
         ],
@@ -134,8 +134,8 @@
                     }
                 ],
                 "host_rewrite": "httpbin.org",
-                "prefix_rewrite": "",
-                "regex": "^\\/http(.*)\\/$"
+                "regex": "^\\/http(.*)\\/$",
+                "prefix_rewrite": ""
             },
             {
                 "__saved": [

--- a/ambassador/tests/010-rewrite/gold.json
+++ b/ambassador/tests/010-rewrite/gold.json
@@ -2,7 +2,7 @@
   "listeners": [
     
     {
-      "address": "tcp://0.0.0.0:8080",
+      "address": "tcp://0.0.0.0:80",
       
       "filters": [
         {
@@ -23,53 +23,52 @@
                   "domains": ["*"],"routes": [
                     
                     {
-                      "timeout_ms": 3000,"prefix": "/ambassador/v0/check_ready","prefix_rewrite": "/ambassador/v0/check_ready","weighted_clusters": {
-                              "clusters": [
-                                  
-                                    { "name": "cluster_127_0_0_1_8877", "weight": 100.0 }
-                                  
-                              ]
-                          }
-
+                      "timeout_ms": 3000,"prefix": "/ambassador/v0/check_ready","prefix_rewrite": "/ambassador/v0/check_ready",
+                      "weighted_clusters": {
+                          "clusters": [
+                              
+                                 { "name": "cluster_127_0_0_1_8877", "weight": 100.0 }
+                              
+                          ]
+                      }
                       
                     }
                     ,
                     
                     {
-                      "timeout_ms": 3000,"prefix": "/ambassador/v0/check_alive","prefix_rewrite": "/ambassador/v0/check_alive","weighted_clusters": {
-                              "clusters": [
-                                  
-                                    { "name": "cluster_127_0_0_1_8877", "weight": 100.0 }
-                                  
-                              ]
-                          }
-
+                      "timeout_ms": 3000,"prefix": "/ambassador/v0/check_alive","prefix_rewrite": "/ambassador/v0/check_alive",
+                      "weighted_clusters": {
+                          "clusters": [
+                              
+                                 { "name": "cluster_127_0_0_1_8877", "weight": 100.0 }
+                              
+                          ]
+                      }
                       
                     }
                     ,
                     
                     {
-                      "timeout_ms": 3000,"prefix": "/ambassador/v0/","prefix_rewrite": "/ambassador/v0/","weighted_clusters": {
-                              "clusters": [
-                                  
-                                    { "name": "cluster_127_0_0_1_8877", "weight": 100.0 }
-                                  
-                              ]
-                          }
-
+                      "timeout_ms": 3000,"prefix": "/ambassador/v0/","prefix_rewrite": "/ambassador/v0/",
+                      "weighted_clusters": {
+                          "clusters": [
+                              
+                                 { "name": "cluster_127_0_0_1_8877", "weight": 100.0 }
+                              
+                          ]
+                      }
                       
                     }
                     ,
-                    
                     {
-                      "timeout_ms": 3000,"regex": "^\\/http(.*)\\/$","headers": [{"name": ":authority", "regex": false, "value": "test.datawire.io"}],"host_rewrite": "httpbin.org","weighted_clusters": {
-                              "clusters": [
-                                  
-                                    { "name": "cluster_http___httpbin_org", "weight": 100.0 }
-                                  
-                              ]
-                          }
-
+                      "timeout_ms": 3000,"regex": "^\\/http(.*)\\/$","host_rewrite": "httpbin.org","headers": [{"name": ":authority", "regex": false, "value": "test.datawire.io"}],
+                      "weighted_clusters": {
+                          "clusters": [
+                              
+                                 { "name": "cluster_http___httpbin_org", "weight": 100.0 }
+                              
+                          ]
+                      }
                       
                     }
                     
@@ -123,7 +122,6 @@
       
     ]
   },
-  
   "statsd_udp_ip_address": "127.0.0.1:8125",
   "stats_flush_interval_ms": 1000
 }

--- a/docs/reference/ambassador-with-aws.md
+++ b/docs/reference/ambassador-with-aws.md
@@ -28,7 +28,7 @@ spec:
   ports:
   - name: ambassador
     port: 443
-    targetPort: 8080
+    targetPort: 80
   selector:
     service: ambassador-{{ build.profile.name }}
 ```

--- a/docs/user-guide/with-istio.md
+++ b/docs/user-guide/with-istio.md
@@ -70,7 +70,7 @@ spec:
   ports:
   - name: ambassador
     port: 80
-    targetPort: 8080
+    targetPort: 80
   selector:
     service: ambassador
 ```
@@ -269,7 +269,7 @@ spec:
   ports:
   - name: ambassador
     port: 80
-    targetPort: 8080
+    targetPort: 80
   selector:
     service: ambassador
 ```

--- a/end-to-end/000-no-base/k8s/ambassador.yaml
+++ b/end-to-end/000-no-base/k8s/ambassador.yaml
@@ -27,5 +27,5 @@ spec:
     - name: http
       protocol: TCP
       port: 80
-      targetPort: 8080
+      targetPort: 80
   type: NodePort

--- a/end-to-end/001-simple/diag-1.json
+++ b/end-to-end/001-simple/diag-1.json
@@ -11,9 +11,9 @@
         "_method": "GET",
         "_precedence": 0,
         "_referenced_by": [
-            "--internal--"
+            "ambassador-default.yaml.1"
         ],
-        "_source": "--internal--",
+        "_source": "ambassador-default.yaml.1",
         "clusters": [
             {
                 "name": "cluster_127_0_0_1_8877",
@@ -35,9 +35,9 @@
         "_method": "GET",
         "_precedence": 0,
         "_referenced_by": [
-            "--internal--"
+            "ambassador-default.yaml.1"
         ],
-        "_source": "--internal--",
+        "_source": "ambassador-default.yaml.1",
         "clusters": [
             {
                 "name": "cluster_127_0_0_1_8877",
@@ -59,9 +59,9 @@
         "_method": "GET",
         "_precedence": 0,
         "_referenced_by": [
-            "--internal--"
+            "ambassador-default.yaml.1"
         ],
-        "_source": "--internal--",
+        "_source": "ambassador-default.yaml.1",
         "clusters": [
             {
                 "name": "cluster_127_0_0_1_8877",

--- a/end-to-end/001-simple/diag-2.json
+++ b/end-to-end/001-simple/diag-2.json
@@ -11,9 +11,9 @@
         "_method": "GET",
         "_precedence": 0,
         "_referenced_by": [
-            "--internal--"
+            "ambassador-default.yaml.1"
         ],
-        "_source": "--internal--",
+        "_source": "ambassador-default.yaml.1",
         "clusters": [
             {
                 "name": "cluster_127_0_0_1_8877",
@@ -35,9 +35,9 @@
         "_method": "GET",
         "_precedence": 0,
         "_referenced_by": [
-            "--internal--"
+            "ambassador-default.yaml.1"
         ],
-        "_source": "--internal--",
+        "_source": "ambassador-default.yaml.1",
         "clusters": [
             {
                 "name": "cluster_127_0_0_1_8877",
@@ -59,9 +59,9 @@
         "_method": "GET",
         "_precedence": 0,
         "_referenced_by": [
-            "--internal--"
+            "ambassador-default.yaml.1"
         ],
-        "_source": "--internal--",
+        "_source": "ambassador-default.yaml.1",
         "clusters": [
             {
                 "name": "cluster_127_0_0_1_8877",

--- a/end-to-end/001-simple/diag-3.json
+++ b/end-to-end/001-simple/diag-3.json
@@ -11,9 +11,9 @@
         "_method": "GET",
         "_precedence": 0,
         "_referenced_by": [
-            "--internal--"
+            "ambassador-default.yaml.1"
         ],
-        "_source": "--internal--",
+        "_source": "ambassador-default.yaml.1",
         "clusters": [
             {
                 "name": "cluster_127_0_0_1_8877",
@@ -35,9 +35,9 @@
         "_method": "GET",
         "_precedence": 0,
         "_referenced_by": [
-            "--internal--"
+            "ambassador-default.yaml.1"
         ],
-        "_source": "--internal--",
+        "_source": "ambassador-default.yaml.1",
         "clusters": [
             {
                 "name": "cluster_127_0_0_1_8877",
@@ -59,9 +59,9 @@
         "_method": "GET",
         "_precedence": 0,
         "_referenced_by": [
-            "--internal--"
+            "ambassador-default.yaml.1"
         ],
-        "_source": "--internal--",
+        "_source": "ambassador-default.yaml.1",
         "clusters": [
             {
                 "name": "cluster_127_0_0_1_8877",

--- a/end-to-end/001-simple/k8s/ambassador.yaml
+++ b/end-to-end/001-simple/k8s/ambassador.yaml
@@ -3,6 +3,14 @@ apiVersion: v1
 kind: Service
 metadata:
   name: ambassador
+  annotations:
+    getambassador.io/config: |
+      ---
+      apiVersion: ambassador/v0
+      kind: Module
+      name:  ambassador
+      config:
+        service_port: 8080
 spec:
   selector:
     service: ambassador
@@ -10,5 +18,5 @@ spec:
     - name: http
       protocol: TCP
       port: 80
-      targetPort: 80
+      targetPort: 8080
   type: NodePort

--- a/end-to-end/001-simple/k8s/ambassador.yaml
+++ b/end-to-end/001-simple/k8s/ambassador.yaml
@@ -10,5 +10,5 @@ spec:
     - name: http
       protocol: TCP
       port: 80
-      targetPort: 8080
+      targetPort: 80
   type: NodePort

--- a/end-to-end/001-simple/k8s/authenable.yaml
+++ b/end-to-end/001-simple/k8s/authenable.yaml
@@ -23,5 +23,5 @@ spec:
     - name: http
       protocol: TCP
       port: 80
-      targetPort: 8080
+      targetPort: 80
   type: NodePort

--- a/end-to-end/001-simple/k8s/authenable.yaml
+++ b/end-to-end/001-simple/k8s/authenable.yaml
@@ -8,6 +8,12 @@ metadata:
       ---
       apiVersion: ambassador/v0
       kind: Module
+      name:  ambassador
+      config:
+        service_port: 8080
+      ---
+      apiVersion: ambassador/v0
+      kind: Module
       name:  authentication
       config:
         auth_service: "example-auth:3000"
@@ -23,5 +29,5 @@ spec:
     - name: http
       protocol: TCP
       port: 80
-      targetPort: 80
+      targetPort: 8080
   type: NodePort

--- a/end-to-end/001-simple/test.sh
+++ b/end-to-end/001-simple/test.sh
@@ -11,13 +11,17 @@ PATH="${ROOT}:${PATH}"
 
 source ${ROOT}/utils.sh
 
+python ${ROOT}/yfix.py ${ROOT}/fixes/ambassador-not-root.yfix \
+    ${ROOT}/ambassador-deployment.yaml \
+    k8s/ambassador-deployment.yaml
+
 initialize_cluster
 
 kubectl cluster-info
 
 kubectl create cm ambassador-config --from-file k8s/base-config.yaml
 kubectl apply -f k8s/ambassador.yaml
-kubectl apply -f ${ROOT}/ambassador-deployment.yaml
+kubectl apply -f k8s/ambassador-deployment.yaml
 kubectl apply -f ${ROOT}/stats-test.yaml
 
 set +e +o pipefail

--- a/end-to-end/002-canary/k8s/ambassador.yaml
+++ b/end-to-end/002-canary/k8s/ambassador.yaml
@@ -19,5 +19,5 @@ spec:
     - name: http
       protocol: TCP
       port: 80
-      targetPort: 8080
+      targetPort: 80
   type: NodePort

--- a/end-to-end/003-headers-and-host/k8s/ambassador.yaml
+++ b/end-to-end/003-headers-and-host/k8s/ambassador.yaml
@@ -19,5 +19,5 @@ spec:
     - name: http
       protocol: TCP
       port: 80
-      targetPort: 8080
+      targetPort: 80
   type: NodePort

--- a/end-to-end/004-tls-1/k8s/ambassador.yaml
+++ b/end-to-end/004-tls-1/k8s/ambassador.yaml
@@ -21,8 +21,8 @@ metadata:
           enabled: True
           redirect_cleartext_from: 80
           # These are optional.
-          cert_chain_file: /etc/certs/tls.crt
-          private_key_file: /etc/certs/tls.key
+          cert_chain_file: /ambassador/certs/tls.crt
+          private_key_file: /ambassador/certs/tls.key
 
         # client:
         #   enabled: True,

--- a/end-to-end/004-tls-1/k8s/ambassador.yaml
+++ b/end-to-end/004-tls-1/k8s/ambassador.yaml
@@ -19,7 +19,7 @@ metadata:
       config:
         server:
           enabled: True
-          redirect_cleartext_from: 8080
+          redirect_cleartext_from: 80
           # These are optional.
           cert_chain_file: /etc/certs/tls.crt
           private_key_file: /etc/certs/tls.key
@@ -50,9 +50,9 @@ spec:
     - name: https
       protocol: TCP
       port: 443
-      targetPort: 8443
+      targetPort: 443
     - name: http
       protocol: TCP
       port: 80
-      targetPort: 8080
+      targetPort: 80
   type: NodePort

--- a/end-to-end/004-tls-1/k8s/canary-100.yaml
+++ b/end-to-end/004-tls-1/k8s/canary-100.yaml
@@ -89,5 +89,5 @@ spec:
     - name: http
       protocol: TCP
       port: 443
-      targetPort: 8443
+      targetPort: 443
   type: NodePort

--- a/end-to-end/005-single-namespace/k8s/ambassador.yaml
+++ b/end-to-end/005-single-namespace/k8s/ambassador.yaml
@@ -19,5 +19,5 @@ spec:
     - name: http
       protocol: TCP
       port: 80
-      targetPort: 8080
+      targetPort: 80
   type: NodePort

--- a/end-to-end/006-auth-canary/k8s/ambassador.yaml
+++ b/end-to-end/006-auth-canary/k8s/ambassador.yaml
@@ -19,5 +19,5 @@ spec:
     - name: http
       protocol: TCP
       port: 80
-      targetPort: 8080
+      targetPort: 80
   type: NodePort

--- a/end-to-end/007-rate-limit/k8s/ambassador.yaml
+++ b/end-to-end/007-rate-limit/k8s/ambassador.yaml
@@ -17,5 +17,5 @@ spec:
     - name: http
       protocol: TCP
       port: 80
-      targetPort: 8080
+      targetPort: 80
   type: NodePort

--- a/end-to-end/008-cacert/k8s/ambassador.yaml
+++ b/end-to-end/008-cacert/k8s/ambassador.yaml
@@ -22,5 +22,5 @@ spec:
     - name: https
       protocol: TCP
       port: 443
-      targetPort: 8443
+      targetPort: 443
   type: NodePort

--- a/end-to-end/008-cacert/listeners-1.json
+++ b/end-to-end/008-cacert/listeners-1.json
@@ -5,9 +5,9 @@
         "service_port": 443,
         "tls": {
             "_source": "tls.yaml.2",
-            "cacert_chain_file": "/etc/cacert/tls.crt",
-            "cert_chain_file": "/etc/certs/tls.crt",
-            "private_key_file": "/etc/certs/tls.key"
+            "cacert_chain_file": "/ambassador/cacert/tls.crt",
+            "cert_chain_file": "/ambassador/certs/tls.crt",
+            "private_key_file": "/ambassador/certs/tls.key"
         },
         "use_proxy_proto": false
     }

--- a/end-to-end/008-cacert/listeners-1.json
+++ b/end-to-end/008-cacert/listeners-1.json
@@ -2,7 +2,7 @@
     {
         "_source": "tls.yaml.2",
         "require_tls": false,
-        "service_port": 8443,
+        "service_port": 443,
         "tls": {
             "_source": "tls.yaml.2",
             "cacert_chain_file": "/etc/cacert/tls.crt",

--- a/end-to-end/009-grpc/k8s/ambassador.yaml
+++ b/end-to-end/009-grpc/k8s/ambassador.yaml
@@ -11,5 +11,5 @@ spec:
     - name: http
       protocol: TCP
       port: 80
-      targetPort: 8080
+      targetPort: 80
   type: NodePort

--- a/end-to-end/010-multiple-ambassadors/k8s/ambassador-1.yaml
+++ b/end-to-end/010-multiple-ambassadors/k8s/ambassador-1.yaml
@@ -11,5 +11,5 @@ spec:
     - name: http
       protocol: TCP
       port: 80
-      targetPort: 8080
+      targetPort: 80
   type: NodePort

--- a/end-to-end/010-multiple-ambassadors/k8s/ambassador-2.yaml
+++ b/end-to-end/010-multiple-ambassadors/k8s/ambassador-2.yaml
@@ -11,5 +11,5 @@ spec:
     - name: http
       protocol: TCP
       port: 80
-      targetPort: 8080
+      targetPort: 80
   type: NodePort

--- a/end-to-end/011-websocket/ambassador/k8s/ambassador-deploy.yaml
+++ b/end-to-end/011-websocket/ambassador/k8s/ambassador-deploy.yaml
@@ -24,7 +24,7 @@ spec:
             - name: admin
               containerPort: 8877
             - name: envoy
-              containerPort: 8080
+              containerPort: 80
           env:
             - name: SCOUT_DISABLE
               value: "1"

--- a/end-to-end/fixes/ambassador-not-root.yfix
+++ b/end-to-end/fixes/ambassador-not-root.yfix
@@ -1,0 +1,8 @@
+MATCH kind Deployment
+MATCH metadata/name ambassador
+MKDICT spec/template/spec/securityContext
+SETINT spec/template/spec/securityContext/runAsUser 8888
+MKDICT spec/template/spec/containers/0/env/1
+SET spec/template/spec/containers/0/imagePullPolicy Always
+SET spec/template/spec/containers/0/env/1/name AMBASSADOR_EXIT_DELAY
+SET spec/template/spec/containers/0/env/1/value 3600

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -18,7 +18,7 @@ spec:
     - name: http
       protocol: TCP
       port: 80
-      targetPort: 8080
+      targetPort: 80
   type: LoadBalancer
 ---
 apiVersion: v1

--- a/templates/ambassador/ambassador-http.yaml
+++ b/templates/ambassador/ambassador-http.yaml
@@ -11,6 +11,6 @@ spec:
   ports:
   - name: ambassador
     port: 80
-    targetPort: 8080
+    targetPort: 80
   selector:
     service: ambassador

--- a/templates/ambassador/ambassador-https.yaml
+++ b/templates/ambassador/ambassador-https.yaml
@@ -11,6 +11,6 @@ spec:
   ports:
   - name: ambassador
     port: 443
-    targetPort: 8443
+    targetPort: 443
   selector:
     service: ambassador

--- a/templates/istio/ambassador.yaml
+++ b/templates/istio/ambassador.yaml
@@ -26,7 +26,7 @@ spec:
   ports:
   - name: http-ambassador
     port: 80
-    targetPort: 8080
+    targetPort: 80
   selector:
     service: ambassador
 ---


### PR DESCRIPTION
If you want to run Ambassador as a non-root user:

1. Make Kubernetes run Ambassador as non-root. Your runtime may do this for you (e.g. OpenShift) or you can do it with a `securityContext`.
2. Use the `service_port` element in the `ambassador` `Module` to set the port you’ll listen on to something above 1024.
3. If for some reason you’re using the `tls` `Module` to explicitly set the certificate paths while _also_ relying on Ambassador to find the certificates in TLS secrets, you should delete the explicit path setting in your `tls` `Module`. (If you're doing this, of course, you're running your own Ambassador build.)
4. Make sure all your Kubernetes resources match the port you select in step 2!

