### PR TITLE
Clean up most mypy warnings

### DIFF
--- a/ambassador/ambassador/config/acresource.py
+++ b/ambassador/ambassador/config/acresource.py
@@ -208,7 +208,9 @@ class ResourceFetcher:
                               (self.filepath, self.ocount, kind))
             return
 
-        self.filename += ":annotation"
+        if self.filename:
+            self.filename += ":annotation"
+
         self.load_yaml(annotations, rkey=resource_identifier)
 
     def process_object(self, obj: dict, rkey: Optional[str]=None, k8s: bool=False) -> int:

--- a/ambassador/ambassador/config/config.py
+++ b/ambassador/ambassador/config/config.py
@@ -64,7 +64,7 @@ class Config:
     # rkey => ACResource
     sources: Dict[str, ACResource]
 
-    errors: Dict[str, List[str]]
+    errors: Dict[str, List[dict]]
     fatal_errors: int
     object_errors: int
 
@@ -126,7 +126,7 @@ class Config:
         return "\n".join(s)
 
     def as_dict(self) -> Dict[str, Any]:
-        od = {
+        od: Dict[str, Any] = {
             '_errors': self.errors,
             '_sources': self.sources,
         }

--- a/ambassador/ambassador/config/config.py
+++ b/ambassador/ambassador/config/config.py
@@ -50,7 +50,7 @@ class Config:
     ambassador_namespace: ClassVar[str] = os.environ.get('AMBASSADOR_NAMESPACE', 'default')
 
     # INSTANCE VARIABLES
-    ambassador_nodename: str = None
+    ambassador_nodename: str = "ambassador"     # overridden in Config.reset
 
     current_resource: Optional[ACResource] = None
 

--- a/ambassador/ambassador/envoy/v1/v1route.py
+++ b/ambassador/ambassador/envoy/v1/v1route.py
@@ -13,10 +13,11 @@
 # limitations under the License
 
 from typing import List, Tuple, TYPE_CHECKING
+from typing import cast as typecast
 
 from ..common import EnvoyRoute
 from ...ir import IRResource
-from ...ir.irmapping import IRMappingGroup
+from ...ir.irmapping import IRMapping, IRMappingGroup
 
 from .v1ratelimitaction import V1RateLimitAction
 
@@ -66,10 +67,12 @@ class V1Route(dict):
         # print(len(group.get('headers', [])) > 0)
 
         if group.get("host_redirect", None):
-            self["host_redirect"] = group.host_redirect.service
+            hr: IRMapping = typecast(IRMapping, group.host_redirect)
 
-            if "path_redirect" in group.host_redirect:
-                self["path_redirect"] = group.host_redirect.path_redirect
+            self["host_redirect"] = hr.service
+
+            if "path_redirect" in hr:
+                self["path_redirect"] = hr.path_redirect
         else:
             # Don't include prefix_rewrite unless group.rewrite is present and not
             # empty. The special handling is so that using rewrite: "" in an

--- a/ambassador/ambassador/envoy/v1/v1tracing.py
+++ b/ambassador/ambassador/envoy/v1/v1tracing.py
@@ -12,7 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License
 
-from typing import Optional, TYPE_CHECKING
+from typing import TYPE_CHECKING
+from typing import cast as typecast
+
+from ...ir.irtracing import IRTracing
 
 if TYPE_CHECKING:
     from . import V1Config
@@ -20,12 +23,17 @@ if TYPE_CHECKING:
 
 class V1Tracing(dict):
     def __init__(self, config: 'V1Config') -> None:
+        # We should never be instantiated unless there is, in fact, defined tracing stuff.
+        assert config.ir.tracing
+
         super().__init__()
+
+        tracing = typecast(IRTracing, config.ir.tracing)
 
         self['http'] = {
             "driver": {
-                "type": config.ir.tracing['driver'],
-                "config": config.ir.tracing['driver_config']
+                "type": tracing['driver'],
+                "config": tracing['driver_config']
             }
         }
 

--- a/ambassador/ambassador/envoy/v2/v2_static_resources.py
+++ b/ambassador/ambassador/envoy/v2/v2_static_resources.py
@@ -12,6 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from . import V2Config
+
+
 class V2StaticResources(dict):
     def __init__(self, config: 'V2Config') -> None:
         super().__init__()

--- a/ambassador/ambassador/envoy/v2/v2admin.py
+++ b/ambassador/ambassador/envoy/v2/v2admin.py
@@ -35,6 +35,5 @@ class V2Admin(dict):
         })
 
     @classmethod
