### PR TITLE
Add optional support for load balancer IP in ambassador service.

### DIFF
--- a/helm/ambassador/README.md
+++ b/helm/ambassador/README.md
@@ -58,6 +58,7 @@ The following tables lists the configurable parameters of the Ambassador chart a
 | `service.targetPorts.http` | Sets the targetPort that maps to the service's port 80 | `80`
 | `service.targetPorts.https` | Sets the targetPort that maps to the service's port 443 | `443`
 | `service.type` | Service type to be used | `LoadBalancer`
+| `service.loadBalancerIP` | If the loadBalancerIP field is not specified, an ephemeral IP will be assigned to the loadBalancer. If the loadBalancerIP is specified, but the cloud provider does not support the feature, the field will be ignored | none
 | `service.annotations` | Annotations to apply to Ambassador service | none
 | `adminService.create` | If `true`, create a service for Ambassador's admin UI | `true`
 | `adminService.type` | Ambassador's admin service type to be used | `ClusterIP`

--- a/helm/ambassador/templates/service.yaml
+++ b/helm/ambassador/templates/service.yaml
@@ -13,6 +13,9 @@ metadata:
 {{- end }}
 spec:
   type: {{ .Values.service.type }}
+  {{- if .Values.service.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.service.loadBalancerIP }}
+  {{- end }}
   ports:
     {{- if .Values.service.enableHttp }}
     - port: {{ .Values.service.port }}


### PR DESCRIPTION
According to K8s official documentation:

> Some cloud providers allow the loadBalancerIP to be specified. In those cases, the load-balancer will be created with the user-specified loadBalancerIP. If the loadBalancerIP field is not specified, an ephemeral IP will be assigned to the loadBalancer. If the loadBalancerIP is specified, but the cloud provider does not support the feature, the field will be ignored.
Reference:
https://kubernetes.io/docs/concepts/services-networking/service/
https://docs.microsoft.com/en-us/azure/aks/static-ip

This PR includes support for load balancer IP in the ambassador service. This is an optional parameter that could be used in cloud providers that support this param, e.g. Azure Cloud.

How to use it?
`helm install datawire/ambassador --set service.loadBalancerIP=137.116.69.22`
Replace `137.116.69.22` with your public static IP address.