### PR TITLE
Fix secret handling

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -63,7 +63,7 @@ RUN releng/install-py.sh prd install */requirements.txt
 RUN rm -rf ./multi ./ambassador
 
 # Grab kubewatch
-RUN wget -q https://s3.amazonaws.com/datawire-static-files/kubewatch/0.3.13/$(go env GOOS)/$(go env GOARCH)/kubewatch
+RUN wget -q https://s3.amazonaws.com/datawire-static-files/kubewatch/0.3.15/$(go env GOOS)/$(go env GOARCH)/kubewatch
 RUN chmod +x kubewatch
 
 # Clean up no-longer-needed dev stuff.
@@ -109,7 +109,8 @@ RUN chgrp -R 0 ${AMBASSADOR_ROOT} && \
 # COPY the entrypoint and Python-kubewatch and make them runnable.
 COPY ambassador/kubewatch.py .
 COPY ambassador/entrypoint.sh .
-RUN chmod 755 kubewatch.py entrypoint.sh
+COPY ambassador/post_update.py .
+RUN chmod 755 kubewatch.py entrypoint.sh post_update.py
 
 # Grab ambex, too.
 RUN wget -q https://s3.amazonaws.com/datawire-static-files/ambex/0.1.1/ambex

--- a/ambassador/ambassador/diagnostics/envoy_stats.py
+++ b/ambassador/ambassador/diagnostics/envoy_stats.py
@@ -141,6 +141,8 @@ class EnvoyStats (object):
         return cstat
 
     def update_log_levels(self, last_attempt, level=None):
+        # logging.info("updating levels")
+
         try:
             url = "http://127.0.0.1:8001/logging"
 
@@ -182,6 +184,8 @@ class EnvoyStats (object):
         return True
         
     def update_envoy_stats(self, last_attempt):
+        # logging.info("updating stats")
+
         try:
             r = requests.get("http://127.0.0.1:8001/stats")
         except OSError as e:
@@ -296,6 +300,8 @@ class EnvoyStats (object):
             "clusters": active_clusters,
             "envoy": envoy_stats
         })
+
+        # logging.info("stats updated")
 
     # def update(self, active_mapping_names):
     def update(self):

--- a/ambassador/ambassador/envoy/v1/v1config.py
+++ b/ambassador/ambassador/envoy/v1/v1config.py
@@ -12,10 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License
 
-from typing import Any, ClassVar, Dict, List, Optional, Tuple, Union
-
-import json
-import logging
+from typing import Any, Dict, List, Optional, Tuple
 
 from ...ir import IR
 from ..common import EnvoyConfig
@@ -55,7 +52,7 @@ class V1Config (EnvoyConfig):
         V1Tracing.generate(self)
         V1GRPCService.generate(self)
 
