### PR TITLE
Fix TLS configuration merging

### DIFF
--- a/ambassador/ambassador/config.py
+++ b/ambassador/ambassador/config.py
@@ -913,6 +913,28 @@ class Config (object):
 
         return svc, cluster_name
 
+    def merge_tmods(self, user_input, generated_input):
+        if user_input is None:
+            return generated_input
+        elif generated_input is None:
+            return user_input
+        else:
+            # set result to user input, because it takes precedence over generated input
+            result = user_input
+            for key in generated_input:
+                if key in user_input:
+                    if user_input[key] != generated_input[key]:
+                        # if the values for a given key don't match, then log this, but user input takes precedence
+                        error = "Found {} set in TLS module as {}, and internal TLS configuration set as {}, " \
+                                "setting to {}".format(key, user_input[key], generated_input[key], user_input[key])
+                        self.logger.debug(error)
+                        self.post_error(RichStatus.fromError(error))
+                else:
+                    # if the key only exists in generated input, then copy it over to result
+                    self.logger.debug("Setting {} to {}".format(key, generated_input[key]))
+                    result[key] = generated_input[key]
+            return result
+
     def generate_intermediate_config(self):
         # First things first. The "Ambassador" module always exists; create it with
         # default values now.
@@ -951,10 +973,17 @@ class Config (object):
 
         # ...most notably the 'ambassador' and 'tls' modules, which are handled first.
         amod = modules.get('ambassador', None)
-        tmod = modules.get('tls', None)
+        user_tmod = modules.get('tls', {})
+        generated_tmod = modules.get('tls-from-ambassador-certs', {})
 
-        if not tmod:
-            tmod = modules.get('tls-from-ambassador-certs',)
+        tmod = {'_source': self.source}
+        tmod_server = self.merge_tmods(user_tmod.get('server'), generated_tmod.get('server'))
+        if tmod_server is not None:
+            tmod['server'] = tmod_server
+        tmod_client = self.merge_tmods(user_tmod.get('client'), generated_tmod.get('client'))
+        if tmod_client is not None:
+            tmod['client'] = tmod_client
+        self.logger.debug("tmod is:\n{}".format(tmod))
 
         if amod or tmod:
             self.module_config_ambassador("ambassador", amod, tmod)

--- a/ambassador/ambassador/config.py
+++ b/ambassador/ambassador/config.py
@@ -937,8 +937,8 @@ class Config (object):
         elif tls_module is None:
             return generated_module
         else:
-            self.logger.debug("tls_module %s" % tls_module)
-            self.logger.debug("generated_module %s" % generated_module)
+            self.logger.debug("tls_module %s" % json.dumps(tls_module, indent=4))
+            self.logger.debug("generated_module %s" % json.dumps(generated_module, indent=4))
 
             # OK, no easy cases. We know that both modules exist: grab the config dicts.
             tls_source = tls_module['_source']
@@ -1030,7 +1030,7 @@ class Config (object):
 
         # OK, done. Make sure we have _something_ for the TLS module going forward.
         tmod = tls_module or {}
-        self.logger.debug("TLS module after merge: %s" % tmod)
+        self.logger.debug("TLS module after merge: %s" % json.dumps(tmod, indent=4))
 
         if amod or tmod:
             self.module_config_ambassador("ambassador", amod, tmod)
@@ -1374,6 +1374,12 @@ class Config (object):
         else:
             self.ambassador_module[key].update(value)
 
+        # XXX This is actually wrong sometimes. If, for example, you have an
+        # ambassador module that defines the admin_port, sure, bringing in its
+        # source makes sense. On the other hand, if you have a TLS module 
+        # created by a secret, that source shouldn't really take over the
+        # admin document. This will take enough unraveling that I'm going to
+        # leave it for now, though.
         self.ambassador_module['_source'] = module['_source']
 
     def update_config_ambassador(self, module, key, value):
@@ -1426,7 +1432,7 @@ class Config (object):
             self.set_config_ambassador(amod, 'tls_config', tmp_config)
 
         self.logger.debug("TLS config: %s" % json.dumps(self.ambassador_module['tls_config'], indent=4))
-        self.logger.debug("TLS contexts: %s" % json.dumps(self.tls_contexts))
+        self.logger.debug("TLS contexts: %s" % json.dumps(self.tls_contexts, indent=4))
 
         return some_enabled
 

--- a/ambassador/ambassador/config.py
+++ b/ambassador/ambassador/config.py
@@ -913,27 +913,72 @@ class Config (object):
 
         return svc, cluster_name
 
