### PR TITLE
Move imagePullPolicy to IfNotPresent from Always

### DIFF
--- a/end-to-end/fixes/ambassador-not-root.yfix
+++ b/end-to-end/fixes/ambassador-not-root.yfix
@@ -3,6 +3,5 @@ MATCH metadata/name ambassador
 MKDICT spec/template/spec/securityContext
 SETINT spec/template/spec/securityContext/runAsUser 8888
 MKDICT spec/template/spec/containers/0/env/1
-SET spec/template/spec/containers/0/imagePullPolicy Always
 SET spec/template/spec/containers/0/env/1/name AMBASSADOR_EXIT_DELAY
 SET spec/template/spec/containers/0/env/1/value 3600

--- a/end-to-end/fixes/ambassador.yfix
+++ b/end-to-end/fixes/ambassador.yfix
@@ -2,6 +2,8 @@ MATCH kind Deployment
 MATCH metadata/name ambassador
 SETINT spec/replicas 1
 SET spec/template/spec/containers/0/image $1
+SET spec/template/spec/containers/0/imagePullPolicy IfNotPresent
 DELETE spec/template/spec/containers/0/livenessProbe
 DELETE spec/template/spec/containers/0/readinessProbe
 SET spec/template/spec/containers/1/image $2
+SET spec/template/spec/containers/1/imagePullPolicy IfNotPresent

--- a/end-to-end/fixes/test-dep.yfix
+++ b/end-to-end/fixes/test-dep.yfix
@@ -12,7 +12,6 @@ DISCARD
 
 MATCH kind Deployment
 SET metadata/namespace $1
-SET spec/template/spec/containers/0/imagePullPolicy Always
 MKLIST spec/template/spec/containers/0/env
 MKDICT spec/template/spec/containers/0/env/0
 SET spec/template/spec/containers/0/env/0/name AMBASSADOR_NAMESPACE


### PR DESCRIPTION
This commit sets imagePullPolicy for ambassador images to
    IfNotPresent instead of Always, because for running the end to end
    tests locally, where the images are directly pushed to the
    registry inside, for e.g., minikube, the pods fail while pulling
    the images from external registry because they don't exist.