### PR TITLE
Enabling Ambassador tracing with TracingService, docs and tutorial

### DIFF
--- a/ambassador/schemas/v0/TracingService.schema
+++ b/ambassador/schemas/v0/TracingService.schema
@@ -1,0 +1,30 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "id": "https://getambassador.io/schemas/tracing.json",
+
+    "type": "object",
+    "properties": {
+        "apiVersion": { "enum": ["ambassador/v0"] },
+        "kind": { "type": "string" },
+        "name": { "type": "string" },
+        "ambassador_id": {
+            "anyOf": [
+                { "type": "string" },
+                { "type": "array", "items": { "type": "string" } }
+            ]
+        },
+        
+        "driver": { "enum": ["lightstep", "zipkin"] },
+        "service": { "type": "string" },
+        "config": {
+            "type": "object",
+            "properties": {
+                "access_token_file": { "type": "string" },
+                "collector_endpoint": { "type": "string" }
+            },
+            "additionalProperties": false
+        }
+    },
+    "required": [ "apiVersion", "kind", "name", "driver", "service" ],
+    "additionalProperties": false
+}

--- a/ambassador/start-envoy.sh
+++ b/ambassador/start-envoy.sh
@@ -19,4 +19,4 @@ SHUTDOWN_TIME=${AMBASSADOR_SHUTDOWN_TIME:-10}
 AMBASSADOR_ROOT="/ambassador"
 
 LATEST=$(ls -1v "$AMBASSADOR_ROOT"/envoy*.json | tail -1)
-exec /usr/local/bin/envoy -c ${LATEST} --restart-epoch $RESTART_EPOCH --drain-time-s "${DRAIN_TIME}" --parent-shutdown-time-s "${SHUTDOWN_TIME}"
+exec /usr/local/bin/envoy -c ${LATEST} --restart-epoch $RESTART_EPOCH --drain-time-s "${DRAIN_TIME}" --service-cluster "${AMBASSADOR_ID:-ambassador}-${AMBASSADOR_NAMESPACE}" --parent-shutdown-time-s "${SHUTDOWN_TIME}"

--- a/ambassador/templates/envoy.j2
+++ b/ambassador/templates/envoy.j2
@@ -35,6 +35,13 @@
                 "path": "/dev/fd/1"
               }
             ],
