### PR TITLE
FIX for #497

### DIFF
--- a/ambassador/ambassador/config.py
+++ b/ambassador/ambassador/config.py
@@ -446,6 +446,11 @@ class Config (object):
                 # No pragma involved here; just default to the filename.
                 self.source = self.filename
 
+            # Is the object empty?
+            if obj == None :
+                self.logger.debug("Annotation has empty config")
+                return
+
             # Is an ambassador_id present in this object?
             allowed_ids = obj.get('ambassador_id', 'default')
 


### PR DESCRIPTION
This PR fixes issue #497 

Empty config in annotations crashed ambassador.
The expected behavior was to give an error message, or at least not a crash.

```yaml
apiVersion: v1
kind: Service
metadata:
  name: qotm
  annotations:
    getambassador.io/config: |
      ---
spec:
  type: ClusterIP
  selector:
    app: qotm
  ports:
  - port: 80
    name: http-qotm
    targetPort: http-api
```

After this fix the above yaml did not crash ambassador and logged an error

Signed-off-by: rohan47 <rohanrgupta1996@gmail.com>