### PR TITLE
Clean up some annoyances

### DIFF
--- a/ambassador/ambassador/config/config.py
+++ b/ambassador/ambassador/config/config.py
@@ -66,7 +66,7 @@ class Config:
     sources: Dict[str, ACResource]
 
     errors: Dict[str, List[dict]]
-    notices: Dict[str, List[dict]]
+    notices: Dict[str, List[str]]
     fatal_errors: int
     object_errors: int
 

--- a/ambassador/ambassador/envoy/v2/v2listener.py
+++ b/ambassador/ambassador/envoy/v2/v2listener.py
@@ -368,7 +368,7 @@ class V2Listener(dict):
 
         # We'll assemble a list of active TLS contexts here. It may end up empty,
         # of course.
-        envoy_contexts: List[Tuple[str, List[str], V2TLSContext]] = []
+        envoy_contexts: List[Tuple[str, Optional[List[str]], V2TLSContext]] = []
 
         for tls_context in config.ir.get_tls_contexts():
             if tls_context.get('hosts', None):
@@ -409,7 +409,9 @@ class V2Listener(dict):
                 # Check if filter chain and SNI route have matching hosts
                 config.ir.logger.info("V2Listener: SNI route check %s, route %s" %
                                       (name, json.dumps(sni_route, indent=4, sort_keys=True)))
-                matched = sorted(sni_route['info']['hosts']) == sorted(hosts)
+
+                context_hosts = sorted(hosts or [])
+                matched = sorted(sni_route['info']['hosts']) == context_hosts
 
                 # Check for certificate match too.
                 for sni_key, ctx_key in [ ('cert_chain_file', 'certificate_chain'),

--- a/ambassador/ambassador/ir/ir.py
+++ b/ambassador/ambassador/ir/ir.py
@@ -117,7 +117,6 @@ class IR:
         # this though.
 
         self.tls_module = None
-        # self.envoy_tls = {}
 
         # OK! Start by wrangling TLS-context stuff, both from the TLS module (if any)...
         TLSModuleFactory.load_all(self, aconf)
@@ -338,8 +337,6 @@ class IR:
                           for cluster_name, cluster in self.clusters.items() },
             'grpc_services': { svc_name: cluster.as_dict()
                                for svc_name, cluster in self.grpc_services.items() },
-            # 'envoy_tls_contexts': { ctx_name: ctx.as_dict()
-            #                         for ctx_name, ctx in self.envoy_tls.items() },
             'listeners': [ listener.as_dict() for listener in self.listeners ],
             'filters': [ filt.as_dict() for filt in self.filters ],
             'groups': [ group.as_dict() for group in self.ordered_groups() ],
@@ -366,15 +363,6 @@ class IR:
         using_tls_module = False
         using_tls_contexts = False
 
-        # for ctx in self.envoy_tls.values():
-        #     using_tls_module = True
-        #
-        #     if ctx.get('certificate_chain_file', None) and ctx.get('valid_tls', False):
-        #         tls_termination_count += 1
-        #
-        #     if ctx.get('cacert_chain_file', None) and ctx.get('valid_tls', False):
-        #         tls_origination_count += 1
-
         for ctx in self.get_tls_contexts():
             if ctx:
                 secret_info = ctx.get('secret_info', {})
@@ -387,6 +375,9 @@ class IR:
 
                     if secret_info.get('cacert_chain_file', None):
                         tls_origination_count += 1
+
+                if ctx.get('_legacy', False):
+                    using_tls_module = True
 
         od['tls_using_module'] = using_tls_module
         od['tls_using_contexts'] = using_tls_contexts

--- a/ambassador/ambassador/ir/irmapping.py
+++ b/ambassador/ambassador/ir/irmapping.py
@@ -241,11 +241,14 @@ class IRMapping (IRResource):
 
     def match_tls_context(self, host: str, ir: 'IR'):
         for context in ir.get_tls_contexts():
-            for context_host in context.get('hosts', []):
+            hosts = context.get('hosts') or []
+
+            for context_host in hosts:
                 if context_host == host:
                     ir.logger.info("Matched host {} with TLSContext {}".format(host, context.get('name')))
                     self.sni = True
                     return context
+
         return None
 
 

--- a/ambassador/ambassador/ir/irtlscontext.py
+++ b/ambassador/ambassador/ir/irtlscontext.py
@@ -316,6 +316,9 @@ class IRTLSContext(IRResource):
                     # Assume they want the 'ambassador-cacert' secret.
                     new_args['secret'] = 'ambassador-cacert'
 
+        # Remember that this is a legacy context.
+        new_args['_legacy'] = True
+
         return IRTLSContext.from_config(ir, rkey, location,
                                         kind="synthesized-TLS-context",
                                         name=name, **new_args)

--- a/ambassador/ambassador/ir/irtlscontext.py
+++ b/ambassador/ambassador/ir/irtlscontext.py
@@ -23,7 +23,7 @@ class IRTLSContext(IRResource):
     ]
 
     name: str
-    hosts: List[str]
+    hosts: Optional[List[str]]
     alpn_protocols: Optional[str]
     cert_required: Optional[bool]
     redirect_cleartext_from: Optional[int]


### PR DESCRIPTION
Fix #1071 by correctly managing upstream contexts when SNI is active (`context.get('hosts', [])` will not return an empty array if `context.hosts` is explicitly set to `None`), and clean up a bunch of mypy warnings around TLS contexts.
