### PR TITLE
Use env and annotations from values file

### DIFF
--- a/helm/ambassador/templates/daemonset.yaml
+++ b/helm/ambassador/templates/daemonset.yaml
@@ -20,8 +20,9 @@ spec:
         app: {{ template "ambassador.name" . }}
         release: {{ .Release.Name }}
       annotations:
-        prometheus.io/scrape: "true"
-        prometheus.io/port: "9102"
+      {{- if .Values.podAnnotations }}
+{{ toYaml .Values.podAnnotations | indent 8 }}
+      {{- end }}
     spec:
       serviceAccountName: {{ template "ambassador.serviceAccountName" . }}
       volumes:
@@ -82,6 +83,12 @@ spec:
           - name: AMBASSADOR_SHUTDOWN_TIME
             value: {{ .Values.timing.shutdown | quote }}
           {{- end -}}
+          {{- end }}
+          {{- if .Values.env }}          
+          {{- range $key,$value := .Values.env }}
+          - name: {{ $key | upper | quote}}
+            value: {{ $value | quote}}
+          {{- end }}
           {{- end }}
           livenessProbe:
             httpGet:

--- a/helm/ambassador/templates/deployment.yaml
+++ b/helm/ambassador/templates/deployment.yaml
@@ -21,8 +21,9 @@ spec:
         app: {{ template "ambassador.name" . }}
         release: {{ .Release.Name }}
       annotations:
-        prometheus.io/scrape: "true"
-        prometheus.io/port: "9102"
+      {{- if .Values.podAnnotations }}
+{{ toYaml .Values.podAnnotations | indent 8 }}
+      {{- end }}
     spec:
       serviceAccountName: {{ template "ambassador.serviceAccountName" . }}
       volumes:
@@ -86,6 +87,12 @@ spec:
           - name: AMBASSADOR_SHUTDOWN_TIME
             value: {{ .Values.timing.shutdown | quote }}
           {{- end -}}
+          {{- end }}
+          {{- if .Values.env }}          
+          {{- range $key,$value := .Values.env }}
+          - name: {{ $key | upper | quote}}
+            value: {{ $value | quote}}
+          {{- end }}
           {{- end }}
           livenessProbe:
             httpGet:

--- a/helm/ambassador/values.yaml
+++ b/helm/ambassador/values.yaml
@@ -66,6 +66,14 @@ volumes: {}
 
 volumeMounts: {}
 
+podAnnotations:
+  prometheus.io/scrape: "true"
+  prometheus.io/port: "9102"
+
+env: {}
+  # Specify any additional environment variables in format 
+  # FOO: bar
+
 resources: {}
   # If you do want to specify resources, uncomment the following
   # lines, adjust them as necessary, and remove the curly braces after 'resources:'.


### PR DESCRIPTION
This change will enable users to pass arbitrary env variables to deployment or daemonset during installation instead of editing deployment object afterward.
Same goes for custom pod annotations.