### PR TITLE
Make sure Envoy sees headers injected by extauth when routing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -117,11 +117,12 @@ DOCKER_OPTS =
 
 NETLIFY_SITE=datawire-ambassador
 
-ENVOY_BASE_IMAGE ?= quay.io/datawire/ambassador-envoy-alpine-stripped:v1.8.0-g14e2c65bb
+ENVOY_BASE_IMAGE ?= quay.io/datawire/ambassador-envoy-alpine-stripped:v1.8.0-15c5befd43fb9ee9b145cc87e507beb801726316-7-g4db17d1fb
+# ENVOY_BASE_IMAGE ?= quay.io/datawire/ambassador-envoy-alpine-stripped:v1.8.0-g14e2c65bb
 AMBASSADOR_DOCKER_TAG ?= $(GIT_VERSION)
 AMBASSADOR_DOCKER_IMAGE ?= $(AMBASSADOR_DOCKER_REPO):$(AMBASSADOR_DOCKER_TAG)
-AMBASSADOR_DOCKER_IMAGE_CACHED ?= "quay.io/datawire/ambassador-base:go-1"
-AMBASSADOR_BASE_IMAGE ?= "quay.io/datawire/ambassador-base:ambassador-1"
+AMBASSADOR_DOCKER_IMAGE_CACHED ?= "quay.io/datawire/ambassador-base:go-2-rc"
+AMBASSADOR_BASE_IMAGE ?= "quay.io/datawire/ambassador-base:ambassador-2-rc"
 
 SCOUT_APP_KEY=
 
@@ -194,10 +195,12 @@ export-vars:
 	@echo "export AMBASSADOR_DOCKER_IMAGE='$(AMBASSADOR_DOCKER_IMAGE)'"
 
 docker-base-images:
+	@if [ -n "$(AMBASSADOR_DEV)" ]; then echo "Do not run this from a dev shell" >&2; exit 1; fi
 	docker build --build-arg ENVOY_BASE_IMAGE=$(ENVOY_BASE_IMAGE) $(DOCKER_OPTS) -t $(AMBASSADOR_DOCKER_IMAGE_CACHED) -f Dockerfile.cached .
 	docker build --build-arg ENVOY_BASE_IMAGE=$(ENVOY_BASE_IMAGE) $(DOCKER_OPTS) -t $(AMBASSADOR_BASE_IMAGE) -f Dockerfile.ambassador .
 
 docker-push-base-images:
+	@if [ -n "$(AMBASSADOR_DEV)" ]; then echo "Do not run this from a dev shell" >&2; exit 1; fi
 	docker push $(AMBASSADOR_DOCKER_IMAGE_CACHED)
 	docker push $(AMBASSADOR_BASE_IMAGE)
 

--- a/ambassador/tests/kat/t_headerrouting.py
+++ b/ambassador/tests/kat/t_headerrouting.py
@@ -1,0 +1,51 @@
+# import json
+
+from kat.harness import variants, Query
+from abstract_tests import AmbassadorTest, MappingTest, ServiceType
+
+
+class HeaderRoutingTest(MappingTest):
+    debug = True
+    parent: AmbassadorTest
+    target: ServiceType
+    target2: ServiceType
+    weight: int
+
+    @classmethod
+    def variants(cls):
+        for v in variants(ServiceType):
+            yield cls(v, v.clone("target2"), name="{self.target.name}")
+
+    def init(self, target: ServiceType, target2: ServiceType):
+        MappingTest.init(self, target)
+        self.target2 = target2
+
+    def config(self):
+        yield self.target, self.format("""
+---
+apiVersion: ambassador/v0
+kind:  Mapping
+name:  {self.name}
+prefix: /{self.name}/
+service: http://{self.target.path.k8s}
+""")
+        yield self.target2, self.format("""
+---
+apiVersion: ambassador/v0
+kind:  Mapping
+name:  {self.name}-canary
+prefix: /{self.name}/
+service: http://{self.target2.path.k8s}
+headers:
+    X-Route: target2
+""")
+
+    def queries(self):
+        yield Query(self.parent.url(self.name + "/"))
+        yield Query(self.parent.url(self.name + "/"), headers={"X-Route": "target2"})
+
+    def check(self):
+        assert self.results[0].backend.name == self.target.path.k8s, f"r0 wanted {self.target.name} got {self.results[0].backend.name}"
+        assert self.results[1].backend.name == self.target2.path.k8s, f"r1 wanted {self.target2.name} got {self.results[1].backend.name}"
+
+

