### PR TITLE
Resupport Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -101,6 +101,9 @@ RUN mkdir envoy
 # COPY in a default config for use with --demo.
 COPY ambassador/default-config/ ambassador-demo-config
 
+# COPY in the starting bootstrap file.
+COPY ambassador/default-bootstrap-ads.json bootstrap-ads.json
+
 # Fix permissions to allow running as a non root user
 RUN chgrp -R 0 ${AMBASSADOR_ROOT} && \
     chmod -R u+x ${AMBASSADOR_ROOT} && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -101,9 +101,6 @@ RUN mkdir envoy
 # COPY in a default config for use with --demo.
 COPY ambassador/default-config/ ambassador-demo-config
 
-# COPY in the starting bootstrap file.
-COPY ambassador/default-bootstrap-ads.json bootstrap-ads.json
-
 # Fix permissions to allow running as a non root user
 RUN chgrp -R 0 ${AMBASSADOR_ROOT} && \
     chmod -R u+x ${AMBASSADOR_ROOT} && \
@@ -112,8 +109,9 @@ RUN chgrp -R 0 ${AMBASSADOR_ROOT} && \
 # COPY the entrypoint and Python-kubewatch and make them runnable.
 COPY ambassador/kubewatch.py .
 COPY ambassador/entrypoint.sh .
+COPY ambassador/kick_ads.sh .
 COPY ambassador/post_update.py .
-RUN chmod 755 kubewatch.py entrypoint.sh post_update.py
+RUN chmod 755 kubewatch.py entrypoint.sh kick_ads.sh post_update.py
 
 # Grab ambex, too.
 RUN wget -q https://s3.amazonaws.com/datawire-static-files/ambex/0.1.1/ambex

--- a/ambassador/ambassador/config/resourcefetcher.py
+++ b/ambassador/ambassador/config/resourcefetcher.py
@@ -1,27 +1,80 @@
+from typing import List, Optional, Tuple, TYPE_CHECKING
+# from typing import cast as typecast
+
 import json
+import logging
 import os
 import yaml
 
-from typing import List, Optional, TYPE_CHECKING
+# from collections import namedtuple
 
 from .acresource import ACResource
-from ..utils import RichStatus
+# from ..utils import RichStatus
 
 if TYPE_CHECKING:
     from .config import Config
 
-########
-## ResourceFetcher and fetch_resources are the Canonical Way to load ambassador config
-## resources from disk.
+# StringOrList is either a string or a list of strings.
+# StringOrList = Union[str, List[str]]
 
+
+# class YAMLElement (dict):
+#     def __init__(self, obj: dict, serialization: str, rkey: Optional[str]=None,
+#                  filename: Optional[str]=None, filepath: Optional[str]=None, ocount=1):
+#
+#         if filename and not rkey:
+#             rkey = filename
+#
+#         super().__init__(obj=obj, serialization=serialization, rkey=rkey,
+#                          filename=filename, filepath=filepath, ocount=ocount)
+
+
+# Some thoughts:
+# - loading a bunch of Ambassador resources is different from loading a bunch of K8s
+#   services, because we should assume that if we're being a fed a bunch of Ambassador
+#   resources, we'll get a full set. The whole 'secret loader' thing needs to have the
+#   concept of a TLSSecret resource that can be force-fed to us, or that can be fetched
+#   through the loader if needed.
+# - If you're running a debug-loop Ambassador, you should just have a flat (or
+#   recursive, I don't care) directory full of Ambassador YAML, including TLSSecrets
+#   and Endpoints and whatnot, as needed. All of it will get read by
+#   load_from_filesystem and end up in the elements array.
+# - If you're running expecting to be fed by kubewatch, at present kubewatch will
+#   send over K8s Service records, and anything annotated in there will end up in
+#   elements. This may include TLSSecrets or Endpoints. Any TLSSecret mentioned that
+#   isn't already in elements will need to be fetched.
+# - Ambassador resources do not have namespaces. They have the ambassador_id. That's
+#   it. The ambassador_id is completely orthogonal to the namespace. No element with
+#   the wrong ambassador_id will end up in elements. It would be nice if they were
+#   never sent by kubewatch, but, well, y'know.
+# - TLSSecret resources are not TLSContexts. TLSSecrets only have a name, a private
+#   half, and a public half. They do _not_ have other TLSContext information.
+# - Endpoint resources probably have just a name, a service name, and an endpoint
+#   address.
 
 class ResourceFetcher:
