### PR TITLE
Cleanup for EA1

### DIFF
--- a/ambassador/ambassador/cli.py
+++ b/ambassador/ambassador/cli.py
@@ -171,12 +171,12 @@ def dump(config_dir_path: Parameter.REQUIRED, *,
             od['diag'] = diag.as_dict()
             od['elements'] = diagconfig.elements
 
-        # json.dump(od, sys.stdout, sort_keys=True, indent=4)
-        # sys.stdout.write("\n")
-
         scout = Scout()
         result = scout.report(action="dump", mode="cli")
         show_notices(result)
+
+        json.dump(od, sys.stdout, sort_keys=True, indent=4)
+        sys.stdout.write("\n")
     except Exception as e:
         handle_exception("EXCEPTION from dump", e,
                          config_dir_path=config_dir_path)

--- a/ambassador/ambassador/envoy/v2/v2route.py
+++ b/ambassador/ambassador/envoy/v2/v2route.py
@@ -73,8 +73,14 @@ class V2Route(dict):
         host_redirect = group.get('host_redirect', None)
 
         if host_redirect:
-            self['redirect']['host_redirect'] = host_redirect.service
-            self['redirect']['path_redirect'] = host_redirect.path_redirect
+            self['redirect'] = {
+                'host_redirect': host_redirect.service
+            }
+
+            path_redirect = host_redirect.get('path_redirect', None)
+
+            if path_redirect:
+                self['redirect']['path_redirect'] = path_redirect
 
         cors = None
 

--- a/ambassador/tests/001-broader-v0/config/mapping-httpbin.yaml
+++ b/ambassador/tests/001-broader-v0/config/mapping-httpbin.yaml
@@ -3,6 +3,6 @@ apiVersion: ambassador/v0
 kind:  Mapping
 name:  httpbin_mapping
 prefix: /httpbin/
-service: http://httpbin.org
+service: wtfo://httpbin.org
 host_rewrite: httpbin.org
 timeout_ms: 50

--- a/ambassador/tests/001-broader-v0/config/mapping-redirector.yaml
+++ b/ambassador/tests/001-broader-v0/config/mapping-redirector.yaml
@@ -10,6 +10,14 @@ timeout_ms: 50
 ---
 apiVersion: ambassador/v0
 kind:  Mapping
+name:  redirect_host_only_mapping
+prefix: /redirect2/
+service: httpbin.org
+host_redirect: true
+timeout_ms: 50
+---
+apiVersion: ambassador/v0
+kind:  Mapping
 name:  bad_redirect_mapping
 prefix: /qotm/
 service: httpbin.org

--- a/ambassador/tests/001-broader-v0/gold.intermediate.json
+++ b/ambassador/tests/001-broader-v0/gold.intermediate.json
@@ -57,7 +57,7 @@
                 "_source": "mapping-httpbin.yaml.1",
                 "host_rewrite": "httpbin.org",
                 "lb_type": "round_robin",
-                "name": "cluster_http___httpbin_org",
+                "name": "cluster_wtfo___httpbin_org",
                 "type": "strict_dns",
                 "urls": [
                     "tcp://httpbin.org:80"
@@ -228,7 +228,7 @@
                 },
                 "type": "strict_dns",
                 "urls": [
-                    "tcp://myservice.org/:443"
+                    "tcp://myservice.org:443"
                 ]
             },
             {
@@ -339,7 +339,7 @@
                 "_source": "mapping-httpbin-shadow.yaml.1",
                 "clusters": [
                     {
-                        "name": "cluster_http___httpbin_org",
+                        "name": "cluster_wtfo___httpbin_org",
                         "weight": 100.0
                     }
                 ],
@@ -1094,7 +1094,7 @@
             "kind": "Mapping",
             "name": "httpbin_mapping",
             "version": "ambassador/v0",
-            "yaml": "apiVersion: ambassador/v0\nhost_rewrite: httpbin.org\nkind: Mapping\nname: httpbin_mapping\nprefix: /httpbin/\nservice: http://httpbin.org\ntimeout_ms: 50\n"
+            "yaml": "apiVersion: ambassador/v0\nhost_rewrite: httpbin.org\nkind: Mapping\nname: httpbin_mapping\nprefix: /httpbin/\nservice: wtfo://httpbin.org\ntimeout_ms: 50\n"
         },
         "test source.1": {
             "_source": "test source",

--- a/ambassador/tests/001-broader-v0/gold.intermediate.json
+++ b/ambassador/tests/001-broader-v0/gold.intermediate.json
@@ -197,10 +197,10 @@
             },
             {
                 "_referenced_by": [
-                    "mapping-redirector.yaml.2"
+                    "mapping-redirector.yaml.3"
                 ],
                 "_service": "httpbin.org",
-                "_source": "mapping-redirector.yaml.2",
+                "_source": "mapping-redirector.yaml.3",
                 "lb_type": "round_robin",
                 "name": "cluster_shadow_httpbin_org",
                 "type": "strict_dns",
@@ -457,6 +457,27 @@
             {
                 "__saved": [
                     0,
+                    11,
+                    0,
+                    "/redirect2/",
+                    "GET"
+                ],
+                "_group_id": "588cefdd117b8793eb86711bd22616b13b853ffb",
+                "_method": "GET",
+                "_precedence": 0,
+                "_referenced_by": [
+                    "mapping-redirector.yaml.2"
+                ],
+                "_source": "mapping-redirector.yaml.2",
+                "clusters": [],
+                "host_redirect": "httpbin.org",
+                "prefix": "/redirect2/",
+                "prefix_rewrite": "/",
+                "timeout_ms": 50
+            },
+            {
+                "__saved": [
+                    0,
                     26,
                     0,
                     "/ambassador/v0/check_alive",
@@ -638,7 +659,7 @@
                 "_precedence": 0,
                 "_referenced_by": [
                     "mapping-qotm.yaml.1",
-                    "mapping-redirector.yaml.2"
+                    "mapping-redirector.yaml.3"
                 ],
                 "_source": "mapping-qotm.yaml.1",
                 "clusters": [
@@ -894,7 +915,7 @@
         ]
     },
     "errors": {
-        "mapping-redirector.yaml.2": [
+        "mapping-redirector.yaml.3": [
             {
                 "error": "At most one of host_redirect and shadow may be set; ignoring host_redirect",
                 "hostname": "sanitized",
@@ -957,7 +978,8 @@
         },
         "mapping-redirector.yaml": {
             "mapping-redirector.yaml.1": true,
-            "mapping-redirector.yaml.2": true
+            "mapping-redirector.yaml.2": true,
+            "mapping-redirector.yaml.3": true
         },
         "mapping-websocket.yaml": {
             "mapping-websocket.yaml.1": true
@@ -1170,6 +1192,15 @@
         },
         "mapping-redirector.yaml.2": {
             "_source": "mapping-redirector.yaml",
+            "filename": "mapping-redirector.yaml",
+            "index": 2,
+            "kind": "Mapping",
+            "name": "redirect_host_only_mapping",
+            "version": "ambassador/v0",
+            "yaml": "apiVersion: ambassador/v0\nhost_redirect: true\nkind: Mapping\nname: redirect_host_only_mapping\nprefix: /redirect2/\nservice: httpbin.org\ntimeout_ms: 50\n"
+        },
+        "mapping-redirector.yaml.3": {
+            "_source": "mapping-redirector.yaml",
             "errors": [
                 {
                     "error": "At most one of host_redirect and shadow may be set; ignoring host_redirect",
@@ -1180,7 +1211,7 @@
                 }
             ],
             "filename": "mapping-redirector.yaml",
-            "index": 2,
+            "index": 3,
             "kind": "Mapping",
             "name": "bad_redirect_mapping",
             "version": "ambassador/v0",

--- a/ambassador/tests/001-broader-v0/gold.json
+++ b/ambassador/tests/001-broader-v0/gold.json
@@ -88,7 +88,14 @@
                       
                     }
                     ,
-                    
+                    {
+                      "timeout_ms": 50,"prefix": "/redirect2/","host_redirect": "httpbin.org"
+
+
+
+
+                    }
+                    ,
                     {
                       "timeout_ms": 50,"prefix": "/redirect/","host_redirect": "httpbin.org",
                          "path_redirect": "/ip/"

--- a/ambassador/tests/001-broader-v0/gold.json
+++ b/ambassador/tests/001-broader-v0/gold.json
@@ -115,7 +115,7 @@
                       "timeout_ms": 50,"prefix": "/httpbin/","prefix_rewrite": "/","host_rewrite": "httpbin.org","weighted_clusters": {
                               "clusters": [
                                   
-                                    { "name": "cluster_http___httpbin_org", "weight": 100.0 }
+                                    { "name": "cluster_wtfo___httpbin_org", "weight": 100.0 }
                                   
                               ]
                           },
@@ -348,17 +348,6 @@
           
         ]},
       {
-        "name": "cluster_http___httpbin_org",
-        "connect_timeout_ms": 3000,
-        "type": "strict_dns",
-        "lb_type": "round_robin",        
-        "hosts": [
-          {
-            "url": "tcp://httpbin.org:80"
-          }
-          
-        ]},
-      {
         "name": "cluster_http___qotm",
         "connect_timeout_ms": 3000,
         "type": "strict_dns",
@@ -480,7 +469,7 @@
         "lb_type": "round_robin",        
         "hosts": [
           {
-            "url": "tcp://myservice.org/:443"
+            "url": "tcp://myservice.org:443"
           }
           
         ],
@@ -499,8 +488,18 @@
             "url": "tcp://slack.com:80"
           }
           
+        ]},
+      {
+        "name": "cluster_wtfo___httpbin_org",
+        "connect_timeout_ms": 3000,
+        "type": "strict_dns",
+        "lb_type": "round_robin",
+        "hosts": [
+          {
+            "url": "tcp://httpbin.org:80"
+          }
+
         ]}
-      
     ]
   },
   


### PR DESCRIPTION
- Reenable output from `ambassador dump` (sigh)
- Be more careful transforming the `service` into a `url` in `IRCluster`
   - for example: `service: https://example.com/` was turning into `tcp://example.com/:443`, which is completely wrong and gave `V2Cluster` fits
- Correctly handle `host_redirect` and `path_redirect` in `V2Route`
- Simple tests for the above changes
