### PR TITLE
Allow specifying optional externalTrafficPolicy

### DIFF
--- a/helm/ambassador/templates/service.yaml
+++ b/helm/ambassador/templates/service.yaml
@@ -16,6 +16,9 @@ spec:
 {{- if .Values.service.loadBalancerIP }}
   loadBalancerIP: "{{ .Values.service.loadBalancerIP }}"
 {{- end }}
+{{- if .Values.service.externalTrafficPolicy }}
+  externalTrafficPolicy: "{{ .Values.service.externalTrafficPolicy }}"
+{{- end }}
   ports:
     {{- if .Values.service.enableHttp }}
     - port: {{ .Values.service.httpPort }}


### PR DESCRIPTION
Modified Helm chart to allow specifying LoadBalancer externalTrafficPolicy for correct setting of x-forwarded-for to upstream clients .  

As per https://www.getambassador.io/reference/modules#use_remote_address

' You may also need to set externalTrafficPolicy: Local ' 

