### PR TITLE
Add anchor link plugin

### DIFF
--- a/docs/book.json
+++ b/docs/book.json
@@ -5,7 +5,8 @@
         "readme": "INDEX.md"
     },
     "plugins": [
-        "gtm"
+        "gtm",
+        "anchorjs"
     ],
     "pluginsConfig": {
         "layout": {
@@ -14,6 +15,13 @@
         "gtm": {
             "token": "GTM-TPMQ838",
             "virtualPageViews": true
+        },
+        "anchorjs": {
+            "selector": "h2,h3,h4,h5",
+            "placement": "right",
+            "visible": "always",
+            "truncate": 64,
+            "ariaLabel": "Anchor"
         }
     }
 }


### PR DESCRIPTION
I tried the available heading-anchor plugins for gitbook and settled on [anchorjs](https://plugins.gitbook.com/plugin/anchorjs) as it seems to be the most active of the choices. Right now it is set up to show anchor links to the right of all non-h1 headings. There is also an option that only shows the link when you hover over the heading. It wasn't clear how you guys wanted it to look so I left them always visible for starters. This can easily be configured if you want something else.