### PR TITLE
Add release-prep target for 1-Click Releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,27 @@
 
 - The `statsd` container is likely to be dropped from our default published YAML soon. If you rely on the `statsd` container, consider switching now to local YAML.
 
+<!---
+Add release notes right after this point.
+
+(version number: MAJOR.MINOR.PATCH)
+
+Format:
+
+## [version] <month> <date>, <year>:
+[version]: https://github.com/datawire/ambassador/compare/<last released version>...<version>
+
+### Major changes:
+- Feature: <insert feature description here>
+- Bugfix: <insert bugfix description here>
+
+### Minor changes:
+- Feature: <insert feature description here>
+- Bugfix: <insert bugfix description here>
+--->
+
+<!--- CueAddReleaseNotes --->
+
 ## [0.37.0] July 31, 2018:
 [0.37.0]: https://github.com/datawire/ambassador/compare/0.36.0...0.37.0
 

--- a/Makefile
+++ b/Makefile
@@ -298,6 +298,9 @@ update-aws:
             --body app.json; \
 	fi
 
+release-prep:
+	bash releng/release-prep.sh
+
 release:
 	@if [ "$(COMMIT_TYPE)" = "GA" -a "$(VERSION)" != "$(GIT_VERSION)" ]; then \
 		set -ex; \

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -12,14 +12,15 @@ If you're still reading, you must be at Datawire. Congrats, you picked a fine pl
 1. PRs will pile up on `master`. **Don't accept PRs for which CI doesn't show passing tests.**
 
 2. Once `master` has all the release drivers, tag `master` with an RC tag, eg `0.33.0-rc1`.
-   - Make sure that `CHANGELOG.md` and `index.html` are up to date!
-   - You don't need to do anything with the Helm chart; CI will tackle that later.
 
 3. The RC tag will trigger CI to run a new build and new tests. It had better pass: if not, figure out why.
 
 4. The RC build will be available as `quay.io/datawire/ambassador:0.33.0-rc1` and also as `quay.io/datawire/ambassador:0.33.0-rc-latest`. Any other testing you want to do against this image, rock on.
 
-5. When you're happy with everything, tag `master` with a GA tag like `0.33.0` and let CI do its thing.
+5. When you're happy with everything, then on `master` -
+   - Run `make release-prep`, it will update `CHANGELOG.md` and `docs/index.html`. Make sure the diff looks right.
+   - You don't need to do anything with the Helm chart; CI will tackle that later.
+   - Tag `master` with a GA tag like `0.33.0` and let CI do its thing.
    - CI will retag the latest RC image as the GA image.
    - CI will update the Helm chart during the GA deploy.
 

--- a/releng/release-prep.sh
+++ b/releng/release-prep.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+
+# Copyright 2018 Datawire. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License
+
+set -e
+
+press_enter() {
+    read -s -p "Press enter to continue"
+    echo
+}
+
+RELEASE_PROMPT="
+Before making the release, make sure that -
+- [ ] the new version number depicts the release accurately
+- [ ] if new features have been added, the MINOR version is bumped
+- [ ] if backwards-incompatible changes have been made, the MINOR version is bumped
+- [ ] if only backwards-compatible bug fixes have been made, the PATCH version is bumped
+- [ ] the changes and the version number has been vetted by project maintainers and stakeholders
+"
+
+echo "$RELEASE_PROMPT"
+press_enter
+
+echo "Fetching latest release tag from GitHub"
+CURRENT_VERSION=$(curl --silent "https://api.github.com/repos/datawire/ambassador/releases/latest" | jq -r '.tag_name')
+
+echo
+echo "Current version: ${CURRENT_VERSION}"
+echo
+git log --pretty=oneline --abbrev-commit ${CURRENT_VERSION}^..
+echo
+echo "^ these changes have been made since the last release, pick the right version number accordingly"
+read -p "Enter new version: " DESIRED_VERSION
+echo "Desired version: ${DESIRED_VERSION}"
+press_enter
+echo
+
+# Update version number in docs/index.html
+echo "Found the following occurrences of $CURRENT_VERSION in ./docs/index.html"
+echo
+grep -C 2 ${CURRENT_VERSION} docs/index.html
+echo
+
+echo "Replacing $CURRENT_VERSION with $DESIRED_VERSION in ./docs/index.html"
+sed -i -e "s/$CURRENT_VERSION/$DESIRED_VERSION/g" docs/index.html
+echo
+git diff docs/index.html
+echo
+echo "^ this is the 'git diff' for docs/index.html"
+press_enter
+
+# Update release notes and changelog now
+RELEASE_NOTES_TEMPLATE="Delete everything from this template that you do not want to be in the template, including this line.
+
+### Major changes:
+- Feature: <insert feature description here>
+- Bugfix: <insert bugfix description here>
+
+### Minor changes:
+- Feature: <insert feature description here>
+- Bugfix: <insert bugfix description here>"
+
+temp_file=$(mktemp)
+echo "${RELEASE_NOTES_TEMPLATE}" > ${temp_file}
+
+if ! ${EDITOR:-vi} ${temp_file}; then
+    exit 1
+fi
+
+RELEASE_NOTES=$(<${temp_file})
+trap 'rm -f ${temp_file}' EXIT
+
+CHANGELOG="## [${DESIRED_VERSION}] $(date "+%B %d, %Y")
+[${DESIRED_VERSION}]: https://github.com/datawire/ambassador/compare/${CURRENT_VERSION}...${DESIRED_VERSION}
+
+${RELEASE_NOTES}"
+echo "Generated changelog -"
+echo "${CHANGELOG}"
+press_enter
+echo "Updating CHANGELOG.md"
+echo "${CHANGELOG}" | sed -i '/CueAddReleaseNotes/r /dev/stdin' CHANGELOG.md
+echo
+git diff CHANGELOG.md
+echo
+echo "^ this is the 'git diff' for CHANGELOG.md"
+press_enter
+git diff
+echo
+echo "^ This is final 'git diff'"
+press_enter
+echo "Staging docs/index.html and CHANGELOG.md"
+git add docs/index.html CHANGELOG.md
+echo "Committing the changes"
+git commit -m "Ambassador ${DESIRED_VERSION} release"
+echo
+GITHUB_RELEASE_NOTES="## :tada: Ambassador ${DESIRED_VERSION} :tada:
+#### Ambassador is an open source, Kubernetes-native microservices API gateway built on the Envoy Proxy.
+
+Upgrade Ambassador - https://www.getambassador.io/reference/upgrading.html
+View changelog - https://github.com/datawire/ambassador/blob/master/CHANGELOG.md
+Get started with Ambassador on Kubernetes - https://www.getambassador.io/user-guide/getting-started
+
+${RELEASE_NOTES}"
+echo "Paste the following content in GitHub release page once the release is done -"
+echo
+echo "${GITHUB_RELEASE_NOTES}"


### PR DESCRIPTION
This commit adds a `release-prep` target to the Makefile which
spins up an interactive script for making a release. The script
- warns and informs the user around picking the right version
- updated the version in docs/index.html
- prompts the user for release notes and generates changelog and
updates CHANGELOG.md
- generates GitHub release notes for the user
- commits the changes to the current branch

All the user will need to do after running `make release-prep` is
push the branch and release from GitHub UI.

Fix #595