-    def as_dict(self):
+    def as_dict(self) -> Dict[str, Any]:
         d = {
             'admin': self.admin,
             'listeners': self.listeners,
@@ -74,5 +71,5 @@ class V1Config (EnvoyConfig):
 
         return d
 
-    def as_json(self):
-        return json.dumps(self.as_dict(), sort_keys=True, indent=4)
+    def split_config(self) -> Tuple[Dict[str, Any], Dict[str, Any]]:
+        raise NotImplementedError

--- a/ambassador/ambassador/envoy/v2/v2config.py
+++ b/ambassador/ambassador/envoy/v2/v2config.py
@@ -57,7 +57,7 @@ class V2Config (EnvoyConfig):
         V2StaticResources.generate(self)
         V2Bootstrap.generate(self)
 
-    def as_dict(self):
+    def as_dict(self) -> Dict[str, Any]:
         d = {
             'bootstrap': self.bootstrap,
             'static_resources': self.static_resources
@@ -65,10 +65,7 @@ class V2Config (EnvoyConfig):
 
         return d
 
-    def as_json(self):
-        return json.dumps(sanitize_pre_json(self.as_dict()), sort_keys=True, indent=4)
-
-    def split_config(self) -> tuple:
+    def split_config(self) -> Tuple[Dict[str, Any], Dict[str, Any]]:
         ads_config = {
             '@type': '/envoy.config.bootstrap.v2.Bootstrap',
             'static_resources': self.static_resources

--- a/ambassador/ambassador/ir/ir.py
+++ b/ambassador/ambassador/ir/ir.py
@@ -74,11 +74,9 @@ class IR:
         self.logger = logging.getLogger("ambassador.ir")
 
         # We're using setattr since since mypy complains about assigning directly to a method.
-        setattr(self, 'secret_reader', secret_reader or KubeSecretReader())
+        secret_root = os.environ.get('AMBASSADOR_CONFIG_BASE_DIR', "/ambassador")
+        setattr(self, 'secret_reader', secret_reader or KubeSecretReader(secret_root))
         setattr(self, 'file_checker', file_checker if file_checker is not None else os.path.isfile)
-
-        # OK. Remember the root of the secret store...
-        self.secret_root = os.environ.get('AMBASSADOR_CONFIG_BASE_DIR', "/ambassador")
 
         self.logger.debug("IR __init__:")
         self.logger.debug("IR: Version         %s built from %s on %s" % (Version, Build.git.commit, Build.git.branch))

--- a/ambassador/ambassador/ir/irtlscontext.py
+++ b/ambassador/ambassador/ir/irtlscontext.py
@@ -127,7 +127,7 @@ class IRTLSContext(IRResource):
             secret_name, namespace = secret_name.split('.', 1)
 
         sr = getattr(self.ir, 'secret_reader')
-        return sr(self, secret_name, namespace, self.ir.secret_root)
+        return sr(self, secret_name, namespace)
 
     def resolve(self) -> bool:
         # is_valid determines if the TLS context is valid

--- a/ambassador/ambassador/utils.py
+++ b/ambassador/ambassador/utils.py
@@ -27,7 +27,6 @@ import requests
 import yaml
 
 from kubernetes import client, config
-from enum import Enum
 
 from .VERSION import Version
 
@@ -72,29 +71,6 @@ def load_url_contents(logger: logging.Logger, url: str) -> Optional[str]:
         return stream.getvalue()
     else:
         return None
-
-
-class TLSPaths(Enum):
-    mount_cert_dir = "/etc/certs"
-    mount_tls_crt = os.path.join(mount_cert_dir, "tls.crt")
-    mount_tls_key = os.path.join(mount_cert_dir, "tls.key")
-
-    client_mount_dir = "/etc/cacert"
-    client_mount_crt = os.path.join(client_mount_dir, "tls.crt")
-
-    cert_dir = "/ambassador/certs"
-    tls_crt = os.path.join(cert_dir, "tls.crt")
-    tls_key = os.path.join(cert_dir, "tls.key")
-
-    client_cert_dir = "/ambassador/cacert"
-    client_tls_crt = os.path.join(client_cert_dir, "tls.crt")
-
-    @staticmethod
-    def generate(directory):
-        return {
-            'crt': os.path.join(directory, 'tls.crt'),
-            'key': os.path.join(directory, 'tls.key')
-        }
 
 
 class SystemInfo:
@@ -154,24 +130,6 @@ class RichStatus:
     @classmethod
     def OK(self, **kwargs):
         return RichStatus(True, **kwargs)
-
-class SourcedDict (dict):
-    def __init__(self, _source="--internal--", _from=None, **kwargs):
-        super().__init__(self, **kwargs)
-
-        if _from and ('_source' in _from):
-            self['_source'] = _from['_source']
-        else:
-            self['_source'] = _source
-
-        # self['_referenced_by'] = []
-
-    def referenced_by(self, source):
-        refby = self.setdefault('_referenced_by', [])
-
-        if source not in refby:
-            refby.append(source)
-
 
 class DelayTrigger (threading.Thread):
     def __init__(self, onfired, timeout=5, name=None):
@@ -458,19 +416,3 @@ def kube_v1():
             pass
 
     return k8s_api
-
-
-def check_cert_file(path):
-    readable = False
-
-    try:
-        data = open(path, "r").read()
-
-        if data and (len(data) > 0):
-            readable = True
-    except OSError:
-        pass
-    except IOError:
-        pass
-
-    return readable

--- a/ambassador/ambassador_diag/diagd.py
+++ b/ambassador/ambassador_diag/diagd.py
@@ -303,6 +303,9 @@ def check_alive():
 
 @app.route('/ambassador/v0/check_ready', methods=[ 'GET' ])
 def check_ready():
+    if not app.ir:
+        return "ambassador waiting for config", 503
+
     status = envoy_status(app.estats)
 
     if status['ready']:

--- a/ambassador/entrypoint.sh
+++ b/ambassador/entrypoint.sh
@@ -37,6 +37,8 @@ fi
 
 ENVOY_DIR="${AMBASSADOR_CONFIG_BASE_DIR}/envoy"
 ENVOY_CONFIG_FILE="${ENVOY_DIR}/envoy.json"
+# The bootstrap file really is in the config base dir, not the Envoy dir.
+ENVOY_BOOTSTRAP_FILE="${AMBASSADOR_CONFIG_BASE_DIR}/bootstrap-ads.json"
 
 # Set AMBASSADOR_DEBUG to things separated by spaces to enable debugging.
 check_debug () {
@@ -177,21 +179,45 @@ AMBASSADOR_CLUSTER_ID="${cluster_id}"
 export AMBASSADOR_CLUSTER_ID
 echo "AMBASSADOR: using cluster ID $AMBASSADOR_CLUSTER_ID"
 
-echo "AMBASSADOR: starting diagd"
-diagd "${CONFIG_DIR}" $DIAGD_DEBUG $DIAGD_K8S --notices "${AMBASSADOR_CONFIG_BASE_DIR}/notices.json" &
-pids="${pids:+${pids} }$!:diagd"
-
 echo "AMBASSADOR: starting ads"
 ./ambex "${ENVOY_DIR}" &
 AMBEX_PID="$!"
 pids="${pids:+${pids} }${AMBEX_PID}:ambex"
 
 echo "AMBASSADOR: starting Envoy"
-envoy $ENVOY_DEBUG -c "${AMBASSADOR_CONFIG_BASE_DIR}/bootstrap-ads.json" &
+envoy $ENVOY_DEBUG -c "${ENVOY_BOOTSTRAP_FILE}" &
 pids="${pids:+${pids} }$!:envoy"
 
+echo "AMBASSADOR: starting diagd"
+diagd "${CONFIG_DIR}" "${ENVOY_BOOTSTRAP_FILE}" "${ENVOY_CONFIG_FILE}" $AMBEX_PID $DIAGD_DEBUG $DIAGD_K8S --notices "${AMBASSADOR_CONFIG_BASE_DIR}/notices.json" &
+pids="${pids:+${pids} }$!:diagd"
+
+# Wait for diagd to start
+tries_left=10
+delay=1
+while [ $tries_left -gt 0 ]; do
+    echo "AMBASSADOR: pinging diagd ($tries_left)..."
+
+    status=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:8877/_internal/v0/ping)
+
+    if [ "$status" = "200" ]; then
+        break
+    fi
+
+    tries_left=$(( $tries_left - 1 ))
+    sleep $delay
+    delay=$(( $delay * 2 ))
+    if [ $delay -gt 10 ]; then delay=5; fi
+done
+
+if [ $tries_left -le 0 ]; then
+    echo "AMBASSADOR: giving up on diagd and hoping for the best..."
+else
+    echo "AMBASSADOR: diagd running"
+fi
+
 if [ -z "${AMBASSADOR_NO_KUBERNETES}" ]; then
-    KUBEWATCH_SYNC_CMD="ambassador splitconfig --debug --k8s --bootstrap-path=${AMBASSADOR_CONFIG_BASE_DIR}/bootstrap-ads.json --ads-path=${ENVOY_CONFIG_FILE} --ambex-pid=${AMBEX_PID}"
+    KUBEWATCH_SYNC_CMD="python3 /ambassador/post_update.py"
 
     KUBEWATCH_NAMESPACE_ARG=""
 
@@ -200,7 +226,7 @@ if [ -z "${AMBASSADOR_NO_KUBERNETES}" ]; then
     fi
 
     set -x
-    "$APPDIR/kubewatch" ${KUBEWATCH_NAMESPACE_ARG} --root "$CONFIG_DIR" --sync "$KUBEWATCH_SYNC_CMD" --warmup-delay 10s secrets services &
+    "$APPDIR/kubewatch" ${KUBEWATCH_NAMESPACE_ARG} --sync "$KUBEWATCH_SYNC_CMD" --warmup-delay 10s secrets services &
     set +x
     pids="${pids:+${pids} }$!:kubewatch"
 fi

--- a/ambassador/entrypoint.sh
+++ b/ambassador/entrypoint.sh
@@ -140,23 +140,6 @@ handle_int() {
     echo "Exiting due to Control-C"
 }
 
-wait_for_ready() {
-    host=$1
-    is_ready=1
-    sleep_for_seconds=4
-    while true; do
-        sleep ${sleep_for_seconds}
-        if getent hosts ${host}; then
-            echo "$host exists"
-            is_ready=0
-            break
-        else
-            echo "$host is not reachable, trying again in ${sleep_for_seconds} seconds ..."
-        fi
-    done
-    return ${is_ready}
-}
-
 # set -o monitor
 trap "handle_chld" CHLD
 trap "handle_int" INT

--- a/ambassador/kubewatch.py
+++ b/ambassador/kubewatch.py
@@ -30,7 +30,7 @@ from typing import Optional, Dict, Union
 from kubernetes import watch
 from kubernetes.client.rest import ApiException
 from ambassador import Config, Scout
-from ambassador.utils import kube_v1
+from ambassador.utils import kube_v1, KubeSecretReader
 from ambassador.ir import IR
 from ambassador.ir.irtlscontext import IRTLSContext
 from ambassador.envoy import V2Config
@@ -39,6 +39,7 @@ from ambassador.VERSION import Version
 
 __version__ = Version
 ambassador_id = os.getenv("AMBASSADOR_ID", "default")
+secret_root = os.environ.get('AMBASSADOR_CONFIG_BASE_DIR', "/ambassador")
 
 logging.basicConfig(
     level=logging.INFO,  # if appDebug else logging.INFO,
@@ -221,7 +222,7 @@ class Restarter(threading.Thread):
 
         aconf = Config()
         aconf.load_from_directory(output)
-        ir = IR(aconf)
+        ir = IR(aconf, secret_reader=KubeSecretReader(secret_root))
         envoy_config = V2Config(ir)
 
         bootstrap_config, ads_config = envoy_config.split_config()

--- a/ambassador/post_update.py
+++ b/ambassador/post_update.py
@@ -1,0 +1,20 @@
+import sys
+
+import os
+import urllib
+
+import requests
+
+base_url = os.environ.get('AMBASSADOR_EVENT_URL', 'http://localhost:8877/_internal/v0/update')
+
+if len(sys.argv) < 2:
+    sys.stderr.write("Usage: %s update-url\n" % os.path.basename(sys.argv[0]))
+    sys.exit(1)
+
+r = requests.post(base_url, params={ 'url': sys.argv[1] })
+
+if r.status_code != 200:
+    sys.stderr.write("update to %s failed:\nstatus %d: %s" % (r.url, r.status_code, r.text))
+    sys.exit(1)
+else:
+    sys.exit(0)

--- a/ambassador/tests/ambassador_test.py
+++ b/ambassador/tests/ambassador_test.py
@@ -666,7 +666,7 @@ def file_always_exists(filename):
     return True
 
 
-def atest_secret_reader(context: 'IRTLSContext', secret_name: str, namespace: str, secret_root: str) -> SavedSecret:
+def atest_secret_reader(context: 'IRTLSContext', secret_name: str, namespace: str) -> SavedSecret:
     # In the Real World, the secret reader should, y'know, read secrets..
     # Here we're just gonna fake it.
 

--- a/ambassador/tests/kat/abstract_tests.py
+++ b/ambassador/tests/kat/abstract_tests.py
@@ -187,7 +187,12 @@ class AmbassadorTest(Test):
             with open(fname, "wb") as fd:
                 fd.write(result.stdout)
             content = result.stdout
-        secret = yaml.load(content)
+        try:
+            secret = yaml.load(content)
+        except Exception as e:
+            print("could not parse YAML:\n%s" % content)
+            raise e
+
         data = secret['data']
         # secret_dir = tempfile.mkdtemp(prefix=self.path.k8s, suffix="secret")
         secret_dir = "/tmp/%s-ambassadormixin-%s" % (self.path.k8s, 'secret')


### PR DESCRIPTION
Rather than persisting all secrets to disk, we don't ask about secrets we haven't been told to use. 

Additionally:
- we no longer re-parse the config on every diag page load
- startup is faster and more robust
- configuration changes should be faster
- some dead code has been removed.

All of this happens by letting the long-lived (and now quite misnamed) `diagd` process own the Ambassador configuration, so that it can be more discriminatory in what it requests from `kubewatch`, and cache the configuration between changes.

This will fix #1093 and #1118. A future PR will finish the job of removing the old `kubewatch.py` (it's now only used in a vestigial startup role).