### PR TITLE
Nkrause/num trusted hops

### DIFF
--- a/ambassador/ambassador/envoy/v2/v2listener.py
+++ b/ambassador/ambassador/envoy/v2/v2listener.py
@@ -418,6 +418,9 @@ class V2Listener(dict):
         if 'use_remote_address' in config.ir.ambassador_module:
             base_http_config["use_remote_address"] = config.ir.ambassador_module.use_remote_address
 
+        if 'xff_num_trusted_hops' in config.ir.ambassador_module:
+            base_http_config["xff_num_trusted_hops"] = config.ir.ambassador_module.xff_num_trusted_hops
+
         if config.ir.tracing:
             base_http_config["generate_request_id"] = True
 

--- a/ambassador/ambassador/ir/ir.py
+++ b/ambassador/ambassador/ir/ir.py
@@ -391,6 +391,8 @@ class IR:
         for key in [ 'use_proxy_proto', 'use_remote_address', 'x_forwarded_proto_redirect' ]:
             od[key] = self.ambassador_module.get(key, False)
 
+        od['xff_num_trusted_hops'] = self.ambassador_module.get('xff_num_trusted_hops', 0)
+
         od['custom_ambassador_id'] = bool(self.ambassador_id != 'default')
 
         default_port = 443 if tls_termination_count else 80

--- a/ambassador/ambassador/ir/irambassador.py
+++ b/ambassador/ambassador/ir/irambassador.py
@@ -32,7 +32,8 @@ class IRAmbassador (IRResource):
         'statsd',
         'use_proxy_proto',
         'use_remote_address',
-        'x_forwarded_proto_redirect'
+        'x_forwarded_proto_redirect',
+        'xff_num_trusted_hops'
     ]
 
     service_port: int
@@ -76,6 +77,7 @@ class IRAmbassador (IRResource):
             use_proxy_proto=False,
             use_remote_address=use_remote_address,
             x_forwarded_proto_redirect=False,
+            xff_num_trusted_hops=0,
             **kwargs
         )
 

--- a/ambassador/ambassador/ir/irlistener.py
+++ b/ambassador/ambassador/ir/irlistener.py
@@ -89,6 +89,9 @@ class ListenerFactory:
         if 'use_remote_address' in amod:
             primary_listener.use_remote_address = amod.use_remote_address
 
+        if 'xff_num_trusted_hops' in amod:
+            primary_listener.xff_num_trusted_hops = amod.xff_num_trusted_hops
+
         ir.add_listener(primary_listener)
 
         if redirect_cleartext_from:
@@ -106,6 +109,9 @@ class ListenerFactory:
 
             if 'use_remote_address' in amod:
                 new_listener.use_remote_address = amod.use_remote_address
+
+            if 'xff_num_trusted_hops' in amod:
+                new_listener.xff_num_trusted_hops = amod.xff_num_trusted_hops
 
             ir.add_listener(new_listener)
 

--- a/docs/reference/modules.md
+++ b/docs/reference/modules.md
@@ -69,6 +69,15 @@ config:
   # X-Forwarded_For header. 
   # use_remote_address: true
 
+  # xff_num_trusted_hops controls the how Envoy sets the trusted 
+  # client IP address of a request. If you have a proxy in front
+  # of Ambassador, Envoy will set the trusted client IP to the
+  # address of that proxy. To preserve the orginal client IP address,
+  # setting x_num_trusted_hops: 1 will tell Envoy to use the client IP
+  # address in X-Forwarded-For. Please see the envoy documentation for
+  # more information: https://www.envoyproxy.io/docs/envoy/latest/configuration/http_conn_man/headers#x-forwarded-for
+  # xff_num_trusted_hops: 0
+
   # Ambassador lets through only the HTTP requests with
   # `X-FORWARDED-PROTO: https` header set, and redirects all the other
   # requests to HTTPS if this field is set to true.
@@ -95,6 +104,18 @@ the values here are used. Most Ambassador installations will probably be able to
 ### `use_remote_address`
 
 In Ambassador 0.50 and later, the default value for `use_remote_address` to `true`. When set to `true`, Ambassador will append to the `X-Forwarded-For` header its IP address so upstream clients of Ambassador can get the full set of IP addresses that have propagated a request.  You may also need to set `externalTrafficPolicy: Local` on your `LoadBalancer` as well to propagate the original source IP address..  See the [Envoy documentation](https://www.envoyproxy.io/docs/envoy/latest/configuration/http_conn_man/headers.html) and the [Kubernetes documentation](https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip) for more details.
+
+### `xff_num_trusted_hops` 
+
+The value of `xff_num_trusted_hops` indicates the number of trusted proxies in front of Ambassador. The default setting is 0 which tells Envoy to use the immediate downstream connection's IP address as the trusted client address. The trusted client address is used to populate the `remote_address` field used for rate limiting and can affect which IP address Envoy will set as `X-Envoy-External-Address`. 
+
+`xff_num_trusted_hops` behavior is determined by the value of `use_remote_address` (which defaults to `true` in Ambassador).
+
+- If `use_remote_address` is `false` and `xff_num_trusted_hops` is set to a value N that is greater than zero, the trusted client address is the (N+1)th address from the right end of XFF. (If the XFF contains fewer than N+1 addresses, Envoy falls back to using the immediate downstream connection’s source address as trusted client address.)
+
+- If `use_remote_address` is `true` and `xff_num_trusted_hops` is set to a value N that is greater than zero, the trusted client address is the Nth address from the right end of XFF. (If the XFF contains fewer than N addresses, Envoy falls back to using the immediate downstream connection’s source address as trusted client address.)
+
+Refer to [Envoy's documentation](https://www.envoyproxy.io/docs/envoy/latest/configuration/http_conn_man/headers#x-forwarded-for) for some detailed examples on this interaction.
 
 ### `use_proxy_proto`
 

--- a/docs/reference/modules.md
+++ b/docs/reference/modules.md
@@ -117,6 +117,8 @@ The value of `xff_num_trusted_hops` indicates the number of trusted proxies in f
 
 Refer to [Envoy's documentation](https://www.envoyproxy.io/docs/envoy/latest/configuration/http_conn_man/headers#x-forwarded-for) for some detailed examples on this interaction.
 
+**NOTE:** This value is not dynamically configurable in Envoy therefor, a restart is required  changing the value of `xff_num_trusted_hops` for Envoy to respect the change.
+
 ### `use_proxy_proto`
 
 Many load balancers can use the [PROXY protocol](https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt) to convey information about the connection they are proxying. In order to support this in Ambassador, you'll need to set `use_proxy_protocol` to `true`; this is not the default since the PROXY protocol is not compatible with HTTP.


### PR DESCRIPTION
## Description
Support `xff_num_trusted_hops` configuration in Ambassador. This is used to maintain the client IP address if Ambassador is behind another trusted proxy. 

Defaults to 0. See documentation in PR for more information.

## Related Issues
https://github.com/datawire/ambassador/issues/760
https://github.com/datawire/apro/issues/127

## Testing
It has passed all of the tests currently in the testing suite as well as my manual tests. Tests still need to be added to KAT.

## Todos
- Add KAT test
