### PR TITLE
Clean CI run!

### DIFF
--- a/ambassador/ambassador/ir/irmapping.py
+++ b/ambassador/ambassador/ir/irmapping.py
@@ -309,6 +309,7 @@ class IRMappingGroup (IRResource):
         'cluster': True,
         'host': True,
         'kind': True,
+        'location': True,
         'name': True,
         'rkey': True,
         'route_weight': True,
@@ -369,11 +370,11 @@ class IRMappingGroup (IRResource):
         for k in IRMappingGroup.CoreMappingKeys:
             if (k in mapping) and ((k not in self) or
                                    (mapping[k] != self[k])):
-                mismatches.append(k)
+                mismatches.append((k, mapping[k], self.get(k, '-unset-')))
 
         if mismatches:
             raise Exception("IRMappingGroup %s: cannot accept IRMapping %s with mismatched %s" %
-                            (self.group_id, mapping.name, ", ".join(mismatches)))
+                            (self.name, mapping.name, ", ".join([ "%s: %s != %s" % (x, y, z) for x, y, z in mismatches ])))
 
         # self.ir.logger.debug("%s: add mapping %s" % (self, mapping.as_json()))
 

--- a/ambassador/ambassador/ir/irmapping.py
+++ b/ambassador/ambassador/ir/irmapping.py
@@ -367,7 +367,8 @@ class IRMappingGroup (IRResource):
         mismatches = []
 
         for k in IRMappingGroup.CoreMappingKeys:
-            if (k in mapping) and (mapping[k] != self[k]):
+            if (k in mapping) and ((k not in self) or
+                                   (mapping[k] != self[k])):
                 mismatches.append(k)
 
         if mismatches:

--- a/ambassador/ambassador/utils.py
+++ b/ambassador/ambassador/utils.py
@@ -47,8 +47,14 @@ class TLSPaths(Enum):
 
 
 class SystemInfo:
-    MyHostName = socket.gethostname()
-    MyResolvedName = socket.gethostbyname(socket.gethostname())
+    MyHostName = 'localhost'
+    MyResolvedName = '127.0.0.1'
+
+    try:
+        MyHostName = socket.gethostname()
+        MyResolvedName = socket.gethostbyname(socket.gethostname())
+    except:
+        pass
 
 class RichStatus:
     def __init__(self, ok, **kwargs):

--- a/ambassador/tests/001-broader-v0/config/mapping-redirector.yaml
+++ b/ambassador/tests/001-broader-v0/config/mapping-redirector.yaml
@@ -16,4 +16,3 @@ service: httpbin.org
 shadow: true
 host_redirect: true
 path_redirect: /ip/
-timeout_ms: 50

--- a/ambassador/tests/001-broader-v0/gold.intermediate.json
+++ b/ambassador/tests/001-broader-v0/gold.intermediate.json
@@ -336,7 +336,7 @@
                     "mapping-httpbin-shadow.yaml.1",
                     "mapping-httpbin.yaml.1"
                 ],
