### PR TITLE
Add support for gRPC-Web using Envoy's grpc_web filter

### DIFF
--- a/ambassador/ambassador/envoy/v2/v2listener.py
+++ b/ambassador/ambassador/envoy/v2/v2listener.py
@@ -103,6 +103,12 @@ def v2filter_buffer(buffer: IRBuffer):
         }        
     }
 
+@v2filter.when("ir.grpc_web")
+def v2filter_grpc_web(irfilter: IRFilter):
+    return {
+        'name': 'envoy.grpc_web',
+        'config': {},
+    }
 
 def auth_cluster_uri(auth: IRAuth, cluster: IRCluster) -> str:
     cluster_context = cluster.get('tls_context')

--- a/ambassador/ambassador/ir/irambassador.py
+++ b/ambassador/ambassador/ir/irambassador.py
@@ -10,6 +10,7 @@ from .irtls import IRAmbassadorTLS
 from .irtlscontext import IRTLSContext
 from .ircors import IRCORS
 from .irbuffer import IRBuffer
+from .irfilter import IRFilter
 
 if TYPE_CHECKING:
     from .ir import IR
@@ -192,6 +193,11 @@ class IRAmbassador (IRResource):
 
                 if not cur.get('service', None):
                     cur['service'] = diag_service
+
+        if amod and ('enable_grpc_web' in amod):
+            self.grpc_web = IRFilter(ir=ir, aconf=aconf, kind='ir.grpc_web', name='grpc_web', config=dict())
+            self.grpc_web.sourced_by(amod)
+            ir.save_filter(self.grpc_web)
 
          # Buffer.
         if amod and ('buffer' in amod):            

--- a/ambassador/tests/001-broader-v0/config/ambassador.yaml
+++ b/ambassador/tests/001-broader-v0/config/ambassador.yaml
@@ -32,6 +32,7 @@ config:
 
   use_proxy_proto: True
   use_remote_address: True
+  enable_grpc_web: True
   
   # TLS defaults to unconfigured. Here's the simplest way.
   tls:

--- a/ambassador/tests/001-broader-v0/gold.intermediate.json
+++ b/ambassador/tests/001-broader-v0/gold.intermediate.json
@@ -309,6 +309,11 @@
                 "type": "decoder"
             },
             {
+                "_source": "ambassador.yaml.1",
+                "config": {},
+                "name": "grpc_web"
+            },
+            {
                 "_source": "--internal--",
                 "config": {},
                 "name": "router",
@@ -1114,7 +1119,7 @@
             "kind": "Module",
             "name": "ambassador",
             "version": "ambassador/v0",
-            "yaml": "apiVersion: ambassador/v0\nconfig:\n  diagnostics:\n    enabled: false\n  statsd:\n    enabled: true\n  tls:\n    client:\n      cacert_chain_file: /etc/ambassador-config/ca_cert_chain/tls.crt\n      cert_required: true\n      enabled: True,\n    server:\n      cert_chain_file: /etc/ambassador-config/certs/tls.crt\n      enabled: true\n      private_key_file: /etc/ambassador-config/certs/tls.key\n  use_proxy_proto: true\n  use_remote_address: true\nkind: Module\nname: ambassador\n"
+            "yaml": "apiVersion: ambassador/v0\nconfig:\n  diagnostics:\n    enabled: false\n  enable_grpc_web: true\n  statsd:\n    enabled: true\n  tls:\n    client:\n      cacert_chain_file: /etc/ambassador-config/ca_cert_chain/tls.crt\n      cert_required: true\n      enabled: True,\n    server:\n      cert_chain_file: /etc/ambassador-config/certs/tls.crt\n      enabled: true\n      private_key_file: /etc/ambassador-config/certs/tls.key\n  use_proxy_proto: true\n  use_remote_address: true\nkind: Module\nname: ambassador\n"
         },
         "auth-2.yaml.1": {
             "_source": "auth-2.yaml",

--- a/ambassador/tests/001-broader-v0/gold.json
+++ b/ambassador/tests/001-broader-v0/gold.json
@@ -296,6 +296,10 @@
               ]
             },
             "filters": [
+              {
+                "name": "grpc_web",
+                "config": {}
+              },
               {"type": "decoder",
                 "name": "extauth",
                 "config": {"allowed_headers": ["x-qotm-session"], "cluster": "cluster_extauth_http___canary_auth_3000", "path_prefix": "/extauth", "timeout_ms": 5000}

--- a/docs/reference/modules.md
+++ b/docs/reference/modules.md
@@ -81,6 +81,10 @@ config:
   #   methods: POST, GET, OPTIONS
   #   ...
   #   ...
+
+  # This enables gRPC-Web; a bridge to have Ambassador translate between
+  # the gRPC-Web protocol and a native gRPC upstream server.
+  # enable_grpc_web: true
 ```
 
 ### `enable_ivp4` and `enable_ipv6`


### PR DESCRIPTION
For more information, please refer to [Envoy's docs](https://www.envoyproxy.io/docs/envoy/v1.9.0/configuration/http_filters/grpc_web_filter#config-http-filters-grpc-web).

Thanks to @rotemtam for the original implementation with the gRPC HTTP/1.1 bridge in #1201 for making this so trivial for me to contribute!

Implements feature request #456.

**(Did not have time to test this yet -- if anyone could do it, that would be great! But currently I can't really test it in my setup due to unrelated issue #1203.)**