### PR TITLE
Fix typo in homepage, insuring -> ensuring

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -155,7 +155,7 @@
                         <p>
                             Ambassador uses the high performance
                             <a target="_blank" href="https://www.envoyproxy.io">Envoy Proxy</a>, which processes
-                            over 2M requests/second at Lyft. Ambassador runs as a sidecar to Envoy, insuring that you
+                            over 2M requests/second at Lyft. Ambassador runs as a sidecar to Envoy, ensuring that you
                             get raw Envoy performance.
                         </p>
                     </div>


### PR DESCRIPTION
Ambassador ensures that we get the speed of Envoy, not insures.