-    def __init__(self, aconf: 'Config', config_dir_path: str, k8s: bool=False, recurse=False) -> None:
+    def __init__(self, logger: logging.Logger, aconf: 'Config') -> None:
         self.aconf = aconf
-        self.logger = aconf.logger
-        self.resources: List[ACResource] = []
+        self.logger = logger
+        self.elements: List[ACResource] = []
+        self.filename: Optional[str] = None
+        self.ocount: int = 1
+        self.saved: List[Tuple[Optional[str], int]] = []
 
-        inputs = []
+    @property
+    def location(self):
+        return "%s.%d" % (self.filename or "anonymous YAML", self.ocount)
+
+    def push_location(self, filename: Optional[str], ocount: int) -> None:
+        self.saved.append((self.filename, self.ocount))
+        self.filename = filename
+        self.ocount = ocount
+
+    def pop_location(self) -> None:
+        self.filename, self.ocount = self.saved.pop()
+
+    def load_from_filesystem(self, config_dir_path, recurse: bool=False, k8s: bool=False):
+        inputs: List[Tuple[str, str]] = []
 
         if os.path.isdir(config_dir_path):
             dirs = [ config_dir_path ]
@@ -54,54 +107,46 @@ class ResourceFetcher:
             inputs.append((config_dir_path, os.path.basename(config_dir_path)))
 
         for filepath, filename in inputs:
-            self.filename = filename
-            self.filepath = filepath
-            self.ocount: int = 1
-
-            # self.logger.debug("%s: init ocount %d" % (self.filename, self.ocount))
+            self.logger.info("reading %s (%s)" % (filename, filepath))
 
             try:
                 serialization = open(filepath, "r").read()
+                self.parse_yaml(serialization, k8s=k8s, filename=filename)
             except IOError as e:
-                self.post_error(RichStatus.fromError("%s: could not load YAML: %s" % (filepath, e)))
-                continue
+                self.aconf.post_error("could not read YAML from %s: %s" % (filepath, e))
 
-            self.load_yaml(serialization, k8s=k8s)
+    def parse_yaml(self, serialization: str, k8s=False, rkey: Optional[str]=None,
+                   filename: Optional[str]=None) -> None:
+        self.logger.info("%s: parsing %d byte%s of YAML" %
+                         (self.location, len(serialization), "" if (len(serialization) == 1) else "s"))
 
-            # self.logger.debug("%s: parsed ocount %d" % (self.filename, self.ocount))
-
-            # Resetting the filename and filepath are basically just paranoia here.
-            self.filename = "-none-"
-            self.filepath = "-none-"
-            self.ocount = 0
-
-    def post_error(self, rc: RichStatus, resource: ACResource=None):
-        self.aconf.post_error(rc, resource=resource)
-
-    def load_yaml(self, serialization: str, rkey: Optional[str]=None, k8s: bool=False) -> None:
         try:
             objects = list(yaml.safe_load_all(serialization))
+
+            self.push_location(filename, 1)
 
             for obj in objects:
                 if k8s:
                     self.extract_k8s(obj)
-                    self.ocount += 1
                 else:
-                    self.ocount = self.process_object(obj, rkey=rkey or self.filename)
+                    self.process_object(obj, rkey=rkey)
+                    self.ocount += 1
+
+            self.pop_location()
         except yaml.error.YAMLError as e:
-            self.post_error(RichStatus.fromError("%s: could not parse YAML: %s" % (self.filepath, e)))
+            self.aconf.post_error("%s: could not parse YAML: %s" % (self.location, e))
 
     def extract_k8s(self, obj: dict) -> None:
         kind = obj.get('kind', None)
 
         if kind != "Service":
