### PR TITLE
Apply back pressure on Kubewatch during reconfigurations

### DIFF
--- a/ambassador/ambassador_diag/diagd.py
+++ b/ambassador/ambassador_diag/diagd.py
@@ -309,9 +309,10 @@ def handle_update():
         return "error: update requested with no URL", 400
 
     app.logger.info("Update requested from %s" % url)
-    app.watcher.post('CONFIG', url)
 
-    return "update requested", 200
+    status, info = app.watcher.post('CONFIG', url)
+
+    return info, status
 
 
 # @app.route('/_internal/v0/fs', methods=[ 'POST' ])
@@ -323,9 +324,10 @@ def handle_update():
 #         return "error: update requested with no PATH", 400
 #
 #     app.logger.info("Update requested from %s" % path)
-#     app.watcher.post('CONFIG_FS', path)
 #
-#     return "update requested", 200
+#     status, info = app.watcher.post('CONFIG_FS', path)
+#
+#     return info, status
 
 
 @app.route('/ambassador/v0/favicon.ico', methods=[ 'GET' ])
@@ -521,9 +523,15 @@ class AmbassadorEventWatcher(threading.Thread):
         self.app = app
         self.logger = self.app.logger
         self.events: queue.Queue = queue.Queue()
+        self.active_config_cmd: Optional[str] = None
+        self.pending_config_cmd: Optional[str] = None
 
-    def post(self, cmd: str, arg: Union[str, Tuple[str, IR]]) -> None:
-        self.events.put((cmd, arg))
+    def post(self, cmd: str, arg: Union[str, Tuple[str, IR]]) -> Tuple[int, str]:
+        rqueue = queue.Queue()
+
+        self.events.put((cmd, arg, rqueue))
+
+        return rqueue.get()
 
     def update_estats(self) -> None:
         self.post('ESTATS', '')
@@ -532,30 +540,32 @@ class AmbassadorEventWatcher(threading.Thread):
         self.logger.info("starting event watcher")
 
         while True:
-            cmd, arg = self.events.get()
+            cmd, arg, rqueue = self.events.get()
             # self.logger.info("EVENT: %s" % cmd)
 
             if cmd == 'ESTATS':
                 # self.logger.info("updating estats")
                 try:
+                    self._respond(rqueue, 200, 'updating')
                     self.app.estats.update()
                 except Exception as e:
                     self.logger.error("could not update estats: %s" % e)
                     self.logger.exception(e)
             elif cmd == 'CONFIG_FS':
                 try:
-                    self.load_config_fs(arg)
+                    self.load_config_fs(rqueue, arg)
                 except Exception as e:
                     self.logger.error("could not reconfigure: %s" % e)
                     self.logger.exception(e)
             elif cmd == 'CONFIG':
                 try:
-                    self.load_config(arg)
+                    self.load_config(rqueue, arg)
                 except Exception as e:
                     self.logger.error("could not reconfigure: %s" % e)
                     self.logger.exception(e)
             elif cmd == 'SCOUT':
                 try:
+                    self._respond(rqueue, 200, 'checking Scout')
                     self.check_scout(*arg)
                 except Exception as e:
                     self.logger.error("could not reconfigure: %s" % e)
@@ -563,7 +573,10 @@ class AmbassadorEventWatcher(threading.Thread):
             else:
                 self.logger.error("unknown event type: '%s' '%s'" % (cmd, arg))
 
-    def load_config_fs(self, path: str) -> None:
+    def _respond(self, rqueue: queue.Queue, status: int, info='') -> None:
+        rqueue.put((status, info))
+
+    def load_config_fs(self, rqueue: queue.Queue, path: str) -> None:
         self.logger.info("loading configuration from disk: %s" % path)
 
         snapshot = re.sub(r'[^A-Za-z0-9_-]', '_', path)
@@ -575,11 +588,12 @@ class AmbassadorEventWatcher(threading.Thread):
 
         if not fetcher.elements:
             self.logger.debug("no configuration found at %s" % path)
+            self._respond(rqueue, 204, 'ignoring empty configuration')
             return
 
-        self._load_ir(aconf, fetcher, scc.null_reader, snapshot)
+        self._load_ir(rqueue, aconf, fetcher, scc.null_reader, snapshot)
 
