### PR TITLE
Add support for AMBASSADOR_ID in Helm chart

### DIFF
--- a/helm/ambassador/README.md
+++ b/helm/ambassador/README.md
@@ -51,6 +51,7 @@ The following tables lists the configurable parameters of the Ambassador chart a
 | `replicaCount`  | Number of Ambassador replicas  | `1` 
 | `resources` | CPU/memory resource requests/limits | None 
 | `rbac.create` | If `true`, create and use RBAC resources | `true`
+| `deployment.ambassadorId` | Sets the AMBASSADOR_ID | `default`
 | `serviceAccount.create` | If `true`, create a new service account | `true`
 | `serviceAccount.name` | Service account to be used | `ambassador`
 | `service.enableHttp` | if port 80 should be opened for service | `true`

--- a/helm/ambassador/templates/deployment.yaml
+++ b/helm/ambassador/templates/deployment.yaml
@@ -59,6 +59,12 @@ spec:
             value: {{ .Values.timing.shutdown | quote }}
           {{- end -}}
           {{- end }}
+          {{- if .Values.deployment }}
+          {{- if .Values.deployment.ambassadorId }}
+          - name: AMBASSADOR_ID
+            value: {{ .Values.deployment.ambassadorId | quote }}
+          {{- end -}}
+          {{- end }}
           livenessProbe:
             httpGet:
               path: /ambassador/v0/check_alive

--- a/helm/ambassador/values.yaml
+++ b/helm/ambassador/values.yaml
@@ -8,6 +8,10 @@ image:
   repository: quay.io/datawire/ambassador
   pullPolicy: IfNotPresent
 
+deployment: {}
+  # Sets AMBASSADOR_ID env var within Deployment
+  # ambassadorId: default
+
 service:
   enableHttp: true
   enableHttps: true


### PR DESCRIPTION
In order to support multiple Ambassador installs, the `AMBASSADOR_ID` env variable needs to be set within the Deployment. This change adds in an optional `deployment.ambassadorId` variable which sets `AMBASSADOR_ID` within `templates/deployment.yaml`.