-            # self.logger.debug("%s.%s: ignoring K8s %s object" % (self.filepath, self.ocount, kind))
+            self.logger.debug("%s: ignoring K8s %s object" % (self.location, kind))
             return
 
         metadata = obj.get('metadata', None)
 
         if not metadata:
-            # self.logger.debug("%s.%s: ignoring unannotated K8s %s" % (self.filepath, self.ocount, kind))
+            self.logger.debug("%s: ignoring unannotated K8s %s" % (self.location, kind))
             return
 
         # Use metadata to build a unique resource identifier
@@ -109,7 +154,7 @@ class ResourceFetcher:
 
         # This should never happen as the name field is required in metadata for Service
         if not resource_name:
-            # self.logger.debug("%s.%s: ignoring unnamed K8s %s" % (self.filepath, self.ocount, kind))
+            self.logger.debug("%s: ignoring unnamed K8s %s" % (self.location, kind))
             return
 
         resource_namespace = metadata.get('namespace', 'default')
@@ -126,75 +171,65 @@ class ResourceFetcher:
 
         if not annotations:
             # self.logger.debug("%s.%s: ignoring K8s %s without Ambassador annotation" %
-            #                   (self.filepath, self.ocount, kind))
+            #                   (filepath or "anonymous YAML", ocount, kind))
             return
 
         if self.filename and (not self.filename.endswith(":annotation")):
             self.filename += ":annotation"
 
-        saved = self.ocount
-        self.ocount = 1
-        # self.logger.debug("%s.%d extract_k8s calling load_yaml with rkey %s" %
-        #                   (self.filename, self.ocount, resource_identifier))
-        self.load_yaml(annotations, rkey=resource_identifier)
-        self.ocount = saved
+        self.parse_yaml(annotations, filename=self.filename, rkey=resource_identifier)
 
-    def process_object(self, obj: dict, rkey: str) -> int:
+    def process_object(self, obj: dict, rkey: Optional[str]=None) -> None:
         if not isinstance(obj, dict):
             # Bug!!
             if not obj:
-                self.post_error(RichStatus.fromError("%s.%d is empty" % (self.filename, self.ocount)))
+                self.aconf.post_error("%s is empty" % self.location)
             else:
-                self.post_error(RichStatus.fromError("%s.%d is not a dictionary? %s" %
-                                                     (self.filename, self.ocount,
-                                                      json.dumps(obj, indent=4, sort_keys=4))))
-            return self.ocount + 1
+                self.aconf.post_error("%s is not a dictionary? %s" %
+                                      (self.location, json.dumps(obj, indent=4, sort_keys=4)))
+            return
+
+        if not self.aconf.good_ambassador_id(obj):
+            self.logger.debug("%s SKIP for ambassador_id mismatch" % self.location)
+            return
 
         if 'kind' not in obj:
             # Bug!!
-            self.post_error(RichStatus.fromError("%s.%d is missing 'kind'?? %s" %
-                                                 (self.filename, self.ocount,
-                                                  json.dumps(obj, indent=4, sort_keys=True))))
-            return self.ocount + 1
+            self.aconf.post_error("%s is missing 'kind'?? %s" %
+                                  (self.location, json.dumps(obj, indent=4, sort_keys=True)))
+            return
 
-        # self.logger.debug("%s.%d PROCESS %s initial rkey %s" %
-        #                   (self.filename, self.ocount, obj['kind'] if obj else "-none-", rkey))
+        self.logger.debug("%s PROCESS %s initial rkey %s" % (self.location, obj['kind'], rkey))
 
         # Is this a pragma object?
         if obj['kind'] == 'Pragma':
-            # Yes. Handle this inline and be done.
-            keylist = sorted([ x for x in sorted(obj.keys()) if ((x != 'apiVersion') and (x != 'kind')) ])
+            # Why did I think this was a good idea? [ :) ]
+            new_source = obj.get('source', None)
 
-            # self.logger.debug("PRAGMA %s" % ", ".join(keylist))
+            if new_source:
+                # We don't save the old self.filename here, so this change will last until
+                # the next input source (or the next Pragma).
+                self.filename = new_source
 
