### PR TITLE
Add ability to override targetPort for http and https

### DIFF
--- a/helm/ambassador/README.md
+++ b/helm/ambassador/README.md
@@ -53,6 +53,10 @@ The following tables lists the configurable parameters of the Ambassador chart a
 | `rbac.create` | If `true`, create and use RBAC resources | `true`
 | `serviceAccount.create` | If `true`, create a new service account | `true`
 | `serviceAccount.name` | Service account to be used | `ambassador`
+| `service.enableHttp` | if port 80 should be opened for service | `true`
+| `service.enableHttps` | if port 443 should be opened for service | `true`
+| `service.targetPorts.http` | Sets the targetPort that maps to the service's port 80 | `80`
+| `service.targetPorts.https` | Sets the targetPort that maps to the service's port 443 | `443`
 | `service.type` | Service type to be used | `LoadBalancer`
 | `service.annotations` | Annotations to apply to Ambassador service | none
 | `adminService.create` | If `true`, create a service for Ambassador's admin UI | `true`

--- a/helm/ambassador/templates/service.yaml
+++ b/helm/ambassador/templates/service.yaml
@@ -14,14 +14,18 @@ metadata:
 spec:
   type: {{ .Values.service.type }}
   ports:
+    {{- if .Values.service.enableHttp }}
     - port: {{ .Values.service.port }}
-      targetPort: http
+      targetPort: {{ .Values.service.targetPorts.http }}
       protocol: TCP
       name: http
+    {{- end }}
+    {{- if .Values.service.enableHttps }}
     - port: 443
-      targetPort: https
+      targetPort: {{ .Values.service.targetPorts.https }}
       protocol: TCP
       name: https
+    {{- end }}
   selector:
     app: {{ template "ambassador.name" . }}
     release: {{ .Release.Name }}

--- a/helm/ambassador/values.yaml
+++ b/helm/ambassador/values.yaml
@@ -9,6 +9,13 @@ image:
   pullPolicy: IfNotPresent
 
 service:
+  enableHttp: true
+  enableHttps: true
+
+  targetPorts:
+    http: http
+    https: https
+
   type: LoadBalancer
   port: 80
   # annotations:


### PR DESCRIPTION
I'm using ELB for SSL termination and without those changes I'm not able to render following spec:
```
spec:
  ports:
  - name: http
    port: 443
    protocol: TCP
    targetPort: 80
  - name: https
    port: 80
    protocol: TCP
    targetPort: 80
 ```