### PR TITLE
add support for querying in phases

### DIFF
--- a/kat/kat/harness.py
+++ b/kat/kat/harness.py
@@ -214,7 +214,8 @@ class Test(Node):
 
 class Query:
 
-    def __init__(self, url, expected=200, method="GET", headers=None, insecure=False, skip = None, xfail = None):
+    def __init__(self, url, expected=200, method="GET", headers=None, insecure=False, skip = None, xfail = None,
+                 phase=1):
         self.method = method
         self.url = url
         self.headers = headers
@@ -222,6 +223,7 @@ class Query:
         self.expected = expected
         self.skip = skip
         self.xfail = xfail
+        self.phase = phase
         self.parent = None
         self.result = None
 
@@ -643,10 +645,13 @@ class Runner:
                     t.pending.append(q)
                     queries.append(q)
 
-        if queries:
-            print("Querying %s urls..." % len(queries), end="")
+        phases = sorted(set([q.phase for q in queries]))
+
+        for phase in phases:
+            phase_queries = [q for q in queries if q.phase == phase]
+            print("Querying %s urls in phase %s..." % (len(phase_queries), phase), end="")
             sys.stdout.flush()
-            results = query(queries)
+            results = query(phase_queries)
             print(" done.")
 
             for r in results:


### PR DESCRIPTION
**Note:** this PR is on top of the rhs/test-readiness-check branch, aka PR #902 

This PR adds support for querying in phases in order to allow some control over ordering of queries. This is utilized by using the optional `phase` keyword argument for `Query`, e.g. `yield Query(url, phase=1); yield Query(url, phase=2)` will result in the phase 2 query being guaranteed to occur after the phase 1 query. The phase argument defaults to 1.