-            for key in keylist:
-                if key == 'source':
-                    self.filename = obj['source']
-
-                    # self.logger.debug("PRAGMA: override source_name to %s" % self.filename)
-
-            return self.ocount
-
-        # Not a pragma.
+            # Don't count Pragma objects, since the user generally doesn't write them.
+            self.ocount -= 1
+            return
 
         if not rkey:
             rkey = self.filename
 
         rkey = "%s.%d" % (rkey, self.ocount)
 
-        # self.logger.debug("%s.%d PROCESS %s updated rkey to %s" %
-        #                   (self.filename, self.ocount, obj['kind'] if obj else "-none-", rkey))
+        self.logger.debug("%s PROCESS %s updated rkey to %s" % (self.location, obj['kind'], rkey))
 
         # Fine. Fine fine fine.
         serialization = yaml.safe_dump(obj, default_flow_style=False)
 
         r = ACResource.from_dict(rkey, rkey, serialization, obj)
-        self.resources.append(r)
+        self.elements.append(r)
 
-        # self.logger.debug("%s.%d: save %s %s" %
-        #                   (self.filename, self.ocount, obj['kind'], obj['name']))
+        self.logger.debug("%s PROCESS %s save %s" % (self.location, obj['kind'], rkey))
 
-        return self.ocount + 1
 
-    def __iter__(self):
-        return self.resources.__iter__()
+    def sorted(self, key=lambda x: x.rkey): # returns an iterator, probably
+        return sorted(self.elements, key=key)

--- a/ambassador/ambassador/ir/ir.py
+++ b/ambassador/ambassador/ir/ir.py
@@ -62,7 +62,7 @@ class IR:
     tls_contexts: Dict[str, IRTLSContext]
     aconf: Config
     secret_root: str
-    secret_reader: Callable[[IRTLSContext, str, str, str], SavedSecret]
+    secret_reader: Callable[[IRTLSContext, str, str], SavedSecret]
     file_checker: Callable[[str], bool]
 
     def __init__(self, aconf: Config, secret_reader=None, file_checker=None) -> None:

--- a/ambassador/ambassador/utils.py
+++ b/ambassador/ambassador/utils.py
@@ -277,6 +277,18 @@ class SecretSaver:
         self.source_root = source_root
         self.cache_dir = cache_dir
 
+    def null_reader(self, context: 'IRTLSContext', secret_name: str, namespace: str):
+        self.context = context
+        self.secret_name = secret_name
+        self.namespace = namespace
+
+        self.source = os.path.join(self.source_root, namespace, "secrets", "%s.yaml" % secret_name)
+
+        self.serialization = None
+        self.logger.error("TLSContext %s: no way to find secret" % context.name)
+
+        return self.secret_parser()
+
     def file_reader(self, context: 'IRTLSContext', secret_name: str, namespace: str):
         self.context = context
         self.secret_name = secret_name

--- a/ambassador/ambassador/utils.py
+++ b/ambassador/ambassador/utils.py
@@ -37,7 +37,7 @@ logger = logging.getLogger("utils")
 logger.setLevel(logging.INFO)
 
 
-def _load_url_contents(logger: logging.Logger, url: str, stream: TextIO) -> bool:
+def _load_url_contents(logger: logging.Logger, url: str, stream1: TextIO, stream2: Optional[TextIO]=None) -> bool:
     saved = False
 
     try:
@@ -47,8 +47,12 @@ def _load_url_contents(logger: logging.Logger, url: str, stream: TextIO) -> bool
                 # All's well, pull the config down.
                 try:
                     for chunk in r.iter_content(chunk_size=65536, decode_unicode=True):
-                        stream.write(chunk)
-                        saved = True
+                        stream1.write(chunk)
+
+                        if stream2:
+                            stream2.write(chunk)
+
+                    saved = True
                 except IOError as e:
                     logger.error("couldn't save Kubernetes service resources: %s" % e)
                 except Exception as e:
@@ -58,14 +62,15 @@ def _load_url_contents(logger: logging.Logger, url: str, stream: TextIO) -> bool
 
     return saved
 
