### PR TITLE
Helm chart bump

### DIFF
--- a/helm/ambassador/.helmignore
+++ b/helm/ambassador/.helmignore
@@ -19,3 +19,4 @@
 .project
 .idea/
 *.tmproj
+.vscode/

--- a/helm/ambassador/Chart.yaml
+++ b/helm/ambassador/Chart.yaml
@@ -1,11 +1,10 @@
 apiVersion: v1
-appVersion: "0.40.2"
+appVersion: "0.50.0"
 description: A Helm chart for Datawire Ambassador
 name: ambassador
-version: 0.40.2
+version: 0.50.0
 sources:
 - https://github.com/datawire/ambassador
 maintainers:
   - name: Flynn
     email: flynn@datawire.io
-engine: gotpl

--- a/helm/ambassador/README.md
+++ b/helm/ambassador/README.md
@@ -46,11 +46,11 @@ The following tables lists the configurable parameters of the Ambassador chart a
 | Parameter                       | Description                                | Default                                                    |
 | ------------------------------- | ------------------------------------------ | ---------------------------------------------------------- |
 | `image.repository` | Image | `quay.io/datawire/ambassador`
-| `image.tag` | Image tag | `0.40.2`
+| `image.tag` | Image tag | `0.50.0`
 | `image.pullPolicy` | Image pull policy | `IfNotPresent`
 | `image.imagePullSecrets` | Image pull secrets | None
 | `daemonSet` | If `true `, Create a daemonSet. By default Deployment controller will be created | `false`
-| `env`  | Any additional environment variables for ambassador pods | `{}` 
+| `env`  | Any additional environment variables for ambassador pods | `{}`
 | `replicaCount` | Number of Ambassador replicas  | `1`
 | `volumes` | Volumes for the ambassador service | None
 | `volumeMounts` | Volume mounts for the ambassador service | None
@@ -60,23 +60,25 @@ The following tables lists the configurable parameters of the Ambassador chart a
 | `serviceAccount.name` | Service account to be used | `ambassador`
 | `namespace.single` | Set the `AMBASSADOR_SINGLE_NAMESPACE` environment variable | `false`
 | `namespace.name` | Set the `AMBASSADOR_NAMESPACE` environment variable | `metadata.namespace`
-| `podAnnotations` | Additional annotations for ambassador pods |  `{"prometheus.io/scrape": "true", "prometheus.io/port": "9102"}` 
+| `podAnnotations` | Additional annotations for ambassador pods |  `{"prometheus.io/scrape": "true", "prometheus.io/port": "9102"}`
 | `ambassador.id` | Set the identifier of the Ambassador instance | none
-| `service.enableHttp` | if port 80 should be opened for service | `true`
-| `service.enableHttps` | if port 443 should be opened for service | `true`
-| `service.targetPorts.http` | Sets the targetPort that maps to the service's cleartext port | `80`
-| `service.targetPorts.https` | Sets the targetPort that maps to the service's TLS port | `443`
+| `service.http.enabled` | if port 80 should be opened for service | `true`
+| `service.http.port` | if port 443 should be opened for service | `true`
+| `service.http.targetPort` | Sets the targetPort that maps to the service's cleartext port | `80`
+| `service.http.nodePort` | If explicit NodePort is required | None
+| `service.https.enabled` | if port 443 should be opened for service | `true`
+| `service.https.port` | if port 443 should be opened for service | `true`
+| `service.https.targetPorts` | Sets the targetPort that maps to the service's TLS port | `443`
+| `service.https.nodePort` | If explicit NodePort is required | None
 | `service.type` | Service type to be used | `LoadBalancer`