-                "_source": "mapping-httpbin.yaml.1",
+                "_source": "mapping-httpbin-shadow.yaml.1",
                 "clusters": [
                     {
                         "name": "cluster_http___httpbin_org",
@@ -651,8 +651,7 @@
                 "prefix_rewrite": "/",
                 "shadow": {
                     "name": "cluster_shadow_httpbin_org"
-                },
-                "timeout_ms": 50
+                }
             },
             {
                 "__saved": [
@@ -1185,7 +1184,7 @@
             "kind": "Mapping",
             "name": "bad_redirect_mapping",
             "version": "ambassador/v0",
-            "yaml": "apiVersion: ambassador/v0\nhost_redirect: true\nkind: Mapping\nname: bad_redirect_mapping\npath_redirect: /ip/\nprefix: /qotm/\nservice: httpbin.org\nshadow: true\ntimeout_ms: 50\n"
+            "yaml": "apiVersion: ambassador/v0\nhost_redirect: true\nkind: Mapping\nname: bad_redirect_mapping\npath_redirect: /ip/\nprefix: /qotm/\nservice: httpbin.org\nshadow: true\n"
         },
         "mapping-websocket.yaml.1": {
             "_source": "mapping-websocket.yaml",

--- a/ambassador/tests/001-broader-v0/gold.json
+++ b/ambassador/tests/001-broader-v0/gold.json
@@ -230,7 +230,7 @@
                     ,
                     
                     {
-                      "timeout_ms": 50,"prefix": "/qotm/","prefix_rewrite": "/","weighted_clusters": {
+                      "timeout_ms": 3000,"prefix": "/qotm/","prefix_rewrite": "/","weighted_clusters": {
                               "clusters": [
                                   
                                     { "name": "cluster_qotm", "weight": 100.0 }

--- a/ambassador/tests/006-headers-and-host/gold.intermediate.json
+++ b/ambassador/tests/006-headers-and-host/gold.intermediate.json
@@ -50,6 +50,21 @@
             },
             {
                 "_referenced_by": [
+                    "mapping-httpbin.yaml.1",
+                    "mapping-qotm.yaml.3"
+                ],
+                "_service": "httpbin.org:80",
+                "_source": "mapping-httpbin.yaml.1",
+                "host_rewrite": "httpbin.org",
+                "lb_type": "round_robin",
+                "name": "cluster_httpbin_org_80",
+                "type": "strict_dns",
+                "urls": [
+                    "tcp://httpbin.org:80"
+                ]
+            },
+            {
+                "_referenced_by": [
                     "mapping-qotm.yaml.1"
                 ],
                 "_service": "demo.getambassador.io",
@@ -72,21 +87,6 @@
                 "type": "strict_dns",
                 "urls": [
                     "tcp://example-auth:3000"
-                ]
-            },
-            {
-                "_referenced_by": [
-                    "mapping-httpbin.yaml.1",
-                    "mapping-qotm.yaml.3"
-                ],
-                "_service": "httpbin.org:80",
-                "_source": "mapping-qotm.yaml.3",
-                "host_rewrite": "httpbin.org",
-                "lb_type": "round_robin",
-                "name": "cluster_httpbin_org_80",
-                "type": "strict_dns",
-                "urls": [
-                    "tcp://httpbin.org:80"
                 ]
             },
             {

--- a/ambassador/tests/ambassador_test.py
+++ b/ambassador/tests/ambassador_test.py
@@ -270,6 +270,8 @@ class old_ir (dict):
 
                         rl_actions.append({'actions': rate_limits_actions})
 
+            route['clusters'].sort(key=cluster_sort_key)
+
             if rl_actions:
                 route['rate_limits'] = rl_actions
 
@@ -483,6 +485,10 @@ def normalize_gold(gold: dict) -> dict:
         if 'clusters' in normalized['envoy_config']:
             normalized['envoy_config']['clusters'].sort(key=cluster_sort_key)
 
+        for route in normalized['envoy_config'].get('routes', []):
+            if 'clusters' in route:
+                route['clusters'].sort(key=cluster_sort_key)
+
     return normalized
 
 #### Test functions
@@ -498,7 +504,12 @@ def test_config(testname, dirpath, configdir):
 
     print("==== loading resources")
 
-    resources = fetch_resources(configdir, logger)
+    raw = list(fetch_resources(configdir, logger))
+    resources = sorted(raw, key=lambda x: x.rkey)
+
+    # print("raw:    %s" % ", ".join([ x.rkey for x in raw ]))
+    # print("sorted: %s" % ", ".join([ x.rkey for x in resources ]))
+
     aconf = Config()
     aconf.load_all(resources)
 

--- a/ambassador/tests/ambassador_test.py
+++ b/ambassador/tests/ambassador_test.py
@@ -507,8 +507,8 @@ def test_config(testname, dirpath, configdir):
     raw = list(fetch_resources(configdir, logger))
     resources = sorted(raw, key=lambda x: x.rkey)
 
-    # print("raw:    %s" % ", ".join([ x.rkey for x in raw ]))
-    # print("sorted: %s" % ", ".join([ x.rkey for x in resources ]))
+    print("raw:    %s" % ", ".join([ x.rkey for x in raw ]))
+    print("sorted: %s" % ", ".join([ x.rkey for x in resources ]))
 
     aconf = Config()
     aconf.load_all(resources)

--- a/ambassador/tests/kat/test_ambassador.py
+++ b/ambassador/tests/kat/test_ambassador.py
@@ -110,7 +110,7 @@ class CaseSensitive(OptionTest):
             idx = q.url.find("/", q.url.find("://") + 3)
             upped = q.url[:idx] + q.url[idx:].upper()
             assert upped != q.url
-            yield Query(upped, xfail="this is broken")
+            yield Query(upped)
 
 class AutoHostRewrite(OptionTest):
 


### PR DESCRIPTION
CI tests now cover:

- unit tests comparing the new IR to the old IR goldfiles
- unit tests comparing the Envoy V1 generated from the new IR to the old Envoy V1 goldfiles
- the first KAT-based tests

and they all pass. It's about time.
