### PR TITLE
LightStep http2

### DIFF
--- a/ambassador/ambassador/config.py
+++ b/ambassador/ambassador/config.py
@@ -1647,7 +1647,7 @@ class Config (object):
             self.add_intermediate_cluster(first_source, cluster_name,
                                           'exttracing', [url],
                                           type="strict_dns", lb_type="round_robin",
-                                          host_rewrite=host_rewrite)
+                                          grpc=True if driver == "lightstep" else False, host_rewrite=host_rewrite)
 
         driver_config['collector_cluster'] = cluster_name
         tracing = SourcedDict(

--- a/ambassador/ambassador/config.py
+++ b/ambassador/ambassador/config.py
@@ -20,6 +20,7 @@ import json
 import logging
 import os
 import re
+from urllib.parse import urlparse
 
 import jsonschema
 import semantic_version
@@ -712,7 +713,7 @@ class Config (object):
     def add_intermediate_cluster(self, _source, name, _service, urls,
                                  type="strict_dns", lb_type="round_robin",
                                  cb_name=None, od_name=None, originate_tls=None,
-                                 grpc=False, host_rewrite=None):
+                                 grpc=False, host_rewrite=None, ssl_context=None):
         if name not in self.envoy_clusters:
             self.logger.debug("CLUSTER %s: new from %s" % (name, _source))
 
@@ -747,6 +748,12 @@ class Config (object):
                     if key.startswith('_'):
                         continue
 
+                    tls_array.append({ 'key': key, 'value': value })
+                    cluster['tls_array'] = sorted(tls_array, key=lambda x: x['key'])
+            elif ssl_context:
+                cluster['tls_context'] = ssl_context
+                tls_array = []
+                for key, value in ssl_context.items():
                     tls_array.append({ 'key': key, 'value': value })
                     cluster['tls_array'] = sorted(tls_array, key=lambda x: x['key'])
 
@@ -1644,10 +1651,19 @@ class Config (object):
 
         if cluster_name not in self.envoy_clusters:
             (svc, url, originate_tls, otls_name) = self.service_tls_check(cluster_hosts, None, host_rewrite)
+            grpc = False
+            ssl_context = None
+            if driver == "lightstep":
+                grpc = True
+                parsed_url = urlparse(url)
+                ssl_context = {
+                    "ca_cert_file": "/etc/ssl/certs/ca-certificates.crt",
+                    "verify_subject_alt_name": [parsed_url.hostname]
+                }
             self.add_intermediate_cluster(first_source, cluster_name,
                                           'exttracing', [url],
                                           type="strict_dns", lb_type="round_robin",
-                                          grpc=True if driver == "lightstep" else False, host_rewrite=host_rewrite)
+                                          host_rewrite=host_rewrite, grpc=grpc, ssl_context=ssl_context)
 
         driver_config['collector_cluster'] = cluster_name
         tracing = SourcedDict(

--- a/ambassador/templates/envoy.j2
+++ b/ambassador/templates/envoy.j2
@@ -163,7 +163,7 @@
         }{%- endif -%}{%- if cluster.tls_context -%},
         "ssl_context": {
           {% for entry in cluster.tls_array %}
-          "{{ entry.key }}": "{{ entry.value }}"{{ "," if not loop.last }}
+          "{{ entry.key }}": {{ entry.value | tojson }}{{ "," if not loop.last }}
           {% endfor %}
         }{%- endif -%}
       }{{ "," if not loop.last }}


### PR DESCRIPTION
Fixing https://github.com/datawire/ambassador/issues/796

I could not yet test the entire request flow with LightStep since I don't have a valid API key.
@danielbryantuk If you want to try it out, you can test this build using docker image: `agervais/ambassador:lightstep-http2-162f648-dirty`

The generated Envoy config looks like:

**Zipkin**
```
{
    "lb_type": "round_robin",
    "name": "cluster_ext_tracing",
    "type": "strict_dns",
    "urls": [
        "tcp://zipkin:9411"
    ]
}
```

**LightStep**
```
{
    "features": "http2",
    "lb_type": "round_robin",
    "name": "cluster_ext_tracing",
    "type": "strict_dns",
    "urls": [
        "tcp://collector-http.lightstep.com:8081"
    ]
}
```

and Envoy is starting/reloading successfully now, no longer complaining about ```cluster_ext_tracing collector cluster must support http2 for gRPC calls```