### PR TITLE
Update NOTES.txt to reflect getting the SERVICE_IP for Azure

### DIFF
--- a/helm/ambassador/templates/NOTES.txt
+++ b/helm/ambassador/templates/NOTES.txt
@@ -12,7 +12,7 @@ To get the IP address of Ambassador, run the following commands:
 NOTE: It may take a few minutes for the LoadBalancer IP to be available.
      You can watch the status of by running 'kubectl get svc -w  --namespace {{ .Release.Namespace }} {{ template "ambassador.fullname" . }}'
 
-  On GKE:
+  On GKE/Azure:
   export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "ambassador.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
 
   On AWS:


### PR DESCRIPTION
Verification for Azure/AKS:

```
➜  tmp kubectl get svc --namespace default ambassador -o jsonpath='{.status.loadBalancer.ingress[0].ip}'
23.99.196.208%                                                                                                                                                                                                                              ➜  tmp kubectl get svc --namespace default ambassador -o jsonpath='{.status.loadBalancer.ingress[0]}'
map[ip:23.99.196.208]%                                                                                                                                                                                                                      ```