### PR TITLE
We don't need RBAC permissions on configmaps. 

### DIFF
--- a/kat/kat/manifests.py
+++ b/kat/kat/manifests.py
@@ -84,7 +84,6 @@ rules:
   - services
   - secrets
   - namespaces
-  - configmaps
   verbs: ["get", "list", "watch"]
 ---
 apiVersion: v1
@@ -119,7 +118,6 @@ rules:
   - services
   - secrets
   - namespaces
-  - configmaps
   verbs: ["get", "list", "watch"]
 ---
 apiVersion: v1


### PR DESCRIPTION
Now the tests reflect that.