### PR TITLE
Adding volumes and volumeMounts to ambassador service helm chart

### DIFF
--- a/helm/ambassador/Chart.yaml
+++ b/helm/ambassador/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: "0.40.0"
+appVersion: "0.40.1"
 description: A Helm chart for Datawire Ambassador
 name: ambassador
-version: 0.40.0
+version: 0.40.1
 sources:
 - https://github.com/datawire/ambassador
 maintainers:

--- a/helm/ambassador/README.md
+++ b/helm/ambassador/README.md
@@ -50,7 +50,9 @@ The following tables lists the configurable parameters of the Ambassador chart a
 | `image.pullPolicy` | Image pull policy | `IfNotPresent`
 | `image.imagePullSecrets` | Image pull secrets | None
 | `daemonSet` | If `true `, Create a daemonSet. By default Deployment controller will be created | `false` 
-| `replicaCount`  | Number of Ambassador replicas  | `1`
+| `replicaCount` | Number of Ambassador replicas  | `1`
+| `volumes` | Volumes for the ambassador service | None
+| `volumeMounts` | Volume mounts for the ambassador service | None
 | `resources` | CPU/memory resource requests/limits | None
 | `rbac.create` | If `true`, create and use RBAC resources | `true`
 | `serviceAccount.create` | If `true`, create a new service account | `true`

--- a/helm/ambassador/templates/deployment.yaml
+++ b/helm/ambassador/templates/deployment.yaml
@@ -32,6 +32,9 @@ spec:
           items:
           - key: exporterConfiguration
             path: mapping-config.yaml
+      {{- with .Values.volumes }}
+{{ toYaml . | indent 6 }}
+      {{- end -}}
       containers:
         - name: statsd-sink
           image: "{{ .Values.exporter.image }}"
@@ -96,6 +99,10 @@ spec:
               port: admin
             initialDelaySeconds: 30
             periodSeconds: 3
+          {{- with .Values.volumeMounts }}
+          volumeMounts:
+{{ toYaml . | indent 10 }}
+          {{- end -}}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
     {{- with .Values.nodeSelector }}

--- a/helm/ambassador/values.yaml
+++ b/helm/ambassador/values.yaml
@@ -60,6 +60,10 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name: 
 
+volumes: {}
+
+volumeMounts: {}
+
 resources: {}
   # If you do want to specify resources, uncomment the following
   # lines, adjust them as necessary, and remove the curly braces after 'resources:'.


### PR DESCRIPTION
We need to use volume mounts to import our SSL certificate into ambassador (due to how it's being stored), and the helm chart doesn't allow us to add volume mounts. This PR adds that capability.