### PR TITLE
Ignore TLS module host when SNI specified

### DIFF
--- a/ambassador/ambassador/envoy/v2/v2listener.py
+++ b/ambassador/ambassador/envoy/v2/v2listener.py
@@ -426,7 +426,19 @@ class V2Listener(dict):
             })
 
         for name, hosts, ctx in envoy_contexts:
+            skip_context = False
             if not ctx:
+                skip_context = True
+
+            if global_sni:
+                for host in hosts:
+                    # Wildcard is not accepted in server_names in envoy, so we need to invalidate this
+                    if host == '*':
+                        config.ir.logger.info("V2Listener: invalid host {} found envoy contexts, ignoring context".format(host))
+                        skip_context = True
+                        break
+
+            if skip_context:
                 continue
 
             config.ir.logger.info("V2Listener: SNI route check %s, %s, %s" %

--- a/ambassador/tests/kat/test_ambassador.py
+++ b/ambassador/tests/kat/test_ambassador.py
@@ -783,6 +783,20 @@ prefix: /{self.name}/
 service: https://{self.target.path.k8s}
 """)
 
+# This TLS module tests that an additional TLS configuration in the TLS module is ignored, and SNI takes effect.
+# Also makes sure Ambassador does not go into a spin loop in case of invalid server_names configuration that this
+# configuration might generate.
+        yield self, self.format("""
+---
+apiVersion: ambassador/v1
+kind:  Module
+name:  tls
+config:
+  server:
+    enabled: True
+    secret: test-certs-secret
+""")
+
     def scheme(self) -> str:
         return "https"
 


### PR DESCRIPTION
This commit makes Ambassador not honor the TLS module's conflicting
configuration when specified with SNI. Prior to this commit, this
configuration made Envoy go into a spin loop and rendering it
unusable.

Also added a test for this fix.

Fix #1156