### PR TITLE
Add tests for X-Forwarded-Proto and extauth

### DIFF
--- a/ambassador/tests/kat/abstract_tests.py
+++ b/ambassador/tests/kat/abstract_tests.py
@@ -240,11 +240,15 @@ class ServiceType(Node):
 
     path: Name
 
+    def __init__(self, service_manifests: str=None, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self._manifests = service_manifests or manifests.BACKEND
+
     def config(self):
         yield from ()
 
     def manifests(self):
-        return self.format(manifests.BACKEND)
+        return self.format(self._manifests)
 
     def requirements(self):
         yield ("url", Query("http://%s" % self.path.k8s))
@@ -257,6 +261,20 @@ class HTTP(ServiceType):
 
 class GRPC(ServiceType):
     pass
+
+
+class AHTTP(ServiceType):
+    skip_variant: ClassVar[bool] = True
+
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, service_manifests=manifests.AUTH_BACKEND, **kwargs)
+
+
+class AGRPC(ServiceType):
+    skip_variant: ClassVar[bool] = True
+
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, service_manifests=manifests.AUTH_BACKEND, **kwargs)
 
 
 @abstract_test

--- a/ambassador/tests/kat/t_extauth.py
+++ b/ambassador/tests/kat/t_extauth.py
@@ -1,6 +1,8 @@
+import json
+
 from kat.harness import Query
 
-from abstract_tests import AmbassadorTest, ServiceType, HTTP
+from abstract_tests import AmbassadorTest, ServiceType, HTTP, AHTTP
 
 
 class AuthenticationHTTPBufferedTest(AmbassadorTest):
@@ -129,7 +131,7 @@ class AuthenticationTestV1(AmbassadorTest):
 
     def init(self):
         self.target = HTTP()
-        self.auth = HTTP(name="auth")
+        self.auth = AHTTP(name="auth")
 
     def config(self):
         yield self, self.format("""
@@ -242,7 +244,7 @@ class AuthenticationTest(AmbassadorTest):
 
     def init(self):
         self.target = HTTP()
-        self.auth = HTTP(name="auth")
+        self.auth = AHTTP(name="auth")
 
     def config(self):
         yield self, self.format("""
@@ -260,6 +262,7 @@ allowed_headers:
 - Requested-Status
 - Requested-Header
 - X-Foo
+- Extauth
 
 """)
         yield self, self.format("""
@@ -292,6 +295,8 @@ service: {self.target.path.k8s}
         yield Query(self.url("target/"), headers={"Requested-Status": "200",
                                                   "Authorization": "foo-11111",
                                                   "Requested-Header": "Authorization"}, expected=200)
+        # [5]
+        yield Query(self.url("target/"), headers={"X-Forwarded-Proto": "https"}, expected=200, debug=True)
 
     def check(self):
         # [0] Verifies all request headers sent to the authorization server.
@@ -338,6 +343,29 @@ service: {self.target.path.k8s}
         assert self.results[4].status == 200
         assert self.results[4].headers["Server"] == ["envoy"]
         assert self.results[4].headers["Authorization"] == ["foo-11111"]
+
+        # [5] Verify that X-Forwarded-Proto makes it to the auth service.
+        #
+        # We use the 'extauth' header returned from the test extauth service for this, since
+        # the extauth service (on success) won't actually alter other things going upstream.
+        r5 = self.results[5]
+        assert r5
+
+        assert r5.status == 200
+        assert r5.headers["Server"] == ["envoy"]
+
+        eahdr = r5.backend.request.headers["extauth"]
+        assert eahdr, "no extauth header was returned?"
+        assert eahdr[0], "an empty extauth header element was returned?"
+
+        try:
+            eainfo = json.loads(eahdr[0])
+
+            if eainfo:
+                # Envoy should force this to HTTP, not HTTPS.
+                assert eainfo['request']['headers']['x-forwarded-proto'] == [ 'http' ]
+        except ValueError as e:
+            assert False, "could not parse Extauth header '%s': %s" % (eahdr, e)
 
         # TODO(gsagula): Write tests for all UCs which request header headers
         # are overridden, e.g. Authorization.

--- a/kat/backend/Makefile
+++ b/kat/backend/Makefile
@@ -1,4 +1,4 @@
-TAG=6
+TAG=7
 
 build:
 	docker build . -t quay.io/datawire/kat-backend:${TAG}

--- a/kat/backend/server.go
+++ b/kat/backend/server.go
@@ -78,6 +78,25 @@ func requestLogger(w http.ResponseWriter, r *http.Request) {
 	    w.Header()[http.CanonicalHeaderKey("Location")] = location
 	}
 
+    add_extauth := os.Getenv("INCLUDE_EXTAUTH_HEADER")
+
+    if len(add_extauth) > 0 {
+        extauth := make(map[string]interface{})
+        extauth["request"] = request
+        extauth["resp_headers"] = lower(w.Header())
+
+        ea_json, err := json.Marshal(extauth)
+
+        if err != nil {
+            ea_json = []byte(fmt.Sprintf("err: %v", err))
+        }
+
+        ea_array := make([]string, 1, 1)
+        ea_array[0] = string(ea_json)
+
+        w.Header()[http.CanonicalHeaderKey("extauth")] = ea_array
+    }
+
 	w.WriteHeader(statusCode)
 
 	// Write out all request/response information

--- a/kat/kat/harness.py
+++ b/kat/kat/harness.py
@@ -70,8 +70,9 @@ def get_nodes(node_type: type):
     if not inspect.isabstract(node_type) and not node_type.__dict__.get("abstract_test", False):
         yield node_type
     for sc in node_type.__subclasses__():
-        for ssc in get_nodes(sc):
-            yield ssc
+        if not sc.__dict__.get("skip_variant", False):
+            for ssc in get_nodes(sc):
+                yield ssc
 
 
 def variants(cls, *args, **kwargs) -> Tuple[Any]:

--- a/kat/kat/manifests.py
+++ b/kat/kat/manifests.py
@@ -26,12 +26,50 @@ metadata:
 spec:
   containers:
   - name: backend
-    image: quay.io/datawire/kat-backend:6
+    image: quay.io/datawire/kat-backend:7
     ports:
     - containerPort: 8080
     env:
     - name: BACKEND
       value: {self.path.k8s}
+"""
+
+AUTH_BACKEND = """
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: {self.path.k8s}
+spec:
+  selector:
+    backend: {self.path.k8s}
+  ports:
+  - name: http
+    protocol: TCP
+    port: 80
+    targetPort: 8080
+  - name: https
+    protocol: TCP
+    port: 443
+    targetPort: 8443
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: {self.path.k8s}
+  labels:
+    backend: {self.path.k8s}
+spec:
+  containers:
+  - name: backend
+    image: quay.io/datawire/kat-backend:7
+    ports:
+    - containerPort: 8080
+    env:
+    - name: BACKEND
+      value: {self.path.k8s}
+    - name: INCLUDE_EXTAUTH_HEADER
+      value: "yes"
 """
 
 AMBASSADOR = """


### PR DESCRIPTION
This is more complex than it might first seem because we use the same backend service for auth and for upstream, so it needed some modification to allow being able to tell what got handed to the extauth service...