### PR TITLE
Quote the value of `.Values.namespace.single` in helm templates

### DIFF
--- a/helm/ambassador/templates/daemonset.yaml
+++ b/helm/ambassador/templates/daemonset.yaml
@@ -57,7 +57,7 @@ spec:
           env:
           {{- if .Values.namespace.single }}
           - name: AMBASSADOR_SINGLE_NAMESPACE
-            value: {{ .Values.namespace.single }}
+            value: {{ .Values.namespace.single | quote }}
           {{- end }}
           - name: AMBASSADOR_ID
             value: {{ .Values.ambassador.id | quote }}

--- a/helm/ambassador/templates/deployment.yaml
+++ b/helm/ambassador/templates/deployment.yaml
@@ -58,7 +58,7 @@ spec:
           env:
           {{- if .Values.namespace.single }}
           - name: AMBASSADOR_SINGLE_NAMESPACE
-            value: {{ .Values.namespace.single }}
+            value: {{ .Values.namespace.single | quote }}
           {{- end }}
           - name: AMBASSADOR_ID
             value: {{ .Values.ambassador.id | quote }}


### PR DESCRIPTION
## Problem

We encountered an error when trying to deploy a  single-namespace instance of Ambassador via the helm chart.

`values.yaml`:

``` yaml
...
namespace:
  single: true
...
```

Error:

``` bash
bash> helm install datawire/ambassador --name ambassador-public  -f ambassador.yaml
Error: release ambassador-public failed: Deployment in version "v1beta2" cannot be handled as a Deployment: v1beta2.Deployment: Spec: v1beta2.DeploymentSpec: Template: v1.PodTemplateSpec: Spec: v1.PodSpec: Containers: []v1.Container: v1.Container: Env: []v1.EnvVar: v1.EnvVar: Value: ReadString: expects " or n, but found t, error found in #10 byte of ...|,"value":true},{"nam|..., bigger context ...|":[{"name":"AMBASSADOR_SINGLE_NAMESPACE","value":true},{"name":"AMBASSADOR_ID","value":"default"},{"|...
```

## Workaround

We were able to deploy when double-quoting the value in `values.yaml`:

``` yaml
namespace:
  single: "\"true\""
```

## Solution

Reading through the code, we saw that the value of the environment variable in the deployment and daemonset templates was not being quoted as other, similar values were.  This PR corrects this disparity by quoting the value.