### PR TITLE
Revert "Remove resource limits from Zipkin tutorial"

### DIFF
--- a/docs/user-guide/tracing-tutorial.md
+++ b/docs/user-guide/tracing-tutorial.md
@@ -59,6 +59,10 @@ spec:
         ports:
         - name: http
           containerPort: 9411
+        resources:
+          limits:
+            cpu: "1"
+            memory: 256Mi
 ```
 
 This configuration tells Ambassador about the tracing service, notably that Zipkin API is listening on `zipkin:9411`.


### PR DESCRIPTION
Reverts datawire/ambassador#681 because #704 actually has a better solution of adding a resource request instead of removing the limits altogether. Also TIL, if no requests are specified, resource requests are set equal to resource limits.