### PR TITLE
Fix ambassador single namespace in helm chart.

### DIFF
--- a/helm/ambassador/templates/deployment.yaml
+++ b/helm/ambassador/templates/deployment.yaml
@@ -41,8 +41,10 @@ spec:
             - name: admin
               containerPort: 8877
           env:
+          {{- if .Values.namespace.single }}
           - name: AMBASSADOR_SINGLE_NAMESPACE
-            value: {{ .Values.namespace.single | quote }}
+            value: {{ .Values.namespace.single }}
+          {{- end }}
           - name: AMBASSADOR_ID
             value: {{ .Values.ambassador.id | quote }}
           - name: AMBASSADOR_NAMESPACE

--- a/helm/ambassador/values.yaml
+++ b/helm/ambassador/values.yaml
@@ -6,7 +6,7 @@ ambassador:
   id: default
 
 namespace:
-  single: false
+  single:
   # name: default
 
 replicaCount: 1


### PR DESCRIPTION
According to the official documentation (https://www.getambassador.io/reference/running):
`If you only want Ambassador to only work within a single namespace, set AMBASSADOR_SINGLE_NAMESPACE as an environment variable.`

The current implementation of the helm chart (in `master`branch) always sets the `AMBASSADOR_SINGLE_NAMESPACE` (even if you set `single: false`, the variable is still present), so ambassador is not able to watch services in any namespace. This issue affects all implementations that have services in several namespaces.

This PR fixes the issue doing the `AMBASSADOR_SINGLE_NAMESPACE` variable as optional.
This change is backward-compatible as well.

**How to replicate the issue?**
1. Deploy ambassador: `helm install --name ambassador-release ../helm/ambassador/`
2. Deploy any service in any namespace (different than ambassador namespace).
e.g. `kubectl apply -f ../httpbin.yaml -n development`
You will notice that ambassador is not able to watch the service, because it is in different namespace.

**How to test this change?**
Replicate the previous steps and you will notice that ambassador is working properly even watching different namespaces.