### PR TITLE
adding support for grpc http 1 bridge

### DIFF
--- a/ambassador/ambassador/envoy/v2/v2listener.py
+++ b/ambassador/ambassador/envoy/v2/v2listener.py
@@ -103,6 +103,12 @@ def v2filter_buffer(buffer: IRBuffer):
         }        
     }
 
+@v2filter.when("ir.grpc_http1_bridge")
+def v2filter_grpc_http1_bridge(irfilter: IRFilter):
+    return {
+        'name': 'envoy.grpc_http1_bridge',
+        'config': {},
+    }
 
 def auth_cluster_uri(auth: IRAuth, cluster: IRCluster) -> str:
     cluster_context = cluster.get('tls_context')

--- a/ambassador/ambassador/ir/irambassador.py
+++ b/ambassador/ambassador/ir/irambassador.py
@@ -1,6 +1,7 @@
 from typing import Any, ClassVar, Dict, List, Optional, TYPE_CHECKING
 
 # import json
+from ambassador.ir.irfilter import IRFilter
 
 from ..config import Config
 
@@ -81,7 +82,7 @@ class IRAmbassador (IRResource):
     def setup(self, ir: 'IR', aconf: Config) -> bool:
         # We're interested in the 'ambassador' module from the Config, if any...
         amod = aconf.get_module("ambassador")
-        
+
         # Is there a TLS module in the Ambassador module?
         if amod:
             self.sourced_by(amod)
@@ -193,8 +194,16 @@ class IRAmbassador (IRResource):
                 if not cur.get('service', None):
                     cur['service'] = diag_service
 
+        if amod and ('enable_grpc_http11_bridge' in amod):
+            self.grpc_http11_bridge = IRFilter(ir=ir, aconf=aconf,
+                                               kind='ir.grpc_http1_bridge',
+                                               name='grpc_http1_bridge',
+                                               config=dict())
+            self.grpc_http11_bridge.sourced_by(amod)
+            ir.save_filter(self.grpc_http11_bridge)
+
          # Buffer.
-        if amod and ('buffer' in amod):            
+        if amod and ('buffer' in amod):
             self.buffer = IRBuffer(ir=ir, aconf=aconf, location=self.location, **amod.buffer)
 
             if self.buffer:

--- a/ambassador/tests/001-broader-v0/config/ambassador.yaml
+++ b/ambassador/tests/001-broader-v0/config/ambassador.yaml
@@ -32,6 +32,7 @@ config:
 
   use_proxy_proto: True
   use_remote_address: True
+  enable_grpc_http11_bridge: True
   
   # TLS defaults to unconfigured. Here's the simplest way.
   tls:

--- a/ambassador/tests/001-broader-v0/gold.intermediate.json
+++ b/ambassador/tests/001-broader-v0/gold.intermediate.json
@@ -309,6 +309,11 @@
                 "type": "decoder"
             },
             {
+                "_source": "ambassador.yaml.1",
+                "config": {},
+                "name": "grpc_http1_bridge"
+            },
+            {
                 "_source": "--internal--",
                 "config": {},
                 "name": "router",
@@ -1114,7 +1119,7 @@
             "kind": "Module",
             "name": "ambassador",
             "version": "ambassador/v0",
-            "yaml": "apiVersion: ambassador/v0\nconfig:\n  diagnostics:\n    enabled: false\n  statsd:\n    enabled: true\n  tls:\n    client:\n      cacert_chain_file: /etc/ambassador-config/ca_cert_chain/tls.crt\n      cert_required: true\n      enabled: True,\n    server:\n      cert_chain_file: /etc/ambassador-config/certs/tls.crt\n      enabled: true\n      private_key_file: /etc/ambassador-config/certs/tls.key\n  use_proxy_proto: true\n  use_remote_address: true\nkind: Module\nname: ambassador\n"
+            "yaml": "apiVersion: ambassador/v0\nconfig:\n  diagnostics:\n    enabled: false\n  enable_grpc_http11_bridge: true\n  statsd:\n    enabled: true\n  tls:\n    client:\n      cacert_chain_file: /etc/ambassador-config/ca_cert_chain/tls.crt\n      cert_required: true\n      enabled: True,\n    server:\n      cert_chain_file: /etc/ambassador-config/certs/tls.crt\n      enabled: true\n      private_key_file: /etc/ambassador-config/certs/tls.key\n  use_proxy_proto: true\n  use_remote_address: true\nkind: Module\nname: ambassador\n"
         },
         "auth-2.yaml.1": {
             "_source": "auth-2.yaml",

--- a/ambassador/tests/001-broader-v0/gold.json
+++ b/ambassador/tests/001-broader-v0/gold.json
@@ -296,6 +296,10 @@
               ]
             },
             "filters": [
+              {
+                "name": "grpc_http1_bridge",
+                "config": {}
+              },
               {"type": "decoder",
                 "name": "extauth",
                 "config": {"allowed_headers": ["x-qotm-session"], "cluster": "cluster_extauth_http___canary_auth_3000", "path_prefix": "/extauth", "timeout_ms": 5000}


### PR DESCRIPTION
adding support for `envoy.grpc_http1_bridge` http filter (https://www.envoyproxy.io/docs/envoy/latest/configuration/http_filters/grpc_http1_bridge_filter).

as suggested by @kflynn i'm adding this as a config option to the `Ambassador` module like so:
```
---
apiVersion: ambassador/v0
kind:  Module
name:  ambassador
config:
  enable_grpc_http11_bridge: True
```

i personally needed this because adding this filter adds success/fail and status code level instrumentation of gRPC response codes but this will probably be useful for the main use case of the filter which is to make gRPC calls from clients which dont support http/2 trailers.