### PR TITLE
Add %version% templating for website YAML

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,7 +20,6 @@ dist
 *.out
 *.log
 
-docs/yaml
 docs/_book
 docs/_site
 docs/Gemfile.lock

--- a/Makefile
+++ b/Makefile
@@ -263,18 +263,6 @@ version: ambassador/ambassador/VERSION.py
 e2e-versioned-manifests: venv website-yaml
 	cd end-to-end && PATH="$(shell pwd)/venv/bin:$(PATH)" bash create-manifests.sh $(AMBASSADOR_DOCKER_IMAGE)
 
-website-yaml:
-	mkdir -p docs/yaml
-	cp -R templates/* docs/yaml
-	find ./docs/yaml \
-		-type f \
-		-exec sed \
-			-i''\
-			-e "s|{{AMBASSADOR_DOCKER_IMAGE}}|$(AMBASSADOR_DOCKER_REPO):$(VERSION)|g" \
-			{} \;
-
-website: website-yaml
-
 e2e: E2E_TEST_NAME=all
 e2e: e2e-versioned-manifests
 	source venv/bin/activate; \

--- a/docs/versions.yml
+++ b/docs/versions.yml
@@ -1,1 +1,2 @@
+version: 0.51.2
 aproVersion: 0.2.3

--- a/docs/yaml
+++ b/docs/yaml
@@ -1,0 +1,1 @@
+../templates/

--- a/releng/publish-website.sh
+++ b/releng/publish-website.sh
@@ -28,7 +28,7 @@ rm -rf /tmp/getambassador.io
 git clone --single-branch -b ${TARGET_BRANCH} https://d6e-automaton:${GH_TOKEN}@github.com/datawire/getambassador.io.git /tmp/getambassador.io
 
 cd docs
-cp -R yaml ${STATIC_DIR}
+cp -RL yaml ${CONTENT_DIR}
 cp doc-links.yml ${CONTENT_DIR}
 cp versions.yml ${CONTENT_DIR}
 cp -r images/ ${STATIC_DIR}

--- a/releng/travis-script.sh
+++ b/releng/travis-script.sh
@@ -59,15 +59,7 @@ if [ "${COMMIT_TYPE}" != "GA" ]; then
         if [[ $VERSION =~ '^v' ]]; then
             VERSION=$(echo "$VERSION" | cut -c2-)
         fi
-
-        echo "making stable docs for $VERSION"
-        make VERSION="$VERSION" DOC_RELEASE_TYPE=stable website
-    else
-        # Anything else, push staging.
-
-        echo "making draft docs for $VERSION"
-        make website
-    fi        
+    fi
 
     # XXX FOR RIGHT NOW DO NOT EVER RUN OLD E2E TESTS.
     # XXX This is wrong in general, since the E2E tests still provide coverage

--- a/templates/ambassador/ambassador-no-rbac.yaml
+++ b/templates/ambassador/ambassador-no-rbac.yaml
@@ -30,7 +30,7 @@ spec:
     spec:
       containers:
       - name: ambassador
-        image: quay.io/datawire/ambassador:0.51.2
+        image: quay.io/datawire/ambassador:%version%
         resources:
           limits:
             cpu: 1

--- a/templates/ambassador/ambassador-rbac-prometheus.yaml
+++ b/templates/ambassador/ambassador-rbac-prometheus.yaml
@@ -81,7 +81,7 @@ spec:
             path: mapping-config.yaml
       containers:
       - name: ambassador
-        image: quay.io/datawire/ambassador:0.51.2
+        image: quay.io/datawire/ambassador:%version%
         resources:
           limits:
             cpu: 1

--- a/templates/ambassador/ambassador-rbac.yaml
+++ b/templates/ambassador/ambassador-rbac.yaml
@@ -61,7 +61,7 @@ spec:
       serviceAccountName: ambassador
       containers:
       - name: ambassador
-        image: quay.io/datawire/ambassador:0.51.2
+        image: quay.io/datawire/ambassador:%version%
         resources:
           limits:
             cpu: 1

--- a/templates/ambassador/pro/ambassador-consul-connector.yaml
+++ b/templates/ambassador/pro/ambassador-consul-connector.yaml
@@ -56,7 +56,7 @@ spec:
       terminationGracePeriodSeconds: 0
       containers:
         - name: consul-connect-integration
-          image: quay.io/datawire/ambassador_pro:consul_connect_integration-0.2.3
+          image: quay.io/datawire/ambassador_pro:consul_connect_integration-%aproVersion%
           imagePullPolicy: Always
           resources:
             limits:


### PR DESCRIPTION
This is the counterpart to https://github.com/datawire/getambassador.io/pull/47

I'm pretty sure that the yaml-fixup stuff for the tests means that putting `%version%` in the `templates/ambassador/*.yaml` isn't a problem, but let's see what CI says.