### PR TITLE
Remove resource limits from Zipkin

### DIFF
--- a/end-to-end/0-serial/014-tracing/k8s/zipkin.yaml
+++ b/end-to-end/0-serial/014-tracing/k8s/zipkin.yaml
@@ -32,7 +32,3 @@ spec:
         ports:
         - name: http
           containerPort: 9411
-        resources:
-          limits:
-            cpu: "1"
-            memory: 256Mi


### PR DESCRIPTION
This commit removes the resource limits from Zipkin's deployment
because this would lead to pods not getting scheduled on Kubernaut
due to insufficient CPU available.