-def save_url_contents(logger: logging.Logger, url: str, path: str) -> bool:
-    with open(path, 'w', encoding='utf-8') as stream:
-        return _load_url_contents(logger, url, stream)
 
-def load_url_contents(logger: logging.Logger, url: str) -> Optional[str]:
+def save_url_contents(logger: logging.Logger, url: str, path: str, stream2: Optional[TextIO]=None) -> bool:
+    with open(path, 'w', encoding='utf-8') as stream:
+        return _load_url_contents(logger, url, stream, stream2=stream2)
+
+def load_url_contents(logger: logging.Logger, url: str, stream2: Optional[TextIO]=None) -> Optional[str]:
     stream = io.StringIO()
 
-    saved = _load_url_contents(logger, url, stream)
+    saved = _load_url_contents(logger, url, stream, stream2=stream2)
 
     if saved:
         return stream.getvalue()

--- a/ambassador/entrypoint.sh
+++ b/ambassador/entrypoint.sh
@@ -24,6 +24,7 @@ fi
 AMBASSADOR_ROOT="/ambassador"
 AMBASSADOR_CONFIG_BASE_DIR="${AMBASSADOR_CONFIG_BASE_DIR:-$AMBASSADOR_ROOT}"
 CONFIG_DIR="${AMBASSADOR_CONFIG_BASE_DIR}/ambassador-config"
+SNAPSHOT_DIR="${AMBASSADOR_CONFIG_BASE_DIR}/snapshots"
 
 # If AMBASSADOR_NO_KUBEWATCH is set, it means that we're not supposed to try
 # to watch for Kubernetes stuff at all. If it's NOT set - so we _are_ allowed
@@ -83,6 +84,7 @@ if [ "$1" == "--demo" ]; then
 fi
 
 mkdir -p "${CONFIG_DIR}"
+mkdir -p "${SNAPSHOT_DIR}"
 mkdir -p "${ENVOY_DIR}"
 
 DELAY=${AMBASSADOR_RESTART_TIME:-1}
@@ -196,6 +198,7 @@ pids="${pids:+${pids} }${AMBEX_PID}:ambex"
 echo "AMBASSADOR: starting diagd"
 
 diagd "${CONFIG_DIR}" "${ENVOY_BOOTSTRAP_FILE}" "${ENVOY_CONFIG_FILE}" $DIAGD_DEBUG $DIAGD_K8S \
+      --snapshot-path "${SNAPSHOT_DIR}" \
       --kick "sh /ambassador/kick_ads.sh $AMBEX_PID" --notices "${AMBASSADOR_CONFIG_BASE_DIR}/notices.json" &
 pids="${pids:+${pids} }$!:diagd"
 

--- a/ambassador/entrypoint.sh
+++ b/ambassador/entrypoint.sh
@@ -79,7 +79,7 @@ if [ "$1" == "--demo" ]; then
 
     # Demo mode doesn't watch for Kubernetes changes.
     DIAGD_K8S=
-    AMBASSADOR_NO_KUBERNETES=no_kubernetes
+    AMBASSADOR_NO_KUBEWATCH=no_kubewatch
     AMBASSADOR_SYNC_DIR=
 fi
 
@@ -226,7 +226,7 @@ else
     echo "AMBASSADOR: diagd running"
 fi
 
-if [ -z "${AMBASSADOR_NO_KUBERNETES}" ]; then
+if [ -z "${AMBASSADOR_NO_KUBEWATCH}" ]; then
     KUBEWATCH_SYNC_CMD="python3 /ambassador/post_update.py"
 
     KUBEWATCH_NAMESPACE_ARG=""

