### PR TITLE
Enable L7 redirection based on X-FORWARDED-PROTO

### DIFF
--- a/ambassador/schemas/v0/Mapping.schema
+++ b/ambassador/schemas/v0/Mapping.schema
@@ -17,7 +17,6 @@
         "prefix": { "type": "string" },
         "prefix_regex": { "type": "boolean" },
         "service": { "type": "string" },
-
         "add_request_headers": { "$ref": "#/definitions/mapStrStr" },
         "auto_host_rewrite": { "type": "boolean" },
         "case_sensitive": { "type": "boolean" },

--- a/ambassador/tests/011-xfp-redirect/config/l7-redirect.yaml
+++ b/ambassador/tests/011-xfp-redirect/config/l7-redirect.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: ambassador/v0
+kind:  Module
+name:  ambassador
+config:
+  x_forwarded_proto_redirect: true

--- a/ambassador/tests/011-xfp-redirect/config/mapping.yaml
+++ b/ambassador/tests/011-xfp-redirect/config/mapping.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: ambassador/v0
+kind: Mapping
+name: httpbin_mapping
+prefix: /httpbin/
+service: httpbin.org

--- a/ambassador/tests/011-xfp-redirect/gold.intermediate.json
+++ b/ambassador/tests/011-xfp-redirect/gold.intermediate.json
@@ -1,0 +1,208 @@
+{
+    "envoy_config": {
+        "admin": [
+            {
+                "_source": "l7-redirect.yaml.1",
+                "admin_port": 8001
+            }
+        ],
+        "clusters": [
+            {
+                "_referenced_by": [
+                    "l7-redirect.yaml.1"
+                ],
+                "_service": "127.0.0.1:8877",
+                "_source": "l7-redirect.yaml.1",
+                "lb_type": "round_robin",
+                "name": "cluster_127_0_0_1_8877",
+                "type": "strict_dns",
+                "urls": [
+                    "tcp://127.0.0.1:8877"
+                ]
+            },
+            {
+                "_referenced_by": [
+                    "mapping.yaml.1"
+                ],
+                "_service": "httpbin.org",
+                "_source": "mapping.yaml.1",
+                "lb_type": "round_robin",
+                "name": "cluster_httpbin_org",
+                "type": "strict_dns",
+                "urls": [
+                    "tcp://httpbin.org:80"
+                ]
+            }
+        ],
+        "filters": [
+            {
+                "_source": "--internal--",
+                "config": {},
+                "name": "cors"
+            },
+            {
+                "_source": "--internal--",
+                "config": {},
+                "name": "router",
+                "type": "decoder"
+            }
+        ],
+        "listeners": [
+            {
+                "_source": "l7-redirect.yaml.1",
+                "require_tls": true,
+                "service_port": 80,
+                "use_proxy_proto": false
+            }
+        ],
+        "routes": [
+            {
+                "__saved": [
+                    0,
+                    9,
+                    0,
+                    "/httpbin/",
+                    "GET"
+                ],
+                "_group_id": "0a0b4a3c06d5d92984505f097c69498d038c5737",
+                "_method": "GET",
+                "_precedence": 0,
+                "_referenced_by": [
+                    "mapping.yaml.1"
+                ],
+                "_source": "mapping.yaml.1",
+                "clusters": [
+                    {
+                        "name": "cluster_httpbin_org",
+                        "weight": 100.0
+                    }
+                ],
+                "prefix": "/httpbin/",
+                "prefix_rewrite": "/"
+            },
+            {
+                "__saved": [
+                    0,
+                    26,
+                    0,
+                    "/ambassador/v0/check_ready",
+                    "GET"
+                ],
+                "_group_id": "0a42187b7b3d283e0079ddab01825e1c71fad9f6",
+                "_method": "GET",
+                "_precedence": 0,
+                "_referenced_by": [
+                    "l7-redirect.yaml.1"
+                ],
+                "_source": "l7-redirect.yaml.1",
+                "clusters": [
+                    {
+                        "name": "cluster_127_0_0_1_8877",
+                        "weight": 100.0
+                    }
+                ],
+                "prefix": "/ambassador/v0/check_ready",
+                "prefix_rewrite": "/ambassador/v0/check_ready"
+            },
+            {
+                "__saved": [
+                    0,
+                    26,
+                    0,
+                    "/ambassador/v0/check_alive",
+                    "GET"
+                ],
+                "_group_id": "6151893fbc2f1f730a1bb946b2eefac391f0d2ec",
+                "_method": "GET",
+                "_precedence": 0,
+                "_referenced_by": [
+                    "l7-redirect.yaml.1"
+                ],
+                "_source": "l7-redirect.yaml.1",
+                "clusters": [
+                    {
+                        "name": "cluster_127_0_0_1_8877",
+                        "weight": 100.0
+                    }
+                ],
+                "prefix": "/ambassador/v0/check_alive",
+                "prefix_rewrite": "/ambassador/v0/check_alive"
+            },
+            {
+                "__saved": [
+                    0,
+                    15,
+                    0,
+                    "/ambassador/v0/",
+                    "GET"
+                ],
+                "_group_id": "b69eeb747b38f5e5fd3955d044ea7797d67d024f",
+                "_method": "GET",
+                "_precedence": 0,
+                "_referenced_by": [
+                    "l7-redirect.yaml.1"
+                ],
+                "_source": "l7-redirect.yaml.1",
+                "clusters": [
+                    {
+                        "name": "cluster_127_0_0_1_8877",
+                        "weight": 100.0
+                    }
+                ],
+                "prefix": "/ambassador/v0/",
+                "prefix_rewrite": "/ambassador/v0/"
+            }
+        ]
+    },
+    "errors": {},
+    "source_map": {
+        "--internal--": {
+            "--internal--": true
+        },
+        "l7-redirect.yaml": {
+            "l7-redirect.yaml.1": true
+        },
+        "mapping.yaml": {
+            "mapping.yaml.1": true
+        }
+
+    },
+    "sources": {
+        "--diagnostics--": {
+            "_source": "--diagnostics--",
+            "description": "The '--diagnostics--' source marks objects created by Ambassador to assist with diagnostic output.",
+            "filename": "--diagnostics--",
+            "index": 0,
+            "kind": "diagnostics",
+            "name": "Ambassador Diagnostics",
+            "version": "v0"
+        },
+        "--internal--": {
+            "_source": "--internal--",
+            "description": "The '--internal--' source marks objects created by Ambassador's internal logic.",
+            "filename": "--internal--",
+            "index": 0,
+            "kind": "Internal",
+            "name": "Ambassador Internals",
+            "version": "v0"
+        },
+        "l7-redirect.yaml.1": {
+            "_source": "l7-redirect.yaml",
+            "filename": "l7-redirect.yaml",
+            "index": 1,
+            "kind": "Module",
+            "name": "ambassador",
+            "version": "ambassador/v0",
+            "yaml": "apiVersion: ambassador/v0\nconfig:\n  x_forwarded_proto_redirect: true\nkind: Module\nname: ambassador\n"
+        },
+        "mapping.yaml.1": {
+            "_source": "mapping.yaml",
+            "filename": "mapping.yaml",
+            "index": 1,
+            "kind": "Mapping",
+            "name": "httpbin_mapping",
+            "version": "ambassador/v0",
+            "yaml": "apiVersion: ambassador/v0\nkind: Mapping\nname: httpbin_mapping\nprefix: /httpbin/\nservice: httpbin.org\n"
+        }
+    }
+}

