### PR TITLE
Fix Scout caching, and rotate snapshots

### DIFF
--- a/ambassador/ambassador/ambscout.py
+++ b/ambassador/ambassador/ambscout.py
@@ -39,7 +39,7 @@ class AmbScout:
     _latest_version: Optional[str] = None
     _latest_semver: Optional[semantic_version.Version] = None
 
-    def __init__(self, install_id=None) -> None:
+    def __init__(self, install_id=None, update_frequency=datetime.timedelta(hours=4)) -> None:
         if not install_id:
             install_id = os.environ.get('AMBASSADOR_CLUSTER_ID',
                                         os.environ.get('AMBASSADOR_SCOUT_ID', "00000000-0000-0000-0000-000000000000"))
@@ -65,7 +65,7 @@ class AmbScout:
         self._notices = None
         self._last_result = None
         self._last_update = datetime.datetime.now() - datetime.timedelta(hours=24)
-        self._update_frequency = datetime.timedelta(hours=4)
+        self._update_frequency = update_frequency
         self._latest_version = None
         self._latest_semver = None
 

--- a/ambassador/ambassador_diag/diagd.py
+++ b/ambassador/ambassador_diag/diagd.py
@@ -15,7 +15,7 @@
 # limitations under the License
 import copy
 import subprocess
-from typing import Any, Callable, Dict, List, Optional, TYPE_CHECKING
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union, TYPE_CHECKING
 
 import datetime
 import functools
@@ -89,6 +89,7 @@ class DiagApp (Flask):
     ads_path: str
     ads_temp_path: str = '/tmp/envoy-test.json'
     health_checks: bool
+    no_envoy: bool
     debugging: bool
     verbose: bool
     notice_path: str
@@ -99,16 +100,17 @@ class DiagApp (Flask):
     diag: Diagnostics
     notices: 'Notices'
     scout: Scout
-    scout_args: Dict[str, Any]
-    scout_result: Dict[str, Any]
+    # scout_args: Dict[str, Any]
+    # scout_result: Dict[str, Any]
     watcher: 'AmbassadorEventWatcher'
     stats_updater: Optional[PeriodicTrigger]
 
     def setup(self, snapshot_path: str, bootstrap_path: str, ads_path: str,
               config_path: Optional[str], ambex_pid: int, kick: Optional[str],
-              do_checks=False, reload=False, debug=False, verbose=False, notices=None):
+              do_checks=True, no_envoy=False, reload=False, debug=False, verbose=False, notices=None):
         self.estats = EnvoyStats()
-        self.health_checks = False
+        self.health_checks = do_checks
+        self.no_envoy = no_envoy
         self.debugging = reload
         self.verbose = verbose
         self.notice_path = notices
@@ -127,9 +129,6 @@ class DiagApp (Flask):
             self.logger.setLevel(logging.DEBUG)
             logging.getLogger('ambassador').setLevel(logging.DEBUG)
 
-        if do_checks:
-            self.health_checks = True
-
         self.config_path = config_path
         self.bootstrap_path = bootstrap_path
         self.ads_path = ads_path
@@ -137,6 +136,12 @@ class DiagApp (Flask):
 
         self.ir = None
         self.stats_updater = None
