### PR TITLE
More KAT cleanup

### DIFF
--- a/ambassador/tests/kat/abstract_tests.py
+++ b/ambassador/tests/kat/abstract_tests.py
@@ -198,7 +198,7 @@ class AmbassadorMixin:
                      "-v", "%s:/var/run/secrets/kubernetes.io/serviceaccount" % dir,
                      "-e", "KUBERNETES_SERVICE_HOST=kubernetes",
                      "-e", "KUBERNETES_SERVICE_PORT=443",
-                     "-e", "AMBASSADOR_ID=%s" % self.path.k8s,
+                     "-e", "AMBASSADOR_ID=%s" % self.ambassador_id,
                      image)
         result.check_returncode()
         self.deadline = time.time() + 3
@@ -276,7 +276,7 @@ class GRPC(ServiceType):
     pass
 
 @abstract_test
-class MappingTest(Test):
+class MappingBaseTest(Test):
 
     target: ServiceType
     options: Sequence['OptionTest']
@@ -284,6 +284,10 @@ class MappingTest(Test):
     def __init__(self, target: ServiceType, options = ()) -> None:
         self.target = target
         self.options = list(options)
+
+@abstract_test
+class MappingTest(MappingBaseTest):
+    pass
 
 @abstract_test
 class OptionTest(Test):

--- a/end-to-end/testscrape
+++ b/end-to-end/testscrape
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+import sys
+
 import os, re, shlex, subprocess, textwrap
 
 from kat import parser
@@ -43,15 +45,39 @@ def merge(kinds, kind):
                 if p not in values: values.append(p)
     return result
 
-def print_merged(obj, kind):
-    for k, v in obj.items():
-        print("%s:" % k)
+MasterKeys = [ 'name', 'apiVersion', 'ambassador_id' ]
 
-        if kind.startswith('Module-') and k == 'kind':
-            print("  %s" % kind)
-        else:
-            for s in v:
-                print("  %s" % s)
+def print_merged_key(printed, k, v, stream):
+    if k in printed:
+        return
+
+    stream.write("%s:\n" % k)
+
+    values = v
+
+    try:
+        values = sorted(v)
+    except TypeError:
+        pass
+
+    for s in values:
+        stream.write("  %s\n" % s)
+
+    printed[k] = True
+
+def print_merged(obj, kind, stream=sys.stdout):
+    printed = { 'kind': True }
+
+    stream.write("==== %s ================\n" % kind)
+
+    for k in MasterKeys:
+        if k in obj:
+            print_merged_key(printed, k, obj[k], stream)
+
+    for k in sorted(obj.keys()):
+        print_merged_key(printed, k, obj[k], stream)
+
+    stream.flush()
 
 KINDS = {
     "Mapping": True,
@@ -61,7 +87,7 @@ KINDS = {
     "RateLimitService": True
 }
 
-def doit(filenames):
+def doit(filenames, stream=sys.stdout):
     inputs = []
 
     for filename in filenames:
@@ -83,15 +109,13 @@ def doit(filenames):
                 kinds[kind] = []
             kinds[kind].append(o)
 
-    for k, v in kinds.items():
-        print("%s: %s" % (k, len(v)))
-
+    for k in sorted(kinds.keys()):
+        stream.write("%s: %s\n" % (k, len(kinds[k])))
 
     for kind in sorted(KINDS.keys()):
         if kind in kinds:
             merged = merge(kinds, kind)
-            print("====================")
-            print_merged(merged, kind)
+            print_merged(merged, kind, stream)
 
 # XXX: maybe map values into categories before merging, e.g. pure
 # alpha, embedded special, special beginning, special end, regex vs
@@ -140,7 +164,13 @@ print()
 
 input("Press enter to continue.")
 
-print("################OLD YAML################")
-doit(find_yaml(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "*.yaml"))
-print("################KAT YAML################")
-doit(find_yaml("/tmp/", "k8s-*.yaml"))
+with open("cov-old.txt", "w") as output:
+    print("Checking old coverage...")
+    output.write("################OLD YAML################\n")
+    doit(find_yaml(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "*.yaml"), output)
+
+with open("cov-new.txt", "w") as output:
+    print("Checking new coverage...")
+    output.write("################KAT YAML################\n")
+    doit(find_yaml("/tmp/", "k8s-*.yaml"), output)
+


### PR DESCRIPTION
But for right now, leave the `AmbassadorIDTest`s disabled. We'll fold them back in in a bit.