--- a/ambassador/tests/011-xfp-redirect/gold.json
+++ b/ambassador/tests/011-xfp-redirect/gold.json
@@ -1,0 +1,129 @@
+{
+  "listeners": [
+    
+    {
+      "address": "tcp://0.0.0.0:80",
+      
+      "filters": [
+        {
+          "type": "read",
+          "name": "http_connection_manager",
+          "config": {"codec_type": "auto",
+            "stat_prefix": "ingress_http",
+            "access_log": [
+              {
+                "format": "ACCESS [%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\"\n",
+                "path": "/dev/fd/1"
+              }
+            ],
+            "route_config": {
+              "virtual_hosts": [
+                {
+                  "name": "backend",
+                  "domains": ["*"],"require_ssl": "all","routes": [
+                    
+                    {
+                      "timeout_ms": 3000,"prefix": "/ambassador/v0/check_ready","prefix_rewrite": "/ambassador/v0/check_ready","weighted_clusters": {
+                              "clusters": [
+                                  
+                                    { "name": "cluster_127_0_0_1_8877", "weight": 100.0 }
+                                  
+                              ]
+                          }
+
+                      
+                    }
+                    ,
+                    
+                    {
+                      "timeout_ms": 3000,"prefix": "/ambassador/v0/check_alive","prefix_rewrite": "/ambassador/v0/check_alive","weighted_clusters": {
+                              "clusters": [
+                                  
+                                    { "name": "cluster_127_0_0_1_8877", "weight": 100.0 }
+                                  
+                              ]
+                          }
+
+                      
+                    }
+                    ,
+                    
+                    {
+                      "timeout_ms": 3000,"prefix": "/ambassador/v0/","prefix_rewrite": "/ambassador/v0/","weighted_clusters": {
+                              "clusters": [
+                                  
+                                    { "name": "cluster_127_0_0_1_8877", "weight": 100.0 }
+                                  
+                              ]
+                          }
+
+                      
+                    }
+                    ,
+                    
+                    {
+                      "timeout_ms": 3000,"prefix": "/httpbin/","prefix_rewrite": "/","weighted_clusters": {
+                              "clusters": [
+                                  
+                                    { "name": "cluster_httpbin_org", "weight": 100.0 }
+                                  
+                              ]
+                          }
+
+                      
+                    }
+                    
+                    
+                  ]
+                }
+              ]
+            },
+            "filters": [
+              {
+                "name": "cors",
+                "config": {}
+              },{"type": "decoder",
+                "name": "router",
+                "config": {}
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ],
+  "admin": {
+    "address": "tcp://127.0.0.1:8001",
+    "access_log_path": "/tmp/admin_access_log"
+  },
+  "cluster_manager": {
+    "clusters": [
+      {
+        "name": "cluster_127_0_0_1_8877",
+        "connect_timeout_ms": 3000,
+        "type": "strict_dns",
+        "lb_type": "round_robin",        
+        "hosts": [
+          {
+            "url": "tcp://127.0.0.1:8877"
+          }
+          
+        ]},
+      {
+        "name": "cluster_httpbin_org",
+        "connect_timeout_ms": 3000,
+        "type": "strict_dns",
+        "lb_type": "round_robin",        
+        "hosts": [
+          {
+            "url": "tcp://httpbin.org:80"
+          }
+          
+        ]}
+      
+    ]
+  },
+  
+  "statsd_udp_ip_address": "127.0.0.1:8125",
+  "stats_flush_interval_ms": 1000
+}

--- a/ambassador/tests/012-xfp-redirect-false/config/l7-redirect.yaml
+++ b/ambassador/tests/012-xfp-redirect-false/config/l7-redirect.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: ambassador/v0
+kind:  Module
+name:  ambassador
+config:
+  x_forwarded_proto_redirect: false

--- a/ambassador/tests/012-xfp-redirect-false/config/mapping.yaml
+++ b/ambassador/tests/012-xfp-redirect-false/config/mapping.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: ambassador/v0
+kind: Mapping
+name: httpbin_mapping
+prefix: /httpbin/
+service: httpbin.org

--- a/ambassador/tests/012-xfp-redirect-false/gold.intermediate.json
+++ b/ambassador/tests/012-xfp-redirect-false/gold.intermediate.json
@@ -1,0 +1,207 @@
+{
+    "envoy_config": {
+        "admin": [
+            {
+                "_source": "l7-redirect.yaml.1",
+                "admin_port": 8001
+            }
+        ],
+        "clusters": [
+            {
+                "_referenced_by": [
+                    "l7-redirect.yaml.1"
+                ],
+                "_service": "127.0.0.1:8877",
+                "_source": "l7-redirect.yaml.1",
+                "lb_type": "round_robin",
+                "name": "cluster_127_0_0_1_8877",
+                "type": "strict_dns",
+                "urls": [
+                    "tcp://127.0.0.1:8877"
+                ]
+            },
+            {
+                "_referenced_by": [
+                    "mapping.yaml.1"
+                ],
+                "_service": "httpbin.org",
+                "_source": "mapping.yaml.1",
+                "lb_type": "round_robin",
+                "name": "cluster_httpbin_org",
+                "type": "strict_dns",
+                "urls": [
+                    "tcp://httpbin.org:80"
+                ]
+            }
+        ],
+        "filters": [
+            {
+                "_source": "--internal--",
+                "config": {},
+                "name": "cors"
+            },
+            {
+                "_source": "--internal--",
+                "config": {},
+                "name": "router",
+                "type": "decoder"
+            }
+        ],
+        "listeners": [
+            {
+                "_source": "l7-redirect.yaml.1",
+                "require_tls": false,
+                "service_port": 80,
+                "use_proxy_proto": false
+            }
+        ],
+        "routes": [
+            {
+                "__saved": [
+                    0,
+                    9,
+                    0,
+                    "/httpbin/",
+                    "GET"
+                ],
+                "_group_id": "0a0b4a3c06d5d92984505f097c69498d038c5737",
+                "_method": "GET",
+                "_precedence": 0,
+                "_referenced_by": [
+                    "mapping.yaml.1"
+                ],
+                "_source": "mapping.yaml.1",
+                "clusters": [
+                    {
+                        "name": "cluster_httpbin_org",
+                        "weight": 100.0
+                    }
+                ],
+                "prefix": "/httpbin/",
+                "prefix_rewrite": "/"
+            },
+            {
+                "__saved": [
+                    0,
+                    26,
+                    0,
+                    "/ambassador/v0/check_ready",
+                    "GET"
+                ],
+                "_group_id": "0a42187b7b3d283e0079ddab01825e1c71fad9f6",
+                "_method": "GET",
+                "_precedence": 0,
+                "_referenced_by": [
+                    "l7-redirect.yaml.1"
+                ],
+                "_source": "l7-redirect.yaml.1",
+                "clusters": [
+                    {
+                        "name": "cluster_127_0_0_1_8877",
+                        "weight": 100.0
+                    }
+                ],
+                "prefix": "/ambassador/v0/check_ready",
+                "prefix_rewrite": "/ambassador/v0/check_ready"
+            },
+            {
+                "__saved": [
+                    0,
+                    26,
+                    0,
+                    "/ambassador/v0/check_alive",
+                    "GET"
+                ],
+                "_group_id": "6151893fbc2f1f730a1bb946b2eefac391f0d2ec",
+                "_method": "GET",
+                "_precedence": 0,
+                "_referenced_by": [
+                    "l7-redirect.yaml.1"
+                ],
+                "_source": "l7-redirect.yaml.1",
+                "clusters": [
+                    {
+                        "name": "cluster_127_0_0_1_8877",
+                        "weight": 100.0
+                    }
+                ],
+                "prefix": "/ambassador/v0/check_alive",
+                "prefix_rewrite": "/ambassador/v0/check_alive"
+            },
+            {
+                "__saved": [
+                    0,
+                    15,
+                    0,
+                    "/ambassador/v0/",
+                    "GET"
+                ],
+                "_group_id": "b69eeb747b38f5e5fd3955d044ea7797d67d024f",
+                "_method": "GET",
+                "_precedence": 0,
+                "_referenced_by": [
+                    "l7-redirect.yaml.1"
+                ],
+                "_source": "l7-redirect.yaml.1",
+                "clusters": [
+                    {
+                        "name": "cluster_127_0_0_1_8877",
+                        "weight": 100.0
+                    }
+                ],
+                "prefix": "/ambassador/v0/",
+                "prefix_rewrite": "/ambassador/v0/"
+            }
+        ]
+    },
+    "errors": {},
+    "source_map": {
+        "--internal--": {
+            "--internal--": true
+        },
+        "l7-redirect.yaml": {
+            "l7-redirect.yaml.1": true
+        },
+        "mapping.yaml": {
+            "mapping.yaml.1": true
+        }
+    },
+    "sources": {
+        "--diagnostics--": {
+            "_source": "--diagnostics--",
+            "description": "The '--diagnostics--' source marks objects created by Ambassador to assist with diagnostic output.",
+            "filename": "--diagnostics--",
+            "index": 0,
+            "kind": "diagnostics",
+            "name": "Ambassador Diagnostics",
+            "version": "v0"
+        },
+        "--internal--": {
+            "_source": "--internal--",
+            "description": "The '--internal--' source marks objects created by Ambassador's internal logic.",
+            "filename": "--internal--",
+            "index": 0,
+            "kind": "Internal",
+            "name": "Ambassador Internals",
+            "version": "v0"
+        },
+        "l7-redirect.yaml.1": {
+            "_source": "l7-redirect.yaml",
+            "filename": "l7-redirect.yaml",
+            "index": 1,
+            "kind": "Module",
+            "name": "ambassador",
+            "version": "ambassador/v0",
+            "yaml": "apiVersion: ambassador/v0\nconfig:\n  x_forwarded_proto_redirect: false\nkind: Module\nname: ambassador\n"
+        },
+        "mapping.yaml.1": {
+            "_source": "mapping.yaml",
+            "filename": "mapping.yaml",
+            "index": 1,
+            "kind": "Mapping",
+            "name": "httpbin_mapping",
+            "version": "ambassador/v0",
+            "yaml": "apiVersion: ambassador/v0\nkind: Mapping\nname: httpbin_mapping\nprefix: /httpbin/\nservice: httpbin.org\n"
+        }
+    }
+}

--- a/ambassador/tests/012-xfp-redirect-false/gold.json
+++ b/ambassador/tests/012-xfp-redirect-false/gold.json
@@ -1,0 +1,129 @@
+{
+  "listeners": [
+    
+    {
+      "address": "tcp://0.0.0.0:80",
+      
+      "filters": [
+        {
+          "type": "read",
+          "name": "http_connection_manager",
+          "config": {"codec_type": "auto",
+            "stat_prefix": "ingress_http",
+            "access_log": [
+              {
+                "format": "ACCESS [%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\"\n",
+                "path": "/dev/fd/1"
+              }
+            ],
+            "route_config": {
+              "virtual_hosts": [
+                {
+                  "name": "backend",
+                  "domains": ["*"],"routes": [
+                    
+                    {
+                      "timeout_ms": 3000,"prefix": "/ambassador/v0/check_ready","prefix_rewrite": "/ambassador/v0/check_ready","weighted_clusters": {
+                              "clusters": [
+                                  
+                                    { "name": "cluster_127_0_0_1_8877", "weight": 100.0 }
+                                  
+                              ]
+                          }
+
+                      
+                    }
+                    ,
+                    
+                    {
+                      "timeout_ms": 3000,"prefix": "/ambassador/v0/check_alive","prefix_rewrite": "/ambassador/v0/check_alive","weighted_clusters": {
+                              "clusters": [
+                                  
+                                    { "name": "cluster_127_0_0_1_8877", "weight": 100.0 }
+                                  
+                              ]
+                          }
+
+                      
+                    }
+                    ,
+                    
+                    {
+                      "timeout_ms": 3000,"prefix": "/ambassador/v0/","prefix_rewrite": "/ambassador/v0/","weighted_clusters": {
+                              "clusters": [
+                                  
+                                    { "name": "cluster_127_0_0_1_8877", "weight": 100.0 }
+                                  
+                              ]
+                          }
+
+                      
+                    }
+                    ,
+                    
+                    {
+                      "timeout_ms": 3000,"prefix": "/httpbin/","prefix_rewrite": "/","weighted_clusters": {
+                              "clusters": [
+                                  
+                                    { "name": "cluster_httpbin_org", "weight": 100.0 }
+                                  
+                              ]
+                          }
+
+                      
+                    }
+                    
+                    
+                  ]
+                }
+              ]
+            },
+            "filters": [
+              {
+                "name": "cors",
+                "config": {}
+              },{"type": "decoder",
+                "name": "router",
+                "config": {}
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ],
+  "admin": {
+    "address": "tcp://127.0.0.1:8001",
+    "access_log_path": "/tmp/admin_access_log"
+  },
+  "cluster_manager": {
+    "clusters": [
+      {
+        "name": "cluster_127_0_0_1_8877",
+        "connect_timeout_ms": 3000,
+        "type": "strict_dns",
+        "lb_type": "round_robin",        
+        "hosts": [
+          {
+            "url": "tcp://127.0.0.1:8877"
+          }
+          
+        ]},
+      {
+        "name": "cluster_httpbin_org",
+        "connect_timeout_ms": 3000,
+        "type": "strict_dns",
+        "lb_type": "round_robin",        
+        "hosts": [
+          {
+            "url": "tcp://httpbin.org:80"
+          }
+          
+        ]}
+      
+    ]
+  },
+  
+  "statsd_udp_ip_address": "127.0.0.1:8125",
+  "stats_flush_interval_ms": 1000
+}

--- a/docs/reference/modules.md
+++ b/docs/reference/modules.md
@@ -55,6 +55,11 @@ config:
   # The current default is not to include any use_remote_address setting,
   # but THAT IS LIKELY TO CHANGE SOON.
   # use_remote_address: false
+
+  # Ambassador lets through only the HTTP requests with
+  # `X-FORWARDED-PROTO: https` header set, and redirects all the other
+  # requests to HTTPS if this field is set to true.
+  # x_forwarded_proto_redirect: false
 ```
 
 #### `use_remote_address`

--- a/docs/reference/redirects.md
+++ b/docs/reference/redirects.md
@@ -1,5 +1,7 @@
 ## Redirects
 
+### Host Redirect
+
 To effect an HTTP 301 `Redirect`, the `Mapping` **must** set `host_redirect` to `true`, with `service` set to the host to which the client should be redirected:
 
 ```yaml
@@ -26,3 +28,23 @@ path_redirect: /ip
 ```
 
 Here, a request to `http://$AMBASSADOR_URL/redirect/` will result in an HTTP 301 `Redirect` to `http://httpbin.org/ip`. As always with Ambassador, attention paid to the trailing `/` on a URL is helpful!
+
+### X-FORWARDED-PROTO Redirect
+
+In cases when TLS is being terminated at an external layer 7 load balancer, then you would want to redirect only the originating HTTP requests to HTTPS, and let the originating HTTPS requests pass through.
+
+This distinction between an originating HTTP request and an originating HTTPS request is done based on the `X-FORWARDED-PROTO` header that the external layer 7 load balancer adds to every request it forwards after TLS termination.
+
+To enable this `X-FORWARDED-PROTO` based HTTP to HTTPS redirection, add a `x_forwarded_proto_redirect: true` field to ambassador module's configuration.
+
+An example configuration is as follows -
+
+```yaml
+apiVersion: ambassador/v0
+kind: Module
+name: ambassador
+config:
+  x_forwarded_proto_redirect: true
+```
+
+Note: Setting `x_forwarded_proto_redirect: true` will impact all your ambassador mappings. Every HTTP request to ambassador will only be allowed to pass if it has an `X-FORWARDED-PROTO: https` header.

--- a/end-to-end/1-parallel/012-xfp-redirect/diag-1.json
+++ b/end-to-end/1-parallel/012-xfp-redirect/diag-1.json
@@ -1,0 +1,122 @@
+[
+    {
+        "__saved": [
+            0,
+            26,
+            0,
+            "/ambassador/v0/check_ready",
+            "GET"
+        ],
+        "_group_id": "0a42187b7b3d283e0079ddab01825e1c71fad9f6",
+        "_method": "GET",
+        "_precedence": 0,
+        "_referenced_by": [
+            "ambassador-012-xfp-redirect.yaml.2"
+        ],
+        "_source": "ambassador-012-xfp-redirect.yaml.2",
+        "clusters": [
+            {
+                "name": "cluster_127_0_0_1_8877",
+                "weight": 100.0
+            }
+        ],
+        "prefix": "/ambassador/v0/check_ready",
+        "prefix_rewrite": "/ambassador/v0/check_ready"
+    },
+    {
+        "__saved": [
+            0,
+            26,
+            0,
+            "/ambassador/v0/check_alive",
+            "GET"
+        ],
+        "_group_id": "6151893fbc2f1f730a1bb946b2eefac391f0d2ec",
+        "_method": "GET",
+        "_precedence": 0,
+        "_referenced_by": [
+            "ambassador-012-xfp-redirect.yaml.2"
+        ],
+        "_source": "ambassador-012-xfp-redirect.yaml.2",
+        "clusters": [
+            {
+                "name": "cluster_127_0_0_1_8877",
+                "weight": 100.0
+            }
+        ],
+        "prefix": "/ambassador/v0/check_alive",
+        "prefix_rewrite": "/ambassador/v0/check_alive"
+    },
+    {
+        "__saved": [
+            0,
+            15,
+            0,
+            "/ambassador/v0/",
+            "GET"
+        ],
+        "_group_id": "b69eeb747b38f5e5fd3955d044ea7797d67d024f",
+        "_method": "GET",
+        "_precedence": 0,
+        "_referenced_by": [
+            "ambassador-012-xfp-redirect.yaml.2"
+        ],
+        "_source": "ambassador-012-xfp-redirect.yaml.2",
+        "clusters": [
+            {
+                "name": "cluster_127_0_0_1_8877",
+                "weight": 100.0
+            }
+        ],
+        "prefix": "/ambassador/v0/",
+        "prefix_rewrite": "/ambassador/v0/"
+    },
+    {
+        "__saved": [
+            0,
+            12,
+            0,
+            "/ambassador/",
+            "GET"
+        ],
+        "_group_id": "688e9f91e06f33c943c0c6373a5bdd32e647f7c4",
+        "_method": "GET",
+        "_precedence": 0,
+        "_referenced_by": [
+            "ambassador-012-xfp-redirect.yaml.1"
+        ],
+        "_source": "ambassador-012-xfp-redirect.yaml.1",
+        "clusters": [
+            {
+                "name": "cluster_127_0_0_1_8877",
+                "weight": 100.0
+            }
+        ],
+        "prefix": "/ambassador/",
+        "prefix_rewrite": "/ambassador/"
+    },
+    {
+        "__saved": [
+            0,
+            6,
+            0,
+            "/qotm/",
+            "GET"
+        ],
+        "_group_id": "9fda39523fe03a3c6aac9c21098375764ec0822d",
+        "_method": "GET",
+        "_precedence": 0,
+        "_referenced_by": [
+            "qotm-012-xfp-redirect.yaml.1"
+        ],
+        "_source": "qotm-012-xfp-redirect.yaml.1",
+        "clusters": [
+            {
+                "name": "cluster_qotm",
+                "weight": 100.0
+            }
+        ],
+        "prefix": "/qotm/",
+        "prefix_rewrite": "/"
+    }
+]

--- a/end-to-end/1-parallel/012-xfp-redirect/k8s/ambassador.yaml
+++ b/end-to-end/1-parallel/012-xfp-redirect/k8s/ambassador.yaml
@@ -1,0 +1,31 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ambassador
+  annotations:
+    getambassador.io/config: |
+      ---
+      apiVersion: ambassador/v0
+      kind: Mapping
+      name: diag_mapping
+      prefix: /ambassador/
+      rewrite: /ambassador/
+      service: 127.0.0.1:8877
+      ambassador_id: 012-xfp-redirect
+      ---
+      apiVersion: ambassador/v0
+      kind: Module
+      name: ambassador
+      ambassador_id: 012-xfp-redirect
+      config:
+        x_forwarded_proto_redirect: true
+spec:
+  selector:
+    service: ambassador
+  ports:
+    - name: https
+      protocol: TCP
+      port: 80
+      targetPort: 80
+  type: NodePort

--- a/end-to-end/1-parallel/012-xfp-redirect/k8s/qotm.yaml
+++ b/end-to-end/1-parallel/012-xfp-redirect/k8s/qotm.yaml
@@ -1,0 +1,42 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: qotm
+  annotations:
+    getambassador.io/config: |
+      ---
+      apiVersion: ambassador/v0
+      kind:  Mapping
+      name:  qotm_mapping
+      prefix: /qotm/
+      service: qotm
+      ambassador_id: 012-xfp-redirect
+spec:
+  selector:
+    app: qotm
+  ports:
+    - port: 80
+      targetPort: http-api
+  type: ClusterIP
+---
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: qotm
+spec:
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: qotm
+    spec:
+      containers:
+      - name: qotm
+        image: datawire/qotm:1.3
+        imagePullPolicy: Always
+        ports:
+        - name: http-api
+          containerPort: 5000

--- a/end-to-end/1-parallel/012-xfp-redirect/k8s/rbac.yaml
+++ b/end-to-end/1-parallel/012-xfp-redirect/k8s/rbac.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ambassador
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: ambassador-012-xfp-redirect
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: ambassador
+subjects:
+- kind: ServiceAccount
+  name: ambassador
+  namespace: 012-xfp-redirect

--- a/end-to-end/1-parallel/012-xfp-redirect/test.sh
+++ b/end-to-end/1-parallel/012-xfp-redirect/test.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+
+# Copyright 2018 Datawire. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License
+
+set -e -o pipefail
+
+NAMESPACE="012-xfp-redirect"
+
+cd $(dirname $0)
+ROOT=$(cd ../..; pwd)
+source ${ROOT}/utils.sh
+bootstrap ${NAMESPACE} ${ROOT}
+
+python ${ROOT}/yfix.py ${ROOT}/fixes/test-dep.yfix \
+    ${ROOT}/ambassador-deployment.yaml \
+    k8s/ambassador-deployment.yaml \
+    ${NAMESPACE} \
+    ${NAMESPACE}
+
+kubectl apply -f k8s/rbac.yaml
+kubectl apply -f k8s/ambassador.yaml
+kubectl apply -f k8s/ambassador-deployment.yaml
+kubectl apply -f k8s/qotm.yaml
+
+set +e +o pipefail
+
+wait_for_pods ${NAMESPACE}
+
+CLUSTER=$(cluster_ip)
+APORT=$(service_port ambassador ${NAMESPACE})
+
+BASEURL="http://${CLUSTER}:${APORT}"
+
+echo "Base URL $BASEURL"
+echo "Diag URL $BASEURL/ambassador/v0/diag/"
+
+extra_args="-H 'X-FORWARDED-PROTO: https'"
+
+wait_for_ready "$BASEURL" "$extra_args"
+
+if ! check_diag "$BASEURL" 1 "QOTM present" "$extra_args"; then
+    exit 1
+fi
+
+# Making a normal HTTP request to /qotm/ should result in a redirect to https://
+code=$(get_http_code "$BASEURL/qotm/")
+if [ $code -ne 301 ]; then
+    echo "Expected 301 HTTP code, but got $code"
+    exit 1
+fi
+echo "Get $code for non XFP HTTP request to $BASEURL/qotm/"
+redirect_url=$(get_redirect_url "$BASEURL/qotm/")
+if [ ${redirect_url} != "https://${CLUSTER}:${APORT}/qotm/" ]; then
+    echo "Expected redirect URL to be "https://${CLUSTER}:${APORT}/qotm/", but got $redirect_url"
+    exit 1
+fi
+echo "Ambassador redirected to $redirect_url for non XFP HTTP request to $BASEURL/qotm/"
+
+# Making an HTTP request with X-FORWARDED-PROTO header set to 'https' should return a 200 without any redirects
+code=$(get_http_code "$BASEURL/qotm/" "$extra_args")
+if [ $code -ne 200 ]; then
+    echo "Expected 200 HTTP code since 'X-FORWARDED-PROTO: https' header was set, but got $code"
+    exit 1
+fi
+echo "Got $code for HTTP request with 'X-FORWARDED-PROTO: https' to URL $BASEURL/qotm/"
+
+# Making an HTTP request with X-FORWARDED-PROTO header set to 'http' should still return a 301 redirect
+code=$(get_http_code "$BASEURL/qotm/" "-H 'X-FORWARDED-PROTO: http'")
+if [ $code -ne 301 ]; then
+    echo "Expected 301 HTTP code since 'X-FORWARDED-PROTO: http' header was set, but got $code"
+    exit 1
+fi
+echo "Got $code for HTTP request with 'X-FORWARDED-PROTO: http' set to URL $BASEURL/qotm/"
+
+redirect_url=$(get_redirect_url "$BASEURL/qotm/" "-H 'X-FORWARDED-PROTO: http'")
+if [ ${redirect_url} != "https://${CLUSTER}:${APORT}/qotm/" ]; then
+    echo "Expected redirect URL to be "https://${CLUSTER}:${APORT}/qotm/", but got $redirect_url"
+    exit 1
+fi
+echo "Ambassador redirected to $redirect_url for HTTP request with 'X-FORWARDED-PROTO: http' to $BASEURL/qotm/"
+
+if [ -n "$CLEAN_ON_SUCCESS" ]; then
+    drop_namespace ${NAMESPACE}
+fi


### PR DESCRIPTION
    This commit lets users specify a `x_forwarded_proto_redirect`
    field in their ambassador mapping which accepts a boolen value.
    
    An example mapping looks like -
    
    ```yaml
        getambassador.io/config: |
          ---
          apiVersion: ambassador/v0
          kind:  Mapping
          name:  httpbin_mapping
          prefix: /httpbin/
          service: httpbin.org:80
          host_rewrite: httpbin.org
          x_forwarded_proto_redirect: true
    ```
    
    When set to true, ambassador, and in turn envoy, behaves like the
    following -
    
    If an incoming request has `X-FORWARDED-PROTO: https` header
    set, then no redirects take place and a normal response if sent.
    
    If `X-FORWARDED-PROTO` is absent or sent to anything else, like
    `http`, then a 301 redirect to https://host is sent as response.
    
    Keep in mind that ambassador does not have access to any TLS certs
    in the entire workflow. This is typically useful in cases when TLS
    termination happens at an external L7 load balancer, which sets
    the protocol of the incoming request in the `X-FORWARDED-PROTO`
    header of the resulting HTTP request after TLS termination.
    
    Partially fixes #469