+            {% if tracing -%}
+            "generate_request_id": true,
+            "tracing": {
+              "operation_name": "egress",
+              "request_headers_for_tags": []
+            },
+            {%- endif %}
             "route_config": {
               "virtual_hosts": [
                 {
@@ -111,6 +118,16 @@
     "address": "tcp://127.0.0.1:{{ admin.admin_port }}",
     "access_log_path": "/tmp/admin_access_log"
   },
+  {% if tracing %}
+  "tracing": {
+    "http": {
+      "driver": {
+        "type": "{{ tracing.driver }}",
+        "config": {{ tracing.config | tojson }}
+      }
+    }
+  },
+  {% endif %}
   "cluster_manager": {
     "clusters": [
       {% for cluster in clusters -%}

--- a/ambassador/tests/013-tracing/config/mapping-qotm.yaml
+++ b/ambassador/tests/013-tracing/config/mapping-qotm.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: ambassador/v0
+kind: Mapping
+name: qotm_mapping
+prefix: /qotm/
+service: qotm

--- a/ambassador/tests/013-tracing/config/tracing-service.yaml
+++ b/ambassador/tests/013-tracing/config/tracing-service.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: ambassador/v0
+kind: TracingService
+name: tracing
+service: "example-tracing:5000"
+driver: zipkin

--- a/ambassador/tests/013-tracing/gold.intermediate.json
+++ b/ambassador/tests/013-tracing/gold.intermediate.json
@@ -1,0 +1,232 @@
+{
+    "envoy_config": {
+        "admin": [
+            {
+                "_source": "--internal--",
+                "admin_port": 8001
+            }
+        ],
+        "clusters": [
+            {
+                "_referenced_by": [
+                    "--internal--"
+                ],
+                "_service": "127.0.0.1:8877",
+                "_source": "--internal--",
+                "lb_type": "round_robin",
+                "name": "cluster_127_0_0_1_8877",
+                "type": "strict_dns",
+                "urls": [
+                    "tcp://127.0.0.1:8877"
+                ]
+            },
+            {
+                "_referenced_by": [
+                    "tracing-service.yaml.1"
+                ],
+                "_service": "exttracing",
+                "_source": "tracing-service.yaml.1",
+                "lb_type": "round_robin",
+                "name": "cluster_ext_tracing",
+                "type": "strict_dns",
+                "urls": [
+                    "tcp://example-tracing:5000"
+                ]
+            },
+            {
+                "_referenced_by": [
+                    "mapping-qotm.yaml.1"
+                ],
+                "_service": "qotm",
+                "_source": "mapping-qotm.yaml.1",
+                "lb_type": "round_robin",
+                "name": "cluster_qotm",
+                "type": "strict_dns",
+                "urls": [
+                    "tcp://qotm:80"
+                ]
+            }
+        ],
+        "filters": [
+            {
+                "_source": "--internal--",
+                "config": {},
+                "name": "cors"
+            },
+            {
+                "_source": "--internal--",
+                "config": {
+                    "start_child_span": true
+                },
+                "name": "router",
+                "type": "decoder"
+            }
+        ],
+        "listeners": [
+            {
+                "_source": "--internal--",
+                "require_tls": false,
+                "service_port": 80,
+                "use_proxy_proto": false
+            }
+        ],
+        "routes": [
+            {
+                "__saved": [
+                    0,
+                    26,
+                    0,
+                    "/ambassador/v0/check_ready",
+                    "GET"
+                ],
+                "_group_id": "0a42187b7b3d283e0079ddab01825e1c71fad9f6",
+                "_method": "GET",
+                "_precedence": 0,
+                "_referenced_by": [
+                    "--internal--"
+                ],
+                "_source": "--internal--",
+                "clusters": [
+                    {
+                        "name": "cluster_127_0_0_1_8877",
+                        "weight": 100.0
+                    }
+                ],
+                "prefix": "/ambassador/v0/check_ready",
+                "prefix_rewrite": "/ambassador/v0/check_ready"
+            },
+            {
+                "__saved": [
+                    0,
+                    26,
+                    0,
+                    "/ambassador/v0/check_alive",
+                    "GET"
+                ],
+                "_group_id": "6151893fbc2f1f730a1bb946b2eefac391f0d2ec",
+                "_method": "GET",
+                "_precedence": 0,
+                "_referenced_by": [
+                    "--internal--"
+                ],
+                "_source": "--internal--",
+                "clusters": [
+                    {
+                        "name": "cluster_127_0_0_1_8877",
+                        "weight": 100.0
+                    }
+                ],
+                "prefix": "/ambassador/v0/check_alive",
+                "prefix_rewrite": "/ambassador/v0/check_alive"
+            },
+            {
+                "__saved": [
+                    0,
+                    6,
+                    0,
+                    "/qotm/",
+                    "GET"
+                ],
+                "_group_id": "9fda39523fe03a3c6aac9c21098375764ec0822d",
+                "_method": "GET",
+                "_precedence": 0,
+                "_referenced_by": [
+                    "mapping-qotm.yaml.1"
+                ],
+                "_source": "mapping-qotm.yaml.1",
+                "clusters": [
+                    {
+                        "name": "cluster_qotm",
+                        "weight": 100.0
+                    }
+                ],
+                "prefix": "/qotm/",
+                "prefix_rewrite": "/"
+            },
+            {
+                "__saved": [
+                    0,
+                    15,
+                    0,
+                    "/ambassador/v0/",
+                    "GET"
+                ],
+                "_group_id": "b69eeb747b38f5e5fd3955d044ea7797d67d024f",
+                "_method": "GET",
+                "_precedence": 0,
+                "_referenced_by": [
+                    "--internal--"
+                ],
+                "_source": "--internal--",
+                "clusters": [
+                    {
+                        "name": "cluster_127_0_0_1_8877",
+                        "weight": 100.0
+                    }
+                ],
+                "prefix": "/ambassador/v0/",
+                "prefix_rewrite": "/ambassador/v0/"
+            }
+        ],
+        "tracing": [
+            {
+                "_source": "tracing-service.yaml.1",
+                "cluster_name": "cluster_ext_tracing",
+                "config": {
+                    "collector_cluster": "cluster_ext_tracing"
+                },
+                "driver": "zipkin"
+            }
+        ]
+    },
+    "errors": {},
+    "source_map": {
+        "--internal--": {
+            "--internal--": true
+        },
+        "mapping-qotm.yaml": {
+            "mapping-qotm.yaml.1": true
+        },
+        "tracing-service.yaml": {
+            "tracing-service.yaml.1": true
+        }
+    },
+    "sources": {
+        "--diagnostics--": {
+            "_source": "--diagnostics--",
+            "description": "The '--diagnostics--' source marks objects created by Ambassador to assist with diagnostic output.",
+            "filename": "--diagnostics--",
+            "index": 0,
+            "kind": "diagnostics",
+            "name": "Ambassador Diagnostics",
+            "version": "v0"
+        },
+        "--internal--": {
+            "_source": "--internal--",
+            "description": "The '--internal--' source marks objects created by Ambassador's internal logic.",
+            "filename": "--internal--",
+            "index": 0,
+            "kind": "Internal",
+            "name": "Ambassador Internals",
+            "version": "v0"
+        },
+        "mapping-qotm.yaml.1": {
+            "_source": "mapping-qotm.yaml",
+            "filename": "mapping-qotm.yaml",
+            "index": 1,
+            "kind": "Mapping",
+            "name": "qotm_mapping",
+            "version": "ambassador/v0",
+            "yaml": "apiVersion: ambassador/v0\nkind: Mapping\nname: qotm_mapping\nprefix: /qotm/\nservice: qotm\n"
+        },
+        "tracing-service.yaml.1": {
+            "_source": "tracing-service.yaml",
+            "filename": "tracing-service.yaml",
+            "index": 1,
+            "kind": "TracingService",
+            "name": "tracing",
+            "version": "ambassador/v0",
+            "yaml": "apiVersion: ambassador/v0\ndriver: zipkin\nkind: TracingService\nname: tracing\nservice: example-tracing:5000\n"
+        }
+    }
+}

--- a/ambassador/tests/013-tracing/gold.json
+++ b/ambassador/tests/013-tracing/gold.json
@@ -1,0 +1,157 @@
+{
+  "listeners": [
+
+    {
+      "address": "tcp://0.0.0.0:80",
+
+      "filters": [
+        {
+          "type": "read",
+          "name": "http_connection_manager",
+          "config": {"codec_type": "auto",
+            "stat_prefix": "ingress_http",
+            "access_log": [
+              {
+                "format": "ACCESS [%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\"\n",
+                "path": "/dev/fd/1"
+              }
+            ],
+            "generate_request_id": true,
+            "tracing": {
+              "operation_name": "egress",
+              "request_headers_for_tags": []
+            },
+            "route_config": {
+              "virtual_hosts": [
+                {
+                  "name": "backend",
+                  "domains": ["*"],"routes": [
+
+                  {
+                    "timeout_ms": 3000,"prefix": "/ambassador/v0/check_ready","prefix_rewrite": "/ambassador/v0/check_ready",
+                    "weighted_clusters": {
+                      "clusters": [
+
+                        { "name": "cluster_127_0_0_1_8877", "weight": 100.0 }
+
+                      ]
+                    }
+
+                  }
+                ,
+
+                  {
+                    "timeout_ms": 3000,"prefix": "/ambassador/v0/check_alive","prefix_rewrite": "/ambassador/v0/check_alive",
+                    "weighted_clusters": {
+                      "clusters": [
+
+                        { "name": "cluster_127_0_0_1_8877", "weight": 100.0 }
+
+                      ]
+                    }
+
+                  }
+                ,
+
+                  {
+                    "timeout_ms": 3000,"prefix": "/ambassador/v0/","prefix_rewrite": "/ambassador/v0/",
+                    "weighted_clusters": {
+                      "clusters": [
+
+                        { "name": "cluster_127_0_0_1_8877", "weight": 100.0 }
+
+                      ]
+                    }
+
+                  }
+                ,
+
+                  {
+                    "timeout_ms": 3000,"prefix": "/qotm/","prefix_rewrite": "/",
+                    "weighted_clusters": {
+                      "clusters": [
+
+                        { "name": "cluster_qotm", "weight": 100.0 }
+
+                      ]
+                    }
+
+                  }
+
+
+                ]
+                }
+              ]
+            },
+            "filters": [
+              {
+                "name": "cors",
+                "config": {}
+              },{"type": "decoder",
+                "name": "router",
+                "config": {
+                  "start_child_span": true
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ],
+  "admin": {
+    "address": "tcp://127.0.0.1:8001",
+    "access_log_path": "/tmp/admin_access_log"
+  },
+  "cluster_manager": {
+    "clusters": [
+      {
+        "name": "cluster_127_0_0_1_8877",
+        "connect_timeout_ms": 3000,
+        "type": "strict_dns",
+        "lb_type": "round_robin",
+        "hosts": [
+          {
+            "url": "tcp://127.0.0.1:8877"
+          }
+
+        ]},
+      {
+        "name": "cluster_ext_tracing",
+        "connect_timeout_ms": 3000,
+        "type": "strict_dns",
+        "lb_type": "round_robin",
+        "hosts": [
+          {
+            "url": "tcp://example-tracing:5000"
+          }
+
+        ]},
+      {
+        "name": "cluster_qotm",
+        "connect_timeout_ms": 3000,
+        "type": "strict_dns",
+        "lb_type": "round_robin",
+        "hosts": [
+          {
+            "url": "tcp://qotm:80"
+          }
+
+        ]}
+
+    ]
+  },
+  "tracing": {
+    "http": {
+      "driver": {
+        "type": "zipkin",
+        "config": {
+          "collector_cluster": "cluster_ext_tracing"
+        }
+      }
+    }
+  },
+
+  "statsd_udp_ip_address": "127.0.0.1:8125",
+  "stats_flush_interval_ms": 1000
+}

--- a/ambassador/tests/ambassador_test.py
+++ b/ambassador/tests/ambassador_test.py
@@ -124,6 +124,7 @@ def test_config(testname, dirpath, configdir):
                             '/usr/local/bin/envoy',
                                '--base-id', '1',
                                '--mode', 'validate',
+                               '--service-cluster', 'test',
                                '-c', '/etc/ambassador-config/envoy.json' ],
                       verbose=True)
 

--- a/ambassador/tests/diag_paranoia.py
+++ b/ambassador/tests/diag_paranoia.py
@@ -32,7 +32,8 @@ Uniqifiers = {
     'tls': lambda x: "TLS",
     'listeners': lambda x: '%s-%s' % (x['service_port'], x.get('require_tls', False)),
     'routes': lambda x: x['_group_id'],
-    'sources': lambda x: '%s.%d' % (x['filename'], x['index']) if (('index' in x) and (x['filename'] != "--internal--")) else x['filename']
+    'sources': lambda x: '%s.%d' % (x['filename'], x['index']) if (('index' in x) and (x['filename'] != "--internal--")) else x['filename'],
+    'tracing': lambda x: x['cluster_name']
 }
 
 def filtered_overview(ov):

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -15,6 +15,7 @@
 
 * [Adding Authentication](user-guide/auth-tutorial.md)
 * [Adding Rate Limiting](user-guide/rate-limiting-tutorial.md)
+* [Adding Tracing](user-guide/tracing-tutorial.md)
 * [Use gRPC with Ambassador](user-guide/grpc.md)
 * [TLS Termination](user-guide/tls-termination.md)
 * [Istio and Ambassador](user-guide/with-istio.md)
@@ -38,6 +39,7 @@
   * [External Services](reference/services/services.md)
     * [Authentication](reference/services/auth-service.md)
     * [Rate Limiting](reference/services/rate-limit-service.md)
+    * [Tracing](reference/services/tracing-service.md)
   * [Advanced configuration topics](reference/advanced.md)
 * [Running Ambassador](reference/running.md)
   * [Diagnostics](reference/diagnostics.md)

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -8,6 +8,8 @@ Ambassador is configured in a declarative fashion, using YAML manifests to descr
 
 - [`RateLimitService`](services/rate-limit-service.md) manifests configures the external rate limiting service that Ambassador will use.
 
+- [`TracingService`](services/tracing-service.md) manifests configures the external tracing service that Ambassador will use.
+
 - [`Mapping`](mappings) manifests associate REST _resources_ with Kubernetes _services_. Ambassador _must_ have one or more mappings defined to provide access to any services at all.
 
 ## Configuration sources

--- a/docs/reference/services/services.md
+++ b/docs/reference/services/services.md
@@ -2,7 +2,8 @@
 
 You may need an API Gateway to enforce policies specific to your organization. Ambassador supports custom policies through external services. The policy logic specific to your organization is implemented in the external service, and Ambassador is configured to send RPC requests to your service.
 
-Currently, Ambassador supports external services for authentication and rate limiting.
+Currently, Ambassador supports external services for authentication, rate limiting and tracing.
 
 * [AuthService](auth-service.md)
 * [RateLimitService](rate-limit-service.md)
+* [TracingService](tracing-service.md)

--- a/docs/reference/services/tracing-service.md
+++ b/docs/reference/services/tracing-service.md
@@ -1,0 +1,31 @@
+## Tracing with the TracingService
+
+In addition to request logging and [metrics](/reference/statistics.md), you can enable request tracing. Enabling this feature will instruct Ambassador to initiate a trace on some sample requests by generating and populating an `x-request-id` HTTP header. Services can make use of this `x-request-id` header in logging and forward it in downstream requests for tracing. Ambassador also integrates with external trace services, namely [LightStep](https://lightstep.com/) and Zipkin-compatible APIs such as [Zipkin](https://zipkin.io/) and [Jaeger](https://github.com/jaegertracing/) to allow you to store and visualize traces. You can read further on [Envoy's Tracing capabilities](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/tracing).
+
+A `TracingService` manifest configures Ambassador to use an external trace visualization service:
+
+```yaml
+---
+apiVersion: ambassador/v0
+kind: TracingService
+name: tracing
+service: "example-zipkin:9411"
+driver: zipkin
+config: {}
+```
+
+- `service` gives the URL of the external HTTP trace service.
+- `driver` provides the driver information that handles communicating with the `service`. Supported values are `lightstep` and `zipkin`.
+- `config` provides additional configuration options for the selected `driver`.
+
+##### `lightstep` driver configurations:
+- `access_token_file` provides the location of the file containing the access token to the LightStep API.
+
+##### `zipkin` driver configurations:
+- `collector_endpoint` gives the API endpoint of the Zipkin service where the spans will be sent. The default value is `/api/v1/spans`
+
+You may only use a single `TracingService` manifest.
+
+## Example
+
+The [Ambassador Tracing Tutorial](../../user-guide/tracing-tutorial.md) has a simple Zipkin tracing example.

--- a/docs/user-guide/getting-started.md
+++ b/docs/user-guide/getting-started.md
@@ -217,5 +217,6 @@ We've just done a quick tour of some of the core features of Ambassador: diagnos
 - Join us on [Slack](https://join.slack.com/t/datawire-oss/shared_invite/enQtMzcwMDEwMTc5ODQ3LTE1NmIzZTFmZWE0OTQ1NDc2MzE2NTkzMDAzZWM0MDIxZTVjOGIxYmRjZjY3N2M2Mjk4NGI5Y2Q4NGY4Njc1Yjg);
 - Learn how to [add authentication](auth-tutorial.md) to existing services; or
 - Learn how to [add rate limiting](rate-limiting-tutorial.md) to existing services; or
+- Learn how to [add tracing](tracing-tutorial.md); or
 - Learn how to [use gRPC with Ambassador](grpc.md); or
 - Read about [configuring Ambassador](/reference/configuration.md).

--- a/docs/user-guide/tracing-tutorial.md
+++ b/docs/user-guide/tracing-tutorial.md
@@ -1,0 +1,112 @@
+# Tracing
+
+Ambassador can enable distributed traces, one of the "3 pillars of observability", allowing developers to visualize request flows in service-oriented architectures. In this tutorial, we'll configure Ambassador to initiate a trace on some sample requests and use an external tracing service to visualize them.
+
+## Before You Get Started
+
+This tutorial assumes you have already followed the [Ambassador Getting Started](/user-guide/getting-started.html) guide. If you haven't done that already, you should do that now.
+
+After completing [Getting Started](/user-guide/getting-started.html), you'll have a Kubernetes cluster running Ambassador and the Quote of the Moment service. Let's walk through adding tracing to this setup.
+
+## 1. Deploy Zipkin
+
+In this tutorial we will use a simple in-memory deployment of [Zipkin](https://zipkin.io/) to store and visualize the Ambassador-generated traces.
+
+> Zipkin is a distributed tracing system. It helps gather timing data needed to troubleshoot latency problems in microservice architectures. It manages both the collection and lookup of this data.
+
+Here's the YAML we'll start with:
+
+```yaml
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: zipkin
+  annotations:
+    getambassador.io/config: |
+      ---
+      apiVersion: ambassador/v0
+      kind: TracingService
+      name: tracing
+      service: zipkin:9411
+      driver: zipkin
+spec:
+  selector:
+    app: zipkin
+  ports:
+  - port: 9411
+    name: http
+    targetPort: http
+  type: NodePort
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: zipkin
+spec:
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: zipkin
+    spec:
+      containers:
+      - name: zipkin
+        image: openzipkin/zipkin
+        imagePullPolicy: Always
+        ports:
+        - name: http
+          containerPort: 9411
+        resources:
+          limits:
+            cpu: "1"
+            memory: 256Mi
+```
+
+This configuration tells Ambassador about the tracing service, notably that Zipkin API is listening on `zipkin:9411`.
+
+Ambassador will see the annotations and reconfigure itself within a few seconds.
+
+## 2. Generate some requests
+
+Use `curl` to generate a few requests to an existing Ambassador mapping. You may need to perform many requests since only a subset of random requests are sampled and instrumented with traces.
+
+```shell
+$ curl http://192.168.99.107:31893/httpbin/
+```
+
+## 3. Test traces
+
+To test things out, we'll need the external IP for Zipkin (it might take some time for this to be available):
+
+```shell
+kubectl get svc -o wide zipkin
+```
+
+Eventually, this should give you something like:
+
+```
+NAME         CLUSTER-IP      EXTERNAL-IP     PORT(S)          AGE
+zipkin       10.11.12.13     35.36.37.38     9411:31043/TCP   1m
+```
+
+or on minikube: 
+
+```shell
+$ minikube service list
+|-------------|----------------------|-----------------------------|
+|  NAMESPACE  |         NAME         |             URL             |
+|-------------|----------------------|-----------------------------|
+| default     | ambassador-admin     | http://192.168.99.107:30319 |
+| default     | ambassador           | http://192.168.99.107:31893 |
+| default     | zipkin               | http://192.168.99.107:31043 |
+|-------------|----------------------|-----------------------------|
+```
+
+Open your web browser to the Zipkin dashboard http://192.168.99.107:31043/zipkin/ and click the "Find Traces" button to get a listing instrumented traces.
+
+## More
+
+For more details about configuring the external tracing service, read the documentation on [external tracing](/reference/services/tracing-service.md).

--- a/end-to-end/0-serial/014-tracing/k8s/ambassador.yaml
+++ b/end-to-end/0-serial/014-tracing/k8s/ambassador.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ambassador
+  annotations:
+    getambassador.io/config: |
+      ---
+      apiVersion: ambassador/v0
+      kind: TracingService
+      name: tracing
+      service: zipkin:9411
+      driver: zipkin
+spec:
+  selector:
+    service: ambassador
+  ports:
+    - name: http
+      protocol: TCP
+      port: 80
+      targetPort: 80
+  type: NodePort

--- a/end-to-end/0-serial/014-tracing/k8s/qotm.yaml
+++ b/end-to-end/0-serial/014-tracing/k8s/qotm.yaml
@@ -1,0 +1,41 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: qotm
+  annotations:
+    getambassador.io/config: |
+      ---
+      apiVersion: ambassador/v0
+      kind: Mapping
+      name: qotm_mapping
+      prefix: /qotm/
+      service: qotm
+spec:
+  selector:
+    app: qotm
+  ports:
+    - port: 80
+      targetPort: http-api
+  type: ClusterIP
+---
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: qotm
+spec:
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: qotm
+    spec:
+      containers:
+      - name: qotm
+        image: datawire/qotm:1.3
+        imagePullPolicy: Always
+        ports:
+        - name: http-api
+          containerPort: 5000

--- a/end-to-end/0-serial/014-tracing/k8s/zipkin.yaml
+++ b/end-to-end/0-serial/014-tracing/k8s/zipkin.yaml
@@ -1,0 +1,38 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: zipkin
+spec:
+  selector:
+    app: zipkin
+  ports:
+  - port: 9411
+    name: http
+    targetPort: http
+  type: NodePort
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: zipkin
+spec:
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: zipkin
+    spec:
+      containers:
+      - name: zipkin
+        image: openzipkin/zipkin
+        imagePullPolicy: Always
+        ports:
+        - name: http
+          containerPort: 9411
+        resources:
+          limits:
+            cpu: "1"
+            memory: 256Mi

--- a/end-to-end/0-serial/014-tracing/test.sh
+++ b/end-to-end/0-serial/014-tracing/test.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+# Copyright 2018 Datawire. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License
+
+set -e -o pipefail
+
+HERE=$(cd $(dirname $0); pwd)
+
+cd "$HERE"
+
+ROOT=$(cd ../..; pwd)
+PATH="${ROOT}:${PATH}"
+
+source ${ROOT}/utils.sh
+
+initialize_cluster
+
+kubectl cluster-info
+
+kubectl apply -f k8s/ambassador.yaml
+kubectl apply -f ${ROOT}/ambassador-deployment.yaml
+kubectl apply -f k8s/qotm.yaml
+kubectl apply -f k8s/zipkin.yaml
+
+set +e +o pipefail
+
+wait_for_pods
+
+CLUSTER=$(cluster_ip)
+APORT=$(service_port ambassador)
+ZPORT=$(service_port zipkin)
+
+BASEURL="http://${CLUSTER}:${APORT}"
+ZIPKINURL="http://${CLUSTER}:${ZPORT}"
+
+echo "Base URL $BASEURL"
+echo "Diag URL $BASEURL/ambassador/v0/diag/"
+echo "Zipkin URL $ZIPKINURL"
+
+wait_for_ready "$BASEURL"
+wait_for_pods
+
+if ! python tracing-test.py $BASEURL $ZIPKINURL; then
+    exit 1
+fi
+
+# kubernaut discard

--- a/end-to-end/0-serial/014-tracing/tracing-test.py
+++ b/end-to-end/0-serial/014-tracing/tracing-test.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python
+
+# Copyright 2018 Datawire. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License
+
+import sys
+
+import requests
+
+
+class QotM(object):
+    def __init__(self, target):
+        self.url = "%s/qotm/" % target
+
+    def decipher(self, r):
+        return r.status_code
+
+    def get(self, headers):
+        return self.decipher(requests.get(self.url, headers=headers))
+
+
+class ZipkinServices(object):
+    def __init__(self, target):
+        self.url = "%s/api/v2" % target
+
+    def decipher(self, r):
+        code = r.status_code
+        result = None
+
+        try:
+            result = r.json()
+        except:
+            pass
+
+        return code, result
+
+    def getServices(self):
+        return self.decipher(requests.get("%s/services" % self.url))
+
+    def getSpans(self):
+        return self.decipher(requests.get("%s/spans" % self.url))
+
+
+def test_qotm_tracing(base, zipkin, test_list, iterations=100):
+    q = QotM(base)
+    z = ZipkinServices(zipkin)
+
+    for iteration in range(iterations):
+        for headers, expected_code in test_list:
+            code = q.get(headers)
+            if code != expected_code:
+                print("%s: expected %d, got %d" % (headers, expected_code, code))
+
+    _, zipkinServices = z.getServices()
+    print("Zipkin Services %s" % zipkinServices)
+
+    _, zipkinSpans = z.getSpans()
+    print("Zipkin Spans len %d" % len(zipkinSpans))
+
+    return 0 if (
+            len(zipkinServices) == 1 and
+            zipkinServices[0] == 'ambassador-default' and
+            len(zipkinSpans) >= 5  # This is a bit flaky, requests are sampled so will be lower than the number of iterations
+    ) else 1
+
+
+if __name__ == "__main__":
+    base = sys.argv[1]
+    zipkin = sys.argv[2]
+
+    test_list = []
+
+    test_list.append((None, 200))
+
+    sys.exit(test_qotm_tracing(base, zipkin, test_list))


### PR DESCRIPTION
Provides :
- Envoy V1 configuration for enabling tracing on all routes
- Unit and end-to-end tests
- Documentation of `TracingService`, tutorial and Zipkin example