### PR TITLE
Ignore TLS if invalid secret or paths

### DIFF
--- a/ambassador/ambassador/ir/ir.py
+++ b/ambassador/ambassador/ir/ir.py
@@ -60,9 +60,11 @@ class IR:
     tls_defaults: Dict[str, Dict[str, str]]
     aconf: Config
 
-    def __init__(self, aconf: Config, tls_secret_resolver=None) -> None:
+    def __init__(self, aconf: Config, tls_secret_resolver=None, file_checker=None) -> None:
         self.logger = logging.getLogger("ambassador.ir")
         self.tls_secret_resolver = tls_secret_resolver
+        self.file_checker = file_checker if file_checker is not None else os.path.isfile
+        self.logger.debug("File checker: {}".format(self.file_checker.__name__))
 
         # First up: save the Config object. Its source map may be necessary later.
         self.aconf = aconf

--- a/ambassador/ambassador/ir/irambassador.py
+++ b/ambassador/ambassador/ir/irambassador.py
@@ -106,13 +106,9 @@ class IRAmbassador (IRResource):
                         self.logger.debug("not updating context %s from %s" % (ctx_name, ctxloc))
                         # self.logger.debug(etls.as_json())
 
-        # Next up, check for the special 'server' and 'client' TLS contexts.
-        ctx = ir.get_tls_context('server')
-
-        if ctx:
-            # Server-side TLS is enabled; switch to port 443.
-            self.logger.debug("TLS termination enabled!")
-            self.service_port = 443
+                    if etls.get('valid_tls'):
+                        self.logger.debug("TLS termination enabled!")
+                        self.service_port = 443
 
         ctx = ir.get_tls_context('client')
 

--- a/ambassador/ambassador/utils.py
+++ b/ambassador/ambassador/utils.py
@@ -185,7 +185,7 @@ def read_cert_secret(k8s_api, secret_name, namespace):
         cert_data = k8s_api.read_namespaced_secret(secret_name, namespace)
     except client.rest.ApiException as e:
         if e.reason == "Not Found":
-            pass
+            logger.info("secret {} not found".format(secret_name))
         else:
             logger.info("secret %s/%s could not be read: %s" % (namespace, secret_name, e))
 
@@ -201,7 +201,7 @@ def read_cert_secret(k8s_api, secret_name, namespace):
         if key:
             key = binascii.a2b_base64(key)
 
-    return (cert, key, cert_data)
+    return cert, key, cert_data
 
 
 def save_cert(cert, key, dir):

--- a/ambassador/tests/001-broader-v0/gold.intermediate.json
+++ b/ambassador/tests/001-broader-v0/gold.intermediate.json
@@ -93,7 +93,8 @@
                 ],
                 "tls_context": {
                     "_ambassador_enabled": true,
-                    "namespace": "default"
+                    "namespace": "default",
+                    "valid_tls": false
                 },
                 "type": "strict_dns",
                 "urls": [
@@ -226,7 +227,8 @@
                 ],
                 "tls_context": {
                     "_ambassador_enabled": true,
-                    "namespace": "default"
+                    "namespace": "default",
+                    "valid_tls": false
                 },
                 "type": "strict_dns",
                 "urls": [

--- a/ambassador/tests/007-originating-tls/gold.intermediate.json
+++ b/ambassador/tests/007-originating-tls/gold.intermediate.json
@@ -46,7 +46,8 @@
                     "_source": "tls.yaml.1",
                     "cert_chain_file": "/etc/ambassador-config/certs/outbound.crt",
                     "private_key_file": "/etc/ambassador-config/certs/outbound.key",
-                    "namespace": "default"
+                    "namespace": "default",
+                    "valid_tls": true
                 },
                 "type": "strict_dns",
                 "urls": [
@@ -79,7 +80,8 @@
                     "_source": "tls.yaml.1",
                     "cert_chain_file": "/etc/ambassador-config/certs/outbound.crt",
                     "private_key_file": "/etc/ambassador-config/certs/outbound.key",
-                    "namespace": "default"
+                    "namespace": "default",
+                    "valid_tls": true
                 },
                 "type": "strict_dns",
                 "urls": [

--- a/ambassador/tests/ambassador_test.py
+++ b/ambassador/tests/ambassador_test.py
@@ -513,7 +513,7 @@ def test_config(testname, dirpath, configdir):
     aconf = Config()
     aconf.load_all(resources)
 
-    ir = IR(aconf)
+    ir = IR(aconf, file_checker=file_always_exists)
     v1config = V1Config(ir)
 
     print("==== checking IR")
@@ -633,3 +633,7 @@ def test_diag(testname, dirpath, configdir):
         print("%s" % results['reconstituted'])
     
     assert errorcount == 0, ("failing, _errors: %d" % errorcount)
+
+
+def file_always_exists(filename):
+    return True

--- a/ambassador/tests/kat/test_ambassador.py
+++ b/ambassador/tests/kat/test_ambassador.py
@@ -67,6 +67,34 @@ service: {self.target.path.k8s}
     def queries(self):
         yield Query(self.url("tls-target/"), insecure=True)
 
+
+class TLSInvalidSecret(TLS):
+
+    def config(self):
+        yield self, self.format("""
+---
+apiVersion: ambassador/v0
+kind: Module
+name: tls
+ambassador_id: {self.ambassador_id}
+config:
+  server:
+    enabled: True
+    secret: test-certs-secret-invalid
+""")
+
+        yield self.target, self.format("""
+---
+apiVersion: ambassador/v0
+kind:  Mapping
+name:  tls_target_mapping
+prefix: /tls-target/
+service: {self.target.path.k8s}
+""")
+
+    def scheme(self) -> str:
+        return "http"
+
 class RedirectTests(AmbassadorTest):
 
     def init(self):


### PR DESCRIPTION
This commit does not turn TLS on and change port to 443 if an
invalid secret or an invalid path is supplied by the end user.