### PR TITLE
Drop default statsd container

### DIFF
--- a/ambassador/Dockerfile
+++ b/ambassador/Dockerfile
@@ -41,7 +41,7 @@ LABEL PROJECT_REPO_URL         = "git@github.com:datawire/ambassador.git" \
 # NOTE: If you don't know what you're doing, it's probably a mistake to
 # blindly hack up this file.
 
-RUN apk --no-cache add curl python3
+RUN apk --no-cache add curl python3 socat
 
 # Set WORKDIR to /ambassador which is the root of all our apps then COPY
 # only requirements.txt to avoid screwing up Docker caching and causing a

--- a/docs/reference/running.md
+++ b/docs/reference/running.md
@@ -10,8 +10,6 @@ Ambassador relies on Kubernetes for reliability, availability, and scalability. 
 
 The default configuration of Ambassador includes default [resource limits](https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/#resource-requests-and-limits-of-pod-and-container), as well as [readiness and liveness probes](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/). These values should be adjusted for your specific environment.
 
-The default configuration also includes a `statsd` sidecar for collecting and forwarding StatsD statistics to your metrics infrastructure. If you are not collecting metrics, you should delete the `statsd` sidecar.
-
 ## Running as non-root
 
 Starting with Ambassador 0.35, we support running Ambassador as non-root. This is the recommended configuration, and will be the default configuration in future releases. We recommend you configure Ambassador to run as non-root as follows:

--- a/docs/reference/statistics.md
+++ b/docs/reference/statistics.md
@@ -8,8 +8,32 @@ As an example, for a given service `usersvc`, here are some interesting statisti
 - `envoy.cluster.usersvc_cluster.upstream_rq_2xx` is the total number of requests to which `usersvc` responded with an HTTP response indicating success. This value divided by the prior one, taken on an rolling window basis, represents the recent success rate of the service. There are corresponding `4xx` and `5xx` counters that can help clarify the nature of unsuccessful requests.
 - `envoy.cluster.usersvc_cluster.upstream_rq_time` is a StatsD timer that tracks the latency in milliseconds of `usersvc` from Ambassador's perspective. StatsD timers include information about means, standard deviations, and decile values.
 
-Statistics are exposed via the ubiquitous and well-tested [StatsD](https://github.com/etsy/statsd) protocol. Ambassador automatically sends statistics information to a Kubernetes service called `statsd-sink` using typical StatsD protocol settings, UDP to port 8125. We have included a few example configurations in the [statsd-sink](https://github.com/datawire/ambassador/tree/master/statsd-sink) subdirectory to help you get started. Clone the repository to get local, editable copies.
+#### Exposing statistics via StatsD
 
+Statistics are exposed via the ubiquitous and well-tested [StatsD](https://github.com/etsy/statsd) protocol.
+
+To expose statistics via StatsD, you will need to set an environment variable `STATSD_ENABLED: true` to Ambassador's Kubernetes Deployment YAML. To set this environment variable, run `kubectl edit deployment ambassador` and add the variable to `spec.template.spec.containers[0].env`.
+
+The YAML snippet will look something like -
+
+```yaml
+<redacted>
+    spec:
+      containers:
+      - env:
+        - name: STATSD_ENABLED
+          value: "true"
+        - name: AMBASSADOR_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        image: <ambassador image>
+        imagePullPolicy: IfNotPresent
+<redacted>
+```
+
+ Ambassador automatically sends statistics information to a Kubernetes service called `statsd-sink` using typical StatsD protocol settings, UDP to port 8125. We have included a few example configurations in the [statsd-sink](https://github.com/datawire/ambassador/tree/master/statsd-sink) subdirectory to help you get started. Clone the repository to get local, editable copies.
 
 ## Graphite
 

--- a/end-to-end/README.md
+++ b/end-to-end/README.md
@@ -19,12 +19,12 @@ It will download `kubernaut` if necessary, allocate a `kubernaut` cluster, then 
   make E2E_TEST_NAME=001-simple e2e
   ```
 
-- Running tests with a specific Ambassador(or statsd) image
+- Running tests with a specific Ambassador image
 
   This is particularly useful when you have only made changes to the end-to-end tests
 
   ```
-  make AMBASSADOR_DOCKER_IMAGE=quay.io/datawire/ambassador:0.37.0 STATSD_DOCKER_IMAGE=quay.io/datawire/statsd:0.37.0 e2e
+  make AMBASSADOR_DOCKER_IMAGE=quay.io/datawire/ambassador:0.37.0 e2e
   ```
 
 - Clean up test artifacts (among other generated junk)

--- a/end-to-end/create-manifests.sh
+++ b/end-to-end/create-manifests.sh
@@ -23,14 +23,13 @@ cd "$HERE"
 ROOT=$(cd ..; pwd)
 
 AMBASSADOR_IMAGE="$1"
-STATSD_IMAGE="$2"
 
 # First start with ambassador-rbac.yaml and edit it to be the 
 # base ambassador-deployments.yaml that e2e needs.
 python ${HERE}/yfix.py ${HERE}/fixes/ambassador.yfix \
     ${ROOT}/docs/yaml/ambassador/ambassador-rbac.yaml \
     ${HERE}/ambassador-deployment.yaml \
-    "$AMBASSADOR_IMAGE" "$STATSD_IMAGE"
+    "$AMBASSADOR_IMAGE"
 
 # Next take that ambassador-deployment.yaml and add some 
 # certificate mountpoints and such.

--- a/end-to-end/fixes/ambassador.yfix
+++ b/end-to-end/fixes/ambassador.yfix
@@ -6,4 +6,3 @@ SET spec/template/spec/containers/0/imagePullPolicy Always
 DELETE spec/template/spec/containers/0/livenessProbe
 DELETE spec/template/spec/containers/0/readinessProbe
 DELETE spec/template/spec/containers/0/resources
-SET spec/template/spec/containers/1/image $2

--- a/helm/ambassador/templates/deployment.yaml
+++ b/helm/ambassador/templates/deployment.yaml
@@ -24,11 +24,6 @@ spec:
     spec:
       serviceAccountName: {{ template "ambassador.serviceAccountName" . }}
       containers:
-        - name: statsd-sink
-          image: "{{ .Values.exporter.image }}"
-          ports:
-          - name: metrics
-            containerPort: 9102
         - name: ambassador
           image: "{{ .Values.image.repository }}:{{ template "ambassador.imageTag" . }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}

--- a/scripts/get_registries.sh
+++ b/scripts/get_registries.sh
@@ -41,11 +41,7 @@ DOCKER_REGISTRY=$(slashify "$DOCKER_REGISTRY")
 # Default to using DOCKER_REGISTRY, but allow overriding.
 AMREG=$(slashify "${AMBASSADOR_REGISTRY:-$DOCKER_REGISTRY}")
 
-# Default to using DOCKER_REGISTRY, but allow overriding.
-STREG=$(slashify "${STATSD_REGISTRY:-$DOCKER_REGISTRY}")
-
 cat <<EOF
 export DOCKER_REGISTRY="$DOCKER_REGISTRY"
 export AMREG="$AMREG"
-export STREG="$STREG"
 EOF

--- a/scripts/template.py
+++ b/scripts/template.py
@@ -31,13 +31,11 @@ if registry and not registry.endswith("/"):
     registry += "/"
 
 ambassador_registry = os.environ.get('AMBASSADOR_REGISTRY', registry)
-statsd_registry = os.environ.get('STATSD_REGISTRY', registry)
 
 TemplateVars = dict(os.environ)
 
 TemplateVars['DOCKER_REGISTRY'] = registry
 TemplateVars['AMREG'] = ambassador_registry
-TemplateVars['STREG'] = statsd_registry
 # TemplateVars['VERSION'] = os.environ.get('VERSION')
 
 template = sys.stdin.read()

--- a/statsd/Dockerfile
+++ b/statsd/Dockerfile
@@ -1,5 +1,0 @@
-FROM alpine:3.7
-
-RUN apk --update add socat
-
-CMD ["socat", "-d", "UDP-RECVFROM:8125,fork", "UDP-SENDTO:statsd-sink:8125"]

--- a/templates/ambassador/ambassador-rbac.yaml
+++ b/templates/ambassador/ambassador-rbac.yaml
@@ -91,6 +91,4 @@ spec:
             port: 8877
           initialDelaySeconds: 30
           periodSeconds: 3
-      - name: statsd
-        image: {{STATSD_DOCKER_IMAGE}}
       restartPolicy: Always


### PR DESCRIPTION
Till now, Ambassador's deployment consisted of 2 containers, one
ambassador container and another statsd container. This commit
removes the statsd container and instead allows exposing
statistics over StatsD using `STATSD_ENABLED: true` environment
variable. Basically, the functionality of statsd sidecar container
has been baked into the ambassdor container. Why?
- The statsd container was essentially just one `socat` command.
  That's a lot of overhead for just one command.
- An extra statsd container by default used to add confusion for
  the end-user who did not have a `statsd-sink` service configured
  because it used to continuously blurt logs complanining about
  the same. Now, users need to be explicit about starting `socat`.

Also, now `socat` is only fired when `statsd-sink` name is
resolvable by the DNS. This is checked every 4 seconds if
`STATSD_ENABLED: true` is set. The DNS is no longer constantly
polled by `socat`.

Fix #568