--- a/ambassador/kick_ads.sh
+++ b/ambassador/kick_ads.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+
+# Is there an Envoy running?
+AMBEX_PID="$1"
+
+ENVOY_RUNNING=
+
+ENVOY_PID_FILE="${ENVOY_DIR}/envoy.pid"
+
+if [ -r "$ENVOY_PID_FILE" ]; then
+    ENVOY_PID=$(cat "${ENVOY_PID_FILE}")
+
+    if kill -0 $ENVOY_PID; then
+        ENVOY_RUNNING=yes
+    fi
+fi
+
+if [ -z "$ENVOY_RUNNING" ]; then
+    # Envoy isn't running. Start it.
+    envoy $ENVOY_DEBUG -c "${ENVOY_BOOTSTRAP_FILE}" &
+    ENVOY_PID="$!"
+    echo "KICK: started Envoy as PID $ENVOY_PID"
+
+    echo "$ENVOY_PID" > "$ENVOY_PID_FILE"
+fi
+
+# Once envoy is running, poke Ambex.
+echo "KICK: kicking ambex"
+kill -HUP "$AMBEX_PID"

--- a/ambassador/kubewatch.py
+++ b/ambassador/kubewatch.py
@@ -476,7 +476,7 @@ class KubeWatcher:
 
 
 @click.command()
-@click.argument("mode", type=click.Choice(["sync", "watch"]))
+@click.argument("mode", type=click.Choice(["cluster-id", "sync", "watch"]))
 @click.argument("ambassador_config_dir")
 @click.argument("envoy_config_file")
 @click.option("--debug", is_flag=True,

--- a/ambassador/tests/ambassador_test.py
+++ b/ambassador/tests/ambassador_test.py
@@ -15,6 +15,7 @@ import re
 
 from diag_paranoia import diag_paranoia, filtered_overview, sanitize_errors
 from ambassador import Config, IR
+from ambassador.config.resourcefetcher import ResourceFetcher
 from ambassador.envoy import V1Config
 from ambassador.utils import SavedSecret
 
@@ -538,7 +539,9 @@ def test_config(testname, dirpath, configdir):
     print("==== loading resources")
 
     aconf = Config()
-    aconf.load_from_directory(configdir)
+    fetcher = ResourceFetcher(logger, aconf)
+    fetcher.load_from_filesystem(configdir, recurse=True)
+    aconf.load_all(fetcher.sorted())
 
     ir = IR(aconf, file_checker=file_always_exists, secret_reader=atest_secret_reader)
     v1config = V1Config(ir)

--- a/ambassador/tests/kat/test_ambassador.py
+++ b/ambassador/tests/kat/test_ambassador.py
@@ -268,8 +268,8 @@ config:
   upstream:
     secret: test-certs-secret
   upstream-files:
-    cert_chain_file: /ambassador/ambassador-config/default/secrets-decoded/test-certs-secret/tls.crt
-    private_key_file: /ambassador/ambassador-config/default/secrets-decoded/test-certs-secret/tls.key
+    cert_chain_file: /ambassador/snapshots/default/secrets-decoded/test-certs-secret/tls.crt
+    private_key_file: /ambassador/snapshots/default/secrets-decoded/test-certs-secret/tls.key
 """)
 
         yield self, self.format("""

--- a/ambassador/tests/kat/test_ambassador.py
+++ b/ambassador/tests/kat/test_ambassador.py
@@ -268,8 +268,8 @@ config:
   upstream:
     secret: test-certs-secret
   upstream-files:
-    cert_chain_file: /ambassador/default/secrets/test-certs-secret/tls.crt
-    private_key_file: /ambassador/default/secrets/test-certs-secret/tls.key
+    cert_chain_file: /ambassador/ambassador-config/default/secrets-decoded/test-certs-secret/tls.crt
+    private_key_file: /ambassador/ambassador-config/default/secrets-decoded/test-certs-secret/tls.key
 """)
 
         yield self, self.format("""

--- a/docs/reference/running.md
+++ b/docs/reference/running.md
@@ -59,7 +59,7 @@ env:
 
 With `AMBASSADOR_CONFIG_BASE_DIR` set as above, Ambassador will create and use the directory `/tmp/ambassador-config`
 for its generated data. (Note that, while the directory will be created if it does not exist, attempts to turn an
-existing file into a direcotry will fail.)
+existing file into a directory will fail.)
 
 ## Running as daemonset
 