-| `service.httpNodePort` | If explicit NodePort is required | None
-| `service.httpsNodePort` | If explicit NodePort is required | None
 | `service.loadBalancerIP` | IP address to assign (if cloud provider supports it) | `""`
 | `service.annotations` | Annotations to apply to Ambassador service | none
 | `service.loadBalancerSourceRanges` | Passed to cloud provider load balancer if created (e.g: AWS ELB) | none
 | `adminService.create` | If `true`, create a service for Ambassador's admin UI | `true`
 | `adminService.nodePort` | If explicit NodePort for admin service is required  | `true`
 | `adminService.type` | Ambassador's admin service type to be used | `ClusterIP`
-| `exporter.enabled` | Exporter side-car enabled | `true`
-| `exporter.image` | Prometheus exporter image | `prom/statsd-exporter:v0.6.0`
+| `prometheusExporter.enabled` | Prometheus exporter side-car enabled | `false`
+| `prometheusExporter.image` | Prometheus exporter image | `prom/statsd-exporter:v0.8.1`
 | `timing.restart` | The minimum number of seconds between Envoy restarts | none
 | `timing.drain` | The number of seconds that the Envoy will wait for open connections to drain on a restart | none
 | `timing.shutdown` | The number of seconds that Ambassador will wait for the old Envoy to clean up and exit on a restart | none

--- a/helm/ambassador/templates/NOTES.txt
+++ b/helm/ambassador/templates/NOTES.txt
@@ -5,22 +5,22 @@ For help, visit our Slack at https://d6e.co/slack or view the documentation onli
 To get the IP address of Ambassador, run the following commands:
 
 {{- if contains "NodePort" .Values.service.type }}
-  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "ambassador.fullname" . }})
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "ambassador.fullname" . }})
   export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
   echo http://$NODE_IP:$NODE_PORT
 {{- else if contains "LoadBalancer" .Values.service.type }}
 NOTE: It may take a few minutes for the LoadBalancer IP to be available.
-     You can watch the status of by running 'kubectl get svc -w  --namespace {{ .Release.Namespace }} {{ template "ambassador.fullname" . }}'
+     You can watch the status of by running 'kubectl get svc -w  --namespace {{ .Release.Namespace }} {{ include "ambassador.fullname" . }}'
 
   On GKE/Azure:
-  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "ambassador.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "ambassador.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
 
   On AWS:
-  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "ambassador.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].hostname}')
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "ambassador.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].hostname}')
 
   echo http://$SERVICE_IP:{{ .Values.service.port }}
 {{- else if contains "ClusterIP" .Values.service.type }}
-  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "ambassador.name" . }},release={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ include "ambassador.name" . }},release={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
   echo "Visit http://127.0.0.1:8080 to use your application"
   kubectl port-forward $POD_NAME 8080:80
 {{- end }}

--- a/helm/ambassador/templates/admin-service.yaml
+++ b/helm/ambassador/templates/admin-service.yaml
@@ -2,16 +2,16 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "ambassador.fullname" . }}-admin
+  name: {{ include "ambassador.fullname" . }}-admins
   labels:
