### PR TITLE
Remove resource limits from Zipkin tutorial

### DIFF
--- a/docs/user-guide/tracing-tutorial.md
+++ b/docs/user-guide/tracing-tutorial.md
@@ -59,10 +59,6 @@ spec:
         ports:
         - name: http
           containerPort: 9411
-        resources:
-          limits:
-            cpu: "1"
-            memory: 256Mi
 ```
 
 This configuration tells Ambassador about the tracing service, notably that Zipkin API is listening on `zipkin:9411`.


### PR DESCRIPTION
The resource limits in the Zipkin tutorial are causing issues in
running Zipkin. This commit removes that.