### PR TITLE
Bump base version and add Makefile docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -120,8 +120,8 @@ NETLIFY_SITE=datawire-ambassador
 ENVOY_BASE_IMAGE ?= quay.io/datawire/ambassador-envoy-alpine-stripped:v1.8.0-15c5befd43fb9ee9b145cc87e507beb801726316-9-gf60eead70
 AMBASSADOR_DOCKER_TAG ?= $(GIT_VERSION)
 AMBASSADOR_DOCKER_IMAGE ?= $(AMBASSADOR_DOCKER_REPO):$(AMBASSADOR_DOCKER_TAG)
-AMBASSADOR_DOCKER_IMAGE_CACHED ?= "quay.io/datawire/ambassador-base:go-2-rc"
-AMBASSADOR_BASE_IMAGE ?= "quay.io/datawire/ambassador-base:ambassador-2-rc"
+AMBASSADOR_DOCKER_IMAGE_CACHED ?= "quay.io/datawire/ambassador-base:go-4"
+AMBASSADOR_BASE_IMAGE ?= "quay.io/datawire/ambassador-base:ambassador-4"
 
 SCOUT_APP_KEY=
 

--- a/Makefile
+++ b/Makefile
@@ -117,9 +117,14 @@ DOCKER_OPTS =
 
 NETLIFY_SITE=datawire-ambassador
 
+# IF YOU MESS WITH ANY OF THESE VALUES, YOU MUST UPDATE THE VERSION NUMBERS
+# BELOW AND THEN RUN make docker-update-base
 ENVOY_BASE_IMAGE ?= quay.io/datawire/ambassador-envoy-alpine-stripped:v1.8.0-15c5befd43fb9ee9b145cc87e507beb801726316-9-gf60eead70
 AMBASSADOR_DOCKER_TAG ?= $(GIT_VERSION)
 AMBASSADOR_DOCKER_IMAGE ?= $(AMBASSADOR_DOCKER_REPO):$(AMBASSADOR_DOCKER_TAG)
+
+# UPDATE THESE VERSION NUMBERS IF YOU UPDATE ANY OF THE VALUES ABOVE, THEN 
+# RUN make docker-update-base.
 AMBASSADOR_DOCKER_IMAGE_CACHED ?= "quay.io/datawire/ambassador-base:go-4"
 AMBASSADOR_BASE_IMAGE ?= "quay.io/datawire/ambassador-base:ambassador-4"
 


### PR DESCRIPTION
Our base images should've been bumped to version `-4` by PR #1307 (really, `-4` -- `-3` was used for an endpoint routing test). Do that, and add some docs to the Makefile for next time. (I'll actually add code to catch this too.)