### PR TITLE
Have tests try to give some more information on failure.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -362,7 +362,7 @@ test: setup-develop cluster.yaml
 	AMBASSADOR_DOCKER_IMAGE=$(AMBASSADOR_DOCKER_IMAGE) \
 	KUBECONFIG=$(KUBECONFIG) \
 	PATH="$(shell pwd)/venv/bin:$(PATH)" \
-	pytest --tb=short --cov=ambassador --cov=ambassador_diag --cov-report term-missing  $(TEST_NAME)
+	sh ../releng/run-tests.sh
 
 test-list: setup-develop
 	cd ambassador && PATH=$(shell pwd)/venv/bin:$(PATH) pytest --collect-only -q

--- a/ambassador/entrypoint.sh
+++ b/ambassador/entrypoint.sh
@@ -155,7 +155,7 @@ wait_for_ready() {
 trap "handle_chld" CHLD
 trap "handle_int" INT
 
-KUBEWATCH_DEBUG="--debug"
+#KUBEWATCH_DEBUG="--debug"
 
 # Start by reading config from ${CONFIG_DIR} itself, to bootstrap the world and get our
 # cluster ID.

--- a/releng/run-tests.sh
+++ b/releng/run-tests.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+if ! pytest --tb=short --cov=ambassador --cov=ambassador_diag --cov-report term-missing  ${TEST_NAME}; then
+    kubectl get pods
+    kubectl get svc
+
+    if [ -n "${AMBASSADOR_DEV}" ]; then
+        docker ps -a
+    fi
+
+    exit 1
+fi
+
+exit 0


### PR DESCRIPTION
Notably, if requirements don't all pass, say which things didn't pass, and log pods & services on a test failure.

While we're at it, cut the requirements timeout from 10 minutes to 5.