### PR TITLE
Utilizing imageTag in helm deployment

### DIFF
--- a/helm/ambassador/README.md
+++ b/helm/ambassador/README.md
@@ -45,9 +45,9 @@ The following tables lists the configurable parameters of the Ambassador chart a
 
 | Parameter                       | Description                                | Default                                                    |
 | ------------------------------- | ------------------------------------------ | ---------------------------------------------------------- |
-| `image` | Image | `quay.io/datawire/ambassador` 
-| `imageTag` | Image tag | `0.29.0` 
-| `imagePullPolicy` | Image pull policy | `IfNotPresent` 
+| `image.repository` | Image | `quay.io/datawire/ambassador` 
+| `imageTag` | Image tag | `0.35.0` 
+| `image.pullPolicy` | Image pull policy | `IfNotPresent` 
 | `replicaCount`  | Number of Ambassador replicas  | `1` 
 | `resources` | CPU/memory resource requests/limits | None 
 | `rbac.create` | If `true`, create and use RBAC resources | `true`

--- a/helm/ambassador/README.md
+++ b/helm/ambassador/README.md
@@ -46,7 +46,7 @@ The following tables lists the configurable parameters of the Ambassador chart a
 | Parameter                       | Description                                | Default                                                    |
 | ------------------------------- | ------------------------------------------ | ---------------------------------------------------------- |
 | `image.repository` | Image | `quay.io/datawire/ambassador` 
-| `imageTag` | Image tag | `0.35.0` 
+| `image.tag` | Image tag | `0.35.0` 
 | `image.pullPolicy` | Image pull policy | `IfNotPresent` 
 | `replicaCount`  | Number of Ambassador replicas  | `1` 
 | `resources` | CPU/memory resource requests/limits | None 

--- a/helm/ambassador/templates/_helpers.tpl
+++ b/helm/ambassador/templates/_helpers.tpl
@@ -41,3 +41,10 @@ Create the name of the service account to use
     {{ default "default" .Values.serviceAccount.name }}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Create imageTag
+*/}}
+{{- define "ambassador.imageTag" -}}
+{{- default .Chart.AppVersion .Values.imageTag -}}
+{{- end -}}

--- a/helm/ambassador/templates/_helpers.tpl
+++ b/helm/ambassador/templates/_helpers.tpl
@@ -46,5 +46,5 @@ Create the name of the service account to use
 Create imageTag
 */}}
 {{- define "ambassador.imageTag" -}}
-{{- default .Chart.AppVersion .Values.imageTag -}}
+{{- default .Chart.AppVersion .Values.image.tag -}}
 {{- end -}}

--- a/helm/ambassador/templates/deployment.yaml
+++ b/helm/ambassador/templates/deployment.yaml
@@ -30,7 +30,7 @@ spec:
           - name: metrics
             containerPort: 9102
         - name: ambassador
-          image: "{{ .Values.image.repository }}:{{ .Chart.AppVersion }}"
+          image: "{{ .Values.image.repository }}:{{ template "ambassador.imageTag" . }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http


### PR DESCRIPTION
The Readme suggests that the `imageTag` parameter can be used to specify the docker image version, but it was not used in the deployment template.