### PR TITLE
Fix incorrect switching of ports

### DIFF
--- a/ambassador/ambassador/ir/irambassador.py
+++ b/ambassador/ambassador/ir/irambassador.py
@@ -110,7 +110,7 @@ class IRAmbassador (IRResource):
                         self.logger.debug("not updating context %s from %s" % (ctx_name, ctxloc))
                         # self.logger.debug(etls.as_json())
 
-                    if etls.get('valid_tls'):
+                    if etls.get('valid_tls') and ctx_name == 'server':
                         self.logger.debug("TLS termination enabled!")
                         self.service_port = 443
 

--- a/ambassador/ambassador/ir/irtls.py
+++ b/ambassador/ambassador/ir/irtls.py
@@ -51,14 +51,7 @@ class IREnvoyTLS (IRResource):
             **kwargs
         )
 
-    def setup(self, ir: 'IR', aconf: Config):
-        if not self.enabled:
-            return False
-
-        self['valid_tls'] = False
-        secret = self.get('secret')
-
-        # Check if secret and certs, both are specified
+    def cert_specified(self, ir: 'IR') -> bool:
         cert_specified = False
 
         cert_chain_file = self.get('cert_chain_file')
@@ -78,6 +71,17 @@ class IREnvoyTLS (IRResource):
                     RichStatus.fromError("TLS is not being turned on, traffic will NOT be served over HTTPS"))
                 return False
             cert_specified = True
+
+        return cert_specified
+
+    def setup(self, ir: 'IR', aconf: Config):
+        if not self.enabled:
+            return False
+
+        self['valid_tls'] = False
+        secret = self.get('secret')
+
+        cert_specified = self.cert_specified(ir)
 
         if secret is not None and cert_specified:
             self.pop('secret', None)

--- a/ambassador/tests/kat/test_ambassador.py
+++ b/ambassador/tests/kat/test_ambassador.py
@@ -49,6 +49,46 @@ spec:
 """
 
 
+class TLSContextsTest(AmbassadorTest):
+    """
+    This test makes sure that TLS is not turned on when it's not intended to. For example, when an 'upstream'
+    TLS configuration is passed, the port is not supposed to switch to 443
+    """
+
+    def init(self):
+        self.target = HTTP()
+
+    def config(self):
+        yield self, self.format("""
+---
+apiVersion: ambassador/v0
+kind: Module
+name: tls
+ambassador_id: {self.ambassador_id}
+config:
+  upstream:
+    enabled: True
+    secret: test-certs-secret
+""")
+
+        yield self, self.format("""
+---
+apiVersion: ambassador/v0
+kind:  Mapping
+name:  {self.target.path.k8s}
+prefix: /{self.name}/
+service: {self.target.path.k8s}
+""")
+
+    def scheme(self) -> str:
+        return "https"
+
+    def queries(self):
+        yield Query(self.url(self.name + "/"), error='connection reset by peer')
+
+    def requirements(self):
+        yield from (r for r in super().requirements() if r[0] == "url" and r[1].url.startswith("http://"))
+
 class AuthenticationHTTPBufferedTest(AmbassadorTest):
 
     target: ServiceType

--- a/kat/kat/harness.py
+++ b/kat/kat/harness.py
@@ -311,7 +311,7 @@ class Result:
             pytest.xfail(self.query.xfail)
 
         if self.query.error is not None:
-            assert self.query.error == self.error, "{}: expected error to be {}, got {} instead".format(
+            assert self.query.error in self.error, "{}: expected error to contain '{}', got {} instead".format(
                 self.query.url, self.query.error, self.error
             )
         else:


### PR DESCRIPTION
Before this commit, if any TLS configuration e.g. server, client
or upstream, had a valid TLS configuration, the port would be
switched to 443, but we need to do that only when the context is
`server`. This commit fixes that.