@@ -177,6 +177,14 @@ Ambassador is constantly watching for changes to the service annotations. When c
 - `AMBASSADOR_SHUTDOWN_TIME` (default 10) sets the number of seconds that Ambassador will wait for the old Envoy to clean up and exit on a restart. **If Envoy is not able to shut down in this time, the Ambassador pod will exit.** If this happens, it is generally indicative of issues with restarts being attempted too often.
 
 These environment variables can be set much like `AMBASSADOR_NAMESPACE`, above.
+
+## Configuration From the Filesystem
+
+If desired, Ambassador can be configured from YAML files in the directory `$AMBASSADOR_CONFIG_BASE_DIR/ambassador-config` (by default, `/ambassador/ambassador-config`, which is empty in the images built by Datawire). You could volume mount an external configuration directory here, for example, or use a custom Dockerfile to build configuration directly into a Docker image.
+
+Note well that while Ambassador will read its initial configuration from this directory, configuration loaded from Kubernetes annotations will _replace_ this initial configuration. If this is not what you want, you will need to set the environment variable `AMBASSADOR_NO_KUBEWATCH` so that Ambassador will not try to update its configuration from Kubernetes resources.
+
+Also note that the YAML files in the configuration directory must contain Ambassador resources, not Kubernetes resources with annotations.
 
 ## Ambassador Update Checks (Scout)
 

--- a/docs/user-guide/docker-compose.md
+++ b/docs/user-guide/docker-compose.md
@@ -53,7 +53,7 @@ Set the contents of the `config/ambassador.yaml` to this yaml configuration:
 
 ```yaml
 ---
-apiVersion: ambassador/v0
+apiVersion: ambassador/v1
 kind: Module
 name: ambassador
 config: {}
@@ -89,7 +89,7 @@ Edit the contents of the `config/ambassador.yaml` to this yaml configuration:
 
 ```yaml
 ---
-apiVersion: ambassador/v0
+apiVersion: ambassador/v1
 kind: Module
 name: ambassador
 config:
@@ -124,7 +124,7 @@ Create a new file `config/mapping-qotm.yaml` with these contents:
 
 ```yaml
 ---
-apiVersion: ambassador/v0
+apiVersion: ambassador/v1
 kind:  Mapping
 name:  qotm_mapping
 prefix: /qotm/
@@ -185,7 +185,7 @@ Edit the `config/mapping-qotm.yaml` file and modify the `service` and `rewrite` 
 
 ```yaml
 ---
-apiVersion: ambassador/v0
+apiVersion: ambassador/v1
 kind:  Mapping
 name:  qotm_mapping
 prefix: /qotm/
@@ -276,7 +276,7 @@ Make a new file called `config/auth.yaml` with an auth definition inside:
 
 ```yaml
 ---
-apiVersion: ambassador/v0
+apiVersion: ambassador/v1
 kind:  AuthService
 name:  authentication
 auth_service: "auth:3000"
@@ -376,7 +376,7 @@ Add a new configuration file `config/tracing.yaml` with these contents:
 
 ```yaml
 ---
-apiVersion: ambassador/v0
+apiVersion: ambassador/v1
 kind: TracingService
 name: tracing
 service: tracing:9411

--- a/docs/user-guide/docker-compose.md
+++ b/docs/user-guide/docker-compose.md
@@ -21,16 +21,45 @@ version: '3.5'
 
 services:
   ambassador:
-    image: quay.io/datawire/ambassador:0.38.0
+    image: quay.io/datawire/ambassador:0.50.1
     ports:
     # expose port 80 via 8080 on the host machine
     - 8080:80
     volumes:
     # mount a volume where we can inject configuration files
     - ./config:/ambassador/ambassador-config
