### PR TITLE
fixed issue with wesocket handshake and authz filter

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@
 #
 # The base image (for everything) is defined here.
 
-FROM quay.io/datawire/ambassador-envoy-alpine-stripped:v1.8.0-15c5befd43fb9ee9b145cc87e507beb801726316 as BASE
+FROM quay.io/datawire/ambassador-envoy-alpine-stripped:v1.8.0-878705f86c as BASE
 
 MAINTAINER Datawire <flynn@datawire.io>
 LABEL PROJECT_REPO_URL         = "git@github.com:datawire/ambassador.git" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@
 #
 # The base image (for everything) is defined here.
 
-FROM quay.io/datawire/ambassador-envoy-alpine-stripped:v1.8.0-878705f86c as BASE
+FROM quay.io/datawire/ambassador-envoy-alpine-stripped:v1.8.0-g14e2c65bb as BASE
 
 MAINTAINER Datawire <flynn@datawire.io>
 LABEL PROJECT_REPO_URL         = "git@github.com:datawire/ambassador.git" \


### PR DESCRIPTION
*Description:* 
This PR updates Ambassador with a new Envoy image that fixes https://github.com/datawire/ambassador/issues/1026. The issue was in Authorization filter with `send request data` was enabled. The previous implementation relied on the headers end of stream signal to start the asynchronous authorization request. However when `sending request data` was enabled and end of the stream was true, the authorization call was supposed to be invoked during data decoding which, in the case of a WebSocket handshake for example, never happens. The issue was fixed by inspecting the request  before initiating the authorization call, which could happen during header decoding or data decoding, depending on the request method and the `send request data` configuration.

Signed-off-by: Gabriel <gsagula@gmail.com>