### PR TITLE
catch urllib3.exceptions.ProtocolError and continue watching

### DIFF
--- a/ambassador/kubewatch.py
+++ b/ambassador/kubewatch.py
@@ -355,6 +355,7 @@ def watch_loop(restarter):
 
                 logger.info("watch loop exited?")
             except ProtocolError:
+                logger.debug("watch connection has been broken. retry automatically.")
                 continue
     else:
         logger.info("No K8s, idling")


### PR DESCRIPTION
fixed #554 

When `urllib3.exceptions.ProtocolError` raised at `watch_loop`,  catch it and reconnect kubernetes to watch events.