### PR TITLE
Expose STATSD_HOST config

### DIFF
--- a/ambassador/entrypoint.sh
+++ b/ambassador/entrypoint.sh
@@ -68,7 +68,7 @@ diediedie() {
     else
         echo "No config generated."
     fi
-    
+
     ambassador_exit 1
 }
 
@@ -150,7 +150,8 @@ pids="${pids:+${pids} }$!:kubewatch"
 
 if [ "$(echo ${STATSD_ENABLED} | tr "[:upper:]" "[:lower:]")" = "true" ]; then
     echo "STATSD_ENABLED is set to true"
-    STATSD_HOST="statsd-sink"
+    # Fallback to statsd-sink if a host isn't provided
+    STATSD_HOST="${STATSD_HOST:-statsd-sink}"
     handle_statsd ${STATSD_HOST} &
 else
     echo "STATSD_ENABLED is not set to true, no stats will be exposed"

--- a/docs/reference/statistics.md
+++ b/docs/reference/statistics.md
@@ -35,6 +35,8 @@ The YAML snippet will look something like -
 
  Ambassador automatically sends statistics information to a Kubernetes service called `statsd-sink` using typical StatsD protocol settings, UDP to port 8125. We have included a few example configurations in the [statsd-sink](https://github.com/datawire/ambassador/tree/master/statsd-sink) subdirectory to help you get started. Clone the repository to get local, editable copies.
 
+ You may also override the StatsD host by setting the `STATSD_HOST` environment variable. This can be useful if you have an existing StatsD sink available in your cluster.
+
 ## Graphite
 
 [Graphite](http://graphite.readthedocs.org/) is a web-based realtime graphing system. Spin up an example Graphite setup:


### PR DESCRIPTION
Allows end users to override the STATSD_HOST value while maintaining the existing behavior of defaulting to `statsd-sink. 

This is specifically valuable if you are hosting a daemonset of statsd sinks and adding node tags (we do this with telegraf) since you can use the downward api to target your node-local statsd sink automatically like so:
```yaml
        env:
        - name: STATSD_HOST
          valueFrom:
            fieldRef:
              fieldPath: status.hostIP
```