### PR TITLE
Feature-use reporting + deprecate ambassador/v0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,43 @@ Format:
 --->
 
 <!--- CueAddReleaseNotes --->
+## [0.50.0-rc1] December 19, 2018
+[0.50.0-rc1]: https://github.com/datawire/ambassador/compare/0.50.0-ea7...0.50.0-rc1
+
+**Ambassador 0.50.0-rc1 is a release candidate.**
+
+### Major changes:
+
+- Ambassador 0.50.0 is a major rearchitecture of Ambassador onto Envoy V2 using the ADS.
+- The KAT suite provides dramatically-faster functional testing. See ambassador/tests/kat.
+
+- **API version `ambassador/v0` is officially deprecated in Ambassador 0.50.0-rc1.**
+    - API version `ambassador/v1` is the minimum recommended version for resources in Ambassador 0.50.0, starting in 0.50.0-rc1.
+
+- Some `ambassador/v1` resources change semantics from their `ambassador/v0` versions:
+    - The `Mapping` resource no longer supports `rate_limits` as that functionality has been 
+      subsumed by `labels`.
+    - The `AuthService` resource supports more extensive configuration options. An `ambassador/v0`
+      `AuthService` preserves the older, less flexible semantics: see the external authentication documentation for more information.
+    - The `RateLimitService` permits configuring its `domain` in `ambassador/v1`. 
+
+### Changes since 0.50.0-ea7:
+
+- Websockets should work happily with external authentication [#1026]
+- A `TracingService` using a long cluster name works now [#1025] 
+- TLS origination certificates are no longer offered to clients when Ambassador does TLS termination [#983]
+- Ambassador will listen on port 443 only if TLS termination contexts are present; a TLS origination context will not cause the switch 
+- The diagnostics service is working, and correctly reporting errors, again. [#1019]
+- `timeout_ms` in a `Mapping` works correctly again [#990]
+- Ambassador sends additional anonymized usage data to help Datawire prioritize bug fixes, etc.
+  See `docs/ambassador/running.md` for more information, including how to disable this function.
+
+[#983]: https://github.com/datawire/ambassador/issues/983
+[#990]: https://github.com/datawire/ambassador/issues/990
+[#1019]: https://github.com/datawire/ambassador/issues/1019
+[#1025]: https://github.com/datawire/ambassador/issues/1025
+[#1026]: https://github.com/datawire/ambassador/issues/1026
+
 ## [0.50.0-ea7] November 19, 2018
 [0.50.0-ea7]: https://github.com/datawire/ambassador/compare/0.50.0-ea6...0.50.0-ea7
 

--- a/ambassador/ambassador/ambscout.py
+++ b/ambassador/ambassador/ambscout.py
@@ -101,9 +101,6 @@ class AmbScout:
             if 'runtime' not in kwargs:
                 kwargs['runtime'] = self.runtime
 
-            if 'namespace' not in kwargs:
-                kwargs['namespace'] = self.namespace
-
             if 'commit' not in kwargs:
                 kwargs['commit'] = Build.git.commit
 

--- a/ambassador/ambassador/cli.py
+++ b/ambassador/ambassador/cli.py
@@ -207,7 +207,12 @@ def dump(config_dir_path: Parameter.REQUIRED, *,
             od['features'] = ir.features()
 
         scout = Scout()
-        result = scout.report(action="dump", mode="cli")
+        scout_args = {}
+
+        if ir and not os.environ.get("AMBASSADOR_DISABLE_FEATURES", None):
+            scout_args["features"] = ir.features()
+
+        result = scout.report(action="dump", mode="cli", **scout_args)
         show_notices(result)
 
         json.dump(od, sys.stdout, sort_keys=True, indent=4)

--- a/ambassador/ambassador/cli.py
+++ b/ambassador/ambassador/cli.py
@@ -130,7 +130,7 @@ def tls_secret_resolver(secret_name: str, context: str, cert_dir=None) -> Option
 
 def dump(config_dir_path: Parameter.REQUIRED, *,
          debug=False, debug_scout=False, k8s=False,
-         aconf=False, ir=False, v1=False, v2=False, diag=False):
+         aconf=False, ir=False, v1=False, v2=False, diag=False, features=False):
     """
     Dump various forms of an Ambassador configuration for debugging
 
@@ -146,6 +146,7 @@ def dump(config_dir_path: Parameter.REQUIRED, *,
     :param v1: If set, dump the Envoy V1 config
     :param v2: If set, dump the Envoy V2 config
     :param diag: If set, dump the Diagnostics overview
+    :param features: If set, dump the feature set
     """
 
     if debug:
@@ -154,18 +155,20 @@ def dump(config_dir_path: Parameter.REQUIRED, *,
     if debug_scout:
         logging.getLogger('ambassador.scout').setLevel(logging.DEBUG)
 
-    if not (aconf or ir or v1 or v2 or diag):
+    if not (aconf or ir or v1 or v2 or diag or features):
         aconf = True
         ir = True
         v1 = False  # Default to NOT dumping V1 any more.
         v2 = True
         diag = False
+        features = False
 
     dump_aconf = aconf
     dump_ir = ir
     dump_v1 = v1
     dump_v2 = v2
     dump_diag = diag
+    dump_features = features
 
     od = {}
     diagconfig: Optional[EnvoyConfig] = None
@@ -199,6 +202,9 @@ def dump(config_dir_path: Parameter.REQUIRED, *,
             diag = Diagnostics(ir, econf)
             od['diag'] = diag.as_dict()
             od['elements'] = econf.elements
+
+        if dump_features:
+            od['features'] = ir.features()
 
         scout = Scout()
         result = scout.report(action="dump", mode="cli")

--- a/ambassador/ambassador/ir/ir.py
+++ b/ambassador/ambassador/ir/ir.py
@@ -358,7 +358,7 @@ class IR:
         return json.dumps(self.as_dict(), sort_keys=True, indent=4)
 
     def features(self) -> Dict[str, Any]:
-        od = {}
+        od: Dict[str, Union[bool, int, str]] = {}
 
         tls_termination_count = 0   # TLS termination contexts
         tls_origination_count = 0   # TLS origination contexts
@@ -480,14 +480,14 @@ class IR:
             tracing_driver = self.tracing.driver
 
         od['extauth'] = extauth
-        od['extauth_proto'] = extauth_proto or "N/A"
+        od['extauth_proto'] = extauth_proto
         od['extauth_allow_body'] = extauth_allow_body
         od['extauth_host_count'] = extauth_host_count
         od['ratelimit'] = ratelimit
         od['ratelimit_data_plane_proto'] = ratelimit_data_plane_proto
         od['ratelimit_custom_domain'] = ratelimit_custom_domain
         od['tracing'] = tracing
-        od['tracing_driver'] = tracing_driver or "N/A"
+        od['tracing_driver'] = tracing_driver
 
         group_count = 0
         group_precedence_count = 0      # groups using explicit precedence
@@ -498,6 +498,7 @@ class IR:
         group_host_redirect_count = 0   # groups using host_redirect
         group_host_rewrite_count = 0    # groups using host_rewrite
         group_canary_count = 0          # groups coalescing multiple mappings
+        mapping_count = 0               # total mappings
 
         for group in self.ordered_groups():
             group_count += 1
@@ -524,6 +525,8 @@ class IR:
             if len(group.mappings) > 1:
                 group_canary_count += 1
 
+            mapping_count += len(group.mappings)
+
             if group.get('shadows', []):
                 group_shadow_count += 1
 
@@ -542,6 +545,7 @@ class IR:
         od['group_host_redirect_count'] = group_host_redirect_count
         od['group_host_rewrite_count'] = group_host_rewrite_count
         od['group_canary_count'] = group_canary_count
+        od['mapping_count'] = mapping_count
 
         od['listener_count'] = len(self.listeners)
 

--- a/ambassador/ambassador/ir/ir.py
+++ b/ambassador/ambassador/ir/ir.py
@@ -343,7 +343,7 @@ class IR:
             'listeners': [ listener.as_dict() for listener in self.listeners ],
             'filters': [ filt.as_dict() for filt in self.filters ],
             'groups': [ group.as_dict() for group in self.ordered_groups() ],
-            'tls_contexts': [context.as_dict() for context in self.tls_contexts]
+            'tls_contexts': [ context.as_dict() for context in self.tls_contexts ]
         }
 
         if self.tracing:
@@ -354,5 +354,195 @@ class IR:
 
         return od
 
-    def as_json(self):
+    def as_json(self) -> str:
         return json.dumps(self.as_dict(), sort_keys=True, indent=4)
+
+    def features(self) -> Dict[str, Any]:
+        od = {}
+
+        tls_termination_count = 0   # TLS termination contexts
+        tls_origination_count = 0   # TLS origination contexts
+
+        using_tls_module = False
+        using_tls_contexts = False
+
+        for ctx in self.envoy_tls.values():
+            using_tls_module = True
+
+            if ctx.get('certificate_chain_file', None) and ctx.get('valid_tls', False):
+                tls_termination_count += 1
+
+            if ctx.get('cacert_chain_file', None) and ctx.get('valid_tls', False):
+                tls_origination_count += 1
+
+        for ctx in self.tls_contexts:
+            if ctx:
+
+                secret_info = ctx.get('secret_info', {})
+
+                if secret_info:
+                    using_tls_contexts = True
+
+                    if secret_info.get('certificate_chain_file', None):
+                        tls_termination_count += 1
+
+                    if secret_info.get('cacert_chain_file', None):
+                        tls_origination_count += 1
+
+        od['tls_using_module'] = using_tls_module
+        od['tls_using_contexts'] = using_tls_contexts
+        od['tls_termination_count'] = tls_termination_count
+        od['tls_origination_count'] = tls_origination_count
+
+        for key in [ 'diagnostics', 'liveness_probe', 'readiness_probe', 'statsd' ]:
+            od[key] = self.ambassador_module.get(key, {}).get('enabled', False)
+
+        for key in [ 'use_proxy_proto', 'use_remote_address', 'x_forwarded_proto_redirect' ]:
+            od[key] = self.ambassador_module.get(key, False)
+
+        od['custom_ambassador_id'] = bool(self.ambassador_id != 'default')
+
+        default_port = 443 if tls_termination_count else 80
+
+        od['custom_listener_port'] = bool(self.ambassador_module.service_port != default_port)
+        od['custom_diag_port'] = bool(self.ambassador_module.diag_port != 8877)
+
+        cluster_count = 0
+        cluster_grpc_count = 0      # clusters using GRPC upstream
+        cluster_http_count = 0      # clusters using HTTP or HTTPS upstream
+        cluster_tls_count = 0       # clusters using TLS origination
+
+        endpoint_grpc_count = 0     # endpoints using GRPC upstream
+        endpoint_http_count = 0     # endpoints using HTTP/HTTPS upstream
+        endpoint_tls_count = 0      # endpoints using TLS origination
+
+        for cluster in self.clusters.values():
+            cluster_count += 1
+            using_tls = False
+            using_http = False
+            using_grpc = False
+
+            if cluster.get('tls_context', None):
+                using_tls = True
+                cluster_tls_count += 1
+
+            if cluster.get('grpc', False):
+                using_grpc = True
+                cluster_grpc_count += 1
+            else:
+                using_http = True
+                cluster_http_count += 1
+
+            for url in cluster.urls:
+                if using_tls:
+                    endpoint_tls_count += 1
+
+                if using_http:
+                    endpoint_http_count += 1
+
+                if using_grpc:
+                    endpoint_grpc_count += 1
+
+        od['cluster_count'] = cluster_count
+        od['cluster_grpc_count'] = cluster_grpc_count
+        od['cluster_http_count'] = cluster_http_count
+        od['cluster_tls_count'] = cluster_tls_count
+        od['endpoint_grpc_count'] = endpoint_grpc_count
+        od['endpoint_http_count'] = endpoint_http_count
+        od['endpoint_tls_count'] = endpoint_tls_count
+
+        extauth = False
+        extauth_proto = None
+        extauth_allow_body = False
+        extauth_host_count = 0
+
+        ratelimit = False
+        ratelimit_data_plane_proto = False
+        ratelimit_custom_domain = False
+
+        tracing = False
+        tracing_driver = None
+
+        for filter in self.filters:
+            if filter.kind == 'IRAuth':
+                extauth = True
+                extauth_proto = filter.get('proto', 'http')
+                extauth_allow_body = filter.get('allow_request_body', False)
+                extauth_host_count = len(filter.hosts.keys())
+
+        if self.ratelimit:
+            ratelimit = True
+            ratelimit_data_plane_proto = self.ratelimit.get('data_plane_proto', False)
+            ratelimit_custom_domain = bool(self.ratelimit.domain != 'ambassador')
+
+        if self.tracing:
+            tracing = True
+            tracing_driver = self.tracing.driver
+
+        od['extauth'] = extauth
+        od['extauth_proto'] = extauth_proto or "N/A"
+        od['extauth_allow_body'] = extauth_allow_body
+        od['extauth_host_count'] = extauth_host_count
+        od['ratelimit'] = ratelimit
+        od['ratelimit_data_plane_proto'] = ratelimit_data_plane_proto
+        od['ratelimit_custom_domain'] = ratelimit_custom_domain
+        od['tracing'] = tracing
+        od['tracing_driver'] = tracing_driver or "N/A"
+
+        group_count = 0
+        group_precedence_count = 0      # groups using explicit precedence
+        group_header_match_count = 0    # groups using header matches
+        group_regex_header_count = 0    # groups using regex header matches
+        group_regex_prefix_count = 0    # groups using regex prefix matches
+        group_shadow_count = 0          # groups using shadows
+        group_host_redirect_count = 0   # groups using host_redirect
+        group_host_rewrite_count = 0    # groups using host_rewrite
+        group_canary_count = 0          # groups coalescing multiple mappings
+
+        for group in self.ordered_groups():
+            group_count += 1
+
+            if group.get('precedence', 0) != 0:
+                group_precedence_count += 1
+
+            using_headers = False
+            using_regex_headers = False
+
+            for header in group.get('headers', []):
+                using_headers = True
+
+                if header['regex']:
+                    using_regex_headers = True
+                    break
+
+            if using_headers:
+                group_header_match_count += 1
+
+            if using_regex_headers:
+                group_regex_header_count += 1
+
+            if len(group.mappings) > 1:
+                group_canary_count += 1
+
+            if group.get('shadows', []):
+                group_shadow_count += 1
+
+            if group.get('host_redirect', {}):
+                group_host_redirect_count += 1
+
+            if group.get('host_rewrite', None):
+                group_host_rewrite_count += 1
+
+        od['group_count'] = group_count
+        od['group_precedence_count'] = group_precedence_count
+        od['group_header_match_count'] = group_header_match_count
+        od['group_regex_header_count'] = group_regex_header_count
+        od['group_regex_prefix_count'] = group_regex_prefix_count
+        od['group_shadow_count'] = group_shadow_count
+        od['group_host_redirect_count'] = group_host_redirect_count
+        od['group_host_rewrite_count'] = group_host_rewrite_count
+        od['group_canary_count'] = group_canary_count
+
+        od['listener_count'] = len(self.listeners)
+
+        return od

--- a/ambassador/ambassador_diag/diagd.py
+++ b/ambassador/ambassador_diag/diagd.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License
 
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 import datetime
 import functools
@@ -22,6 +22,7 @@ import glob
 import json
 import logging
 import multiprocessing
+import os
 import re
 import time
 import uuid
@@ -30,11 +31,11 @@ from pkg_resources import Requirement, resource_filename
 
 import clize
 from clize import Parameter
-from flask import Flask, render_template, send_from_directory, request, jsonify # Response
+from flask import Flask, render_template, send_from_directory, request, jsonify
 import gunicorn.app.base
 from gunicorn.six import iteritems
 
-from ambassador import Config, IR, EnvoyConfig, Diagnostics, Scout, ScoutNotice, Version
+from ambassador import Config, IR, EnvoyConfig, Diagnostics, Scout, Version
 from ambassador.utils import SystemInfo, PeriodicTrigger
 
 from ambassador.diagnostics import EnvoyStats
@@ -69,6 +70,11 @@ envoy_targets = {
 
 def number_of_workers():
     return (multiprocessing.cpu_count() * 2) + 1
+
+
+# Get the Flask app defined early.
+app = Flask(__name__,
+            template_folder=resource_filename(Requirement.parse("ambassador"), "templates"))
 
 
 ######## DECORATORS
@@ -119,12 +125,9 @@ def standard_handler(f):
     return wrapper
 
 
-# Get the Flask app defined early.
-app = Flask(__name__,
-            template_folder=resource_filename(Requirement.parse("ambassador"), "templates"))
+######## UTILITIES
 
 
-# Next, various helpers.
 class Notices:
     def __init__(self, local_config_path: str) -> None:
         self.local_path = local_config_path
@@ -155,7 +158,8 @@ class Notices:
         for notice in notices:
             self.post(notice)
 
-def get_aconf(app, what):
+
+def get_aconf(app) -> Config:
     configs = glob.glob("%s-*" % app.config_dir_prefix)
 
     if configs:
@@ -174,23 +178,30 @@ def get_aconf(app, what):
     aconf = Config()
     aconf.load_from_directory(latest, k8s=app.k8s)
 
-    uptime = datetime.datetime.now() - boot_time
-    hr_uptime = td_format(uptime)
-
     app.notices = Notices(app.notice_path)
     app.notices.reset()
 
-    app.scout = Scout()
-    app.scout_result = app.scout.report(mode="diagd", action=what,
-                                        uptime=int(uptime.total_seconds()),
-                                        hr_uptime=hr_uptime)
+    return aconf
 
+
+def check_scout(app, what: str, ir: Optional[IR]=None) -> None:
+    uptime = datetime.datetime.now() - boot_time
+    hr_uptime = td_format(uptime)
+
+    app.scout = Scout()
+    app.scout_args = {
+        "uptime": int(uptime.total_seconds()),
+        "hr_uptime": hr_uptime
+    }
+
+    if ir and not os.environ.get("AMBASSADOR_DISABLE_FEATURES", None):
+        app.scout_args["features"] = ir.features()
+
+    app.scout_result = app.scout.report(mode="diagd", action=what, **app.scout_args)
     app.notices.extend(app.scout_result.pop('notices', []))
 
     app.logger.info("Scout reports %s" % json.dumps(app.scout_result))
     app.logger.info("Scout notices: %s" % json.dumps(app.notices.notices))
-
-    return aconf
 
 
 def td_format(td_object):
@@ -296,8 +307,10 @@ def show_overview(reqid=None):
         # else:
         #     return redirect("/ambassador/v0/diag/", code=302)
 
-    aconf = get_aconf(app, "overview")
+    aconf = get_aconf(app)
     ir = IR(aconf)
+    check_scout(app, "overview", ir)
+
     econf = EnvoyConfig.generate(ir, "V2")
     diag = Diagnostics(ir, econf)
 
@@ -354,8 +367,10 @@ def show_overview(reqid=None):
 def show_intermediate(source=None, reqid=None):
     app.logger.debug("SRC %s - getting intermediate for '%s'" % (reqid, source))
 
-    aconf = get_aconf(app, "detail: %s" % source)
+    aconf = get_aconf(app)
     ir = IR(aconf)
+    check_scout(app, "detail: %s" % source, ir)
+
     econf = EnvoyConfig.generate(ir, "V2")
     diag = Diagnostics(ir, econf)
 

--- a/ambassador/kubewatch.py
+++ b/ambassador/kubewatch.py
@@ -258,9 +258,12 @@ class Restarter(threading.Thread):
         bootstrap_config = dict(envoy_config.bootstrap)
 
         scout = Scout()
-        result = scout.report(mode="kubewatch", action="reconfigure",
-                              gencount=self.restart_count)
+        scout_args = { "gencount": self.restart_count }
 
+        if not os.environ.get("AMBASSADOR_DISABLE_FEATURES", None):
+            scout_args["features"] = ir.features()
+
+        result = scout.report(mode="kubewatch", action="reconfigure", **scout_args)
         notices = result.pop("notices", [])
 
         logger.debug("scout result %s" % json.dumps(result, sort_keys=True, indent=4))

--- a/ambassador/schemas/v1/Module.schema
+++ b/ambassador/schemas/v1/Module.schema
@@ -1,8 +1,9 @@
 {
     "$schema": "http://json-schema.org/schema#",
     "id": "https://getambassador.io/schemas/mapping.json",
-     "type": "object",
-     "properties": {
+
+    "type": "object",
+    "properties": {
         "apiVersion": { "enum": ["ambassador/v1"] },
         "kind": { "type": "string" },
         "name": { "type": "string" },
@@ -12,9 +13,9 @@
                 { "type": "array", "items": { "type": "string" } }
             ]
         },
-        "max_request_bytes": { "type": "integer" },
-        "max_request_time": { "type": "integer" }
+        
+        "config": { "type": "object" }
     },
-    "required": [ "apiVersion", "kind", "name", "max_request_bytes", "max_request_time" ],
+    "required": [ "apiVersion", "kind", "name", "config" ],
     "additionalProperties": false
 }

--- a/ambassador/schemas/v1/TLSContext.schema
+++ b/ambassador/schemas/v1/TLSContext.schema
@@ -4,7 +4,7 @@
 
     "type": "object",
     "properties": {
-        "apiVersion": { "enum": ["ambassador/v0"] },
+        "apiVersion": { "enum": ["ambassador/v1"] },
         "kind": { "type": "string" },
         "name": { "type": "string" },
         "ambassador_id": {

--- a/ambassador/schemas/v1/TracingService.schema
+++ b/ambassador/schemas/v1/TracingService.schema
@@ -1,0 +1,36 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "id": "https://getambassador.io/schemas/tracing.json",
+
+    "type": "object",
+    "properties": {
+        "apiVersion": { "enum": ["ambassador/v1"] },
+        "kind": { "type": "string" },
+        "name": { "type": "string" },
+        "ambassador_id": {
+            "anyOf": [
+                { "type": "string" },
+                { "type": "array", "items": { "type": "string" } }
+            ]
+        },
+        
+        "driver": { "enum": ["lightstep", "zipkin"] },
+        "service": { "type": "string" },
+        "config": {
+            "type": "object",
+            "properties": {
+                "access_token_file": { "type": "string" },
+                "collector_endpoint": { "type": "string" },
+                "trace_id_128bit": { "type": "boolean" },
+                "shared_span_context": { "type": "boolean" }
+            },
+            "additionalProperties": false
+        },
+        "tag_headers": {
+            "type": "array",
+            "items": { "type": "string" }
+        }
+    },
+    "required": [ "apiVersion", "kind", "name", "driver", "service" ],
+    "additionalProperties": false
+}

--- a/ambassador/tests/kat/test_ambassador.py
+++ b/ambassador/tests/kat/test_ambassador.py
@@ -585,7 +585,7 @@ class RedirectTests(AmbassadorTest):
         # be annotated on the Ambassador itself.
         yield self, self.format("""
 ---
-apiVersion: ambassador/v0
+apiVersion: ambassador/v1
 kind: Module
 name: tls
 ambassador_id: {self.ambassador_id}
@@ -597,7 +597,7 @@ config:
 
         yield self.target, self.format("""
 ---
-apiVersion: ambassador/v0
+apiVersion: ambassador/v1
 kind:  Mapping
 name:  tls_target_mapping
 prefix: /tls-target/
@@ -652,7 +652,7 @@ class SimpleMapping(MappingTest):
     def config(self):
         yield self, self.format("""
 ---
-apiVersion: ambassador/v0
+apiVersion: ambassador/v1
 kind:  Mapping
 name:  {self.name}
 prefix: /{self.name}/
@@ -699,7 +699,7 @@ class HostHeaderMapping(MappingTest):
     def config(self):
         yield self, self.format("""
 ---
-apiVersion: ambassador/v0
+apiVersion: ambassador/v1
 kind:  Mapping
 name:  {self.name}
 prefix: /{self.name}/
@@ -751,7 +751,7 @@ host: tls-context-host-1
 """)
         yield self, self.format("""
 ---
-apiVersion: ambassador/v0
+apiVersion: ambassador/v1
 kind: TLSContext
 name: {self.name}-same-context-1
 hosts:
@@ -760,7 +760,7 @@ secret: same-secret-1
 """)
         yield self, self.format("""
 ---
-apiVersion: ambassador/v0
+apiVersion: ambassador/v1
 kind:  Mapping
 name:  {self.name}-same-prefix-2
 prefix: /tls-context-same/
@@ -769,7 +769,7 @@ host: tls-context-host-2
 """)
         yield self, self.format("""
 ---
-apiVersion: ambassador/v0
+apiVersion: ambassador/v1
 kind: TLSContext
 name: {self.name}-same-context-2
 hosts:
@@ -780,7 +780,7 @@ alpn_protocols: h2,http/1.1
 
         yield self, self.format("""
 ---
-apiVersion: ambassador/v0
+apiVersion: ambassador/v1
 kind:  Mapping
 name:  {self.name}-other-mapping
 prefix: /{self.name}/

--- a/docs/reference/running.md
+++ b/docs/reference/running.md
@@ -191,3 +191,53 @@ Ambassador ID itself. Ambassador needs RBAC permission to get namespaces for thi
 default YAML files provided by Datawire; if not granted this permission it will generate a UUID based only on
 the Ambassador ID. To disable cluster ID generation entirely, set the environment variable `AMBASSADOR_CLUSTER_ID`
 to a UUID that will be used for the cluster ID.
+
+Finally, each Ambassador installation reports a sanitized set of information about which features are in use.
+The current feature set reported is:
+
+| Attribute                 | Type  | Description               |
+| :------------------------ | :---- | :------------------------ |
+| `cluster_count` | int | total count of clusters in use |
+| `cluster_grpc_count` | int | count of clusters using GRPC upstream |
+| `cluster_http_count` | int | count of clusters using HTTP or HTTPS upstream |
+| `cluster_tls_count` | int | count of clusters originating TLS |
+| `custom_ambassador_id` | bool | has the `ambassador_id` been changed from 'default'? |
+| `custom_diag_port` | bool | has the diag port been changed from 8877? |
+| `custom_listener_port` | bool | has the listener port been changed from 80/443? |
+| `diagnostics` | bool | is the diagnostics service enabled? |
+| `endpoint_grpc_count` | int | count of endpoints to which Ambassador will originate GRPC |
+| `endpoint_http_count` | int | count of endpoints to which Ambassador will originate HTTP or HTTPS |
+| `endpoint_tls_count` | int | count of endpoints to which Ambassador will originate TLS |
+| `extauth` | bool | is extauth enabled? |
+| `extauth_allow_body` | bool | will Ambassador send the body to extauth? |
+| `extauth_host_count` | int | count of extauth hosts in use |
+| `extauth_proto` | str | extauth protocol in use ('http', 'grpc', or `null` if not active) |
+| `group_canary_count` | int | count of Mapping groups that include more than one Mapping |
+| `group_count` | int | total count of Mapping groups in use (length of the route table) |
+| `group_header_match_count` | int | count of groups using header matching (including `host` and `method`) |
+| `group_host_redirect_count` | int | count of groups using host_redirect |
+| `group_host_rewrite_count` | int | count of groups using host_rewrite |
+| `group_precedence_count` | int | count of groups that explicitly set the precedence of the group |
+| `group_regex_header_count` | int | count of groups using regex header matching |
+| `group_regex_prefix_count` | int | count of groups using regex prefix matching |
+| `group_shadow_count` | int | count of groups using shadows |
+| `listener_count` | int | count of active listeners (1 unless `redirect_cleartext_from` is in use) |
+| `liveness_probe` | bool | are liveness probes enabled? |
+| `ratelimit` | bool | is rate limiting in use? |
+| `ratelimit_custom_domain` | bool | has the rate limiting domain been changed from 'ambassador'? |
+| `ratelimit_data_plane_proto` | bool | is rate limiting using the data plane proto? |
+| `readiness_probe` | bool | are readiness probes enabled? |
+| `statsd` | bool | is statsd enabled? |
+| `tls_origination_count` | int | count of TLS origination contexts |
+| `tls_termination_count` | int | count of TLS termination contexts |
+| `tls_using_contexts` | bool | is the old TLS module in use? |
+| `tls_using_module` | bool | are new TLSContext resources in use? |
+| `tracing` | bool | is tracing in use? |
+| `tracing_driver` | str | tracing driver in use ('zipkin', 'lightstep', or `null` if not active) |
+| `use_proxy_proto` | bool | is the `PROXY` protocol in use? |
+| `use_remote_address` | bool | is Ambassador honoring remote addresses? |
+| `x_forwarded_proto_redirect` | bool | is Ambassador redirecting based on `X-Forwarded-Proto`? |
+
+To completely disable feature reporting, set the environment variable `AMBASSADOR_DISABLE_FEATURES` to any non-empty
+value.
+

--- a/docs/reference/running.md
+++ b/docs/reference/running.md
@@ -180,10 +180,10 @@ These environment variables can be set much like `AMBASSADOR_NAMESPACE`, above.
 
 ## Ambassador Update Checks (Scout)
 
-A running Ambassador instance checks with Datawire to be able to advise of available updates, and to help 
-Datawire better understand how Ambassador is being used. To completely disable this check, set the environment
-variable `SCOUT_DISABLE` to `1` in your Ambassador deployment (but note that this is not recommended, as you will
-lose notifications about new releases).
+Ambassador integrates Scout, a service that periodically checks with Datawire servers to advise of available updates. Scout also sends anonymized usage data and the Ambassador version. This information is important to us as we prioritize test coverage, bug fixes, and feature development. Note that Ambassador will run regardless of the status of Scout (i.e., our uptime has zero impact on your uptime.)
+
+We do not recommend you disable Scout, since we use this mechanism to notify users of new release (including critical fixes and security issues). This check can be disabled by setting the environment
+variable `SCOUT_DISABLE` to `1` in your Ambassador deployment.
   
 Each Ambassador installation generates a unique cluster ID based on the UID of its Kubernetes namespace and
 its Ambassador ID: the resulting cluster ID is a UUID which cannot be used to reveal the namespace name nor
@@ -192,8 +192,7 @@ default YAML files provided by Datawire; if not granted this permission it will 
 the Ambassador ID. To disable cluster ID generation entirely, set the environment variable `AMBASSADOR_CLUSTER_ID`
 to a UUID that will be used for the cluster ID.
 
-Finally, each Ambassador installation reports a sanitized set of information about which features are in use.
-The current feature set reported is:
+Unless disabled, Ambassador will also report the following anonymized information back to Datawire:
 
 | Attribute                 | Type  | Description               |
 | :------------------------ | :---- | :------------------------ |


### PR DESCRIPTION
Unless disabled, Ambassador will now report anonymized information about feature usage back to Datawire, to help us prioritize test coverage, bug fixes, and feature development. To disable this function, set the environment variable `AMBASSADOR_DISABLE_FEATURES` to any non-empty value.

This PR also deprecates the `ambassador/v0` API version. Everything supported by 0.50.0 now has an `ambassador/v1` resource; note, though, that some resources change semantics (see the updated `CHANGELOG` for more).