-    def load_config(self, url):
+    def load_config(self, rqueue: queue.Queue, url):
         snapshot = url.split('/')[-1]
         ss_path = os.path.join(app.snapshot_path, "snapshot-tmp.yaml")
 
@@ -590,6 +604,8 @@ class AmbassadorEventWatcher(threading.Thread):
 
         if not serialization:
             self.logger.debug("no data loaded from snapshot %s" % snapshot)
+            self._respond(rqueue, 204, 'ignoring: no data loaded from snapshot %s' % snapshot)
+            return
 
         scc = SecretSaver(app.logger, url, app.snapshot_path)
 
@@ -599,10 +615,12 @@ class AmbassadorEventWatcher(threading.Thread):
 
         if not fetcher.elements:
             self.logger.debug("no configuration found in snapshot %s" % snapshot)
+            self._respond(rqueue, 204, 'ignoring: no configuration found in snapshot %s' % snapshot)
+            return
 
-        self._load_ir(aconf, fetcher, scc.url_reader, snapshot)
+        self._load_ir(rqueue, aconf, fetcher, scc.url_reader, snapshot)
 
-    def _load_ir(self, aconf: Config, fetcher: ResourceFetcher,
+    def _load_ir(self, rqueue: queue.Queue, aconf: Config, fetcher: ResourceFetcher,
                  secret_reader: Callable[['IRTLSContext', str, str], SavedSecret],
                  snapshot: str) -> None:
 
@@ -624,6 +642,7 @@ class AmbassadorEventWatcher(threading.Thread):
         if not self.validate_envoy_config(config=ads_config):
             self.logger.info("no updates were performed due to invalid envoy configuration, continuing with current configuration...")
             app.check_scout("attempted bad update")
+            self._respond(rqueue, 500, 'ignoring: invalid Envoy configuration in snapshot %s' % snapshot)
             return
 
         self.logger.info("rotating snapshots for snapshot %s" % snapshot)
@@ -663,7 +682,8 @@ class AmbassadorEventWatcher(threading.Thread):
             self.logger.info("notifying PID %d ambex" % app.ambex_pid)
             os.kill(app.ambex_pid, signal.SIGHUP)
 
-        self.logger.info("configuration updated")
+        self.logger.info("configuration updated from snapshot %s" % snapshot)
+        self._respond(rqueue, 200, 'configuration updated from snapshot %s' % snapshot)
 
         if app.health_checks and not app.stats_updater:
             app.logger.info("starting Envoy status updater")

--- a/ambassador/ambassador_diag/diagd.py
+++ b/ambassador/ambassador_diag/diagd.py
@@ -523,8 +523,6 @@ class AmbassadorEventWatcher(threading.Thread):
         self.app = app
         self.logger = self.app.logger
         self.events: queue.Queue = queue.Queue()
-        self.active_config_cmd: Optional[str] = None
-        self.pending_config_cmd: Optional[str] = None
 
     def post(self, cmd: str, arg: Union[str, Tuple[str, IR]]) -> Tuple[int, str]:
         rqueue = queue.Queue()

--- a/ambassador/ambassador_diag/diagd.py
+++ b/ambassador/ambassador_diag/diagd.py
@@ -603,8 +603,9 @@ class AmbassadorEventWatcher(threading.Thread):
 
         if not serialization:
             self.logger.debug("no data loaded from snapshot %s" % snapshot)
-            self._respond(rqueue, 204, 'ignoring: no data loaded from snapshot %s' % snapshot)
-            return
+            # We never used to return here. I'm not sure if that's really correct?
+            # self._respond(rqueue, 204, 'ignoring: no data loaded from snapshot %s' % snapshot)
+            # return
 
         scc = SecretSaver(app.logger, url, app.snapshot_path)
 


### PR DESCRIPTION
It used to be that, when kubewatch requested that Ambassador load a new snapshot, that was non-blocking and potentially slow. This means that Kubewatch could end up issuing more load requests while Ambassador was still processing an older load requests, which turns out to be a very bad thing™.

This PR makes the configuration request blocking, so that kubewatch can't overrun us.