--- a/ambassador/tests/kat/t_headerrouting.py
+++ b/ambassador/tests/kat/t_headerrouting.py
@@ -1,11 +1,12 @@
 # import json
 
+from typing import ClassVar
+
 from kat.harness import variants, Query
-from abstract_tests import AmbassadorTest, MappingTest, ServiceType
+from abstract_tests import AmbassadorTest, MappingTest, ServiceType, HTTP
 
 
 class HeaderRoutingTest(MappingTest):
-    debug = True
     parent: AmbassadorTest
     target: ServiceType
     target2: ServiceType
@@ -25,7 +26,7 @@ class HeaderRoutingTest(MappingTest):
 ---
 apiVersion: ambassador/v0
 kind:  Mapping
-name:  {self.name}
+name:  {self.name}-target1
 prefix: /{self.name}/
 service: http://{self.target.path.k8s}
 """)
@@ -33,7 +34,7 @@ service: http://{self.target.path.k8s}
 ---
 apiVersion: ambassador/v0
 kind:  Mapping
-name:  {self.name}-canary
+name:  {self.name}-target2
 prefix: /{self.name}/
 service: http://{self.target2.path.k8s}
 headers:
@@ -45,7 +46,128 @@ headers:
         yield Query(self.parent.url(self.name + "/"), headers={"X-Route": "target2"})
 
     def check(self):
-        assert self.results[0].backend.name == self.target.path.k8s, f"r0 wanted {self.target.name} got {self.results[0].backend.name}"
-        assert self.results[1].backend.name == self.target2.path.k8s, f"r1 wanted {self.target2.name} got {self.results[1].backend.name}"
+        assert self.results[0].backend.name == self.target.path.k8s, f"r0 wanted {self.target.path.k8s} got {self.results[0].backend.name}"
+        assert self.results[1].backend.name == self.target2.path.k8s, f"r1 wanted {self.target2.path.k8s} got {self.results[1].backend.name}"
 
+class HeaderRoutingAuth(ServiceType):
+    skip_variant: ClassVar[bool] = True
 
+    def __init__(self, *args, **kwargs) -> None:
+        manifests = """
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: {self.path.k8s}
+spec:
+  selector:
+    backend: {self.path.k8s}
+  ports:
+  - name: http
+    protocol: TCP
+    port: 80
+    targetPort: 80
+  - name: https
+    protocol: TCP
+    port: 443
+    targetPort: 443
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: {self.path.k8s}
+  labels:
+    backend: {self.path.k8s}
+spec:
+  containers:
+  - name: backend
+    image: dwflynn/auth:0.0.3
+    ports:
+    - containerPort: 80
+    env:
+    - name: BACKEND
+      value: {self.path.k8s}
+"""
+
+        super().__init__(*args, service_manifests=manifests, **kwargs)
+
+    def requirements(self):
+        yield ("url", Query("http://%s/ambassador/check/" % self.path.k8s))
+
+class AuthenticationHeaderRouting(AmbassadorTest):
+    debug = True
+
+    target: ServiceType
+    target2: ServiceType
+    auth: ServiceType
+
+    def init(self):
+        self.target1 = HTTP(name="target1")
+        self.target2 = HTTP(name="target2")
+        self.auth = HeaderRoutingAuth()
+
+    def config(self):
+        # The auth service we're using works like this:
+        #
+        # prefix ENDS WITH /good/ -> 200, include X-Auth-Route -> we should hit target2
+        # prefix ENDS WITH /nohdr/ -> 200, no X-Auth-Route -> we should hit target1
+        # anything else -> 403 -> we should see the 403
+
+        yield self, self.format("""
+---
+apiVersion: ambassador/v1
+kind: AuthService
+name:  {self.auth.path.k8s}
+auth_service: "{self.auth.path.k8s}"
+proto: http
+path_prefix: ""
+timeout_ms: 5000
+
+allowed_authorization_headers:
+- X-Auth-Route
+- Extauth
+""")
+        yield self.target1, self.format("""
+---
+apiVersion: ambassador/v0
+kind:  Mapping
+name:  {self.name}-target1
+prefix: /target/
+service: http://{self.target1.path.k8s}
+""")
+        yield self.target2, self.format("""
+---
+apiVersion: ambassador/v0
+kind:  Mapping
+name:  {self.name}-target2
+prefix: /target/
+service: http://{self.target2.path.k8s}
+headers:
+    X-Auth-Route: Route
+""")
+
+    def queries(self):
+        # [0]
+        yield Query(self.url("target/"), expected=403)
+
+        # [1]
+        yield Query(self.url("target/good/"), expected=200)
+
+        # [2]
+        yield Query(self.url("target/nohdr/"), expected=200)
+
+        # [3]
+        yield Query(self.url("target/crap/"), expected=403)
+
+    def check(self):
+        # [0] should be a 403 from auth
+        assert self.results[0].backend.name == self.auth.path.k8s, f"r0 wanted {self.auth.path.k8s} got {self.results[0].backend.name}"
+
+        # [1] should go to target2
+        assert self.results[1].backend.name == self.target2.path.k8s, f"r1 wanted {self.target2.path.k8s} got {self.results[1].backend.name}"
+
+        # [2] should go to target1
+        assert self.results[2].backend.name == self.target1.path.k8s, f"r2 wanted {self.target1.path.k8s} got {self.results[2].backend.name}"
+
+        # [3] should be a 403 from auth
+        assert self.results[3].backend.name == self.auth.path.k8s, f"r3 wanted {self.auth.path.k8s} got {self.results[3].backend.name}"

--- a/ambassador/tests/kat/test_ambassador.py
+++ b/ambassador/tests/kat/test_ambassador.py
@@ -11,6 +11,7 @@ from kat.manifests import AMBASSADOR, RBAC_CLUSTER_SCOPE
 from abstract_tests import DEV, AmbassadorTest, HTTP
 from abstract_tests import MappingTest, OptionTest, ServiceType, Node
 
+from t_headerrouting import HeaderRoutingTest
 from t_ratelimit import RateLimitTest
 from t_tracing import TracingTest
 from t_shadow import ShadowTest

--- a/end-to-end/buildall.sh
+++ b/end-to-end/buildall.sh
@@ -20,8 +20,8 @@ docker build -q -t dwflynn/demo:1.0.0 --build-arg VERSION=1.0.0 demo-service
 docker build -q -t dwflynn/demo:2.0.0 --build-arg VERSION=2.0.0 demo-service
 docker build -q -t dwflynn/demo:1.0.0tls --build-arg VERSION=1.0.0 --build-arg TLS=--tls demo-service
 docker build -q -t dwflynn/demo:2.0.0tls --build-arg VERSION=2.0.0 --build-arg TLS=--tls demo-service
-docker build -q -t dwflynn/auth:0.0.1 auth-service
-docker build -q -t dwflynn/auth:0.0.1tls --build-arg TLS=--tls auth-service
+docker build -q -t dwflynn/auth:0.0.3 auth-service
+docker build -q -t dwflynn/auth:0.0.3tls --build-arg TLS=--tls auth-service
 docker build -q -t dwflynn/stats-test:0.0.1 stats-test-service
 docker build -q -t dwflynn/grpc-service:0.0.1 grpc-service
 docker build -q -t dwflynn/shadow:0.0.2 shadow-service


### PR DESCRIPTION
This PR switches to an Envoy build that correctly invalidates the route cache when headers are changed by extauth, and adds tests for routing by headers both with and without extauth.

Fixes #1226.