### PR TITLE
Minor documentation clarifications

### DIFF
--- a/docs/reference/ambassador-with-aws.md
+++ b/docs/reference/ambassador-with-aws.md
@@ -1,16 +1,16 @@
 # Ambassador on AWS
 
-The following is a sample configuration for deploying Ambassador in AWS (this configuration is templated using [Forge](https://forge.sh)):
+The following is a sample configuration for deploying Ambassador in AWS:
 
 ```
 ---
 apiVersion: v1
 kind: Service
 metadata:
-  name: ambassador-main-{{ build.profile.name }}
-  namespace: {{ service.namespace }}
+  name: ambassador
+  namespace: {{ ambassador namespace }}
   annotations:
-    service.beta.kubernetes.io/aws-load-balancer-ssl-cert: "{{ service.ambassador.tlsCertificateArn }}"
+    service.beta.kubernetes.io/aws-load-balancer-ssl-cert: "{{ tls certificate ARN }}"
     service.beta.kubernetes.io/aws-load-balancer-ssl-ports: "*"
     service.beta.kubernetes.io/aws-load-balancer-backend-protocol: "tcp"
     service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: "true"
@@ -21,7 +21,7 @@ metadata:
       kind:  Module
       name:  ambassador
       config:
-        use_proxy_proto: {{ service.ambassador.useProxyProtocol | lower }}
+        use_proxy_proto: true
         use_remote_address: true
 spec:
   type: LoadBalancer
@@ -30,7 +30,7 @@ spec:
     port: 443
     targetPort: 80
   selector:
-    service: ambassador-{{ build.profile.name }}
+    service: ambassador
 ```
 
 In this configuration, an ELB is deployed with a multi-domain AWS Certificate Manager certificate. The ELB is configured to route TCP to support both WebSockets and HTTP. Ambassador is configured with `use_remote_address` and `use_proxy_proto` to ensure that remote IP addresses are passed through properly. TLS termination then occurs at the ELB.

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -37,3 +37,5 @@ Ambassador's configuration is assembled from multiple YAML blocks, to help enabl
 - Be careful of mapping collisions.
 
     If two different developers try to map `/user/` to something, this can lead to unexpected behavior. Ambassador's canary-deployment logic means that it's more likely that traffic will be split between them than that it will throw an error -- again, the diagnostic service can help you here.
+    
+**Note:** Unless specified, mapping attributes cannot be applied to any other resource type.

--- a/docs/reference/running.md
+++ b/docs/reference/running.md
@@ -68,6 +68,16 @@ Given that `AMBASSADOR_NAMESPACE` is set, Ambassador [mappings](/reference/mappi
 
 If you only want Ambassador to only work within a single namespace, set `AMBASSADOR_SINGLE_NAMESPACE` as an environment variable.
 
+```
+env:
+- name: AMBASSADOR_NAMESPACE
+  valueFrom:
+    fieldRef:
+      fieldPath: metadata.namespace 
+- name: AMBASSADOR_SINGLE_NAMESPACE
+  value: "true"
+```
+
 ## Multiple Ambassadors in One Cluster
 
 Ambassador supports running multiple Ambassadors in the same cluster, without restricting a given Ambassador to a single namespace. This is done with the `AMBASSADOR_ID` setting. In the Ambassador module, set the `ambassador_id`, e.g.,
@@ -131,7 +141,7 @@ service: demo4
 
 The list syntax (shown in `mapping_used_2` above) permits including a given object in the configuration for multiple Ambassadors. In this case `mapping_used_2` will be included in the configuration for `ambassador-1` and also for `ambassador-2`.
 
-**Note well that _any_ object can have an `ambassador_id` included** so, for example, it is _fully supported_ to use `ambassador_id` to qualify the `ambassador Module`, `TLS`, and `AuthService` objects.
+**Note well that _any_ object can and should have an `ambassador_id` included** so, for example, it is _fully supported_ to use `ambassador_id` to qualify the `ambassador Module`, `TLS`, and `AuthService` objects. You will need to set Ambassador_id in all resources you want to use for Ambassador.
 
 If no `AMBASSADOR_ID` is assigned to an Ambassador, it will use the ID `default`. If no `ambassador_id` is present in a YAML object, it will also use the ID `default`.
 

--- a/docs/user-guide/grpc.md
+++ b/docs/user-guide/grpc.md
@@ -278,7 +278,7 @@ spec:
         client:
           enabled: false
         upstream:
-          alpn_protocols: ["h2"]
+          alpn_protocols: h2
 ```
 We need to tell Ambassador to route to the `service:` over https and have the service listen on `443`. We also need to give tell Ambassador to use ALPN protocols when originating TLS with the application, the same way we did with TLS termination. This is done by setting `alpn_protocols: ["h2"]` under a tls-context name (like `upstream`) in the TLS module and telling the service to use that tls-context in the mapping by setting `tls: upstream`. 
 


### PR DESCRIPTION
_AWS:_ Removed Forge templating since it was confusing users

_Running:_ Added example for using `AMBASSADOR_SINGLE_NAMESPACE` since it was a little ambiguous. Adding wording to clarify you *need* `ambassador_id` in all configuration resources

_Configuration:_ Added wording to try and clarify mapping attributes don't apply to other resources unless specified

_gRPC:_ Fixed configuration error in example config