### PR TITLE
Bump Helm chart version to 0.40.0

### DIFF
--- a/helm/ambassador/Chart.yaml
+++ b/helm/ambassador/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: "0.35.3"
+appVersion: "0.40.0"
 description: A Helm chart for Datawire Ambassador
 name: ambassador
-version: 0.35.4
+version: 0.40.0
 sources:
 - https://github.com/datawire/ambassador
 maintainers:


### PR DESCRIPTION
Set Helm chart `appVersion` and `version` to `0.40.0` so that the latest image is pulled.