### PR TITLE
Update documentation, and remove zipkin resource limits

### DIFF
--- a/docs/user-guide/tracing-tutorial.md
+++ b/docs/user-guide/tracing-tutorial.md
@@ -1,20 +1,24 @@
 # Tracing
 
-Ambassador can enable distributed traces, one of the "3 pillars of observability", allowing developers to visualize request flows in service-oriented architectures. In this tutorial, we'll configure Ambassador to initiate a trace on some sample requests and use an external tracing service to visualize them.
+Ambassador can support distributed tracing, one of the ["3 pillars of observability"](https://medium.com/@copyconstruct/monitoring-in-the-time-of-cloud-native-c87c7a5bfa3e), which allows developers to visualize request flows in microservice and service-oriented architectures. In this tutorial, we'll configure Ambassador to initiate a trace on some sample requests, and use an external tracing service to visualize them.
 
 ## Before You Get Started
 
 This tutorial assumes you have already followed the [Ambassador Getting Started](/user-guide/getting-started.html) guide. If you haven't done that already, you should do that now.
 
-After completing [Getting Started](/user-guide/getting-started.html), you'll have a Kubernetes cluster running Ambassador and the Quote of the Moment service. Let's walk through adding tracing to this setup.
+After completing the Getting Started guide you will have a Kubernetes cluster running Ambassador and the Quote of the Moment service. Let's walk through adding tracing to this setup.
 
 ## 1. Deploy Zipkin
 
-In this tutorial we will use a simple in-memory deployment of [Zipkin](https://zipkin.io/) to store and visualize the Ambassador-generated traces.
+In this tutorial you will use a simple deployment of the open source [Zipkin](https://zipkin.io/) distributed tracing system to store and visualize the Ambassador-generated traces. The trace data will be stored in-memory within the
+Zipkin container, and you will be able to explore the traces via the Zipkin
+web UI.
 
-> Zipkin is a distributed tracing system. It helps gather timing data needed to troubleshoot latency problems in microservice architectures. It manages both the collection and lookup of this data.
-
-Here's the YAML we'll start with:
+First, add the following YAML to a file named `zipkin.yaml`. This configuration
+will create a zipkin Deployment that uses the [`openzipkin/zipkin`](https://hub.docker.com/r/openzipkin/zipkin/) container image
+and also an associated Service. You will notice that the Service also has an
+annotation on it that configures Ambassador to use the zipkin service (running on the
+default port of 9411) to provide tracing support.
 
 ```yaml
 ---
@@ -59,25 +63,22 @@ spec:
         ports:
         - name: http
           containerPort: 9411
-        resources:
-          limits:
-            cpu: "1"
-            memory: 256Mi
-          requests:
-            cpu: 200m
-            memory: 100Mi
 ```
 
-This configuration tells Ambassador about the tracing service, notably that Zipkin API is listening on `zipkin:9411`.
+You can deploy this configuration into your Kubernetes cluster like so:
 
-Ambassador will see the annotations and reconfigure itself within a few seconds.
+```shell
+$ kubectl apply -f zipkin.yaml
+```
+
+The Ambassador Service will detect the annotations and reconfigure itself within a few seconds.
 
 ## 2. Generate some requests
 
 Use `curl` to generate a few requests to an existing Ambassador mapping. You may need to perform many requests since only a subset of random requests are sampled and instrumented with traces.
 
 ```shell
-$ curl $AMBASSADOR_IP/httpbin/
+$ curl $AMBASSADOR_IP/httpbin/ip
 ```
 
 ## 3. Test traces
@@ -100,7 +101,10 @@ $ kubectl port-forward zipkin-868b97667c-58v4r 9411
 
 Open your web browser to `http://localhost:9411` for the Zipkin UI.
 
-If you're on `minikube`, you can access the `NodePort` directly:
+If you're on `minikube` you can access the `NodePort` directly, and this ports
+number can be obtained via the `minikube services list` command.
+If you are using `Docker for Mac/Windows`, you can use the
+`kubectl get svc` command to get the same information.
 
 ```shell
 $ minikube service list
@@ -115,7 +119,8 @@ $ minikube service list
 
 Open your web browser to the Zipkin dashboard http://192.168.99.107:31043/zipkin/.
 
-In the Zipkin UI, click on the "Find Traces" button to get a listing instrumented traces.
+In the Zipkin UI, click on the "Find Traces" button to get a listing instrumented traces. Each of the traces that are displayed can be clicked on, which provides further information
+about each span and associated metadata.
 
 ## More
 


### PR DESCRIPTION
I've tweaked a couple of sentences in the Getting Started guide, as I constantly get asked questions around this.

I've also added to the tracing tutorial, and removed the `resources` config in the zipkin deployment, as this causes issues on minikube and Docker for Mac (a friend mention an OOM kill of Zipkin and a CrashLoopBackoff, which I could recreate).