### PR TITLE
Add sidecar.istio.io/inject: false by default

### DIFF
--- a/helm/ambassador/templates/daemonset.yaml
+++ b/helm/ambassador/templates/daemonset.yaml
@@ -20,6 +20,7 @@ spec:
         app: {{ template "ambassador.name" . }}
         release: {{ .Release.Name }}
       annotations:
+        sidecar.istio.io/inject: false
       {{- if .Values.podAnnotations }}
 {{ toYaml .Values.podAnnotations | indent 8 }}
       {{- end }}

--- a/helm/ambassador/templates/deployment.yaml
+++ b/helm/ambassador/templates/deployment.yaml
@@ -21,6 +21,7 @@ spec:
         app: {{ template "ambassador.name" . }}
         release: {{ .Release.Name }}
       annotations:
+        sidecar.istio.io/inject: false
       {{- if .Values.podAnnotations }}
 {{ toYaml .Values.podAnnotations | indent 8 }}
       {{- end }}
@@ -112,7 +113,7 @@ spec:
             periodSeconds: 3
           {{- with .Values.volumeMounts }}
           volumeMounts:
-{{ toYaml . | indent 10 }}
+{{ toYaml . | indent 12 }}
           {{- end }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}


### PR DESCRIPTION
Ambassador cannot start with the Istio sidecar injected. This pod annotation exists in the yaml deployment by default, it should in helm as well.