### PR TITLE
Add service label in helm chart deployment file of ambassador.

### DIFF
--- a/helm/ambassador/templates/deployment.yaml
+++ b/helm/ambassador/templates/deployment.yaml
@@ -16,6 +16,7 @@ spec:
   template:
     metadata:
       labels:
+        service: {{ template "ambassador.name" . }}
         app: {{ template "ambassador.name" . }}
         release: {{ .Release.Name }}
       annotations:


### PR DESCRIPTION
The `service` label is required to capture ambassador metrics in prometheus.

**In detail:**
- If the `service` label is defined in ambassador deployment yaml file, prometheus displays ambassador metrics and the `ambassador-monitor` target is configured properly in prometheus.
- If the `service` label is not defined in ambassador deployment yaml file, prometheus does not display metrics and there are no targets configured in prometheus.

**Evidence:**
- If you install ambassador manually (using kubectl and the `ambassador-rbac.yaml` file), prometheus displays metrics. **The `ambassador-rbac.yaml` file contains the `service` label in deployment configuration.**
- If you install ambassador using `helm chart`, prometheus does not display metrics. **The helm chart does not contain the `service` label in deployment configuration.**

**How to test?**
Follow these steps to configure ambassador + prometheus:
http://www.datawire.io/faster/ambassador-prometheus/
1. Install ambassador manually using `ambassador-rbac.yaml` and you will be able to see the ambassador metrics in prometheus.
2. Repeat the process but installing ambassador using `helm chart` and you will be able to see that prometheus does not display metrics and the target is not configured properly.