-    def merge_tmods(self, user_input, generated_input):
-        if user_input is None:
-            return generated_input
-        elif generated_input is None:
-            return user_input
+    def merge_tmods(self, tls_module, generated_module, key):
+        """
+        Merge TLS module configuration for a particular key. In the event of conflicts, the 
+        tls_module element wins, and an error is posted so that the diagnostics service can 
+        show it.
+
+        Returns a TLS module with a correctly-merged config element. This will be the
+        tls_module (possibly modified) unless no tls_module is present, in which case
+        the generated_module will be promoted. If any changes were made to the module, it
+        will be marked as referenced by the generated_module.
+
+        :param tls_module: the `tls` module; may be None
+        :param generated_module: the `tls-from-ambassador-certs` module; may be None
+        :param key: the key in the module config to merge
+        :return: TLS module object; see above.
+        """
+
+        # First up, the easy cases. If either module is missing, return the other.
+        # (The other might be None too, of course.)
+        if generated_module is None:
+            return tls_module
+        elif tls_module is None:
+            return generated_module
         else:
-            # set result to user input, because it takes precedence over generated input
-            result = user_input
-            for key in generated_input:
-                if key in user_input:
-                    if user_input[key] != generated_input[key]:
-                        # if the values for a given key don't match, then log this, but user input takes precedence
-                        error = "Found {} set in TLS module as {}, and internal TLS configuration set as {}, " \
-                                "setting to {}".format(key, user_input[key], generated_input[key], user_input[key])
-                        self.logger.debug(error)
-                        self.post_error(RichStatus.fromError(error))
+            self.logger.debug("tls_module %s" % tls_module)
+            self.logger.debug("generated_module %s" % generated_module)
+
+            # OK, no easy cases. We know that both modules exist: grab the config dicts.
+            tls_source = tls_module['_source']
+            tls_config = tls_module.get(key, {})
+
+            gen_source = generated_module['_source']
+            gen_config = generated_module.get(key, {})
+
+            # Now walk over the tls_config and copy anything needed.
+            any_changes = False
+
+            for ckey in gen_config:
+                if ckey in tls_config:
+                    # ckey exists in both modules. Do they have the same value?
+                    if tls_config[ckey] != gen_config[ckey]:
+                        # No -- post an error, but let the version from the TLS module win.
+                        errfmt = "CONFLICT in TLS config for {}.{}: using {} from TLS module in {}"
+                        errstr = errfmt.format(key, ckey, tls_config[ckey], tls_source)
+                        self.post_error(RichStatus.fromError(errstr))
+                    else:
+                        # They have the same value. Worth mentioning in debug.
+                        self.logger.debug("merge_tmods: {}.{} duplicated with same value".format(key, ckey))
                 else:
-                    # if the key only exists in generated input, then copy it over to result
-                    self.logger.debug("Setting {} to {}".format(key, generated_input[key]))
-                    result[key] = generated_input[key]
-            return result
+                    # ckey only exists in gen_config. Copy it over.
+                    self.logger.debug("merge_tmods: copy {}.{} from gen_config".format(key, ckey))
+                    tls_config[ckey] = gen_config[ckey]
+                    any_changes = True
+
+            # If we had changes...
+            if any_changes:
+                # ...then mark the tls_module as referenced by the generated_module's
+                # source..
+                tls_module._mark_referenced_by(gen_source)
+
+                # ...and copy the tls_config back in (in case the key wasn't in the tls_module 
+                # config at all originally).
+                tls_module[key] = tls_config
+
+            # Finally, return the tls_module.
+            return tls_module
 
     def generate_intermediate_config(self):
         # First things first. The "Ambassador" module always exists; create it with
@@ -973,17 +1018,19 @@ class Config (object):
 
         # ...most notably the 'ambassador' and 'tls' modules, which are handled first.
         amod = modules.get('ambassador', None)
-        user_tmod = modules.get('tls', {})
-        generated_tmod = modules.get('tls-from-ambassador-certs', {})
+        tls_module = modules.get('tls', None)
 
-        tmod = {'_source': self.source}
-        tmod_server = self.merge_tmods(user_tmod.get('server'), generated_tmod.get('server'))
-        if tmod_server is not None:
-            tmod['server'] = tmod_server
-        tmod_client = self.merge_tmods(user_tmod.get('client'), generated_tmod.get('client'))
-        if tmod_client is not None:
-            tmod['client'] = tmod_client
-        self.logger.debug("tmod is:\n{}".format(tmod))
+        # Part of handling the 'tls' module is folding in the 'tls-from-ambassador-certs'
+        # module, so grab that too...
+        generated_module = modules.get('tls-from-ambassador-certs', None)
+
+        # ...and merge the 'server' and 'client' config elements.
+        tls_module = self.merge_tmods(tls_module, generated_module, 'server')
+        tls_module = self.merge_tmods(tls_module, generated_module, 'client')
+
+        # OK, done. Make sure we have _something_ for the TLS module going forward.
+        tmod = tls_module or {}
+        self.logger.debug("TLS module after merge: %s" % tmod)
 
         if amod or tmod:
             self.module_config_ambassador("ambassador", amod, tmod)

