### PR TITLE
Add envoy configuration validation before running

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -80,7 +80,7 @@ WORKDIR ${AMBASSADOR_ROOT}
 RUN echo "https://mirror.math.princeton.edu/pub/alpinelinux/v3.8/main" > /etc/apk/repositories && \
     echo "https://mirror.math.princeton.edu/pub/alpinelinux/v3.8/community" >> /etc/apk/repositories
 
-RUN apk --no-cache add curl python3
+RUN apk --no-cache add curl python3 jq
 
 # One could argue that this is perhaps a bit of a hack. However, it's also the way to
 # get all the stuff that pip installed without needing the whole of the Python dev


### PR DESCRIPTION
This commit adds a pre-step of validation envoy's configuration
before feeding it to envoy. Before this commit the configuration
was directly fed to envoy, which sometimes led to issues like
infinite loops and envoy failures.

The validation has been added at 2 places -
1) Ambassador's entrypoint script, which takes care of validation
if the configuration is broken to start with
2) Before ambex is notified of new changes. This is for the times
when configuration updates have resulted in a broken envoy
configuration.

There are no tests for this behavior, because all known cases which
yield an invalid envoy configuration have been taken care of, but
this has been tested manually by altering code.