### PR TITLE
document TLS redirection

### DIFF
--- a/docs/reference/ambassador-with-aws.md
+++ b/docs/reference/ambassador-with-aws.md
@@ -1,4 +1,4 @@
-# Ambassador on AWS
+## Ambassador on AWS
 
 The following is a sample configuration for deploying Ambassador in AWS (this configuration is templated using [Forge](https://forge.sh)):
 
@@ -35,4 +35,31 @@ spec:
 
 In this configuration, an ELB is deployed with a multi-domain AWS Certificate Manager certificate. The ELB is configured to route TCP to support both WebSockets and HTTP. Ambassador is configured with `use_remote_address` and `use_proxy_proto` to ensure that remote IP addresses are passed through properly. TLS termination then occurs at the ELB.
 
-Ambassador can also terminate TLS directly, as discussed elsewhere in the documentation.
+### Ambassador and AWS load balancer notes
+
+AWS provides three types of load balancers:
+
+* "Classic" Load Balancer (abbreviated ELB or CLB, sometimes referred to as ELBv1 or Elastic Load Balancer)
+  * Supports L4 (TCP, TCP+SSL) and L7 load balancing (HTTP 1.1, HTTPS 1.1)
+  * Does not support WebSockets unless running in L4 mode
+  * Does not support HTTP 2 (which is required for GRPC) unless running in L4 mode
+  * Can perform SSL/TLS offload
+* Application Load Balancer (abbreviated ALB, sometimes referred to as ELBv2)
+  * Supports L7 only
+  * Supports WebSockets
+  * Supports a broken implementation of HTTP2 (trailers are not supported and these are needed for GRPC)
+  * Can perform SSL/TLS offload
+* Network Load Balancer (abbreviated NLB)
+  * Supports L4 only
+  * Cannot perform SSL/TLS offload
+
+In Kubernetes, when using the AWS integration and a service of type `LoadBalancer`, the only types of load balancers that can be created are ELBs and NLBs (in Kubernetes 1.9 nand later). 
+
+If you are running an ELB in L4 mode, you need to:
+
+* Run the ELB with the following listener configuration:
+  * `:443` -> `:8443` (the Envoy port doesn't matter)
+  * `:80` -> `:8080` (the Envoy port doesn't matter)
+  * Configure `redirect_cleartext_from` to redirect traffic on `8080` to the secure port
+
+


### PR DESCRIPTION
This PR documents how to configure ELBs for TLS redirection as discussed in #469. 