### PR TITLE
Update Alpine mirrors to avoid build failures

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,6 +40,9 @@ FROM BASE as builder
 ENV AMBASSADOR_ROOT=/ambassador
 
 # Compilers and pip and all that good stuff go here.
+RUN echo "https://mirror.math.princeton.edu/pub/alpinelinux/v3.8/main" > /etc/apk/repositories && \
+    echo "https://mirror.math.princeton.edu/pub/alpinelinux/v3.8/community" >> /etc/apk/repositories
+
 RUN apk --no-cache add go build-base libffi-dev openssl-dev python3-dev
 RUN pip3 install -U pip
 
@@ -76,6 +79,9 @@ RUN chmod +x kubewatch
 FROM BASE as foundation
 ENV AMBASSADOR_ROOT=/ambassador
 WORKDIR ${AMBASSADOR_ROOT}
+
+RUN echo "https://mirror.math.princeton.edu/pub/alpinelinux/v3.8/main" > /etc/apk/repositories && \
+    echo "https://mirror.math.princeton.edu/pub/alpinelinux/v3.8/community" >> /etc/apk/repositories
 
 RUN apk --no-cache add curl python3
 


### PR DESCRIPTION
The default Alpine mirror (dl-cdn) is known not to always work,
like in my case where apk installs have been failing for hours
throwing "protocol error" messages.

This commit updates the mirror to a new reliable mirror which
works well enough and does not cause random ambassador container
image build failures.