### PR TITLE
Update to use latest Envoy

### DIFF
--- a/ambassador/Dockerfile
+++ b/ambassador/Dockerfile
@@ -26,7 +26,7 @@
 # and then read DATAWIRE/README.md.
 
 # FROM datawire/ambassador-envoy-alpine-stripped:v1.6.0-446-g100a92e2
-FROM quay.io/datawire/ambassador-envoy:v1.7.0-64-g09ba72b1-alpine-stripped
+FROM quay.io/datawire/ambassador-envoy:v1.7.0-235-gaf17ea9a-alpine-stripped
 
 MAINTAINER Datawire <flynn@datawire.io>
 LABEL PROJECT_REPO_URL         = "git@github.com:datawire/ambassador.git" \

--- a/ambassador/kubewatch.py
+++ b/ambassador/kubewatch.py
@@ -173,7 +173,7 @@ class Restarter(threading.Thread):
             envoy_config = "%s-%s" % (output, "envoy.json")
             aconf.pretty(rc.envoy_config, out=open(envoy_config, "w"))
             try:
-                result = subprocess.check_output(["/usr/local/bin/envoy", "--base-id", "1", "--mode", "validate",
+                result = subprocess.check_output(["/usr/local/bin/envoy", "--allow-deprecated-v1-api", "--base-id", "1", "--mode", "validate",
                                                   "-c", envoy_config])
                 if result.strip().endswith(b" OK"):
                     logger.debug("Configuration %s valid" % envoy_config)

--- a/ambassador/start-envoy.sh
+++ b/ambassador/start-envoy.sh
@@ -19,4 +19,4 @@ SHUTDOWN_TIME=${AMBASSADOR_SHUTDOWN_TIME:-10}
 AMBASSADOR_ROOT="/ambassador"
 
 LATEST=$(ls -1v "$AMBASSADOR_ROOT"/envoy*.json | tail -1)
-exec /usr/local/bin/envoy -c ${LATEST} --restart-epoch $RESTART_EPOCH --drain-time-s "${DRAIN_TIME}" --service-cluster "${AMBASSADOR_ID:-ambassador}-${AMBASSADOR_NAMESPACE}" --parent-shutdown-time-s "${SHUTDOWN_TIME}"
+exec /usr/local/bin/envoy --allow-deprecated-v1-api -c ${LATEST} --restart-epoch $RESTART_EPOCH --drain-time-s "${DRAIN_TIME}" --service-cluster "${AMBASSADOR_ID:-ambassador}-${AMBASSADOR_NAMESPACE}" --parent-shutdown-time-s "${SHUTDOWN_TIME}"

--- a/ambassador/tests/ambassador_test.py
+++ b/ambassador/tests/ambassador_test.py
@@ -12,7 +12,7 @@ from shell import shell
 
 from diag_paranoia import diag_paranoia, filtered_overview, sanitize_errors
 
-VALIDATOR_IMAGE = "quay.io/datawire/ambassador-envoy:v1.7.0-64-g09ba72b1-alpine-stripped"
+VALIDATOR_IMAGE = "quay.io/datawire/ambassador-envoy:v1.7.0-235-gaf17ea9a-alpine-stripped"
 
 DIR = os.path.dirname(__file__)
 EXCLUDES = [ "__pycache__" ] 
@@ -122,6 +122,7 @@ def test_config(testname, dirpath, configdir):
                             '-v', '%s:/etc/ambassador-config' % dirpath,
                             VALIDATOR_IMAGE,
                             '/usr/local/bin/envoy',
+                               '--allow-deprecated-v1-api',
                                '--base-id', '1',
                                '--mode', 'validate',
                                '--service-cluster', 'test',


### PR DESCRIPTION
This commit updates Envoy's container image that Ambassador uses
to point to the latest built image. The envoy commands have been
updated to use the `--allow-deprecated-v1-api` flag since the
latest envoy only supports v1 config is specified explicitly.