### PR TITLE
Move Helm charts to S3

### DIFF
--- a/docs/_redirects
+++ b/docs/_redirects
@@ -5,3 +5,4 @@
 /how-to/auth-external      /reference/services/auth-service
 /user-guide/running        /reference/running
 /reference/auth-external   /reference/services/auth-service
+/helm/*                    https://s3.amazonaws.com/datawire-static-files/ambassador/:splat

--- a/helm/ambassador/README.md
+++ b/helm/ambassador/README.md
@@ -5,7 +5,7 @@ Ambassador is an open source, Kubernetes-native [microservices API gateway](http
 ## TL;DR;
 
 ```console
-$ helm repo add datawire https://www.getambassador.io
+$ helm repo add datawire https://www.getambassador.io/helm
 $ helm install datawire/ambassador
 ```
 


### PR DESCRIPTION
Move the Helm charts onto S3, using a Netlify redirect to give us a nicer URL.