### PR TITLE
Make certificate and secret TLS configs consistent

### DIFF
--- a/ambassador/ambassador/envoy/v2/v2cluster.py
+++ b/ambassador/ambassador/envoy/v2/v2cluster.py
@@ -55,7 +55,7 @@ class V2Cluster(dict):
 
             envoy_ctx = V2TLSContext(ctx=ctx, host_rewrite=cluster.get('host_rewrite', None))
             if envoy_ctx:
-                self['tls_context'] = envoy_ctx
+                fields['tls_context'] = envoy_ctx
 
         self.update(fields)
 

--- a/ambassador/ambassador/ir/irtls.py
+++ b/ambassador/ambassador/ir/irtls.py
@@ -89,6 +89,10 @@ class IREnvoyTLS (IRResource):
             return False
 
         self['valid_tls'] = False
+
+        if self.get('cert_chain_file') is not None:
+            self['certificate_chain_file'] = self.pop('cert_chain_file')
+
         secret = self.get('secret')
 
         cert_specified = self.cert_specified(ir)

--- a/ambassador/tests/001-broader-v0/gold.intermediate.json
+++ b/ambassador/tests/001-broader-v0/gold.intermediate.json
@@ -291,7 +291,6 @@
                 "tls": {
                     "_source": "ambassador.yaml.1",
                     "cacert_chain_file": "/etc/ambassador-config/ca_cert_chain/tls.crt",
-                    "cert_chain_file": "/etc/ambassador-config/certs/tls.crt",
                     "cert_required": true,
                     "private_key_file": "/etc/ambassador-config/certs/tls.key",
                     "ssl_context": true

--- a/ambassador/tests/001-broader-v0/gold.json
+++ b/ambassador/tests/001-broader-v0/gold.json
@@ -4,8 +4,7 @@
     {
       "address": "tcp://0.0.0.0:443",
       "use_proxy_proto": true,
-      "ssl_context": {"cert_chain_file": "/etc/ambassador-config/certs/tls.crt",
-          "private_key_file": "/etc/ambassador-config/certs/tls.key","ca_cert_file": "/etc/ambassador-config/ca_cert_chain/tls.crt","require_client_certificate": true
+      "ssl_context": {"private_key_file": "/etc/ambassador-config/certs/tls.key","ca_cert_file": "/etc/ambassador-config/ca_cert_chain/tls.crt","require_client_certificate": true
       },"filters": [
         {
           "type": "read",

--- a/ambassador/tests/002-tls-module-1/gold.intermediate.json
+++ b/ambassador/tests/002-tls-module-1/gold.intermediate.json
@@ -57,7 +57,6 @@
                     "_source": "tls.yaml.1",
                     "alpn_protocols": "h2",
                     "cacert_chain_file": "/etc/ambassador-config/ca_cert_chain/tls.crt",
-                    "cert_chain_file": "/etc/ambassador-config/certs/tls.crt",
                     "cert_required": true,
                     "private_key_file": "/etc/ambassador-config/certs/tls.key",
                     "ssl_context": true

--- a/ambassador/tests/002-tls-module-1/gold.json
+++ b/ambassador/tests/002-tls-module-1/gold.json
@@ -4,8 +4,7 @@
     {
       "address": "tcp://0.0.0.0:443",
       
-      "ssl_context": {"cert_chain_file": "/etc/ambassador-config/certs/tls.crt",
-          "private_key_file": "/etc/ambassador-config/certs/tls.key","alpn_protocols": "h2","ca_cert_file": "/etc/ambassador-config/ca_cert_chain/tls.crt","require_client_certificate": true
+      "ssl_context": {"private_key_file": "/etc/ambassador-config/certs/tls.key","alpn_protocols": "h2","ca_cert_file": "/etc/ambassador-config/ca_cert_chain/tls.crt","require_client_certificate": true
       },"filters": [
         {
           "type": "read",

--- a/ambassador/tests/003-tls-module-2/gold.intermediate.json
+++ b/ambassador/tests/003-tls-module-2/gold.intermediate.json
@@ -55,7 +55,6 @@
                 "tls": {
                     "_source": "ambassador.yaml.1",
                     "cacert_chain_file": "/etc/ambassador-config/ca_cert_chain/tls.crt",
-                    "cert_chain_file": "/etc/ambassador-config/certs/tls.crt",
                     "cert_required": true,
                     "private_key_file": "/etc/ambassador-config/certs/tls.key",
                     "ssl_context": true

--- a/ambassador/tests/003-tls-module-2/gold.json
+++ b/ambassador/tests/003-tls-module-2/gold.json
@@ -4,8 +4,7 @@
     {
       "address": "tcp://0.0.0.0:443",
       
-      "ssl_context": {"cert_chain_file": "/etc/ambassador-config/certs/tls.crt",
-          "private_key_file": "/etc/ambassador-config/certs/tls.key","ca_cert_file": "/etc/ambassador-config/ca_cert_chain/tls.crt","require_client_certificate": true
+      "ssl_context": {"private_key_file": "/etc/ambassador-config/certs/tls.key","ca_cert_file": "/etc/ambassador-config/ca_cert_chain/tls.crt","require_client_certificate": true
       },"filters": [
         {
           "type": "read",

--- a/ambassador/tests/004-tls-without-ambassador-module/gold.intermediate.json
+++ b/ambassador/tests/004-tls-without-ambassador-module/gold.intermediate.json
@@ -56,7 +56,6 @@
                 "tls": {
                     "_source": "tls.yaml.1",
                     "cacert_chain_file": "/etc/ambassador-config/ca_cert_chain/tls.crt",
-                    "cert_chain_file": "/etc/ambassador-config/certs/tls.crt",
                     "cert_required": true,
                     "private_key_file": "/etc/ambassador-config/certs/tls.key",
                     "ssl_context": true

--- a/ambassador/tests/004-tls-without-ambassador-module/gold.json
+++ b/ambassador/tests/004-tls-without-ambassador-module/gold.json
@@ -4,8 +4,7 @@
     {
       "address": "tcp://0.0.0.0:443",
       
-      "ssl_context": {"cert_chain_file": "/etc/ambassador-config/certs/tls.crt",
-          "private_key_file": "/etc/ambassador-config/certs/tls.key","ca_cert_file": "/etc/ambassador-config/ca_cert_chain/tls.crt","require_client_certificate": true
+      "ssl_context": {"private_key_file": "/etc/ambassador-config/certs/tls.key","ca_cert_file": "/etc/ambassador-config/ca_cert_chain/tls.crt","require_client_certificate": true
       },"filters": [
         {
           "type": "read",

--- a/ambassador/tests/007-originating-tls/gold.intermediate.json
+++ b/ambassador/tests/007-originating-tls/gold.intermediate.json
@@ -30,10 +30,6 @@
                 "name": "cluster_extauth_https___example_auth_3000_otls",
                 "tls_array": [
                     {
-                        "key": "cert_chain_file",
-                        "value": "/etc/ambassador-config/certs/outbound.crt"
-                    },
-                    {
                         "key": "private_key_file",
                         "value": "/etc/ambassador-config/certs/outbound.key"
                     }
@@ -44,7 +40,7 @@
                         "mapping-qotm.yaml.1"
                     ],
                     "_source": "tls.yaml.1",
-                    "cert_chain_file": "/etc/ambassador-config/certs/outbound.crt",
+                    "certificate_chain_file": "/etc/ambassador-config/certs/outbound.crt",
                     "private_key_file": "/etc/ambassador-config/certs/outbound.key",
                     "namespace": "default",
                     "valid_tls": true
@@ -64,10 +60,6 @@
                 "name": "cluster_qotm_otls_upstream",
                 "tls_array": [
                     {
-                        "key": "cert_chain_file",
-                        "value": "/etc/ambassador-config/certs/outbound.crt"
-                    },
-                    {
                         "key": "private_key_file",
                         "value": "/etc/ambassador-config/certs/outbound.key"
                     }
@@ -78,7 +70,7 @@
                         "mapping-qotm.yaml.1"
                     ],
                     "_source": "tls.yaml.1",
-                    "cert_chain_file": "/etc/ambassador-config/certs/outbound.crt",
+                    "certificate_chain_file": "/etc/ambassador-config/certs/outbound.crt",
                     "private_key_file": "/etc/ambassador-config/certs/outbound.key",
                     "namespace": "default",
                     "valid_tls": true
@@ -128,7 +120,6 @@
                 "service_port": 443,
                 "tls": {
                     "_source": "tls.yaml.1",
-                    "cert_chain_file": "/etc/ambassador-config/certs/tls.crt",
                     "private_key_file": "/etc/ambassador-config/certs/tls.key",
                     "ssl_context": true
                 },

--- a/ambassador/tests/007-originating-tls/gold.json
+++ b/ambassador/tests/007-originating-tls/gold.json
@@ -4,8 +4,7 @@
     {
       "address": "tcp://0.0.0.0:443",
 
-      "ssl_context": {"cert_chain_file": "/etc/ambassador-config/certs/tls.crt",
-          "private_key_file": "/etc/ambassador-config/certs/tls.key"
+      "ssl_context": {"private_key_file": "/etc/ambassador-config/certs/tls.key"
       },"filters": [
         {
           "type": "read",
@@ -115,7 +114,6 @@
         ],
         "ssl_context": {
 
-          "cert_chain_file": "/etc/ambassador-config/certs/outbound.crt",
 
           "private_key_file": "/etc/ambassador-config/certs/outbound.key"
 
@@ -133,7 +131,6 @@
         ],
         "ssl_context": {
 
-          "cert_chain_file": "/etc/ambassador-config/certs/outbound.crt",
 
           "private_key_file": "/etc/ambassador-config/certs/outbound.key"
 

--- a/ambassador/tests/kat/test_ambassador.py
+++ b/ambassador/tests/kat/test_ambassador.py
@@ -108,6 +108,9 @@ name: tls
 config:
   upstream:
     secret: test-certs-secret
+  upstream-files:
+    cert_chain_file: /ambassador/upstream/tls.crt
+    private_key_file: /ambassador/upstream/tls.key
 """)
 
         yield self, self.format("""
@@ -120,8 +123,19 @@ service: {self.target.path.k8s}
 tls: upstream
 """)
 
+        yield self, self.format("""
+---
+apiVersion: ambassador/v0
+kind:  Mapping
+name:  {self.target.path.k8s}-files
+prefix: /{self.name}-files/
+service: {self.target.path.k8s}
+tls: upstream-files
+""")
+
     def queries(self):
         yield Query(self.url(self.name + "/"))
+        yield Query(self.url(self.name + "-files/"))
 
     def check(self):
         for r in self.results:


### PR DESCRIPTION
This commit makes `certificate_chain_file` field consistent in
the IR for both ways of supplying certificates, i.e. via a secret
or via specifying files. A test has been added for this as well.