+
+        # self.scout = Scout(update_frequency=datetime.timedelta(seconds=30))
+        self.scout = Scout()
+
+    def check_scout(self, what: str) -> None:
+        self.watcher.post("SCOUT", (what, self.ir))
 
 # Get the Flask app defined early. Setup happens later.
 app = DiagApp(__name__,
@@ -230,30 +235,6 @@ class Notices:
             self.post(notice)
 
 
-def check_scout(app, what: str, ir: Optional[IR]=None) -> None:
-    uptime = datetime.datetime.now() - boot_time
-    hr_uptime = td_format(uptime)
-
-    app.notices.reset()
-
-    app.scout = Scout()
-    app.scout_args = {
-        "uptime": int(uptime.total_seconds()),
-        "hr_uptime": hr_uptime
-    }
-
-    if ir and not os.environ.get("AMBASSADOR_DISABLE_FEATURES", None):
-        app.scout_args["features"] = ir.features()
-
-    app.scout_result = app.scout.report(mode="diagd", action=what, **app.scout_args)
-    scout_notices = app.scout_result.pop('notices', [])
-    app.notices.extend(scout_notices)
-
-    app.logger.info("Scout reports %s" % json.dumps(app.scout_result))
-    app.logger.info("Scout notices: %s" % json.dumps(scout_notices))
-    app.logger.info("App notices after scout: %s" % json.dumps(app.notices.notices))
-
-
 def td_format(td_object):
     seconds = int(td_object.total_seconds())
     periods = [
@@ -334,6 +315,20 @@ def handle_update():
     return "update requested", 200
 
 
+# @app.route('/_internal/v0/fs', methods=[ 'POST' ])
+# def handle_fs():
+#     path = request.args.get('path', None)
+#
+#     if not path:
+#         app.logger.error("error: update requested with no PATH")
+#         return "error: update requested with no PATH", 400
+#
+#     app.logger.info("Update requested from %s" % path)
+#     app.watcher.post('CONFIG_FS', path)
+#
+#     return "update requested", 200
+
+
 @app.route('/ambassador/v0/favicon.ico', methods=[ 'GET' ])
 def favicon():
     template_path = resource_filename(Requirement.parse("ambassador"), "templates")
@@ -369,10 +364,9 @@ def check_ready():
 def show_overview(reqid=None):
     app.logger.debug("OV %s - showing overview" % reqid)
 
-    ir = app.ir
     diag = app.diag
 
-    check_scout(app, "overview", ir)
+    app.check_scout("overview")
 
     if app.verbose:
         app.logger.debug("OV %s: DIAG" % reqid)
@@ -455,10 +449,9 @@ def collect_errors_and_notices(request, reqid, what: str, diag: Diagnostics) -> 
 def show_intermediate(source=None, reqid=None):
     app.logger.debug("SRC %s - getting intermediate for '%s'" % (reqid, source))
 
-    ir = app.ir
     diag = app.diag
 
-    check_scout(app, "detail: %s" % source, ir)
+    app.check_scout("detail: %s" % source)
 
     method = request.args.get('method', None)
     resource = request.args.get('resource', None)
@@ -530,7 +523,7 @@ class AmbassadorEventWatcher(threading.Thread):
         self.logger = self.app.logger
         self.events: queue.Queue = queue.Queue()
 
-    def post(self, cmd: str, arg: str) -> None:
+    def post(self, cmd: str, arg: Union[str, Tuple[str, IR]]) -> None:
         self.events.put((cmd, arg))
 
     def update_estats(self) -> None:
@@ -541,6 +534,7 @@ class AmbassadorEventWatcher(threading.Thread):
 
         while True:
             cmd, arg = self.events.get()
+            self.logger.info("EVENT: %s" % cmd)
 
             if cmd == 'ESTATS':
                 # self.logger.info("updating estats")
@@ -558,6 +552,12 @@ class AmbassadorEventWatcher(threading.Thread):
             elif cmd == 'CONFIG':
                 try:
                     self.load_config(arg)
+                except Exception as e:
+                    self.logger.error("could not reconfigure: %s" % e)
+                    self.logger.exception(e)
+            elif cmd == 'SCOUT':
+                try:
+                    self.check_scout(*arg)
                 except Exception as e:
                     self.logger.error("could not reconfigure: %s" % e)
                     self.logger.exception(e)
@@ -617,8 +617,6 @@ class AmbassadorEventWatcher(threading.Thread):
         ir_path = os.path.join(app.snapshot_path, "ir-%s.json" % snapshot)
         open(ir_path, "w").write(ir.as_json())
 
-        check_scout(app, "update", ir)
-
         econf = EnvoyConfig.generate(ir, "V2")
         diag = Diagnostics(ir, econf)
 
@@ -626,6 +624,7 @@ class AmbassadorEventWatcher(threading.Thread):
 
         if not self.validate_envoy_config(config=ads_config):
             self.logger.info("no updates were performed due to invalid envoy configuration, continuing with current configuration...")
+            app.check_scout("attempted bad update")
             return
 
         self.logger.info("saving Envoy configuration for snapshot %s" % snapshot)
@@ -641,6 +640,8 @@ class AmbassadorEventWatcher(threading.Thread):
         app.econf = econf
         app.diag = diag
 
+        app.check_scout("update")
+
         if app.kick:
             self.logger.info("running '%s'" % app.kick)
             os.system(app.kick)
@@ -654,8 +655,33 @@ class AmbassadorEventWatcher(threading.Thread):
             app.logger.info("starting Envoy status updater")
             app.stats_updater = PeriodicTrigger(app.watcher.update_estats, period=5)
 
+    def check_scout(self, what: str, ir: Optional[IR] = None) -> None:
+        uptime = datetime.datetime.now() - boot_time
+        hr_uptime = td_format(uptime)
+
+        self.app.notices.reset()
+
+        scout_args = {
+            "uptime": int(uptime.total_seconds()),
+            "hr_uptime": hr_uptime
+        }
+
+        if ir and not os.environ.get("AMBASSADOR_DISABLE_FEATURES", None):
+            scout_args["features"] = ir.features()
+
+        scout_result = self.app.scout.report(mode="diagd", action=what, **scout_args)
+        scout_notices = scout_result.pop('notices', [])
+        self.app.notices.extend(scout_notices)
+
+        self.app.logger.info("Scout reports %s" % json.dumps(scout_result))
+        self.app.logger.info("Scout notices: %s" % json.dumps(scout_notices))
+        self.app.logger.debug("App notices after scout: %s" % json.dumps(app.notices.notices))
 
     def validate_envoy_config(self, config) -> bool:
+        if self.app.no_envoy:
+            self.app.logger.debug("Skipping validation")
+            return True
+
         # We want to keep the original config untouched
         validation_config = copy.deepcopy(config)
         # Envoy fails to validate with @type field in envoy config, so removing that
@@ -711,7 +737,7 @@ class StandaloneApplication(gunicorn.app.base.BaseApplication):
 
 def _main(snapshot_path: Parameter.REQUIRED, bootstrap_path: Parameter.REQUIRED, ads_path: Parameter.REQUIRED,
           *, config_path=None, ambex_pid=0, kick=None,
-          no_checks=False, reload=False, debug=False, verbose=False,
+          no_checks=False, no_envoy=False, reload=False, debug=False, verbose=False,
           workers=None, port=8877, host='0.0.0.0', notices=None):
     """
     Run the diagnostic daemon.
@@ -723,6 +749,7 @@ def _main(snapshot_path: Parameter.REQUIRED, bootstrap_path: Parameter.REQUIRED,
     :param ambex_pid: Optional PID to signal with HUP after updating Envoy configuration
     :param kick: Optional command to run after updating Envoy configuration
     :param no_checks: If True, don't do Envoy-cluster health checking
+    :param no_envoy: If True, don't interact with Envoy at all
     :param reload: If True, run Flask in debug mode for live reloading
     :param debug: If True, do debug logging
     :param verbose: If True, do really verbose debug logging
@@ -732,9 +759,12 @@ def _main(snapshot_path: Parameter.REQUIRED, bootstrap_path: Parameter.REQUIRED,
     :param notices: Optional file to read for local notices
     """
 
+    if no_envoy:
+        no_checks = True
+
     # Create the application itself.
     app.setup(snapshot_path, bootstrap_path, ads_path, config_path, ambex_pid, kick,
-              not no_checks, reload, debug, verbose, notices)
+              not no_checks, no_envoy, reload, debug, verbose, notices)
 
     if not workers:
         workers = number_of_workers()


### PR DESCRIPTION
Previously Ambassador wouldn't talk to Scout more often than once every four hours. That got broken; this PR fixes it.

Also, rather than keep snapshot files forever, we rotate them now. In the `snapshots` directory, e.g. `ir.json` is now always current; `ir-1.json` is always the previous, then `ir-2.json` before that, etc. We keep snapshots up to `-4` before tossing them.
