### PR TITLE
adding correct protocol for upstream service

### DIFF
--- a/docs/user-guide/with-istio.md
+++ b/docs/user-guide/with-istio.md
@@ -292,7 +292,7 @@ metadata:
       prefix: /productpage/
       rewrite: /productpage
       tls: upstream
-      service: productpage:9080
+      service: https://productpage:9080
 spec:
   ports:
   - port: 9080


### PR DESCRIPTION
For Ambassador to use mTLS correctly, the upstream should specify the right protocol to use, in this case, https. Setting the "tls" option is not enough. Tested today with 0.40