+    environment:
+    # don't try to watch Kubernetes for configuration changes
+    - AMBASSADOR_NO_KUBEWATCH=no_kubewatch
 ```
 
 Note the mounted volume. When Ambassador bootstraps on container startup it checks the `/ambassador/ambassador-config` directory for configuration files. We will use this behavior to configure ambassador.
+
+Note also the `AMBASSADOR_NO_KUBEWATCH` environment variable. Without this, Ambassador will try to use the Kubernetes API to watch for service changes, which won't work in Docker.
+
+### Create the initial configuration
+
+Ambassador will interpret a total absence of configuration information as meaning that it should wait for dynamic configuration, so we'll give it a bare-bones configuration to get started.
+
+Create a `config` folder (which must match the mounted volume in the `docker-compose.yaml` file) and add a file called `ambassador.yaml` to the directory.
+(Note: Configuration files can have any name or combined into the same yaml file)
+
+```bash
+mkdir config
+touch config/ambassador.yaml
+```
+
+Set the contents of the `config/ambassador.yaml` to this yaml configuration:
+
+```yaml
+---
+apiVersion: ambassador/v0
+kind: Module
+name: ambassador
+config: {}
+```
+
+This will allow Ambassador to come up with a completely default configuration.
 
 ### Test using Ambassador's Diagnostics
 
@@ -56,15 +85,7 @@ x-envoy-upstream-service-time: 10
 
 Let's turn off the diagnostics page to demonstrate how we will enable and configure Ambassador.
 
-Create a `config` folder (which must match the mounted volume in the `docker-compose.yaml` file) and add a file called `ambassador.yaml` to the directory.
-(Note: Configuration files can have any name or combined into the same yaml file)
-
-```bash
-mkdir config
-touch config/ambassador.yaml
-```
-
-Set the contents of the `config/ambassador.yaml` to this yaml configuration:
+Edit the contents of the `config/ambassador.yaml` to this yaml configuration:
 
 ```yaml
 ---
@@ -143,12 +164,15 @@ version: '3.5'
 
 services:
   ambassador:
-    image: quay.io/datawire/ambassador:0.38.0
+    image: quay.io/datawire/ambassador:0.50.1
     ports:
     - 8080:80
     volumes:
     # mount a volume where we can inject configuration files
     - ./config:/ambassador/ambassador-config
+    environment:
+    # don't try to watch Kubernetes for configuration changes
+    - AMBASSADOR_NO_KUBEWATCH=no_kubewatch
   qotm:
     image: datawire/qotm:1.3
     ports:
@@ -227,12 +251,15 @@ version: '3.5'
 
 services:
   ambassador:
-    image: quay.io/datawire/ambassador:0.38.0
+    image: quay.io/datawire/ambassador:0.50.1
     ports:
     - 8080:80
     volumes:
     # mount a volume where we can inject configuration files
     - ./config:/ambassador/ambassador-config
+    environment:
+    # don't try to watch Kubernetes for configuration changes
+    - AMBASSADOR_NO_KUBEWATCH=no_kubewatch
   qotm:
     image: datawire/qotm:1.3
     ports:
@@ -312,12 +339,15 @@ version: '3.5'
 
 services:
   ambassador:
-    image: quay.io/datawire/ambassador:0.38.0
+    image: quay.io/datawire/ambassador:0.50.1
     ports:
     - 8080:80
     volumes:
     # mount a volume where we can inject configuration files
     - ./config:/ambassador/ambassador-config
+    environment:
+    # don't try to watch Kubernetes for configuration changes
+    - AMBASSADOR_NO_KUBEWATCH=no_kubewatch   
   qotm:
     image: datawire/qotm:1.3
     ports:


### PR DESCRIPTION
Arrange things such that, first, the `docker run` in the five-minute quickstart works. I expect this to allow running in `docker compose` too.

- You can mount a config on `$AMBASSADOR_CONFIG_BASE_DIR/ambassador-config` (default `/ambassador/ambassador-config`) and Ambassador will come up with that configuration

- Configuration snapshots are now saved in `$AMBASSADOR_CONFIG_BASE_DIR/snapshots` rather than in `$AMBASSADOR_CONFIG_BASE_DIR/ambassador-config`

- If you set up an initial config on the filesystem it will be _completely replaced_ by whatever we find in Kubernetes annotations. This is intentional for the moment.

- If you set environment variable `AMBASSADOR_NO_KUBERNETES` to a non-empty value, we won't watch for anything in Kubernetes at all (this happens automatically when you use `docker run` with the `--demo` flag).

This is a larger change than one might expect. Part of this is because we're also doing some cleanup on how configuration happens, for future work.