### PR TITLE
Tracing (and other) notification fixes

### DIFF
--- a/ambassador/ambassador/ambscout.py
+++ b/ambassador/ambassador/ambscout.py
@@ -131,7 +131,7 @@ class AmbScout:
 
         if not self.semver:
             _notices.append({
-                "level": "warning",
+                "level": "WARNING",
                 "message": "Ambassador has invalid version '%s'??!" % self.version
             })
 

--- a/ambassador/ambassador_diag/diagd.py
+++ b/ambassador/ambassador_diag/diagd.py
@@ -142,7 +142,7 @@ class Notices:
         except OSError:
             pass
         except:
-            local_notices.append({ 'lvl': 'error', 'msg': 'bad local notices: %s' % local_data })
+            local_notices.append({ 'level': 'ERROR', 'message': 'bad local notices: %s' % local_data })
 
         self.notices = local_notices
 
@@ -177,7 +177,7 @@ def get_aconf(app, what):
     uptime = datetime.datetime.now() - boot_time
     hr_uptime = td_format(uptime)
 
-    app.notices = Notices()
+    app.notices = Notices(app.notice_path)
     app.notices.reset()
 
     app.scout = Scout()
@@ -188,6 +188,7 @@ def get_aconf(app, what):
     app.notices.extend(app.scout_result.pop('notices', []))
 
     app.logger.info("Scout reports %s" % json.dumps(app.scout_result))
+    app.logger.info("Scout notices: %s" % json.dumps(app.notices.notices))
 
     return aconf
 
@@ -291,7 +292,7 @@ def show_overview(reqid=None):
         app.logger.debug("OV %s -- requesting loglevel %s" % (reqid, loglevel))
 
         if not app.estats.update_log_levels(time.time(), level=loglevel):
-            notice = { 'lvl': 'warning', 'msg': "Could not update log level!" }
+            notice = { 'level': 'WARNING', 'message': "Could not update log level!" }
         # else:
         #     return redirect("/ambassador/v0/diag/", code=302)
 
@@ -300,7 +301,8 @@ def show_overview(reqid=None):
     econf = EnvoyConfig.generate(ir, "V2")
     diag = Diagnostics(ir, econf)
 
-    app.notices.prepend(notice)
+    if notice:
+        app.notices.prepend(notice)
 
     if app.verbose:
         app.logger.debug("OV %s: DIAG" % reqid)

--- a/ambassador/kubewatch.py
+++ b/ambassador/kubewatch.py
@@ -199,7 +199,8 @@ class Restarter(threading.Thread):
             logger.warning("RESTART REQUIRED: bootstrap changed")
 
             with open(os.path.join(self.config_root, "notices.json"), "w") as notices:
-                notices.write(json.dumps([{ 'lvl': 'warning', 'msg': 'RESTART REQUIRED! after bootstrap change' }],
+                notices.write(json.dumps([{ 'level': 'WARNING',
+                                            'message': 'RESTART REQUIRED! after bootstrap change' }],
                                          sort_keys=True, indent=4))
                 notices.write("\n")
 


### PR DESCRIPTION
If you change the `TracingService` configuration, Ambassador 0.50.0 currently requires a restart. Report that correctly -- and fix a bunch of other annoying notification issues, too.
