### PR TITLE
Configure use_proxy_proto correctly

### DIFF
--- a/ambassador/ambassador/envoy/v2/v2listener.py
+++ b/ambassador/ambassador/envoy/v2/v2listener.py
@@ -331,6 +331,9 @@ class V2Listener(dict):
                 }
             ]
 
+            if self.use_proxy_proto is not None:
+                chain['use_proxy_proto'] = self.use_proxy_proto
+
         self.update({
             'name': self.name,
             'address': {
@@ -437,8 +440,5 @@ class V2Listener(dict):
 
                 if matched:
                     chain['routes'].append(sni_route['route'])
-
-            if self.use_proxy_proto is not None:
-                chain['use_proxy_proto'] = self.use_proxy_proto
 
             self.filter_chains.append(chain)


### PR DESCRIPTION
`use_proxy_proto` was being configured at the wrong place in some (most?) situations. This moves it to the correct place.

Fixes #1050.