### PR TITLE
Add support for AMBASSADOR_VERIFY_SSL_FALSE to helm chart

### DIFF
--- a/helm/ambassador/templates/deployment.yaml
+++ b/helm/ambassador/templates/deployment.yaml
@@ -62,6 +62,8 @@ spec:
           {{- end }}
           - name: AMBASSADOR_ID
             value: {{ .Values.ambassador.id | quote }}
+          - name: AMBASSADOR_VERIFY_SSL_FALSE
+            value: {{ .Values.ambassador.verifySslFalse | quote }}            
           - name: AMBASSADOR_NAMESPACE
             {{- if .Values.namespace.name }}
             value: {{ .Values.namespace.name | quote }}

--- a/helm/ambassador/values.yaml
+++ b/helm/ambassador/values.yaml
@@ -4,6 +4,7 @@
 
 ambassador:
   id: default
+  verifySslFalse: false
 
 namespace:
   single: false


### PR DESCRIPTION
Add support for AMBASSADOR_VERIFY_SSL_FALSE to helm chart by adding the variable to deployment and setting the default in values.yaml to false