### PR TITLE
Add envoy.router filter to redirect listener

### DIFF
--- a/ambassador/ambassador/envoy/v2/v2listener.py
+++ b/ambassador/ambassador/envoy/v2/v2listener.py
@@ -173,8 +173,9 @@ class V2Listener(dict):
             }
         } ])
 
-        # OK. If this is _not_ the redirect listener, override everything.
-        if not listener.redirect_listener:
+        if listener.redirect_listener:
+            filters: List[dict] = [{'name': 'envoy.router'}]
+        else:
             # Use the actual listener name
             name = listener.name
 

--- a/ambassador/tests/kat/test_ambassador.py
+++ b/ambassador/tests/kat/test_ambassador.py
@@ -357,13 +357,7 @@ service: {self.target.path.k8s}
 """)
 
     def queries(self):
-        q = Query(self.url("tls-target/"), expected=301)
-
-        # if DEV:
-        q.xfail="skip until port madness is wrangled"
-
-        yield q
-
+        yield Query(self.url("tls-target/"), expected=301)
 
 class Plain(AmbassadorTest):
 


### PR DESCRIPTION
Current redirect listener does not specify the envoy.router field
in envoy filters, which causes redirects to fail. This commit
fixes that.