### PR TITLE
Bypass Authentication via Configuration

### DIFF
--- a/ambassador/ambassador/config/acmapping.py
+++ b/ambassador/ambassador/config/acmapping.py
@@ -23,7 +23,7 @@ from .acresource import ACResource
 ## Each Mapping object has a group_id that reflects the group of Mappings
 ## that it is a part of. By definition, two Mappings with the same group_id
 ## are reflecting a single mapped resource that's going to multiple services.
-## This implies that Mapping.group_id() is a very, very, very important 
+## This implies that Mapping.group_id() is a very, very, very important
 ## thing that can have dramatic customer impact if changed! (At some point,
 ## we should probably allow the human writing the Mapping to override the
 ## grouping, in much the same way we allow overriding precedence.)
@@ -55,6 +55,7 @@ class ACMapping (ACResource):
                  rewrite: Optional[str]="/",
                  case_sensitive: bool=False,
                  grpc: bool=False,
+                 bypass_auth: bool=False,
 
                  # We don't list "method" or "method_regex" above because if they're
                  # not present, we want them to be _not present_. Having them be always
@@ -81,4 +82,5 @@ class ACMapping (ACResource):
                          rewrite=rewrite,
                          case_sensitive=case_sensitive,
                          grpc=grpc,
+                         bypass_auth=bypass_auth,
                          **kwargs)

--- a/ambassador/ambassador/envoy/v2/v2route.py
+++ b/ambassador/ambassador/envoy/v2/v2route.py
@@ -42,6 +42,15 @@ class V2Route(dict):
 
         self['match'] = match
 
+        # `per_filter_config` is used for customization of an Envoy filter
+        per_filter_config = {}
+
+        if group.get('bypass_auth', False):
+            per_filter_config['envoy.ext_authz'] = {'disabled': True}
+
+        if per_filter_config:
+            self['per_filter_config'] = per_filter_config
+
         request_headers_to_add = group.get('add_request_headers', None)
 
         if request_headers_to_add:

--- a/ambassador/ambassador/ir/irmapping.py
+++ b/ambassador/ambassador/ir/irmapping.py
@@ -81,6 +81,7 @@ class IRMapping (IRResource):
         "tls": True,
         "use_websocket": True,
         "weight": True,
+        "bypass_auth": True,
 
         # Include the serialization, too.
         "serialization": True,
@@ -275,7 +276,8 @@ class IRMappingGroup (IRResource):
         'prefix': True,
         'prefix_regex': True,
         'rewrite': True,
-        'timeout_ms': True
+        'timeout_ms': True,
+        'bypass_auth': True
     }
 
     DoNotFlattenKeys: ClassVar[Dict[str, bool]] = dict(CoreMappingKeys)
@@ -427,8 +429,8 @@ class IRMappingGroup (IRResource):
         """
         Finalize a MappingGroup based on the attributes of its Mappings. Core elements get lifted into
         the Group so we can more easily build Envoy routes; host-redirect and shadow get handled, etc.
-        
-        :param ir: the IR we're working from 
+
+        :param ir: the IR we're working from
         :param aconf: the Config we're working from
         :return: a list of the IRClusters this Group uses
         """

--- a/ambassador/schemas/v1/Mapping.schema
+++ b/ambassador/schemas/v1/Mapping.schema
@@ -13,7 +13,7 @@
                 { "type": "array", "items": { "type": "string" } }
             ]
         },
-        
+
         "prefix": { "type": "string" },
         "prefix_regex": { "type": "boolean" },
         "service": { "type": "string" },
@@ -69,6 +69,7 @@
         "tls": { "type": [ "string", "boolean" ] },
         "use_websocket": { "type": "boolean" },
         "weight": { "type": "integer" },
