### PR TITLE
Fix tls-termination doc typo.

### DIFF
--- a/docs/user-guide/tls-termination.md
+++ b/docs/user-guide/tls-termination.md
@@ -176,4 +176,4 @@ spec:
       - cloud.foo.com
 ```
 
-Note the `secretName` line above. When the certificate has been stored in the secret, restart Ambasador to pick up the new certificate.
+Note the `secretName` line above. When the certificate has been stored in the secret, restart Ambassador to pick up the new certificate.


### PR DESCRIPTION
Hi, thanks for the awesome work!
Here is a modest PR to fix a small typo in the documentation introduced in #505 

Signed-off-by: Theotime Leveque <theotime.leveque@gmail.com>