### PR TITLE
Fix Helm charts Nodeport setup by setting Nodeport on HTTPS side

### DIFF
--- a/helm/ambassador/templates/service.yaml
+++ b/helm/ambassador/templates/service.yaml
@@ -18,19 +18,22 @@ spec:
 {{- end }}
   ports:
     {{- if .Values.service.enableHttp }}
-    - port: {{ .Values.service.port }}
+    - port: {{ .Values.service.httpPort }}
       targetPort: http
       protocol: TCP
       name: http
-      {{- with .Values.service.nodePort }}
+      {{- with .Values.service.httpNodePort }}
       nodePort: {{ toYaml . }}
       {{- end }}
     {{- end }}
     {{- if .Values.service.enableHttps }}
-    - port: 443
+    - port: {{ .Values.service.httpsPort }}
       targetPort: https
       protocol: TCP
       name: https
+      {{- with .Values.service.httpsNodePort }}
+      nodePort: {{ toYaml . }}
+      {{- end }}
     {{- end }}
   selector:
     app: {{ template "ambassador.name" . }}

--- a/helm/ambassador/values.yaml
+++ b/helm/ambassador/values.yaml
@@ -30,9 +30,11 @@ service:
 
 
   type: LoadBalancer
-  port: 80
+  httpPort: 80
+  httpsPort: 443
   #Nodeport to use  if type is selected as Nodeport otherwise it will be ignored
-  #nodePort : 30039
+  #httpNodePort : 30080
+  #httpsNodePort : 30443
   # annotations:
   #   getambassador.io/config: |
   #     ---


### PR DESCRIPTION
**What**

- Add `nodePort` to `https` side in the k8s service
- Make both `http` and `https` ports configurable rather than hardcoding latter to 443

**Why**

Without a dedicated `nodePort` per `port` k8s will just choose one randomly and most likely it will be orphaned from the actual backend

The latter change for having 443 configurable is more of a nicety, but usually people being behind ELB's and such don't use 80/443 here.