### PR TITLE
Source kubernaut-utils.sh in save-token.sh

### DIFF
--- a/end-to-end/save-token.sh
+++ b/end-to-end/save-token.sh
@@ -6,6 +6,7 @@ set -o pipefail
 ROOT=$(cd $(dirname $0); pwd)
 
 source ${ROOT}/utils.sh
+source ${ROOT}/kubernaut_utils.sh
 
 KUBERNAUT="$ROOT/kubernaut"
 


### PR DESCRIPTION
This commit sources the kubernaut-utils.sh which is required to
run the get-kubernaut function. This fixes running end-to-end
locally.

Fix #551

Co-authored-by: Philip Lombardi <plombardi@datawire.io>