### PR TITLE
The statsd.listen-address arg was missing from example

### DIFF
--- a/statsd-sink/prometheus/prom-statsd-sink.yaml
+++ b/statsd-sink/prometheus/prom-statsd-sink.yaml
@@ -16,6 +16,7 @@ spec:
       containers:
       - name: statsd-sink
         image: prom/statsd-exporter:v0.6.0
+        args: ["-statsd.listen-address=:8125"]
         resources: {}
       restartPolicy: Always
 status: {}


### PR DESCRIPTION
By default, the `prom/statsd-exporter` process listens on port 9125.