### PR TITLE
Fix namespace regression

### DIFF
--- a/ambassador/ambassador/config/config.py
+++ b/ambassador/ambassador/config/config.py
@@ -30,7 +30,6 @@ from ..utils import RichStatus
 from ..resource import Resource
 from .acresource import ACResource
 from .acmapping import ACMapping
-from .resourcefetcher import ResourceFetcher
 
 
 #############################################################################
@@ -49,6 +48,7 @@ class Config:
     # When using multiple Ambassadors in one cluster, use AMBASSADOR_ID to distinguish them.
     ambassador_id: ClassVar[str] = os.environ.get('AMBASSADOR_ID', 'default')
     ambassador_namespace: ClassVar[str] = os.environ.get('AMBASSADOR_NAMESPACE', 'default')
+    single_namespace: ClassVar[bool] = bool(os.environ.get('AMBASSADOR_SINGLE_NAMESPACE'))
 
     # INSTANCE VARIABLES
     ambassador_nodename: str = "ambassador"     # overridden in Config.reset

--- a/ambassador/ambassador/config/resourcefetcher.py
+++ b/ambassador/ambassador/config/resourcefetcher.py
@@ -6,28 +6,8 @@ import logging
 import os
 import yaml
 
-# from collections import namedtuple
-
+from .config import Config
 from .acresource import ACResource
-# from ..utils import RichStatus
-
-if TYPE_CHECKING:
-    from .config import Config
-
-# StringOrList is either a string or a list of strings.
-# StringOrList = Union[str, List[str]]
-
-
-# class YAMLElement (dict):
-#     def __init__(self, obj: dict, serialization: str, rkey: Optional[str]=None,
-#                  filename: Optional[str]=None, filepath: Optional[str]=None, ocount=1):
-#
-#         if filename and not rkey:
-#             rkey = filename
-#
-#         super().__init__(obj=obj, serialization=serialization, rkey=rkey,
-#                          filename=filename, filepath=filepath, ocount=ocount)
-
 
 # Some thoughts:
 # - loading a bunch of Ambassador resources is different from loading a bunch of K8s
@@ -176,13 +156,13 @@ class ResourceFetcher:
             skip = True
 
         if not skip and not annotations:
-            # self.logger.debug("%s: ignoring K8s %s without Ambassador annotation" % (self.location, kind))
+            self.logger.debug("%s: ignoring K8s %s without Ambassador annotation" % (self.location, kind))
             skip = True
 
-        if not skip and (resource_namespace != self.aconf.ambassador_namespace):
+        if not skip and (Config.single_namespace and (resource_namespace != self.aconf.ambassador_namespace)):
             # This should never happen in actual usage, since we shouldn't be given things
             # in the wrong namespace. However, in development, this can happen a lot.
-            # self.logger.debug("%s: ignoring K8s %s in wrong namespace" % (self.location, kind))
+            self.logger.debug("%s: ignoring K8s %s in wrong namespace" % (self.location, kind))
             skip = True
 
         if not skip:

--- a/ambassador/tests/abstract_tests.py
+++ b/ambassador/tests/abstract_tests.py
@@ -284,8 +284,15 @@ class ServiceType(Node):
     _manifests: Optional[str]
     use_superpod: bool = True
  
-    def __init__(self, service_manifests: str=None, *args, **kwargs) -> None:
-        super().__init__(*args, **kwargs)
+    def __init__(self, service_manifests: str=None, namespace: str=None, *args, **kwargs) -> None:
+        if namespace is not None:
+            print("%s init %s" % (type(self), namespace))
+
+        super().__init__(namespace=namespace, *args, **kwargs)
+
+        if namespace is not None:
+            print("%s %s after super %s" % (type(self), self.name, self.namespace))
+
         self._manifests = service_manifests
 
         if self._manifests:

--- a/ambassador/tests/test_ambassador.py
+++ b/ambassador/tests/test_ambassador.py
@@ -572,6 +572,11 @@ metadata:
 apiVersion: v1
 kind: Namespace
 metadata:
+  name: other-namespace
+---
+apiVersion: v1
+kind: Namespace
+metadata:
   name: evil-namespace
 ---
 kind: Service
@@ -710,6 +715,7 @@ class AddResponseHeaders(OptionTest):
 class HostHeaderMapping(MappingTest):
 
     parent: AmbassadorTest
+    namespace = "other-namespace"
 
     @classmethod
     def variants(cls):

--- a/ambassador/tests/test_ambassador.py
+++ b/ambassador/tests/test_ambassador.py
@@ -572,11 +572,6 @@ metadata:
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: other-namespace
----
-apiVersion: v1
-kind: Namespace
-metadata:
   name: evil-namespace
 ---
 kind: Service
@@ -715,7 +710,6 @@ class AddResponseHeaders(OptionTest):
 class HostHeaderMapping(MappingTest):
 
     parent: AmbassadorTest
-    namespace = "other-namespace"
 
     @classmethod
     def variants(cls):

--- a/kat/kat/harness.py
+++ b/kat/kat/harness.py
@@ -136,6 +136,10 @@ class Node(ABC):
         self.skip_node = False
 
         name = kwargs.pop("name", None)
+
+        if 'namespace' in kwargs:
+            self.namespace = kwargs.pop('namespace', None)
+
         _clone: Node = kwargs.pop("_clone", None)
 
         if _clone:


### PR DESCRIPTION
0.50.0 introduces a regression where Ambassador could not span namespaces like it should. This is the fix -- and perhaps more importantly, this includes the test to make sure we can't regress again.
