### PR TITLE
Add support for add_response_headers

### DIFF
--- a/ambassador/ambassador/envoy/v1/v1route.py
+++ b/ambassador/ambassador/envoy/v1/v1route.py
@@ -115,6 +115,12 @@ class V1Route(dict):
                     for k, v in group.add_request_headers.items()
                 ]
 
+            if "add_response_headers" in group:
+                self["response_headers_to_add"] = [
+                    {"key": k, "value": v}
+                    for k, v in group.add_response_headers.items()
+                ]
+
             if "use_websocket" in group:
                 self["cluster"] = group.mappings[0].cluster.name
             else:

--- a/ambassador/ambassador/envoy/v2/v2route.py
+++ b/ambassador/ambassador/envoy/v2/v2route.py
@@ -55,6 +55,19 @@ class V2Route(dict):
                 } for k, v in request_headers_to_add.items()
             ]
 
+        response_headers_to_add = group.get('add_response_headers', None)
+
+        if response_headers_to_add:
+            self['response_headers_to_add'] = [
+                {
+                    'header': {
+                        'key': k,
+                        'value': v
+                    },
+                    'append': True  # ???
+                } for k, v in response_headers_to_add.items()
+            ]
+
         # If a host_redirect is set, we won't do a 'route' entry.
         host_redirect = group.get('host_redirect', None)
 

--- a/ambassador/ambassador/ir/irmapping.py
+++ b/ambassador/ambassador/ir/irmapping.py
@@ -50,6 +50,7 @@ class IRMapping (IRResource):
 
     AllowedKeys: ClassVar[Dict[str, bool]] = {
         "add_request_headers": True,
+        "add_response_headers": True,
         "auto_host_rewrite": True,
         "case_sensitive": True,
         # "circuit_breaker": True,
@@ -352,6 +353,7 @@ class IRMappingGroup (IRResource):
     DoNotFlattenKeys: ClassVar[Dict[str, bool]] = dict(CoreMappingKeys)
     DoNotFlattenKeys.update({
         'add_request_headers': True,    # do this manually.
+        'add_response_headers': True,    # do this manually.
         'cluster': True,
         'host': True,
         'kind': True,
@@ -507,6 +509,7 @@ class IRMappingGroup (IRResource):
         #     self.ir.logger.debug("%s: FINALIZING: %s" % (self, self.as_json()))
 
         add_request_headers = {}
+        add_response_headers = {}
 
         for mapping in sorted(self.mappings, key=lambda m: m.route_weight):
             # if verbose:
@@ -524,9 +527,12 @@ class IRMappingGroup (IRResource):
                 self[k] = mapping[k]
 
             add_request_headers.update(mapping.get('add_request_headers', {}))
+            add_response_headers.update(mapping.get('add_response_headers', {}))
 
         if add_request_headers:
             self.add_request_headers = add_request_headers
+        if add_response_headers:
+            self.add_response_headers = add_response_headers
 
         # if verbose:
         #     self.ir.logger.debug("%s after flattening %s" % (self, self.as_json()))

--- a/ambassador/schemas/v0/Mapping.schema
+++ b/ambassador/schemas/v0/Mapping.schema
@@ -18,6 +18,7 @@
         "prefix_regex": { "type": "boolean" },
         "service": { "type": "string" },
         "add_request_headers": { "$ref": "#/definitions/mapStrStr" },
+        "add_response_headers": { "$ref": "#/definitions/mapStrStr" },
         "auto_host_rewrite": { "type": "boolean" },
         "case_sensitive": { "type": "boolean" },
         "circuit_breaker": { "type": "string" },

--- a/ambassador/schemas/v1/Mapping.schema
+++ b/ambassador/schemas/v1/Mapping.schema
@@ -18,6 +18,7 @@
         "prefix_regex": { "type": "boolean" },
         "service": { "type": "string" },
         "add_request_headers": { "$ref": "#/definitions/mapStrStr" },
+        "add_response_headers": { "$ref": "#/definitions/mapStrStr" },
         "auto_host_rewrite": { "type": "boolean" },
         "case_sensitive": { "type": "boolean" },
         "circuit_breaker": { "type": "string" },

--- a/ambassador/templates/envoy.j2
+++ b/ambassador/templates/envoy.j2
@@ -75,6 +75,7 @@
                         {%- if route.host_rewrite -%}"host_rewrite": "{{ route.host_rewrite }}",{% endif %}
                         {%- if route.auto_host_rewrite -%}"auto_host_rewrite": {{ route.auto_host_rewrite | tojson }},{% endif %}
                         {%- if route.request_headers_to_add -%}"request_headers_to_add": {{ route.request_headers_to_add | tojson }},{% endif %}
+                        {%- if route.response_headers_to_add -%}"response_headers_to_add": {{ route.response_headers_to_add | tojson }},{% endif %}
                         {%- if route.use_websocket -%}
                           "cluster": "{{ route.clusters[0].name }}"
                         {%- else -%}

--- a/ambassador/tests/006-headers-and-host/config/mapping-qotm.yaml
+++ b/ambassador/tests/006-headers-and-host/config/mapping-qotm.yaml
@@ -31,3 +31,5 @@ add_request_headers:
   x-test-proto: "%PROTOCOL%"
   x-test-ip: "%DOWNSTREAM_REMOTE_ADDRESS_WITHOUT_PORT%"
   x-test-static: testing
+add_response_headers:
+  x-response-header: testing

--- a/ambassador/tests/006-headers-and-host/gold.intermediate.json
+++ b/ambassador/tests/006-headers-and-host/gold.intermediate.json
@@ -475,6 +475,12 @@
                         "key": "x-test-static",
                         "value": "testing"
                     }
+                ],
+                "response_headers_to_add": [
+                    {
+                        "key": "x-response-header",
+                        "value": "testing"
+                    }
                 ]
             },
             {
@@ -649,7 +655,7 @@
             "kind": "Mapping",
             "name": "qotm_host_mapping",
             "version": "ambassador/v0",
-            "yaml": "add_request_headers:\n  x-test-ip: '%DOWNSTREAM_REMOTE_ADDRESS_WITHOUT_PORT%'\n  x-test-proto: '%PROTOCOL%'\n  x-test-static: testing\napiVersion: ambassador/v0\nheaders:\n  x-demo-mode: host\nhost: httpbin.org\nhost_rewrite: httpbin.org\nkind: Mapping\nname: qotm_host_mapping\nprefix: /qotm/\nrewrite: /\nservice: httpbin.org:80\n"
+            "yaml": "add_request_headers:\n  x-test-ip: '%DOWNSTREAM_REMOTE_ADDRESS_WITHOUT_PORT%'\n  x-test-proto: '%PROTOCOL%'\n  x-test-static: testing\nadd_response_headers:\n  x-response-header: testing\napiVersion: ambassador/v0\nheaders:\n  x-demo-mode: host\nhost: httpbin.org\nhost_rewrite: httpbin.org\nkind: Mapping\nname: qotm_host_mapping\nprefix: /qotm/\nrewrite: /\nservice: httpbin.org:80\n"
         }
     }
 }