-    app: {{ template "ambassador.name" . }}
-    chart: {{ template "ambassador.chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "ambassador.name" . }}
+    helm.sh/chart: {{ include "ambassador.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
   type: {{ .Values.adminService.type }}
   ports:
-    - port: 8877
+    - port: {{ .Values.adminService.port }}
       targetPort: admin
       protocol: TCP
       name: admin
@@ -19,6 +19,6 @@ spec:
       nodePort: {{ .Values.adminService.nodePort }}
       {{- end }}
   selector:
-    app: {{ template "ambassador.name" . }}
-    release: {{ .Release.Name }}
+    app.kubernetes.io/name: {{ include "ambassador.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}

--- a/helm/ambassador/templates/config.yaml
+++ b/helm/ambassador/templates/config.yaml
@@ -1,12 +1,17 @@
-{{- if .Values.exporter.enabled }}
+{{- if .Values.prometheusExporter.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: '{{ template "ambassador.fullname" . }}-config'
+  name: '{{ include "ambassador.fullname" . }}-config'
+  labels:
+    app.kubernetes.io/name: {{ include "ambassador.name" . }}
+    helm.sh/chart: {{ include "ambassador.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
 data:
   exporterConfiguration:
-{{- if .Values.exporter.configuration }} |
-{{ .Values.exporter.configuration | indent 4 }}
+{{- if .Values.prometheusExporter.configuration }} |
+    {{- .Values.prometheusExporter.configuration | nindent 4 }}
 {{- else }} ''
 {{- end }}
 {{- end }}

--- a/helm/ambassador/templates/daemonset.yaml
+++ b/helm/ambassador/templates/daemonset.yaml
@@ -1,99 +1,114 @@
 {{- if .Values.daemonSet -}}
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-  name: {{ template "ambassador.fullname" . }}
+  name: {{ include "ambassador.fullname" . }}
   labels:
-    app: {{ template "ambassador.name" . }}
-    chart: {{ template "ambassador.chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "ambassador.name" . }}
+    helm.sh/chart: {{ include "ambassador.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
   selector:
     matchLabels:
-      app: {{ template "ambassador.name" . }}
-      release: {{ .Release.Name }}
+      app.kubernetes.io/name: {{ include "ambassador.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
   template:
     metadata:
       labels:
-        service: {{ template "ambassador.name" . }}
-        app: {{ template "ambassador.name" . }}
-        release: {{ .Release.Name }}
-      annotations:
+        app.kubernetes.io/name: {{ include "ambassador.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
       {{- if .Values.podAnnotations }}
-{{ toYaml .Values.podAnnotations | indent 8 }}
+      annotations:
+        {{- toYaml .Values.podAnnotations | nindent 8 }}
       {{- end }}
     spec:
-      serviceAccountName: {{ template "ambassador.serviceAccountName" . }}
+      serviceAccountName: {{ include "ambassador.serviceAccountName" . }}
       volumes:
-      {{- if .Values.exporter.enabled }}
-      - name: stats-exporter-mapping-config
-        configMap:
-          name: '{{ template "ambassador.fullname" . }}-config'
-          items:
-          - key: exporterConfiguration
-            path: mapping-config.yaml
+        {{- if .Values.prometheusExporter.enabled }}
+        - name: stats-exporter-mapping-config
+          configMap:
+            name: '{{ template "ambassador.fullname" . }}-config'
+            items:
+            - key: exporterConfiguration
+              path: mapping-config.yaml
+        {{- end }}
+      {{- with .Values.volumes }}
+        {{- toYaml . | nindent 8 }}
       {{- end }}
       containers:
-        {{- if .Values.exporter.enabled }}
-        - name: statsd-sink
-          image: "{{ .Values.exporter.image }}"
+        {{- if .Values.prometheusExporter.enabled }}
+        - name: prometheus-exporter
+          image: "{{ .Values.prometheusExporter.image.repository }}:{{ .Values.prometheusExporter.image.tag }}"
           ports:
-          - name: metrics
-            containerPort: 9102
-          - name: listener
-            containerPort: 8125
-          args: ["-statsd.listen-address=:8125", "-statsd.mapping-config=/statsd-exporter/mapping-config.yaml"]
+            - name: metrics
+              containerPort: 9102
+            - name: listener
+              containerPort: 8125
+          args:
+            - --statsd.listen-udp=:8125
+            - --web.listen-address=:9102
+            - --statsd.mapping-config=/statsd-exporter/mapping-config.yaml
           volumeMounts:
-          - name: stats-exporter-mapping-config
-            mountPath: /statsd-exporter/
-            readOnly: true
+            - name: stats-exporter-mapping-config
+              mountPath: /statsd-exporter/
+              readOnly: true
         {{- end }}
-        - name: ambassador
-          image: "{{ .Values.image.repository }}:{{ template "ambassador.imageTag" . }}"
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ include "ambassador.imageTag" . }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
+            {{- if .Values.service.http.enabled }}
             - name: http
-              containerPort: {{ .Values.service.targetPorts.http }}
+              containerPort: {{ .Values.service.http.targetPort }}
+            {{- end }}
+            {{- if .Values.service.https.enabled }}
             - name: https
-              containerPort: {{ .Values.service.targetPorts.https }}
+              containerPort: {{ .Values.service.https.targetPort }}
+            {{- end }}
             - name: admin
               containerPort: 8877
           env:
-          {{- if .Values.namespace.single }}
-          - name: AMBASSADOR_SINGLE_NAMESPACE
-            value: {{ .Values.namespace.single | quote }}
-          {{- end }}
-          - name: AMBASSADOR_ID
-            value: {{ .Values.ambassador.id | quote }}
-          - name: AMBASSADOR_NAMESPACE
-            {{- if .Values.namespace.name }}
-            value: {{ .Values.namespace.name | quote }}
-            {{ else }}
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.namespace
+            {{- if .Values.prometheusExporter.enabled }}
+            - name: STATSD_ENABLED
+              value: "true"
+            - name: STATSD_HOST
+              value: "localhost"
+            {{- end }}
+            {{- if .Values.namespace.single }}
+            - name: AMBASSADOR_SINGLE_NAMESPACE
+              value: {{ .Values.namespace.single | quote }}
+            {{- end }}
+            - name: AMBASSADOR_ID
+              value: {{ .Values.ambassador.id | quote }}
+            - name: AMBASSADOR_NAMESPACE
+              {{- if .Values.namespace.name }}
+              value: {{ .Values.namespace.name | quote }}
+              {{ else }}
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+              {{- end -}}
+            {{- if .Values.timing }}
+            {{- if .Values.timing.restart }}
+            - name: AMBASSADOR_RESTART_TIME
+              value: {{ .Values.timing.restart | quote }}
             {{- end -}}
-          {{- if .Values.timing }}
-          {{- if .Values.timing.restart }}
-          - name: AMBASSADOR_RESTART_TIME
-            value: {{ .Values.timing.restart | quote }}
-          {{- end -}}
-          {{- if .Values.timing.drain }}
-          - name: AMBASSADOR_DRAIN_TIME
-            value: {{ .Values.timing.drain | quote }}
-          {{- end -}}
-          {{- if .Values.timing.shutdown }}
-          - name: AMBASSADOR_SHUTDOWN_TIME
-            value: {{ .Values.timing.shutdown | quote }}
-          {{- end -}}
-          {{- end }}
-          {{- if .Values.env }}          
-          {{- range $key,$value := .Values.env }}
-          - name: {{ $key | upper | quote}}
-            value: {{ $value | quote}}
-          {{- end }}
-          {{- end }}
+            {{- if .Values.timing.drain }}
+            - name: AMBASSADOR_DRAIN_TIME
+              value: {{ .Values.timing.drain | quote }}
+            {{- end -}}
+            {{- if .Values.timing.shutdown }}
+            - name: AMBASSADOR_SHUTDOWN_TIME
+              value: {{ .Values.timing.shutdown | quote }}
+            {{- end -}}
+            {{- end }}
+            {{- if .Values.env }}
+            {{- range $key,$value := .Values.env }}
+            - name: {{ $key | upper | quote}}
+              value: {{ $value | quote}}
+            {{- end }}
+            {{- end }}
           livenessProbe:
             httpGet:
               path: /ambassador/v0/check_alive
@@ -106,22 +121,26 @@ spec:
               port: admin
             initialDelaySeconds: 30
             periodSeconds: 3
+          {{- with .Values.volumeMounts }}
+          volumeMounts:
+          {{- toYaml . | nindent 10 }}
+          {{- end }}
           resources:
-{{ toYaml .Values.resources | indent 12 }}
-    {{- with .Values.nodeSelector }}
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
       nodeSelector:
-{{ toYaml . | indent 8 }}
-    {{- end }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     {{- with .Values.affinity }}
       affinity:
-{{ toYaml . | indent 8 }}
+        {{- toYaml . | nindent 8 }}
     {{- end }}
     {{- with .Values.tolerations }}
       tolerations:
-{{ toYaml . | indent 8 }}
+        {{- toYaml . | nindent 8 }}
     {{- end }}
-     {{- with .Values.image.imagePullSecrets}}
+    {{- with .Values.image.imagePullSecrets }}
       imagePullSecrets:
-       - name : {{ toYaml . }}
-     {{- end }}
+       - name: {{ toYaml . }}
+    {{- end }}
 {{- end }}

--- a/helm/ambassador/templates/deployment.yaml
+++ b/helm/ambassador/templates/deployment.yaml
@@ -1,103 +1,115 @@
-{{- if not  .Values.daemonSet -}}
-apiVersion: apps/v1beta2
+{{- if not .Values.daemonSet -}}
+apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ template "ambassador.fullname" . }}
+  name: {{ include "ambassador.fullname" . }}
   labels:
-    app: {{ template "ambassador.name" . }}
-    chart: {{ template "ambassador.chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "ambassador.name" . }}
+    helm.sh/chart: {{ include "ambassador.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels:
-      app: {{ template "ambassador.name" . }}
-      release: {{ .Release.Name }}
+      app.kubernetes.io/name: {{ include "ambassador.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
   template:
     metadata:
       labels:
-        service: {{ template "ambassador.name" . }}
-        app: {{ template "ambassador.name" . }}
-        release: {{ .Release.Name }}
-      annotations:
+        app.kubernetes.io/name: {{ include "ambassador.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
       {{- if .Values.podAnnotations }}
-{{ toYaml .Values.podAnnotations | indent 8 }}
+      annotations:
+        {{- toYaml .Values.podAnnotations | nindent 8 }}
       {{- end }}
     spec:
-      serviceAccountName: {{ template "ambassador.serviceAccountName" . }}
+      serviceAccountName: {{ include "ambassador.serviceAccountName" . }}
       volumes:
-      {{- if .Values.exporter.enabled }}
-      - name: stats-exporter-mapping-config
-        configMap:
-          name: '{{ template "ambassador.fullname" . }}-config'
-          items:
-          - key: exporterConfiguration
-            path: mapping-config.yaml
-      {{- end }}
+        {{- if .Values.prometheusExporter.enabled }}
+        - name: stats-exporter-mapping-config
+          configMap:
+            name: '{{ template "ambassador.fullname" . }}-config'
+            items:
+            - key: exporterConfiguration
+              path: mapping-config.yaml
+        {{- end }}
       {{- with .Values.volumes }}
-{{ toYaml . | indent 6 }}
+        {{- toYaml . | nindent 8 }}
       {{- end }}
       containers:
-        {{- if .Values.exporter.enabled }}
-        - name: statsd-sink
-          image: "{{ .Values.exporter.image }}"
+        {{- if .Values.prometheusExporter.enabled }}
+        - name: prometheus-exporter
+          image: "{{ .Values.prometheusExporter.image.repository }}:{{ .Values.prometheusExporter.image.tag }}"
           ports:
-          - name: metrics
-            containerPort: 9102
-          - name: listener
-            containerPort: 8125
-          args: ["-statsd.listen-address=:8125", "-statsd.mapping-config=/statsd-exporter/mapping-config.yaml"]
+            - name: metrics
+              containerPort: 9102
+            - name: listener
+              containerPort: 8125
+          args:
+            - --statsd.listen-udp=:8125
+            - --web.listen-address=:9102
+            - --statsd.mapping-config=/statsd-exporter/mapping-config.yaml
           volumeMounts:
-          - name: stats-exporter-mapping-config
-            mountPath: /statsd-exporter/
-            readOnly: true
+            - name: stats-exporter-mapping-config
+              mountPath: /statsd-exporter/
+              readOnly: true
         {{- end }}
-        - name: ambassador
-          image: "{{ .Values.image.repository }}:{{ template "ambassador.imageTag" . }}"
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ include "ambassador.imageTag" . }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
+            {{- if .Values.service.http.enabled }}
             - name: http
-              containerPort: {{ .Values.service.targetPorts.http }}
+              containerPort: {{ .Values.service.http.targetPort }}
+            {{- end }}
+            {{- if .Values.service.https.enabled }}
             - name: https
-              containerPort: {{ .Values.service.targetPorts.https }}
+              containerPort: {{ .Values.service.https.targetPort }}
+            {{- end }}
             - name: admin
               containerPort: 8877
           env:
-          {{- if .Values.namespace.single }}
-          - name: AMBASSADOR_SINGLE_NAMESPACE
-            value: {{ .Values.namespace.single | quote }}
-          {{- end }}
-          - name: AMBASSADOR_ID
-            value: {{ .Values.ambassador.id | quote }}
-          - name: AMBASSADOR_NAMESPACE
-            {{- if .Values.namespace.name }}
-            value: {{ .Values.namespace.name | quote }}
-            {{ else }}
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.namespace
+            {{- if .Values.prometheusExporter.enabled }}
+            - name: STATSD_ENABLED
+              value: "true"
+            - name: STATSD_HOST
+              value: "localhost"
+            {{- end }}
+            {{- if .Values.namespace.single }}
+            - name: AMBASSADOR_SINGLE_NAMESPACE
+              value: {{ .Values.namespace.single | quote }}
+            {{- end }}
+            - name: AMBASSADOR_ID
+              value: {{ .Values.ambassador.id | quote }}
+            - name: AMBASSADOR_NAMESPACE
+              {{- if .Values.namespace.name }}
+              value: {{ .Values.namespace.name | quote }}
+              {{ else }}
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+              {{- end -}}
+            {{- if .Values.timing }}
+            {{- if .Values.timing.restart }}
+            - name: AMBASSADOR_RESTART_TIME
+              value: {{ .Values.timing.restart | quote }}
             {{- end -}}
-          {{- if .Values.timing }}
-          {{- if .Values.timing.restart }}
-          - name: AMBASSADOR_RESTART_TIME
-            value: {{ .Values.timing.restart | quote }}
-          {{- end -}}
-          {{- if .Values.timing.drain }}
-          - name: AMBASSADOR_DRAIN_TIME
-            value: {{ .Values.timing.drain | quote }}
-          {{- end -}}
-          {{- if .Values.timing.shutdown }}
-          - name: AMBASSADOR_SHUTDOWN_TIME
-            value: {{ .Values.timing.shutdown | quote }}
-          {{- end -}}
-          {{- end }}
-          {{- if .Values.env }}          
-          {{- range $key,$value := .Values.env }}
-          - name: {{ $key | upper | quote}}
-            value: {{ $value | quote}}
-          {{- end }}
-          {{- end }}
+            {{- if .Values.timing.drain }}
+            - name: AMBASSADOR_DRAIN_TIME
+              value: {{ .Values.timing.drain | quote }}
+            {{- end -}}
+            {{- if .Values.timing.shutdown }}
+            - name: AMBASSADOR_SHUTDOWN_TIME
+              value: {{ .Values.timing.shutdown | quote }}
+            {{- end -}}
+            {{- end }}
+            {{- if .Values.env }}
+            {{- range $key,$value := .Values.env }}
+            - name: {{ $key | upper | quote}}
+              value: {{ $value | quote}}
+            {{- end }}
+            {{- end }}
           livenessProbe:
             httpGet:
               path: /ambassador/v0/check_alive
@@ -112,24 +124,24 @@ spec:
             periodSeconds: 3
           {{- with .Values.volumeMounts }}
           volumeMounts:
-{{ toYaml . | indent 10 }}
+          {{- toYaml . | nindent 10 }}
           {{- end }}
           resources:
-{{ toYaml .Values.resources | indent 12 }}
-    {{- with .Values.nodeSelector }}
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
       nodeSelector:
-{{ toYaml . | indent 8 }}
-    {{- end }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     {{- with .Values.affinity }}
       affinity:
-{{ toYaml . | indent 8 }}
+        {{- toYaml . | nindent 8 }}
     {{- end }}
     {{- with .Values.tolerations }}
       tolerations:
-{{ toYaml . | indent 8 }}
+        {{- toYaml . | nindent 8 }}
     {{- end }}
-     {{- with .Values.image.imagePullSecrets}}
+    {{- with .Values.image.imagePullSecrets }}
       imagePullSecrets:
-       - name : {{ toYaml . }}
-     {{- end }}
+       - name: {{ toYaml . }}
+    {{- end }}
 {{- end }}

--- a/helm/ambassador/templates/rbac.yaml
+++ b/helm/ambassador/templates/rbac.yaml
@@ -2,12 +2,12 @@
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
-  name: {{ template "ambassador.fullname" . }}
+  name: {{ include "ambassador.fullname" . }}
   labels:
-    app: {{ template "ambassador.name" . }}
-    chart: {{ template "ambassador.chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "ambassador.name" . }}
+    helm.sh/chart: {{ include "ambassador.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
 rules:
   - apiGroups: [""]
     resources:
@@ -23,18 +23,18 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ template "ambassador.fullname" . }}
+  name: {{ include "ambassador.fullname" . }}
   labels:
-    app: {{ template "ambassador.name" . }}
-    chart: {{ template "ambassador.chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "ambassador.name" . }}
+    helm.sh/chart: {{ include "ambassador.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ template "ambassador.fullname" . }}
+  name: {{ include "ambassador.fullname" . }}
 subjects:
-  - name: {{ template "ambassador.serviceAccountName" . }}
+  - name: {{ include "ambassador.serviceAccountName" . }}
     namespace: {{ .Release.Namespace | quote }}
     kind: ServiceAccount
 {{- end -}}

--- a/helm/ambassador/templates/service.yaml
+++ b/helm/ambassador/templates/service.yaml
@@ -1,44 +1,45 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "ambassador.fullname" . }}
+  name: {{ include "ambassador.fullname" . }}
   labels:
-    app: {{ template "ambassador.name" . }}
-    chart: {{ template "ambassador.chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
-{{- with .Values.service.annotations }}
+    app.kubernetes.io/name: {{ include "ambassador.name" . }}
+    helm.sh/chart: {{ include "ambassador.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  {{- with .Values.service.annotations }}
   annotations:
-{{ toYaml . | indent 4 }}
-{{- end }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.service.type }}
-{{- if .Values.service.loadBalancerIP }}
+  {{- if .Values.service.loadBalancerIP }}
   loadBalancerIP: "{{ .Values.service.loadBalancerIP }}"
-{{- end }}
+  {{- end }}
+  type: {{ .Values.service.type }}
   ports:
-    {{- if .Values.service.enableHttp }}
-    - port: {{ .Values.service.httpPort }}
+    {{- if .Values.service.http.enabled }}
+    - port: {{ .Values.service.http.port }}
       targetPort: http
       protocol: TCP
       name: http
-      {{- with .Values.service.httpNodePort }}
+      {{- with .Values.service.http.nodePort }}
       nodePort: {{ toYaml . }}
       {{- end }}
     {{- end }}
-    {{- if .Values.service.enableHttps }}
-    - port: {{ .Values.service.httpsPort }}
+    {{- if .Values.service.https.enabled }}
+    - port: {{ .Values.service.https.port }}
       targetPort: https
       protocol: TCP
       name: https
-      {{- with .Values.service.httpsNodePort }}
+      {{- with .Values.service.https.nodePort }}
       nodePort: {{ toYaml . }}
       {{- end }}
     {{- end }}
   selector:
-    app: {{ template "ambassador.name" . }}
-    release: {{ .Release.Name }}
-{{- with .Values.service.loadBalancerSourceRanges }}
+    app.kubernetes.io/name: {{ include "ambassador.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  {{- with .Values.service.loadBalancerSourceRanges }}
   loadBalancerSourceRanges:
-{{ toYaml . | indent 4 }}
-{{- end }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}

--- a/helm/ambassador/templates/serviceaccount.yaml
+++ b/helm/ambassador/templates/serviceaccount.yaml
@@ -2,10 +2,10 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ template "ambassador.serviceAccountName" . }}
+  name: {{ include "ambassador.serviceAccountName" . }}
   labels:
-    app: {{ template "ambassador.name" . }}
-    chart: {{ template "ambassador.chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "ambassador.name" . }}
+    helm.sh/chart: {{ include "ambassador.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end -}}

--- a/helm/ambassador/values.yaml
+++ b/helm/ambassador/values.yaml
@@ -2,6 +2,9 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
+replicaCount: 1
+daemonSet: false
+
 ambassador:
   id: default
 
@@ -9,38 +12,44 @@ namespace:
   single: false
   # name: default
 
-replicaCount: 1
-# If ambassador is needed as daemonSet then set create to true
-daemonSet: false
-
+# Additional container environment variable
+env: {}
+  # Exposing statistics via StatsD
+  # STATSD_ENABLED: true
+  # STATSD_HOST: statsd-sink
 
 image:
   repository: quay.io/datawire/ambassador
+  # tag:
   pullPolicy: IfNotPresent
-  #imagePullSecrets: sample
+  # imagePullSecrets:
 
+nameOverride: ""
+fullnameOverride: ""
 
 service:
-  enableHttp: true
-  enableHttps: true
-
-  targetPorts:
-    http: 80
-    https: 443
-
-
   type: LoadBalancer
-  httpPort: 80
-  httpsPort: 443
-  #Nodeport to use  if type is selected as Nodeport otherwise it will be ignored
-  #httpNodePort : 30080
-  #httpsNodePort : 30443
+
+  # Note that target http ports need to match your ambassador configurations service_port
+  # https://www.getambassador.io/reference/modules/#the-ambassador-module
+  http:
+    enabled: true
+    port: 80
+    targetPort: 80
+    # nodePort: 30080
+
+  https:
+    enabled: true
+    port: 443
+    targetPort: 443
+    # nodePort: 30443
+
   # annotations:
   #   getambassador.io/config: |
   #     ---
-  #     apiVersion: ambassador/v0
+  #     apiVersion: ambassador/v1
   #     kind: Module
-  #     name:  ambassador
+  #     name: ambassador
   #     config:
   #       diagnostics:
   #         enabled: false
@@ -50,8 +59,9 @@ service:
 adminService:
   create: true
   type: ClusterIP
+  port: 8877
   # NodePort used if type is NodePort
-  #nodePort: 38877
+  # nodePort: 38877
 
 rbac:
   # Specifies whether RBAC resources should be created
@@ -92,11 +102,13 @@ tolerations: []
 
 affinity: {}
 
-exporter:
-  enabled: true
-  image: prom/statsd-exporter:v0.6.0
+# Enabling the prometheus exporter creates a sidecar and configures ambassador to use it
+prometheusExporter:
+  enabled: false
+  repository: prom/statsd-exporter
+  tag: v0.8.1
   # You can configure the statsd exporter to modify the behavior of mappings and other features.
-  # See documentation: https://github.com/prometheus/statsd_exporter/tree/v0.6.0#metric-mapping-and-configuration
+  # See documentation: https://github.com/prometheus/statsd_exporter/tree/v0.8.1#metric-mapping-and-configuration
   # Uncomment the following line if you wish to specify a custom configuration:
   # configuration: |
   #   ---


### PR DESCRIPTION
Would solve #1034, #1081 and #1084 for 0.50

Closes #1138 
Closes #1136 

I took some liberties.
I generated a new chart with helm create and migrated over existing configs.
To avoid confusion with the statsd previous socat solution I renamed the sidecar to prometheus exporter.

I recommend checking the diff without whitespace diffing