### PR TITLE
Handle long tracing names

### DIFF
--- a/ambassador/ambassador/ir/ir.py
+++ b/ambassador/ambassador/ir/ir.py
@@ -202,6 +202,16 @@ class IR:
                 self.logger.info("%s => %s" % (name, mangled_name))
                 self.clusters[name]['name'] = mangled_name
 
+        # After we have the cluster names fixed up, go finalize filters.
+        if self.tracing:
+            self.tracing.finalize()
+
+        if self.ratelimit:
+            self.ratelimit.finalize()
+
+        for filter in self.filters:
+            filter.finalize()
+
     # XXX Brutal hackery here! Probably this is a clue that Config and IR and such should have
     # a common container that can hold errors.
     def post_error(self, rc: Union[str, RichStatus], resource: Optional[IRResource]=None):

--- a/ambassador/ambassador/ir/irfilter.py
+++ b/ambassador/ambassador/ir/irfilter.py
@@ -26,3 +26,6 @@ class IRFilter(IRResource):
 
     def config_dict(self) -> Optional[dict]:
         return self.config
+
+    def finalize(self) -> None:
+        pass

--- a/ambassador/ambassador/ir/irtracing.py
+++ b/ambassador/ambassador/ir/irtracing.py
@@ -92,7 +92,9 @@ class IRTracing (IRResource):
         cluster.referenced_by(self)
         self.cluster = cluster
 
-        self.driver_config['collector_cluster'] = cluster.name
-
         # if not ir.add_to_primary_listener(tracing=True):
         #     raise Exception("Failed to update primary listener with tracing config")
+
+    def finalize(self):
+        self.ir.logger.info("tracing cluster name: %s" % self.cluster.name)
+        self.driver_config['collector_cluster'] = self.cluster.name

--- a/ambassador/tests/013-tracing/config/tracing-service.yaml
+++ b/ambassador/tests/013-tracing/config/tracing-service.yaml
@@ -2,7 +2,7 @@
 apiVersion: ambassador/v0
 kind: TracingService
 name: tracing
-service: "example-tracing:5000"
+service: "example-tracing-with-a-really-really-long-name-omfg-baby-baby:5000"
 tag_headers:
 - ":authority"
 - ":path"

--- a/ambassador/tests/013-tracing/gold.intermediate.json
+++ b/ambassador/tests/013-tracing/gold.intermediate.json
@@ -24,14 +24,13 @@
                 "_referenced_by": [
                     "tracing-service.yaml.1"
                 ],
-                "_service": "example-tracing:5000",
+                "_service": "example-tracing-with-a-really-really-long-name-omfg-baby-baby:5000",
                 "_source": "tracing-service.yaml.1",
                 "lb_type": "round_robin",
-                "name": "cluster_tracing_example_tracing_5000",
+                "name": "cluster_tracing_example_tracing_with_a_r-0",
                 "type": "strict_dns",
                 "urls": [
-                    "tcp://example-tracing:5000"
-                ]
+                    "tcp://example-tracing-with-a-really-really-long-name-omfg-baby-baby:5000"                ]
             },
             {
                 "_referenced_by": [
@@ -173,10 +172,9 @@
         "tracing": [
             {
                 "_source": "tracing-service.yaml.1",
-                "cluster_name": "cluster_tracing_example_tracing_5000",
+                "cluster_name": "cluster_tracing_example_tracing_with_a_r-0",
                 "config": {
-                    "collector_cluster": "cluster_tracing_example_tracing_5000"
-                },
+                    "collector_cluster": "cluster_tracing_example_tracing_with_a_r-0"                },
                 "driver": "zipkin",
                 "tag_headers": [
                     ":authority",
@@ -232,7 +230,6 @@
             "kind": "TracingService",
             "name": "tracing",
             "version": "ambassador/v0",
-            "yaml": "apiVersion: ambassador/v0\ndriver: zipkin\nkind: TracingService\nname: tracing\nservice: example-tracing:5000\ntag_headers:\n- :authority\n- :path\n"
-        }
+            "yaml": "apiVersion: ambassador/v0\ndriver: zipkin\nkind: TracingService\nname: tracing\nservice: example-tracing-with-a-really-really-long-name-omfg-baby-baby:5000\ntag_headers:\n- :authority\n- :path\n"        }
     }
 }

--- a/ambassador/tests/013-tracing/gold.json
+++ b/ambassador/tests/013-tracing/gold.json
@@ -129,13 +129,13 @@
 
         ]},
       {
-        "name": "cluster_tracing_example_tracing_5000",
+        "name": "cluster_tracing_example_tracing_with_a_r-0",
         "connect_timeout_ms": 3000,
         "type": "strict_dns",
         "lb_type": "round_robin",
         "hosts": [
           {
-            "url": "tcp://example-tracing:5000"
+            "url": "tcp://example-tracing-with-a-really-really-long-name-omfg-baby-baby:5000"
           }
 
         ]}
@@ -146,8 +146,7 @@
       "driver": {
         "type": "zipkin",
         "config": {
-          "collector_cluster": "cluster_tracing_example_tracing_5000"
-        }
+          "collector_cluster": "cluster_tracing_example_tracing_with_a_r-0"        }
       }
     }
   }


### PR DESCRIPTION
Fix #1025: correctly handle very long tracing-service names.
