### PR TITLE
Populate default TLS config only if files exist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ envoy.json
 intermediate.json
 check-*.json
 end-to-end/forge
+stats.json

--- a/ambassador/templates/envoy.j2
+++ b/ambassador/templates/envoy.j2
@@ -4,7 +4,7 @@
     {
       "address": "tcp://0.0.0.0:{{ listener.service_port }}",
       {% if listener.use_proxy_proto -%}"use_proxy_proto": true,{%- endif %}
-      {% if listener.tls -%}
+      {% if listener.tls and listener.tls.ssl_context -%}
       "ssl_context": {
         {%- if listener.tls.cert_chain_file -%}
           "cert_chain_file": "{{ listener.tls.cert_chain_file }}",

--- a/ambassador/tests/001-broader-v0/gold.intermediate.json
+++ b/ambassador/tests/001-broader-v0/gold.intermediate.json
@@ -370,7 +370,8 @@
                     "cacert_chain_file": "/etc/ambassador-config/ca_cert_chain/tls.crt",
                     "cert_chain_file": "/etc/ambassador-config/certs/tls.crt",
                     "cert_required": true,
-                    "private_key_file": "/etc/ambassador-config/certs/tls.key"
+                    "private_key_file": "/etc/ambassador-config/certs/tls.key",
+                    "ssl_context": true
                 },
                 "use_proxy_proto": true,
                 "use_remote_address": true

--- a/ambassador/tests/002-tls-module-1/gold.intermediate.json
+++ b/ambassador/tests/002-tls-module-1/gold.intermediate.json
@@ -58,7 +58,8 @@
                     "cacert_chain_file": "/etc/ambassador-config/ca_cert_chain/tls.crt",
                     "cert_chain_file": "/etc/ambassador-config/certs/tls.crt",
                     "cert_required": true,
-                    "private_key_file": "/etc/ambassador-config/certs/tls.key"
+                    "private_key_file": "/etc/ambassador-config/certs/tls.key",
+                    "ssl_context": true
                 },
                 "use_proxy_proto": false,
                 "use_remote_address": false

--- a/ambassador/tests/003-tls-module-2/gold.intermediate.json
+++ b/ambassador/tests/003-tls-module-2/gold.intermediate.json
@@ -57,7 +57,8 @@
                     "cacert_chain_file": "/etc/ambassador-config/ca_cert_chain/tls.crt",
                     "cert_chain_file": "/etc/ambassador-config/certs/tls.crt",
                     "cert_required": true,
-                    "private_key_file": "/etc/ambassador-config/certs/tls.key"
+                    "private_key_file": "/etc/ambassador-config/certs/tls.key",
+                    "ssl_context": true
                 },
                 "use_proxy_proto": false
             }

--- a/ambassador/tests/007-originating-tls/gold.intermediate.json
+++ b/ambassador/tests/007-originating-tls/gold.intermediate.json
@@ -122,7 +122,8 @@
                 "tls": {
                     "_source": "tls.yaml.1",
                     "cert_chain_file": "/etc/ambassador-config/certs/tls.crt",
-                    "private_key_file": "/etc/ambassador-config/certs/tls.key"
+                    "private_key_file": "/etc/ambassador-config/certs/tls.key",
+                    "ssl_context": true
                 },
                 "use_proxy_proto": false
             }

--- a/ambassador/tests/011-only-redirect-cleartext-from/config/module.yaml
+++ b/ambassador/tests/011-only-redirect-cleartext-from/config/module.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: ambassador/v0
+kind:  Module
+name:  tls
+config:
+  server:
+    enabled: True
+    redirect_cleartext_from: 8888