-    def generate(cls, config: 'V2Config') -> 'V2Admin':
+    def generate(cls, config: 'V2Config') -> None:
         config.admin = config.save_element('admin', config.ir.ambassador_module, V2Admin(config))
-

--- a/ambassador/ambassador/envoy/v2/v2bootstrap.py
+++ b/ambassador/ambassador/envoy/v2/v2bootstrap.py
@@ -1,6 +1,8 @@
 from typing import TYPE_CHECKING
+from typing import cast as typecast
 
 from .v2cluster import V2Cluster
+from ...ir.ircluster import IRCluster
 
 if TYPE_CHECKING:
     from . import V2Config
@@ -11,9 +13,9 @@ class V2Bootstrap(dict):
         super().__init__(**{
             "node": {
                 "cluster": config.ir.ambassador_nodename,
-                "id": "test-id"     # MUST BE test-id, see below
+                "id": "test-id"         # MUST BE test-id, see below
             },
-            "static_resources": {}, # Filled in later
+            "static_resources": {},     # Filled in later
             "dynamic_resources": {
                 "ads_config": {
                     "api_type": "GRPC",
@@ -43,11 +45,11 @@ class V2Bootstrap(dict):
 
         if config.tracing:
             self['tracing'] = dict(config.tracing)
-            clusters.append(V2Cluster(config, self['tracing']['cluster']))
+            clusters.append(V2Cluster(config, typecast(IRCluster, config.ir.tracing.cluster)))
 
         if config.ratelimit:
             self['rate_limit_service'] = dict(config.ratelimit)
-            clusters.append(V2Cluster(config, self['rate_limit_service']['cluster']))
+            clusters.append(V2Cluster(config, typecast(IRCluster, config.ir.ratelimit.cluster)))
 
         self['static_resources']['clusters'] = clusters
 

--- a/ambassador/ambassador/envoy/v2/v2bootstrap.py
+++ b/ambassador/ambassador/envoy/v2/v2bootstrap.py
@@ -1,8 +1,11 @@
 from typing import TYPE_CHECKING
 from typing import cast as typecast
 
-from .v2cluster import V2Cluster
 from ...ir.ircluster import IRCluster
+from ...ir.irtracing import IRTracing
+from ...ir.irratelimit import IRRateLimit
+
+from .v2cluster import V2Cluster
 
 if TYPE_CHECKING:
     from . import V2Config
@@ -45,11 +48,19 @@ class V2Bootstrap(dict):
 
         if config.tracing:
             self['tracing'] = dict(config.tracing)
-            clusters.append(V2Cluster(config, typecast(IRCluster, config.ir.tracing.cluster)))
+
+            tracing = typecast(IRTracing, config.ir.tracing)
+
+            assert tracing.cluster
+            clusters.append(V2Cluster(config, typecast(IRCluster, tracing.cluster)))
 
         if config.ratelimit:
             self['rate_limit_service'] = dict(config.ratelimit)
-            clusters.append(V2Cluster(config, typecast(IRCluster, config.ir.ratelimit.cluster)))
+
+            ratelimit = typecast(IRRateLimit, config.ir.ratelimit)
+
+            assert ratelimit.cluster
+            clusters.append(V2Cluster(config, ratelimit.cluster))
 
         self['static_resources']['clusters'] = clusters
 

--- a/ambassador/ambassador/envoy/v2/v2bootstrap.py
+++ b/ambassador/ambassador/envoy/v2/v2bootstrap.py
@@ -43,15 +43,14 @@ class V2Bootstrap(dict):
 
         if config.tracing:
             self['tracing'] = dict(config.tracing)
-            clusters.append(V2Cluster(config, config.ir.tracing.cluster))
+            clusters.append(V2Cluster(config, self['tracing']['cluster']))
 
         if config.ratelimit:
             self['rate_limit_service'] = dict(config.ratelimit)
-            clusters.append(V2Cluster(config, config.ir.ratelimit.cluster))
+            clusters.append(V2Cluster(config, self['rate_limit_service']['cluster']))
 
         self['static_resources']['clusters'] = clusters
 
     @classmethod
-    def generate(cls, config: 'V2Config') -> 'V2Bootstrap':
-        # Should we save this?
+    def generate(cls, config: 'V2Config') -> None:
         config.bootstrap = V2Bootstrap(config)

--- a/ambassador/ambassador/envoy/v2/v2config.py
+++ b/ambassador/ambassador/envoy/v2/v2config.py
@@ -42,6 +42,7 @@ class V2Config (EnvoyConfig):
     listeners: List[V2Listener]
     clusters: List[V2Cluster]
     static_resources: V2StaticResources
+    sni_routes: List[Dict[str, Any]]
 
     def __init__(self, ir: IR) -> None:
         super().__init__(ir)

--- a/ambassador/ambassador/envoy/v2/v2ratelimit.py
+++ b/ambassador/ambassador/envoy/v2/v2ratelimit.py
@@ -12,7 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License
 
-from typing import Optional, TYPE_CHECKING
+from typing import TYPE_CHECKING
+from typing import cast as typecast
+
+from ...ir.irratelimit import IRRateLimit
 
 if TYPE_CHECKING:
     from . import V2Config
@@ -20,12 +23,17 @@ if TYPE_CHECKING:
 
 class V2RateLimit(dict):
     def __init__(self, config: 'V2Config') -> None:
+        # We should never be instantiated unless there is, in fact, defined ratelimit stuff.
+        assert config.ir.ratelimit
+
         super().__init__()
 
-        self['use_data_plane_proto'] = config.ir.ratelimit.data_plane_proto
+        ratelimit = typecast(IRRateLimit, config.ir.ratelimit)
+
+        self['use_data_plane_proto'] = ratelimit.data_plane_proto
         self['grpc_service'] = {
             'envoy_grpc': {
-                'cluster_name': config.ir.ratelimit.cluster.name
+                'cluster_name': ratelimit.cluster.name
             }
         }
 

--- a/ambassador/ambassador/envoy/v2/v2tls.py
+++ b/ambassador/ambassador/envoy/v2/v2tls.py
@@ -28,7 +28,7 @@ class V2TLSContext(Dict):
         #     self['sni'] = host_rewrite
 
     def add_context(self, ctx: IREnvoyTLS) -> None:
-        common_tls_context = {}
+        common_tls_context: dict = {}
 
         tls_certificate = {}
         if "cert_chain_file" in ctx:

--- a/ambassador/ambassador/envoy/v2/v2tracing.py
+++ b/ambassador/ambassador/envoy/v2/v2tracing.py
@@ -12,7 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License
 
-from typing import Optional, TYPE_CHECKING
+from typing import TYPE_CHECKING
+from typing import cast as typecast
+
+from ...ir.irtracing import IRTracing
 
 if TYPE_CHECKING:
     from . import V2Config
@@ -20,16 +23,21 @@ if TYPE_CHECKING:
 
 class V2Tracing(dict):
     def __init__(self, config: 'V2Config') -> None:
+        # We should never be instantiated unless there is, in fact, defined tracing stuff.
+        assert config.ir.tracing
+
         super().__init__()
 
-        name = config.ir.tracing['driver']
+        tracing = typecast(IRTracing, config.ir.tracing)
+
+        name = tracing['driver']
 
         if not name.startswith('envoy.'):
             name = 'envoy.%s' % (name.lower())
 
         self['http'] = {
             "name": name,
-            "config": config.ir.tracing['driver_config'],
+            "config": tracing['driver_config'],
         }
 
     @classmethod

--- a/ambassador/ambassador/ir/ir.py
+++ b/ambassador/ambassador/ir/ir.py
@@ -12,10 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License
 
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Iterable
 from typing import cast as typecast
-
-import sys
 
 import json
 import logging
@@ -36,7 +34,6 @@ from .irlistener import ListenerFactory, IRListener
 from .irtracing import IRTracing
 from .irtlscontext import IRTLSContext
 
-#from .VERSION import Version
 
 #############################################################################
 ## ir.py -- the Ambassador Intermediate Representation (IR)
@@ -130,8 +127,8 @@ class IR:
         self.outliers = aconf.get_config("OutlierDetection") or {}
 
         # Save tracing and ratelimit settings.
-        self.tracing = self.save_resource(IRTracing(self, aconf))
-        self.ratelimit = self.save_resource(IRRateLimit(self, aconf))
+        self.tracing = typecast(IRTracing, self.save_resource(IRTracing(self, aconf)))
+        self.ratelimit = typecast(IRRateLimit, self.save_resource(IRRateLimit(self, aconf)))
 
         # Save TLSContext resource settings.
         self.save_tls_contexts(aconf)
@@ -272,7 +269,7 @@ class IR:
 
         return group
 
-    def ordered_groups(self) -> List[IRMappingGroup]:
+    def ordered_groups(self) -> Iterable[IRMappingGroup]:
         return reversed(sorted(self.groups.values(), key=lambda x: x['group_weight']))
 
     def has_cluster(self, name: str) -> bool:
@@ -320,10 +317,10 @@ class IR:
                           for cluster_name, cluster in self.clusters.items() },
             'grpc_services': { svc_name: cluster.as_dict()
                                for svc_name, cluster in self.grpc_services.items() },
-            'envoy_tls_contexts': {ctx_name: ctx.as_dict()
-                             for ctx_name, ctx in self.envoy_tls.items()},
+            'envoy_tls_contexts': { ctx_name: ctx.as_dict()
+                                    for ctx_name, ctx in self.envoy_tls.items() },
             'listeners': [ listener.as_dict() for listener in self.listeners ],
-            'filters': [ filter.as_dict() for filter in self.filters ],
+            'filters': [ filt.as_dict() for filt in self.filters ],
             'groups': [ group.as_dict() for group in self.ordered_groups() ],
             'tls_contexts': [context.as_dict() for context in self.tls_contexts]
         }

--- a/ambassador/ambassador/ir/ir.py
+++ b/ambassador/ambassador/ir/ir.py
@@ -52,7 +52,7 @@ class IR:
     tracing: Optional[IRTracing]
     ratelimit: Optional[IRRateLimit]
     router_config: Dict[str, Any]
-    filters: List[IRResource]
+    filters: List[IRFilter]
     listeners: List[IRListener]
     groups: Dict[str, IRMappingGroup]
     clusters: Dict[str, IRCluster]
@@ -213,10 +213,10 @@ class IR:
     def get_tls_contexts(self):
         return self.tls_contexts
 
-    def save_filter(self, resource: IRResource, already_saved=False) -> None:
+    def save_filter(self, resource: IRFilter, already_saved=False) -> None:
         if resource.is_active():
             if not already_saved:
-                resource = self.save_resource(resource)
+                resource = typecast(IRFilter, self.save_resource(resource))
 
             self.filters.append(resource)
 

--- a/ambassador/ambassador/ir/irresource.py
+++ b/ambassador/ambassador/ir/irresource.py
@@ -1,4 +1,4 @@
-from typing import Any, ClassVar, Dict, List, Tuple, TYPE_CHECKING
+from typing import Any, Dict, List, Optional, Tuple, TYPE_CHECKING
 
 from ..config import Config
 from ..resource import Resource
@@ -25,7 +25,7 @@ class IRResource (Resource):
     def helper_list(res: 'IRResource', k: str) -> Tuple[str, list]:
         return k, list([ x.as_dict() for x in res[k] ])
 
-    __as_dict_helpers: ClassVar[Dict[str, Any]] = {
+    __as_dict_helpers: Dict[str, Any] = {
         "apiVersion": "drop",
         "logger": "drop",
         "ir": "drop"
@@ -144,21 +144,21 @@ class IRResource (Resource):
 
         return service_url
 
-    def get_name_fields(self, service: str, context: dict, host_rewrite) -> str:
-        name_fields = None
-        is_tls = self.is_service_tls(service, context)
-
-        if is_tls:
-            name_fields = ['otls']
-
-        if context is not None:
-            if context in self.ir.envoy_tls:
-                name_fields.append(context)
-
-        if is_tls and host_rewrite:
-            name_fields.append("hr-%s" % host_rewrite)
-
-        return "_".join(name_fields) if name_fields else None
+    # def get_name_fields(self, service: str, context: dict, host_rewrite) -> Optional[str]:
+    #     name_fields: List[str] = []
+    #     is_tls = self.is_service_tls(service, context)
+    #
+    #     if is_tls:
+    #         name_fields.append('otls')
+    #
+    #     if context is not None:
+    #         if context in self.ir.envoy_tls:
+    #             name_fields.append(context)
+    #
+    #     if is_tls and host_rewrite:
+    #         name_fields.append("hr-%s" % host_rewrite)
+    #
+    #     return "_".join(name_fields) if name_fields else None
 
     # def service_tls_check(self, svc, context, host_rewrite):
     #     originate_tls = False

--- a/ambassador/ambassador/ir/irtracing.py
+++ b/ambassador/ambassador/ir/irtracing.py
@@ -12,12 +12,18 @@ if TYPE_CHECKING:
 
 class IRTracing (IRResource):
     cluster: Optional[IRCluster]
+    service: str
+    driver: str
+    driver_config: dict
+    tag_headers: list
+    host_rewrite: Optional[str]
 
     def __init__(self, ir: 'IR', aconf: Config,
                  rkey: str="ir.tracing",
                  kind: str="ir.tracing",
                  name: str="tracing",
                  **kwargs) -> None:
+        del kwargs  # silence unused-variable warning
 
         super().__init__(
             ir=ir, aconf=aconf, rkey=rkey, kind=kind, name=name
@@ -39,7 +45,7 @@ class IRTracing (IRResource):
         if number_configs is not 1:
             self.post_error(
                 RichStatus.fromError("exactly one TracingService is supported, got {}".format(number_configs),
-                                     module=config))
+                                     module=aconf))
             return False
 
         config = list(configs)[0]

--- a/ambassador/tests/kat/abstract_tests.py
+++ b/ambassador/tests/kat/abstract_tests.py
@@ -258,6 +258,7 @@ class MappingTest(Test):
 
     target: ServiceType
     options: Sequence['OptionTest']
+    parent: AmbassadorTest
 
     def init(self, target: ServiceType, options=()) -> None:
         self.target = target
@@ -269,6 +270,7 @@ class OptionTest(Test):
 
     VALUES: ClassVar[Any] = None
     value: Any
+    parent: Test
 
     @classmethod
     def variants(cls):

--- a/ambassador/tests/kat/abstract_tests.py
+++ b/ambassador/tests/kat/abstract_tests.py
@@ -1,12 +1,16 @@
+import sys
+
+import base64
 import os
-
+import pytest
 import shutil
+import subprocess
+import yaml
 
-from abc import abstractmethod
-from typing import Any, ClassVar, Generator, List, Optional, Sequence, Tuple, Type
+from typing import Any, ClassVar, Optional, Sequence
 from typing import cast as typecast
 
-from kat.harness import abstract_test, sanitize, variants, Name, Node, Test
+from kat.harness import abstract_test, sanitize, Name, Node, Test
 from kat import manifests
 
 AMBASSADOR_LOCAL = """
@@ -89,13 +93,13 @@ metadata:
 type: kubernetes.io/service-account-token
 """
 
-import base64, pytest, subprocess, sys, tempfile, time, yaml
 
 def run(*args, **kwargs):
     for arg in "stdout", "stderr":
         if arg not in kwargs:
             kwargs[arg] = subprocess.PIPE
     return subprocess.run(args, **kwargs)
+
 
 DEV = os.environ.get("AMBASSADOR_DEV", "0").lower() in ("1", "yes", "true")
 
@@ -143,7 +147,8 @@ class AmbassadorTest(Test):
         return typecast(int, self._index)
 
     def post_manifest(self):
-        if not DEV: return
+        if not DEV:
+            return
 
         run("docker", "kill", self.path.k8s)
         run("docker", "rm", self.path.k8s)
@@ -175,21 +180,21 @@ class AmbassadorTest(Test):
             content = result.stdout
         secret = yaml.load(content)
         data = secret['data']
-        # dir = tempfile.mkdtemp(prefix=self.path.k8s, suffix="secret")
-        dir = "/tmp/%s-ambassadormixin-%s" % (self.path.k8s, 'secret')
+        # secret_dir = tempfile.mkdtemp(prefix=self.path.k8s, suffix="secret")
+        secret_dir = "/tmp/%s-ambassadormixin-%s" % (self.path.k8s, 'secret')
 
-        shutil.rmtree(dir, ignore_errors=True)
-        os.mkdir(dir, 0o777)
+        shutil.rmtree(secret_dir, ignore_errors=True)
+        os.mkdir(secret_dir, 0o777)
 
         for k, v in data.items():
-            with open(os.path.join(dir, k), "wb") as f:
+            with open(os.path.join(secret_dir, k), "wb") as f:
                 f.write(base64.decodebytes(bytes(v, "utf8")))
         print("Launching %s container." % self.path.k8s)
         result = run("docker", "run", "-d", "--name", self.path.k8s,
                      "-p", "%s:8877" % (8877 + self.index),
                      "-p", "%s:80" % (8080 + self.index),
                      "-p", "%s:443" % (8443 + self.index),
-                     "-v", "%s:/var/run/secrets/kubernetes.io/serviceaccount" % dir,
+                     "-v", "%s:/var/run/secrets/kubernetes.io/serviceaccount" % secret_dir,
                      "-e", "KUBERNETES_SERVICE_HOST=kubernetes",
                      "-e", "KUBERNETES_SERVICE_PORT=443",
                      "-e", "AMBASSADOR_ID=%s" % self.ambassador_id,
@@ -227,8 +232,10 @@ class AmbassadorTest(Test):
 @abstract_test
 class ServiceType(Node):
 
+    path: Name
+
     def config(self):
-        if False: yield
+        yield from ()
 
     def manifests(self):
         return self.format(manifests.BACKEND)
@@ -237,8 +244,10 @@ class ServiceType(Node):
         yield ("url", "http://%s" % self.path.k8s)
         yield ("url", "https://%s" % self.path.k8s)
 
+
 class HTTP(ServiceType):
     pass
+
 
 class GRPC(ServiceType):
     pass
@@ -250,7 +259,7 @@ class MappingTest(Test):
     target: ServiceType
     options: Sequence['OptionTest']
 
-    def init(self, target: ServiceType, options = ()) -> None:
+    def init(self, target: ServiceType, options=()) -> None:
         self.target = target
         self.options = list(options)
 
@@ -259,6 +268,7 @@ class MappingTest(Test):
 class OptionTest(Test):
 
     VALUES: ClassVar[Any] = None
+    value: Any
 
     @classmethod
     def variants(cls):
@@ -268,5 +278,5 @@ class OptionTest(Test):
             for val in cls.VALUES:
                 yield cls(val, name=sanitize(val))
 
-    def init(self, value = None):
+    def init(self, value=None):
         self.value = value

--- a/ambassador/tests/kat/t_ratelimit.py
+++ b/ambassador/tests/kat/t_ratelimit.py
@@ -1,17 +1,11 @@
-import json
-import pytest
+from kat.harness import Query
 
-from typing import ClassVar, Dict, List, Sequence, Tuple, Union
-
-from kat.harness import sanitize, variants, Query, Runner
-from kat import manifests
-
-from abstract_tests import AmbassadorTest, HTTP
-from abstract_tests import MappingTest, OptionTest, ServiceType, Node, Test
+from abstract_tests import AmbassadorTest, HTTP, ServiceType
 
 
 class RateLimitTest(AmbassadorTest):
     # debug = True
+    target: ServiceType
 
     def init(self):
         self.target = HTTP()


### PR DESCRIPTION
This tackles most of the `mypy` (and pycharm) warnings about Ambassador.

What's left: 
- we use some packages for which we have no stubs (including `multi`? gotta fix that)
- there are still warnings around `post_error`, but those will get resolved as I clean up the sad path through Ambassador in general.