+        "bypass_auth": { "type": "boolean" },
 
         "modules": {
             "type": "array",

--- a/ambassador/templates/envoy.j2
+++ b/ambassador/templates/envoy.j2
@@ -54,6 +54,7 @@
                     {% for route in routes %}
                     {
                       "timeout_ms": {{ route.timeout_ms if (route.timeout_ms == 0 or route.timeout_ms) else 3000 }},
+                      {%- if route.per_filter_config -%}"per_filter_config": {{ route.per_filter_config | tojson }},{% endif %}
                       {%- if route.prefix -%}"prefix": "{{ route.prefix }}",{% endif %}
                       {%- if route.regex -%}"regex": {{ route.regex | tojson }},{% endif %}
                       {%- if route.case_sensitive -%}"case_sensitive": {{ route.case_sensitive | tojson }},{% endif %}
@@ -106,7 +107,7 @@
             },
             "filters": [
               {% for filter in filters -%}
-              { 
+              {
                 {%- if filter.type -%}"type": "{{ filter.type }}",{% endif %}
                 "name": "{{ filter.name }}",
                 "config": {{ filter.config | tojson }}
@@ -141,7 +142,7 @@
         "connect_timeout_ms": {{ cluster.timeout_ms or 3000 }},
         "type": "{{ cluster.type or 'strict_dns' }}",
         "lb_type": "{{ cluster.lb_type or 'round_robin' }}",
-        {%- if cluster.features -%}"features": "{{ cluster.features }}",{% endif %}        
+        {%- if cluster.features -%}"features": "{{ cluster.features }}",{% endif %}
         "hosts": [
           {% for url in cluster.urls -%}
           {

--- a/ambassador/tests/kat/t_extauth.py
+++ b/ambassador/tests/kat/t_extauth.py
@@ -21,7 +21,7 @@ apiVersion: ambassador/v0
 kind:  Module
 name:  ambassador
 config:
-  buffer:  
+  buffer:
     max_request_bytes: 16384
     max_request_time: 5000
 ---
@@ -183,6 +183,13 @@ kind:  Mapping
 name:  {self.target.path.k8s}
 prefix: /target/
 service: {self.target.path.k8s}
+---
+apiVersion: ambassador/v0
+kind:  Mapping
+name:  {self.target.path.k8s}-unauthed
+prefix: /target/unauthed/
+service: {self.target.path.k8s}
+bypass_auth: true
 """)
 
     def queries(self):
@@ -281,6 +288,11 @@ service: {self.target.path.k8s}
         assert eahdr, "no extauth header was returned?"
         assert eahdr[0], "an empty extauth header element was returned?"
 
+        # [6] Verifies that Envoy bypasses external auth when disabled for a mapping.
+        assert self.results[6].backend.request.headers["requested-status"] == ["200"]
+        assert self.results[6].status == 200
+        assert self.results[6].headers["Server"] == ["envoy"]
+
         try:
             eainfo = json.loads(eahdr[0])
 
@@ -356,6 +368,9 @@ service: {self.target.path.k8s}
                                                   "Requested-Header": "Authorization"}, expected=200)
         # [5]
         yield Query(self.url("target/"), headers={"X-Forwarded-Proto": "https"}, expected=200)
+
+        # [6]
+        yield Query(self.url("target/unauthed/"), headers={"Requested-Status": "200"}, expected=200)
 
     def check(self):
         # [0] Verifies all request headers sent to the authorization server.

--- a/ambassador/tests/kat/t_extauth.py
+++ b/ambassador/tests/kat/t_extauth.py
@@ -220,7 +220,6 @@ bypass_auth: true
         # [6]
         yield Query(self.url("target/unauthed/"), headers={"Requested-Status": "200"}, expected=200)
 
-
     def check_backend_name(self, result) -> bool:
         backend_name = result.backend.name
 

--- a/docs/reference/mappings.md
+++ b/docs/reference/mappings.md
@@ -121,7 +121,7 @@ If absolutely necessary, you can manually set a `precedence` on the mapping (see
 
 Ambassador will respond with a `404 Not Found` to any request for which no mapping exists. If desired, you can define a fallback "catch-all" mapping so all unmatched requests will be sent to an upstream service.
 
-For example, defining a mapping with only a `/` prefix will catch all requests previously unhandled and forward them to an external service, bypassing authentication (if configured):
+For example, defining a mapping with only a `/` prefix will catch all requests previously unhandled and forward them to an external service:
 
 ```yaml
 ---

--- a/docs/reference/mappings.md
+++ b/docs/reference/mappings.md
@@ -128,7 +128,6 @@ For example, defining a mapping with only a `/` prefix will catch all requests p
 apiVersion: ambassador/v0
 kind: Mapping
 name: catch-all
-bypass_auth: true
 prefix: /
 service: https://www.getambassador.io
 ```

--- a/docs/reference/mappings.md
+++ b/docs/reference/mappings.md
@@ -22,7 +22,7 @@ Ambassador supports a number of attributes to configure and customize mappings.
 | :------------------------ | :------------------------ |
 | [`add_request_headers`](/reference/add_request_headers) | specifies a dictionary of other HTTP headers that should be added to each request when talking to the service |
 | [`add_response_headers`](/reference/add_response_headers) | specifies a dictionary of other HTTP headers that should be added to each response when returning response to client |
-| [`cors`](/reference/cors)           | enables Cross-Origin Resource Sharing (CORS) setting on a mapping | 
+| [`cors`](/reference/cors)           | enables Cross-Origin Resource Sharing (CORS) setting on a mapping |
 | [`grpc`](/user-guide/grpc) | if true, tells the system that the service will be handling gRPC calls |
 | [`headers`](/reference/headers)      | specifies a list of other HTTP headers which _must_ appear in the request for this mapping to be used to route the request |
 | [`host`](/reference/host) | specifies the value which _must_ appear in the request's HTTP `Host` header for this mapping to be used to route the request |
@@ -55,6 +55,7 @@ These attributes are less commonly used, but can be used to override Ambassador'
 | [`host_redirect`](/reference/redirects) | if true, this `Mapping` performs an HTTP 301 `Redirect`, with the host portion of the URL replaced with the `service` value. |
 | [`path_redirect`](/reference/redirects)           | if set when `host_redirect` is also true, the path portion of the URL will replaced with the `path_redirect` value in the HTTP 301 `Redirect`. |
 | [`precedence`](#a-nameprecedencea-using-precedence)           | an integer overriding Ambassador's internal ordering for `Mapping`s. An absent `precedence` is the same as a `precedence` of 0. Higher `precedence` values are matched earlier. |
+| `bypass_auth`             | if true, tells Ambassador that this service should bypass `ExtAuth` (if configured) |
 
 The name of the mapping must be unique. If no `method` is given, all methods will be proxied.
 
@@ -120,13 +121,14 @@ If absolutely necessary, you can manually set a `precedence` on the mapping (see
 
 Ambassador will respond with a `404 Not Found` to any request for which no mapping exists. If desired, you can define a fallback "catch-all" mapping so all unmatched requests will be sent to an upstream service.
 
-For example, defining a mapping with only a `/` prefix will catch all requests previously unhandled and forward them to an external service:
+For example, defining a mapping with only a `/` prefix will catch all requests previously unhandled and forward them to an external service, bypassing authentication (if configured):
 
 ```yaml
 ---
 apiVersion: ambassador/v0
 kind: Mapping
 name: catch-all
+bypass_auth: true
 prefix: /
 service: https://www.getambassador.io
 ```

--- a/docs/reference/services/auth-service.md
+++ b/docs/reference/services/auth-service.md
@@ -2,7 +2,7 @@
 
 Ambassador supports a highly flexible mechanism for authentication. An `AuthService` manifest configures Ambassador to use an external service to check authentication and authorization for incoming requests. Each incoming request is authenticated before routing to its destination.
 
-There are currently two supported versions of the `AuthService` manifest: 
+There are currently two supported versions of the `AuthService` manifest:
 
 ### V1 (Ambassador 0.50.0 and higher):
 
@@ -95,7 +95,7 @@ For every incoming request, the HTTP `method` and headers are forwarded to the a
 1. The `Content-Length` header is overwritten with `0`.
 2. The body is removed.
 
-So, for example, if the incoming request is 
+So, for example, if the incoming request is
 
 ```
 PUT /path/to/service HTTP/1.1
@@ -138,6 +138,10 @@ Giving the external auth service control over the response on failure allows man
 - The external auth service can issue a 301 `Redirect` to divert the client into an OAuth or OIDC authentication sequence.
 
 Finally, if Ambassador cannot reach the auth service at all, it will return a HTTP 503 status code to the client.
+
+## Configuring Public Mappings
+
+Authentication can be disabled for a mapping by setting `bypass_auth` to `true`. This will tell Ambassador to allow all requests for that mapping through without interacting with the external auth service.
 
 ## Example
 


### PR DESCRIPTION
This PR adds a `per_filter_config` to the Envoy route when a mapping has `bypass_auth` set to `true` in Ambassador 0.50.0+. To accomplish this, I added:
- a `bypass_auth` field to the v1 Mapping schema
- `bypass_auth` to the ACMapping resource with a default of `False`
- `per_filter_config` to the Envoy v2 route configuration (conditionally)
- `per_filter_config` to the Envoy configuration template
- a test to ensure a 200 response from a mapping with `bypass_auth` set to `true`
- references to `bypass_auth`

Additionally, my editor decided to clean up some whitespace.

Seeking feedback as this is a non-trivial change. The testing is a little light -- I would especially appreciate feedback on where/how to effectively test this.

Fixes #174 