### PR TITLE
Update .gitignore, Makefile to ignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ intermediate.json
 check-*.json
 end-to-end/forge
 stats.json
+end-to-end/0-serial/011-websocket/ambassador/service.yaml

--- a/Makefile
+++ b/Makefile
@@ -133,6 +133,7 @@ clean:
 		| xargs -0 rm -f
 	rm -rf end-to-end/ambassador-deployment.yaml end-to-end/ambassador-deployment-mounts.yaml
 	find end-to-end \( -name 'check-*.json' -o -name 'envoy.json' \) -print0 | xargs -0 rm -f
+	rm -f end-to-end/0-serial/011-websocket/ambassador/service.yaml
 
 clobber: clean
 	-rm -rf docs/node_modules


### PR DESCRIPTION
end-to-end/0-serial/011-websocket/ambassador/service.yaml
This file is generated for the e2e tests, but never cleaned up.
It also keeps on popping up in `git status`.

This commit fixes that!