--- a/ambassador/entrypoint.sh
+++ b/ambassador/entrypoint.sh
@@ -21,7 +21,7 @@ AMBASSADOR_ROOT="/ambassador"
 CONFIG_DIR="$AMBASSADOR_ROOT/ambassador-config"
 ENVOY_CONFIG_FILE="$AMBASSADOR_ROOT/envoy.json"
 
-export PYTHON_EGG_CACHE=$(AMBASSADOR_ROOT)
+export PYTHON_EGG_CACHE=${AMBASSADOR_ROOT}
 
 if [ "$1" == "--demo" ]; then
     CONFIG_DIR="$AMBASSADOR_ROOT/ambassador-demo-config"

--- a/end-to-end/008-cacert/diag-1.json
+++ b/end-to-end/008-cacert/diag-1.json
@@ -11,9 +11,9 @@
         "_method": "GET",
         "_precedence": 0,
         "_referenced_by": [
-            "tls.yaml.2"
+            "ambassador-008-cacert.yaml.2"
         ],
-        "_source": "tls.yaml.2",
+        "_source": "ambassador-008-cacert.yaml.2",
         "clusters": [
             {
                 "name": "cluster_127_0_0_1_8877",
@@ -35,9 +35,9 @@
         "_method": "GET",
         "_precedence": 0,
         "_referenced_by": [
-            "tls.yaml.2"
+            "ambassador-008-cacert.yaml.2"
         ],
-        "_source": "tls.yaml.2",
+        "_source": "ambassador-008-cacert.yaml.2",
         "clusters": [
             {
                 "name": "cluster_127_0_0_1_8877",
@@ -59,9 +59,9 @@
         "_method": "GET",
         "_precedence": 0,
         "_referenced_by": [
-            "tls.yaml.2"
+            "ambassador-008-cacert.yaml.2"
         ],
-        "_source": "tls.yaml.2",
+        "_source": "ambassador-008-cacert.yaml.2",
         "clusters": [
             {
                 "name": "cluster_127_0_0_1_8877",

--- a/end-to-end/008-cacert/k8s/ambassador.yaml
+++ b/end-to-end/008-cacert/k8s/ambassador.yaml
@@ -4,17 +4,16 @@ kind: Service
 metadata:
   name: ambassador
   namespace: 008-cacert
-  # annotations:
-  #   getambassador.io/config: |
-  #     ---
-  #     apiVersion: ambassador/v0
-  #     kind:  Module
-  #     name:  tls
-  #     config:
-  #       server:
-  #         enabled: True
-  #       client:
-  #         enabled: True
+  annotations:
+    getambassador.io/config: |
+      ---
+      apiVersion: ambassador/v0
+      kind:  Module
+      name:  tls
+      ambassador_id: 008-cacert
+      config:
+        server:
+          use_remote_address: True
 spec:
   selector:
     service: ambassador

--- a/end-to-end/008-cacert/listeners-1.json
+++ b/end-to-end/008-cacert/listeners-1.json
@@ -1,13 +1,14 @@
 [
     {
-        "_source": "tls.yaml.2",
+        "_source": "ambassador-008-cacert.yaml.2",
         "require_tls": false,
         "service_port": 443,
         "tls": {
-            "_source": "tls.yaml.2",
+            "_source": "ambassador-008-cacert.yaml.2",
             "cacert_chain_file": "/ambassador/cacert/tls.crt",
             "cert_chain_file": "/ambassador/certs/tls.crt",
-            "private_key_file": "/ambassador/certs/tls.key"
+            "private_key_file": "/ambassador/certs/tls.key",
+            "use_remote_address": true
         },
         "use_proxy_proto": false
     }

--- a/end-to-end/fixes/ambassador.yfix
+++ b/end-to-end/fixes/ambassador.yfix
@@ -2,6 +2,7 @@ MATCH kind Deployment
 MATCH metadata/name ambassador
 SETINT spec/replicas 1
 SET spec/template/spec/containers/0/image $1
+SET spec/template/spec/containers/0/imagePullPolicy Always
 DELETE spec/template/spec/containers/0/livenessProbe
 DELETE spec/template/spec/containers/0/readinessProbe
 SET spec/template/spec/containers/1/image $2


### PR DESCRIPTION
We need to merge configs from the user-supplied `tls``Module` and the `Module` synthesized by `kubewatch` when it finds a secret with TLS certs, not just blindly override.

Fixes #573.