### PR TITLE
added ingress resource

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,4 @@ ambassador-deployment-*.yaml
 ambassador-secrets-deployment.yaml
 *failures.txt
 kubernaut-claim.txt
+*.swp

--- a/helm/ambassador/README.md
+++ b/helm/ambassador/README.md
@@ -70,6 +70,12 @@ The following tables lists the configurable parameters of the Ambassador chart a
 | `service.loadBalancerIP` | IP address to assign (if cloud provider supports it) | `""`
 | `service.annotations` | Annotations to apply to Ambassador service | none
 | `service.loadBalancerSourceRanges` | Passed to cloud provider load balancer if created (e.g: AWS ELB) | none
+| `ingress.enabled` | If an ingress resource should be created | `false`
+| `ingress.port` | Which port on the service should be targeted | `http`
+| `ingress.annotations | Annotations to apply to the ingress resource | `{}`
+| `ingress.path` | What path the ingress should match | `/`
+| `ingress.hosts` | What host names the ingress should match | `- chart-example.local`
+| `ingress.tls` | Ingress TLS configuration (Should be used if terminating TLS at the ingress controller) | `[]`
 | `adminService.create` | If `true`, create a service for Ambassador's admin UI | `true`
 | `adminService.nodePort` | If explicit NodePort for admin service is required  | `true`
 | `adminService.type` | Ambassador's admin service type to be used | `ClusterIP`
@@ -112,4 +118,10 @@ Alternatively, a YAML file that specifies the values for the above parameters ca
 
 ```console
 $ helm upgrade --install --wait my-release -f values.yaml datawire/ambassador
+```
+
+If using ingress to route to ambassador set the following:
+```
+ingress.enabled: true
+service.type: ClusterIP
 ```

--- a/helm/ambassador/templates/NOTES.txt
+++ b/helm/ambassador/templates/NOTES.txt
@@ -2,8 +2,14 @@ Congratuations! You've successfully installed Ambassador.
 
 For help, visit our Slack at https://d6e.co/slack or view the documentation online at https://www.getambassador.io.
 
+{{ if .Values.ingress.enabled }}
+Get the application URL at:
+{{ range .Values.ingress.hosts }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ . }}{{ $.Values.ingress.path }}
+{{ end }}
+{{- else }}
 To get the IP address of Ambassador, run the following commands:
-
+{{- end }}
 {{- if contains "NodePort" .Values.service.type }}
   export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "ambassador.fullname" . }})
   export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")

--- a/helm/ambassador/templates/ingress.yaml
+++ b/helm/ambassador/templates/ingress.yaml
@@ -1,0 +1,39 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "ambassador.fullname" . -}}
+{{- $ingressPath := .Values.ingress.path -}}
+{{- $ingressPort := .Values.ingress.port -}}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    app.kubernetes.io/name: {{ include "ambassador.name" . }}
+    helm.sh/chart: {{ include "ambassador.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- with .Values.ingress.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+spec:
+{{- if .Values.ingress.tls }}
+  tls:
+  {{- range .Values.ingress.tls }}
+    - hosts:
+      {{- range .hosts }}
+        - {{ . | quote }}
+      {{- end }}
+      secretName: {{ .secretName }}
+  {{- end }}
+{{- end }}
+  rules:
+  {{- range .Values.ingress.hosts }}
+    - host: {{ . | quote }}
+      http:
+        paths:
+          - path: {{ $ingressPath }}
+            backend:
+              serviceName: {{ $fullName }}
+              servicePort: {{ $ingressPort }}
+  {{- end }}
+{{- end }}

--- a/helm/ambassador/values.yaml
+++ b/helm/ambassador/values.yaml
@@ -47,6 +47,20 @@ service:
   # loadBalancerSourceRanges:
   #   - YOUR_IP_RANGE
 
+ingress:
+  enabled: false
+  port: http
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  path: /
+  hosts:
+    - chart-example.local
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
 adminService:
   create: true
   type: ClusterIP


### PR DESCRIPTION
I've added an ingress resource as an alternate method to route traffic to ambassador.

My use-case is such that I want the cluster ingress controller to handle TLS and redirects. I encountered a problem where http->https redirects are applied to all requests, with no way to differentiate internal and external traffic. 

In addition this allows a convenient way to handle Certificate resources, as annotations on the ingress resource will automatically prompt cert-bot to grab the required cert. 