### PR TITLE
Remove container ports if service not enabled

### DIFF
--- a/helm/ambassador/templates/daemonset.yaml
+++ b/helm/ambassador/templates/daemonset.yaml
@@ -52,10 +52,14 @@ spec:
           image: "{{ .Values.image.repository }}:{{ template "ambassador.imageTag" . }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
+            {{- if .Values.service.enableHttp }}
             - name: http
               containerPort: {{ .Values.service.targetPorts.http }}
+            {{- end }}
+            {{- if .Values.service.enableHttps }}
             - name: https
               containerPort: {{ .Values.service.targetPorts.https }}
+            {{- end }}
             - name: admin
               containerPort: 8877
           env:

--- a/helm/ambassador/templates/deployment.yaml
+++ b/helm/ambassador/templates/deployment.yaml
@@ -56,10 +56,14 @@ spec:
           image: "{{ .Values.image.repository }}:{{ template "ambassador.imageTag" . }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
+            {{- if .Values.service.enableHttp }}
             - name: http
               containerPort: {{ .Values.service.targetPorts.http }}
+            {{- end }}
+            {{- if .Values.service.enableHttps }}
             - name: https
               containerPort: {{ .Values.service.targetPorts.https }}
+            {{- end }}
             - name: admin
               containerPort: 8877
           env:


### PR DESCRIPTION
Currently when trying to setup ambassador with SSL termination in a load balancer you can get some confusing errors when using the helm chart

Using values like:
```yaml
service:
  enableHttp: false
  targetPorts:
    https: 80
```

Will generate container ports:
```yaml
ports:
  - name: http
    containerPort: 80
```

While as a user I would expect
```yaml
ports:
  - name: https
    containerPort: 80
```

What the current template tries to do is:

```yaml
ports:
  - name: http
    containerPort: 80
  - name: https
    containerPort: 80
```

However it seems like you cannot set two different names for the same port, leading to only the first name remaining and your ambassador service being unable to communicate with the container.

There's a few work arounds for this, either with values:
```yaml
service:
  enableHttp: false
  targetPorts:
    http: 81 # Some port other than the one below
    https: 80
```

Or changing the `service_port` in ambassador config.
