### PR TITLE
Using named targetPort to match backend pod

### DIFF
--- a/helm/ambassador/README.md
+++ b/helm/ambassador/README.md
@@ -55,8 +55,8 @@ The following tables lists the configurable parameters of the Ambassador chart a
 | `serviceAccount.name` | Service account to be used | `ambassador`
 | `service.enableHttp` | if port 80 should be opened for service | `true`
 | `service.enableHttps` | if port 443 should be opened for service | `true`
-| `service.targetPorts.http` | Sets the targetPort that maps to the service's port 80 | `80`
-| `service.targetPorts.https` | Sets the targetPort that maps to the service's port 443 | `443`
+| `service.targetPorts.http` | Sets the targetPort that maps to the service's cleartext port | `80`
+| `service.targetPorts.https` | Sets the targetPort that maps to the service's TLS port | `443`
 | `service.type` | Service type to be used | `LoadBalancer`
 | `service.annotations` | Annotations to apply to Ambassador service | none
 | `adminService.create` | If `true`, create a service for Ambassador's admin UI | `true`
@@ -65,6 +65,8 @@ The following tables lists the configurable parameters of the Ambassador chart a
 | `timing.restart` | The minimum number of seconds between Envoy restarts | none
 | `timing.drain` | The number of seconds that the Envoy will wait for open connections to drain on a restart | none
 | `timing.shutdown` | The number of seconds that Ambassador will wait for the old Envoy to clean up and exit on a restart | none
+
+Make sure the configured `service.targetPorts.http` and `service.targetPorts.https` ports match your Ambassador Module's `service_port` and `redirect_cleartext_from` configurations. 
 
 If you intend to use `service.annotations`, remember to include the annotation key, for example:
 
@@ -81,6 +83,8 @@ service:
       config:
         diagnostics:
           enabled: false
+        redirect_cleartext_from: 80
+        service_port: 443
 ```
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,

--- a/helm/ambassador/templates/deployment.yaml
+++ b/helm/ambassador/templates/deployment.yaml
@@ -34,9 +34,9 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http
-              containerPort: 80
+              containerPort: {{ .Values.service.targetPorts.http }}
             - name: https
-              containerPort: 443
+              containerPort: {{ .Values.service.targetPorts.https }}
             - name: admin
               containerPort: 8877
           env:

--- a/helm/ambassador/templates/service.yaml
+++ b/helm/ambassador/templates/service.yaml
@@ -16,13 +16,13 @@ spec:
   ports:
     {{- if .Values.service.enableHttp }}
     - port: {{ .Values.service.port }}
-      targetPort: {{ .Values.service.targetPorts.http }}
+      targetPort: http
       protocol: TCP
       name: http
     {{- end }}
     {{- if .Values.service.enableHttps }}
     - port: 443
-      targetPort: {{ .Values.service.targetPorts.https }}
+      targetPort: https
       protocol: TCP
       name: https
     {{- end }}

--- a/templates/ambassador/ambassador-http.yaml
+++ b/templates/ambassador/ambassador-http.yaml
@@ -11,6 +11,6 @@ spec:
   ports:
   - name: ambassador
     port: 80
-    targetPort: 80
+    targetPort: http
   selector:
     service: ambassador

--- a/templates/ambassador/ambassador-https.yaml
+++ b/templates/ambassador/ambassador-https.yaml
@@ -11,6 +11,6 @@ spec:
   ports:
   - name: ambassador
     port: 443
-    targetPort: 443
+    targetPort: https
   selector:
     service: ambassador

--- a/templates/ambassador/ambassador-no-rbac.yaml
+++ b/templates/ambassador/ambassador-no-rbac.yaml
@@ -41,7 +41,14 @@ spec:
         - name: AMBASSADOR_NAMESPACE
           valueFrom:
             fieldRef:
-              fieldPath: metadata.namespace          
+              fieldPath: metadata.namespace
+        ports:
+        - name: http
+          containerPort: 80
+        - name: https
+          containerPort: 443
+        - name: admin
+          containerPort: 8877
         livenessProbe:
           httpGet:
             path: /ambassador/v0/check_alive

--- a/templates/ambassador/ambassador-rbac-prometheus.yaml
+++ b/templates/ambassador/ambassador-rbac-prometheus.yaml
@@ -79,6 +79,13 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        ports:
+        - name: http
+          containerPort: 80
+        - name: https
+          containerPort: 443
+        - name: admin
+          containerPort: 8877
         livenessProbe:
           httpGet:
             path: /ambassador/v0/check_alive

--- a/templates/ambassador/ambassador-rbac.yaml
+++ b/templates/ambassador/ambassador-rbac.yaml
@@ -78,7 +78,14 @@ spec:
         - name: AMBASSADOR_NAMESPACE
           valueFrom:
             fieldRef:
-              fieldPath: metadata.namespace          
+              fieldPath: metadata.namespace
+        ports:
+        - name: http
+          containerPort: 80
+        - name: https
+          containerPort: 443
+        - name: admin
+          containerPort: 8877
         livenessProbe:
           httpGet:
             path: /ambassador/v0/check_alive


### PR DESCRIPTION
In helm and templates, using a named Service `targetPort` to match backend Pod. This will make the transition from running as root (port 80, 443) much easier as the Service will be able to target newly created Pods running as non-root (port 8080, 8443) without downtime during the rolling deployment.

No tests as this relate only to documentation.