### PR TITLE
Make config dirs tunable

### DIFF
--- a/ambassador/entrypoint.sh
+++ b/ambassador/entrypoint.sh
@@ -18,10 +18,8 @@ export LC_ALL=C.UTF-8
 export LANG=C.UTF-8
 
 AMBASSADOR_ROOT="/ambassador"
-CONFIG_DIR="$AMBASSADOR_ROOT/ambassador-config"
-ENVOY_CONFIG_FILE="$AMBASSADOR_ROOT/envoy.json"
-
-export PYTHON_EGG_CACHE=${AMBASSADOR_ROOT}
+CONFIG_DIR="${CUSTOM_CONFIG_BASE_DIR:-$AMBASSADOR_ROOT}/ambassador-config"
+ENVOY_CONFIG_FILE="${CUSTOM_CONFIG_BASE_DIR:-$AMBASSADOR_ROOT}/envoy.json"
 
 if [ "$1" == "--demo" ]; then
     CONFIG_DIR="$AMBASSADOR_ROOT/ambassador-demo-config"
@@ -33,7 +31,7 @@ APPDIR=${APPDIR:-"$AMBASSADOR_ROOT"}
 
 # If we don't set PYTHON_EGG_CACHE explicitly, /.cache is set by default, which fails when running as a non-privileged
 # user
-export PYTHON_EGG_CACHE=${APPDIR/.cache}
+export PYTHON_EGG_CACHE="${PYTHON_EGG_CACHE:-$APPDIR}/.cache"
 
 export PYTHONUNBUFFERED=true
 
@@ -62,7 +60,7 @@ diediedie() {
     fi
 
     echo "Here's the envoy.json we were trying to run with:"
-    LATEST="$(ls -v $AMBASSADOR_ROOT/envoy*.json | tail -1)"
+    LATEST="$(ls -v ${CUSTOM_CONFIG_BASE_DIR:-$AMBASSADOR_ROOT}/envoy*.json | tail -1)"
     if [ -e "$LATEST" ]; then
         cat "$LATEST"
     else

--- a/ambassador/start-envoy.sh
+++ b/ambassador/start-envoy.sh
@@ -17,6 +17,7 @@
 DRAIN_TIME=${AMBASSADOR_DRAIN_TIME:-5}
 SHUTDOWN_TIME=${AMBASSADOR_SHUTDOWN_TIME:-10}
 AMBASSADOR_ROOT="/ambassador"
+CONFIG_DIR="${CUSTOM_CONFIG_BASE_DIR:-$AMBASSADOR_ROOT}"
 
-LATEST=$(ls -1v "$AMBASSADOR_ROOT"/envoy*.json | tail -1)
+LATEST=$(ls -1v "$CONFIG_DIR"/envoy*.json | tail -1)
 exec /usr/local/bin/envoy -c ${LATEST} --restart-epoch $RESTART_EPOCH --drain-time-s "${DRAIN_TIME}" --service-cluster "${AMBASSADOR_ID:-ambassador}-${AMBASSADOR_NAMESPACE}" --parent-shutdown-time-s "${SHUTDOWN_TIME}"


### PR DESCRIPTION
**What**

- Make config dirs for both `ambassador` and `envoy` tunable via custom ENV `CUSTOM_CONFIG_BASE_DIR`. Defaults to current dir (`$AMBASSADOR_ROOT`) if not set

- Also fixed a bug how the `PYTHON_EGG_CACHE` is set, it was not overwritable and was writing to root of the app while  the original intent was `$APPDIR}/.cache`

**Why**
This allows folks to eg. use `tmpfs` mounts on k8s when writing to read is not permitted.

**Open**

I didn't quite grasp why both `envoy.json` and `envoy*.json` is used, could be cleaned up if latter could be dropped.