--- a/ambassador/tests/006-headers-and-host/gold.json
+++ b/ambassador/tests/006-headers-and-host/gold.json
@@ -144,7 +144,7 @@
                     {
                       "timeout_ms": 3000,"prefix": "/qotm/",
                         "cors": {"allow_credentials": true, "allow_headers": "Content-Type", "allow_methods": "POST, GET, OPTIONS", "allow_origin": ["http://foo.example", "http://bar.example"], "enabled": true, "expose_headers": "X-Custom-Header", "max_age": "86400"},
-                      "headers": [{"name": "x-demo-mode", "regex": false, "value": "host"}, {"name": ":authority", "regex": false, "value": "httpbin.org"}],"prefix_rewrite": "/","host_rewrite": "httpbin.org","request_headers_to_add": [{"key": "x-test-proto", "value": "%PROTOCOL%"}, {"key": "x-test-ip", "value": "%DOWNSTREAM_REMOTE_ADDRESS_WITHOUT_PORT%"}, {"key": "x-test-static", "value": "testing"}],"weighted_clusters": {
+                      "headers": [{"name": "x-demo-mode", "regex": false, "value": "host"}, {"name": ":authority", "regex": false, "value": "httpbin.org"}],"prefix_rewrite": "/","host_rewrite": "httpbin.org","request_headers_to_add": [{"key": "x-test-proto", "value": "%PROTOCOL%"}, {"key": "x-test-ip", "value": "%DOWNSTREAM_REMOTE_ADDRESS_WITHOUT_PORT%"}, {"key": "x-test-static", "value": "testing"}],"response_headers_to_add": [{"key": "x-response-header", "value": "testing"}],"weighted_clusters": {
                               "clusters": [
                                   
                                     { "name": "cluster_httpbin_org_80", "weight": 100.0 }

--- a/ambassador/tests/ambassador_test.py
+++ b/ambassador/tests/ambassador_test.py
@@ -242,6 +242,13 @@ class old_ir (dict):
                 route['request_headers_to_add'] = to_add
                 del(route['add_request_headers'])
 
+            if 'add_response_headers' in route:
+                to_add = [ { "key": k, "value": v }
+                           for k, v in route['add_response_headers'].items() ]
+
+                route['response_headers_to_add'] = to_add
+                del(route['add_response_headers'])
+
             route['clusters'] = []
             rl_actions = []
             

--- a/ambassador/tests/kat/test_ambassador.py
+++ b/ambassador/tests/kat/test_ambassador.py
@@ -728,6 +728,24 @@ class AddRequestHeaders(OptionTest):
                 actual = r.backend.request.headers.get(k.lower())
                 assert actual == [v], (actual, [v])
 
+class AddResponseHeaders(OptionTest):
+
+    parent: Test
+
+    VALUES: ClassVar[Sequence[Dict[str, str]]] = (
+        { "foo": "bar" },
+        { "moo": "arf" }
+    )
+
+    def config(self):
+        yield "add_response_headers: %s" % json.dumps(self.value)
+
+    def check(self):
+        for r in self.parent.results:
+            for k, v in self.value.items():
+                actual = r.backend.response.headers.get(k.lower())
+                assert actual == [v], (actual, [v])
+
 
 class HostHeaderMapping(MappingTest):
 

--- a/docs/doc-links.yml
+++ b/docs/doc-links.yml
@@ -126,6 +126,8 @@
               link: /reference/redirects
             - title: Request Headers
               link: /reference/add_request_headers
+            - title: Response Headers
+              link: /reference/add_response_headers
             - title: Rewrites
               link: /reference/rewrites
             - title: Traffic Shadowing

--- a/docs/features.html
+++ b/docs/features.html
@@ -214,6 +214,13 @@
                 <strong>Request Transformers</strong>
                 <p>Add a dictionary of HTTP headers that can be added to each request to your service</p>
             </a>
+            <a href="/reference/add_response_headers" class="card">
+                <div class="icon">
+                    <img src="/images/features-icons/request-transformers.svg" />
+                </div>
+                <strong>Request Transformers</strong>
+                <p>Add a dictionary of HTTP headers added to each response that is returned to client</p>
+            </a>
             <div class="card">
                 <div class="icon">
                     <img src="/images/features-icons/regex-routing.svg" />

--- a/docs/reference/add_response_headers.md
+++ b/docs/reference/add_response_headers.md
@@ -1,0 +1,24 @@
+# Add Response Headers
+
+Ambassador can add a dictionary of HTTP headers that can be added to each response that is returned to client.
+
+## The `add_response_headers` annotation
+
+The `add_response_headers` attribute is a dictionary of `header`: `value` pairs. Envoy dynamic values `%DOWNSTREAM_REMOTE_ADDRESS_WITHOUT_PORT%` and `%PROTOCOL%` are supported, in addition to static values.
+
+## A basic example
+
+```yaml
+---
+apiVersion: ambassador/v0
+kind:  Mapping
+name:  qotm_mapping
+prefix: /qotm/
+add_response_headers:
+  x-test-proto: "%PROTOCOL%"
+  x-test-ip: "%DOWNSTREAM_REMOTE_ADDRESS_WITHOUT_PORT%"
+  x-test-static: This is a test header
+service: qotm
+```
+
+will add the protocol, client IP, and a static header to returning response to client.

--- a/docs/reference/mappings.md
+++ b/docs/reference/mappings.md
@@ -21,6 +21,7 @@ Ambassador supports a number of attributes to configure and customize mappings.
 | Attribute                 | Description               |
 | :------------------------ | :------------------------ |
 | [`add_request_headers`](/reference/add_request_headers) | specifies a dictionary of other HTTP headers that should be added to each request when talking to the service |
+| [`add_response_headers`](/reference/add_response_headers) | specifies a dictionary of other HTTP headers that should be added to each response when returning response to client |
 | [`cors`](/reference/cors)           | enables Cross-Origin Resource Sharing (CORS) setting on a mapping | 
 | [`grpc`](/user-guide/grpc) | if true, tells the system that the service will be handling gRPC calls |
 | [`headers`](/reference/headers)      | specifies a list of other HTTP headers which _must_ appear in the request for this mapping to be used to route the request |


### PR DESCRIPTION
Adds support for adding headers to the response going to client. Especially useful for setting security headers.

Basically copypaste from `add_request_headers` following [envoy docs](https://www.envoyproxy.io/docs/envoy/latest/configuration/http_conn_man/headers#custom-request-response-headers)

Tested out locally, seems to do the right thing :)