--- a/ambassador/tests/011-only-redirect-cleartext-from/gold.intermediate.json
+++ b/ambassador/tests/011-only-redirect-cleartext-from/gold.intermediate.json
@@ -2,35 +2,22 @@
     "envoy_config": {
         "admin": [
             {
-                "_source": "tls.yaml.1",
+                "_source": "module.yaml.1",
                 "admin_port": 8001
             }
         ],
         "clusters": [
             {
                 "_referenced_by": [
-                    "tls.yaml.1"
+                    "module.yaml.1"
                 ],
                 "_service": "127.0.0.1:8877",
-                "_source": "tls.yaml.1",
+                "_source": "module.yaml.1",
                 "lb_type": "round_robin",
                 "name": "cluster_127_0_0_1_8877",
                 "type": "strict_dns",
                 "urls": [
                     "tcp://127.0.0.1:8877"
-                ]
-            },
-            {
-                "_referenced_by": [
-                    "mapping-qotm.yaml.1"
-                ],
-                "_service": "qotm",
-                "_source": "mapping-qotm.yaml.1",
-                "lb_type": "round_robin",
-                "name": "cluster_qotm",
-                "type": "strict_dns",
-                "urls": [
-                    "tcp://qotm:80"
                 ]
             }
         ],
@@ -49,17 +36,19 @@
         ],
         "listeners": [
             {
-                "_source": "tls.yaml.1",
+                "_source": "module.yaml.1",
                 "require_tls": false,
                 "service_port": 443,
                 "tls": {
-                    "_source": "tls.yaml.1",
-                    "cacert_chain_file": "/etc/ambassador-config/ca_cert_chain/tls.crt",
-                    "cert_chain_file": "/etc/ambassador-config/certs/tls.crt",
-                    "cert_required": true,
-                    "private_key_file": "/etc/ambassador-config/certs/tls.key",
-                    "ssl_context": true
+                    "_source": "module.yaml.1",
+                    "redirect_cleartext_from": 8888
                 },
+                "use_proxy_proto": false
+            },
+            {
+                "_source": "module.yaml.1",
+                "require_tls": true,
+                "service_port": 8888,
                 "use_proxy_proto": false
             }
         ],
@@ -76,9 +65,9 @@
                 "_method": "GET",
                 "_precedence": 0,
                 "_referenced_by": [
-                    "tls.yaml.1"
+                    "module.yaml.1"
                 ],
-                "_source": "tls.yaml.1",
+                "_source": "module.yaml.1",
                 "clusters": [
                     {
                         "name": "cluster_127_0_0_1_8877",
@@ -100,9 +89,9 @@
                 "_method": "GET",
                 "_precedence": 0,
                 "_referenced_by": [
-                    "tls.yaml.1"
+                    "module.yaml.1"
                 ],
-                "_source": "tls.yaml.1",
+                "_source": "module.yaml.1",
                 "clusters": [
                     {
                         "name": "cluster_127_0_0_1_8877",
@@ -111,30 +100,6 @@
                 ],
                 "prefix": "/ambassador/v0/check_alive",
                 "prefix_rewrite": "/ambassador/v0/check_alive"
-            },
-            {
-                "__saved": [
-                    0,
-                    6,
-                    0,
-                    "/qotm/",
-                    "GET"
-                ],
-                "_group_id": "9fda39523fe03a3c6aac9c21098375764ec0822d",
-                "_method": "GET",
-                "_precedence": 0,
-                "_referenced_by": [
-                    "mapping-qotm.yaml.1"
-                ],
-                "_source": "mapping-qotm.yaml.1",
-                "clusters": [
-                    {
-                        "name": "cluster_qotm",
-                        "weight": 100.0
-                    }
-                ],
-                "prefix": "/qotm/",
-                "prefix_rewrite": "/"
             },
             {
                 "__saved": [
@@ -148,9 +113,9 @@
                 "_method": "GET",
                 "_precedence": 0,
                 "_referenced_by": [
-                    "tls.yaml.1"
+                    "module.yaml.1"
                 ],
-                "_source": "tls.yaml.1",
+                "_source": "module.yaml.1",
                 "clusters": [
                     {
                         "name": "cluster_127_0_0_1_8877",
@@ -167,11 +132,8 @@
         "--internal--": {
             "--internal--": true
         },
-        "mapping-qotm.yaml": {
-            "mapping-qotm.yaml.1": true
-        },
-        "tls.yaml": {
-            "tls.yaml.1": true
+        "module.yaml": {
+            "module.yaml.1": true
         }
     },
     "sources": {
@@ -193,23 +155,14 @@
             "name": "Ambassador Internals",
             "version": "v0"
         },
-        "mapping-qotm.yaml.1": {
-            "_source": "mapping-qotm.yaml",
-            "filename": "mapping-qotm.yaml",
-            "index": 1,
-            "kind": "Mapping",
-            "name": "qotm_mapping",
-            "version": "ambassador/v0",
-            "yaml": "apiVersion: ambassador/v0\nkind: Mapping\nname: qotm_mapping\nprefix: /qotm/\nservice: qotm\n"
-        },
-        "tls.yaml.1": {
-            "_source": "tls.yaml",
-            "filename": "tls.yaml",
+        "module.yaml.1": {
+            "_source": "module.yaml",
+            "filename": "module.yaml",
             "index": 1,
             "kind": "Module",
             "name": "tls",
             "version": "ambassador/v0",
-            "yaml": "apiVersion: ambassador/v0\nconfig:\n  client:\n    cacert_chain_file: /etc/ambassador-config/ca_cert_chain/tls.crt\n    cert_required: true\n    enabled: True,\n  server:\n    cert_chain_file: /etc/ambassador-config/certs/tls.crt\n    enabled: true\n    private_key_file: /etc/ambassador-config/certs/tls.key\nkind: Module\nname: tls\n"
+            "yaml": "apiVersion: ambassador/v0\nconfig:\n  server:\n    enabled: true\n    redirect_cleartext_from: 8888\nkind: Module\nname: tls\n"
         }
     }
 }

--- a/ambassador/tests/011-only-redirect-cleartext-from/gold.json
+++ b/ambassador/tests/011-only-redirect-cleartext-from/gold.json
@@ -1,0 +1,182 @@
+{
+  "listeners": [
+    
+    {
+      "address": "tcp://0.0.0.0:443",
+      
+      "filters": [
+        {
+          "type": "read",
+          "name": "http_connection_manager",
+          "config": {"codec_type": "auto",
+            "stat_prefix": "ingress_http",
+            "access_log": [
+              {
+                "format": "ACCESS [%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\"\n",
+                "path": "/dev/fd/1"
+              }
+            ],
+            "route_config": {
+              "virtual_hosts": [
+                {
+                  "name": "backend",
+                  "domains": ["*"],"routes": [
+                    
+                    {
+                      "timeout_ms": 3000,"prefix": "/ambassador/v0/check_ready","prefix_rewrite": "/ambassador/v0/check_ready","weighted_clusters": {
+                              "clusters": [
+                                  
+                                    { "name": "cluster_127_0_0_1_8877", "weight": 100.0 }
+                                  
+                              ]
+                          }
+
+                      
+                    }
+                    ,
+                    
+                    {
+                      "timeout_ms": 3000,"prefix": "/ambassador/v0/check_alive","prefix_rewrite": "/ambassador/v0/check_alive","weighted_clusters": {
+                              "clusters": [
+                                  
+                                    { "name": "cluster_127_0_0_1_8877", "weight": 100.0 }
+                                  
+                              ]
+                          }
+
+                      
+                    }
+                    ,
+                    
+                    {
+                      "timeout_ms": 3000,"prefix": "/ambassador/v0/","prefix_rewrite": "/ambassador/v0/","weighted_clusters": {
+                              "clusters": [
+                                  
+                                    { "name": "cluster_127_0_0_1_8877", "weight": 100.0 }
+                                  
+                              ]
+                          }
+
+                      
+                    }
+                    
+                    
+                  ]
+                }
+              ]
+            },
+            "filters": [
+              {
+                "name": "cors",
+                "config": {}
+              },{"type": "decoder",
+                "name": "router",
+                "config": {}
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "address": "tcp://0.0.0.0:8888",
+      
+      "filters": [
+        {
+          "type": "read",
+          "name": "http_connection_manager",
+          "config": {"codec_type": "auto",
+            "stat_prefix": "ingress_http",
+            "access_log": [
+              {
+                "format": "ACCESS [%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\"\n",
+                "path": "/dev/fd/1"
+              }
+            ],
+            "route_config": {
+              "virtual_hosts": [
+                {
+                  "name": "backend",
+                  "domains": ["*"],"require_ssl": "all","routes": [
+                    
+                    {
+                      "timeout_ms": 3000,"prefix": "/ambassador/v0/check_ready","prefix_rewrite": "/ambassador/v0/check_ready","weighted_clusters": {
+                              "clusters": [
+                                  
+                                    { "name": "cluster_127_0_0_1_8877", "weight": 100.0 }
+                                  
+                              ]
+                          }
+
+                      
+                    }
+                    ,
+                    
+                    {
+                      "timeout_ms": 3000,"prefix": "/ambassador/v0/check_alive","prefix_rewrite": "/ambassador/v0/check_alive","weighted_clusters": {
+                              "clusters": [
+                                  
+                                    { "name": "cluster_127_0_0_1_8877", "weight": 100.0 }
+                                  
+                              ]
+                          }
+
+                      
+                    }
+                    ,
+                    
+                    {
+                      "timeout_ms": 3000,"prefix": "/ambassador/v0/","prefix_rewrite": "/ambassador/v0/","weighted_clusters": {
+                              "clusters": [
+                                  
+                                    { "name": "cluster_127_0_0_1_8877", "weight": 100.0 }
+                                  
+                              ]
+                          }
+
+                      
+                    }
+                    
+                    
+                  ]
+                }
+              ]
+            },
+            "filters": [
+              {
+                "name": "cors",
+                "config": {}
+              },{"type": "decoder",
+                "name": "router",
+                "config": {}
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ],
+  "admin": {
+    "address": "tcp://127.0.0.1:8001",
+    "access_log_path": "/tmp/admin_access_log"
+  },
+  "cluster_manager": {
+    "clusters": [
+      {
+        "name": "cluster_127_0_0_1_8877",
+        "connect_timeout_ms": 3000,
+        "type": "strict_dns",
+        "lb_type": "round_robin",        
+        "hosts": [
+          {
+            "url": "tcp://127.0.0.1:8877"
+          }
+          
+        ]}
+      
+    ]
+  },
+  
+  "statsd_udp_ip_address": "127.0.0.1:8125",
+  "stats_flush_interval_ms": 1000
+}

--- a/end-to-end/1-parallel/013-port-redirect/diag-1.json
+++ b/end-to-end/1-parallel/013-port-redirect/diag-1.json
@@ -1,0 +1,122 @@
+[
+    {
+        "__saved": [
+            0,
+            26,
+            0,
+            "/ambassador/v0/check_ready",
+            "GET"
+        ],
+        "_group_id": "0a42187b7b3d283e0079ddab01825e1c71fad9f6",
+        "_method": "GET",
+        "_precedence": 0,
+        "_referenced_by": [
+            "ambassador-013-port-redirect.yaml.2"
+        ],
+        "_source": "ambassador-013-port-redirect.yaml.2",
+        "clusters": [
+            {
+                "name": "cluster_127_0_0_1_8877",
+                "weight": 100.0
+            }
+        ],
+        "prefix": "/ambassador/v0/check_ready",
+        "prefix_rewrite": "/ambassador/v0/check_ready"
+    },
+    {
+        "__saved": [
+            0,
+            26,
+            0,
+            "/ambassador/v0/check_alive",
+            "GET"
+        ],
+        "_group_id": "6151893fbc2f1f730a1bb946b2eefac391f0d2ec",
+        "_method": "GET",
+        "_precedence": 0,
+        "_referenced_by": [
+            "ambassador-013-port-redirect.yaml.2"
+        ],
+        "_source": "ambassador-013-port-redirect.yaml.2",
+        "clusters": [
+            {
+                "name": "cluster_127_0_0_1_8877",
+                "weight": 100.0
+            }
+        ],
+        "prefix": "/ambassador/v0/check_alive",
+        "prefix_rewrite": "/ambassador/v0/check_alive"
+    },
+    {
+        "__saved": [
+            0,
+            15,
+            0,
+            "/ambassador/v0/",
+            "GET"
+        ],
+        "_group_id": "b69eeb747b38f5e5fd3955d044ea7797d67d024f",
+        "_method": "GET",
+        "_precedence": 0,
+        "_referenced_by": [
+            "ambassador-013-port-redirect.yaml.2"
+        ],
+        "_source": "ambassador-013-port-redirect.yaml.2",
+        "clusters": [
+            {
+                "name": "cluster_127_0_0_1_8877",
+                "weight": 100.0
+            }
+        ],
+        "prefix": "/ambassador/v0/",
+        "prefix_rewrite": "/ambassador/v0/"
+    },
+    {
+        "__saved": [
+            0,
+            12,
+            0,
+            "/ambassador/",
+            "GET"
+        ],
+        "_group_id": "688e9f91e06f33c943c0c6373a5bdd32e647f7c4",
+        "_method": "GET",
+        "_precedence": 0,
+        "_referenced_by": [
+            "ambassador-013-port-redirect.yaml.1"
+        ],
+        "_source": "ambassador-013-port-redirect.yaml.1",
+        "clusters": [
+            {
+                "name": "cluster_127_0_0_1_8877",
+                "weight": 100.0
+            }
+        ],
+        "prefix": "/ambassador/",
+        "prefix_rewrite": "/ambassador/"
+    },
+    {
+        "__saved": [
+            0,
+            6,
+            0,
+            "/qotm/",
+            "GET"
+        ],
+        "_group_id": "9fda39523fe03a3c6aac9c21098375764ec0822d",
+        "_method": "GET",
+        "_precedence": 0,
+        "_referenced_by": [
+            "qotm-013-port-redirect.yaml.1"
+        ],
+        "_source": "qotm-013-port-redirect.yaml.1",
+        "clusters": [
+            {
+                "name": "cluster_qotm",
+                "weight": 100.0
+            }
+        ],
+        "prefix": "/qotm/",
+        "prefix_rewrite": "/"
+    }
+]

--- a/end-to-end/1-parallel/013-port-redirect/k8s/ambassador.yaml
+++ b/end-to-end/1-parallel/013-port-redirect/k8s/ambassador.yaml
@@ -1,0 +1,37 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ambassador
+  annotations:
+    getambassador.io/config: |
+      ---
+      apiVersion: ambassador/v0
+      kind: Mapping
+      name: diag_mapping
+      prefix: /ambassador/
+      rewrite: /ambassador/
+      service: 127.0.0.1:8877
+      ambassador_id: 013-port-redirect
+      ---
+      apiVersion: ambassador/v0
+      kind:  Module
+      name:  tls
+      ambassador_id: 013-port-redirect
+      config:
+        server:
+          enabled: True
+          redirect_cleartext_from: 8080
+spec:
+  selector:
+    service: ambassador
+  ports:
+    - name: https
+      protocol: TCP
+      port: 443
+      targetPort: 443
+    - name: redirect-port
+      protocol: TCP
+      port: 8080
+      targetPort: 8080
+  type: NodePort

--- a/end-to-end/1-parallel/013-port-redirect/k8s/qotm.yaml
+++ b/end-to-end/1-parallel/013-port-redirect/k8s/qotm.yaml
@@ -1,0 +1,42 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: qotm
+  annotations:
+    getambassador.io/config: |
+      ---
+      apiVersion: ambassador/v0
+      kind:  Mapping
+      name:  qotm_mapping
+      prefix: /qotm/
+      service: qotm
+      ambassador_id: 013-port-redirect
+spec:
+  selector:
+    app: qotm
+  ports:
+    - port: 80
+      targetPort: http-api
+  type: ClusterIP
+---
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: qotm
+spec:
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: qotm
+    spec:
+      containers:
+      - name: qotm
+        image: datawire/qotm:1.3
+        imagePullPolicy: Always
+        ports:
+        - name: http-api
+          containerPort: 5000

--- a/end-to-end/1-parallel/013-port-redirect/k8s/rbac.yaml
+++ b/end-to-end/1-parallel/013-port-redirect/k8s/rbac.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ambassador
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: ambassador-013-port-redirect
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: ambassador
+subjects:
+- kind: ServiceAccount
+  name: ambassador
+  namespace: 013-port-redirect

--- a/end-to-end/1-parallel/013-port-redirect/test.sh
+++ b/end-to-end/1-parallel/013-port-redirect/test.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+
+# Copyright 2018 Datawire. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License
+
+set -e -o pipefail
+
+NAMESPACE="013-port-redirect"
+
+cd $(dirname $0)
+ROOT=$(cd ../..; pwd)
+source ${ROOT}/utils.sh
+bootstrap ${NAMESPACE} ${ROOT}
+
+python ${ROOT}/yfix.py ${ROOT}/fixes/test-dep.yfix \
+    ${ROOT}/ambassador-deployment.yaml \
+    k8s/ambassador-deployment.yaml \
+    ${NAMESPACE} \
+    ${NAMESPACE}
+
+kubectl apply -f k8s/rbac.yaml
+kubectl apply -f k8s/ambassador.yaml
+kubectl apply -f k8s/ambassador-deployment.yaml
+kubectl apply -f k8s/qotm.yaml
+
+set +e +o pipefail
+
+wait_for_pods ${NAMESPACE}
+
+CLUSTER=$(cluster_ip)
+APORT=$(service_port ambassador ${NAMESPACE})
+
+REDIRECTPORT=$(service_port ambassador ${NAMESPACE} 1)
+ADMINPORT=$(service_port ambassador-admin ${NAMESPACE})
+
+BASEURL="http://${CLUSTER}:${APORT}"
+ADMINURL="http://${CLUSTER}:${ADMINPORT}"
+REDIRECTURL="http://${CLUSTER}:${REDIRECTPORT}"
+
+echo "Base URL $BASEURL"
+echo "Diag URL $ADMINURL/ambassador/v0/diag/"
+
+wait_for_ready "$ADMINURL"
+
+if ! check_diag "$ADMINURL" 1 "QOTM present"; then
+    exit 1
+fi
+
+# The HTTP request to the the redirecting port should result in a 301
+# This is where HTTP requests from the L4 load balancer will be forwarded.
+code=$(get_http_code "$REDIRECTURL/qotm/")
+if [ $code -ne 301 ]; then
+    echo "Expected 301 HTTP code, but got $code"
+    exit 1
+fi
+echo "Got $code for request to $REDIRECTURL/qotm/"
+redirect_url=$(get_redirect_url "$REDIRECTURL/qotm/")
+if [ ${redirect_url} != "https://${CLUSTER}:${REDIRECTPORT}/qotm/" ]; then
+    echo "Expected redirect URL to be "https://${CLUSTER}:${REDIRECTPORT}/qotm/", but got $redirect_url"
+    exit 1
+fi
+echo "Ambassador redirected to $redirect_url for HTTP request to $REDIRECTURL/qotm/"
+
+# HTTP request to regular ambassador's port (443 in this case) should go through without any TLS certs
+# This is where the HTTPS requests from the L4 load balancer will be forwarded to after terminating TLS.
+code=$(get_http_code "$BASEURL/qotm/")
+if [ $code -ne 200 ]; then
+    echo "Expected 200 HTTP code, but got $code"
+    exit 1
+fi
+echo "Got $code for request to $BASEURL/qotm/"
+
+if [ -n "$CLEAN_ON_SUCCESS" ]; then
+    drop_namespace ${NAMESPACE}
+fi

--- a/end-to-end/utils.sh
+++ b/end-to-end/utils.sh
@@ -437,6 +437,22 @@ kubectl_context () {
     kubectl config current-context
 }
 
+get_http_code() {
+    url=$1
+    extra_args=$2
+
+    command="curl $extra_args -w %{http_code} -s -o /dev/null $url"
+    echo $(eval ${command})
+}
+
+get_redirect_url() {
+    url=$1
+    extra_args=$2
+
+    command="curl $extra_args -w %{redirect_url} -s -o /dev/null $url"
+    echo $(eval ${command})
+}
+
 interactive_check_context () {
     CONTEXT=$(kubectl_context)
     namespace="$1"


### PR DESCRIPTION
This commit checks if the certs exist on disk before populating
the default TLS config. This will allow users to set other options
in TLS module without ambassador erroring out because the certs
don't exist.