### PR TITLE
Nkrause/docs/non root

### DIFF
--- a/docs/docs/dev-guide/canary-release-concepts.md
+++ b/docs/docs/dev-guide/canary-release-concepts.md
@@ -99,7 +99,7 @@ spec:
  ports:
  - name: ambassador
    port: 80
-   targetPort: 80
+   targetPort: 8080
  selector:
    service: ambassador
 ```

--- a/docs/reference/ambassador-with-aws.md
+++ b/docs/reference/ambassador-with-aws.md
@@ -31,7 +31,7 @@ spec:
   ports:
   - name: ambassador
     port: 443
-    targetPort: 80
+    targetPort: 8080
   selector:
     service: ambassador
 ```
@@ -128,10 +128,10 @@ spec:
   ports:
   - name: https
     port: 443
-    targetPort: 443
+    targetPort: 8443
   - name: http
     port: 80
-    targetPort: 80
+    targetPort: 8080
 ```
 
 Now, we want every request on port 80 to be redirected to port 443.
@@ -145,7 +145,7 @@ name:  tls
 config:
   server:
     enabled: True
-    redirect_cleartext_from: 80
+    redirect_cleartext_from: 8080
 ```
 
 **Note:** Ensure there is no `ambassador-certs` secret in Ambassador's Namespace. If present, the tls `Module` will configure Ambassador to expect HTTPS traffic.
@@ -180,17 +180,17 @@ metadata:
       config:
         server:
           enabled: true
-          redirect_cleartext_from: 80
+          redirect_cleartext_from: 8080
 spec:
   externalTrafficPolicy: Local
   type: LoadBalancer
   ports:
   - name: https
     port: 443
-    targetPort: 443
+    targetPort: 8443
   - name: http
     port: 80
-    targetPort: 80
+    targetPort: 8080
   selector:
     service: ambassador
 ```
@@ -231,7 +231,7 @@ spec:
   ports:
   - name: ambassador
     port: 443
-    targetPort: 80
+    targetPort: 8080
   selector:
     service: ambassador
 ```

--- a/docs/reference/core/tls.md
+++ b/docs/reference/core/tls.md
@@ -20,8 +20,8 @@ config:
 
     # If you set 'redirect_cleartext_from' to a port number, HTTP traffic 
     # to that port will be redirected to HTTPS traffic. Typically you would
-    # use port 80, of course.
-    # redirect_cleartext_from: 80
+    # use port 8080, of course.
+    # redirect_cleartext_from: 8080
 
     # These are optional. They should not be present unless you are using
     # a custom Docker build to install certificates onto the container
@@ -67,7 +67,7 @@ name:  tls
 config:
   server:
     enabled: True
-    redirect_cleartext_from: 80
+    redirect_cleartext_from: 8080
 ```
 
 ## X-FORWARDED-PROTO Redirect

--- a/docs/reference/modules.md
+++ b/docs/reference/modules.md
@@ -51,10 +51,8 @@ config:
 
   # If present, service_port will be the port Ambassador listens
   # on for microservice access. If not present, Ambassador will
-  # use 443 if TLS is configured, 80 otherwise. In future releases
-  # of Ambassador, this will change to 8080 when we run Ambassador
-  # as non-root by default.
-  # service_port: 80
+  # use 8443 if TLS is configured, 8080 otherwise.
+  # service_port: 8080
 
   # statsd configures Ambassador statistics. These values can be
   # set in the Ambassador module or in an environment variable.

--- a/docs/reference/running.md
+++ b/docs/reference/running.md
@@ -10,39 +10,15 @@ Ambassador relies on Kubernetes for reliability, availability, and scalability. 
 
 The default configuration of Ambassador includes default [resource limits](https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/#resource-requests-and-limits-of-pod-and-container), as well as [readiness and liveness probes](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/). These values should be adjusted for your specific environment.
 
-## Running as non-root
+## Running as root
 
-Starting with Ambassador 0.35, we support running Ambassador as non-root. This is the recommended configuration, and will be the default configuration in future releases. We recommend you configure Ambassador to run as non-root as follows:
+Starting with Ambassador 0.52.0, the default YAML configuration will install Ambassador running as non-root. If you would like to run Ambassador with root privileges, remove the `securityContext` from the deployment. Running Ambassador with root privileges will allow it to listen on the standard HTTP and HTTPS ports (80 and 443). If you wish to use these ports instead of 8080 and 8443:
 
-* Have Kubernetes run Ambassador as non-root. This may happen by default (e.g., OpenShift) or you can set a `securityContext` in your Deployment as shown below in this abbreviated example:
-
-```yaml
----
-apiVersion: extensions/v1beta1
-kind: Deployment
-metadata:
-  name: ambassador
-spec:
-  replicas: 1
-  template:
-    metadata:
-      labels:
-        service: ambassador
-    spec:
-      containers:
-        image: quay.io/datawire/ambassador:0.50.0
-        name: ambassador
-     restartPolicy: Always
-     securityContext:
-       runAsUser: 8888
-     serviceAccountName: ambassador
-```
-
-* Set the `service_port` element in the ambassador Module to 8080 (cleartext) or 8443 (TLS). This is the port that Ambassador will use to listen to incoming traffic. Note that any port number above 1024 will work; Ambassador will use 8080/8443 as its defaults in the future.
+* Set the `service_port` element in the ambassador Module to 80 (cleartext) or 443 (TLS). This is the port that Ambassador will use to listen to incoming traffic.
 
 * Make sure that incoming traffic to Ambassador is configured to route to the `service_port`. If you're using the default Ambassador configuration, this means configuring the `targetPort` to point to the `service_port` above.
 
-* If you are using `redirect_cleartext_from`, change the value of this field to point to your cleartext port (e.g., 8080) and set `service_port` to be your TLS port (e.g., 8443).
+* If you are using `redirect_cleartext_from`, change the value of this field to point to your cleartext port (e.g., 80) and set `service_port` to be your TLS port (e.g., 443).
 
 ## Changing the configuration directory
 

--- a/docs/user-guide/ambassador-pro-install.md
+++ b/docs/user-guide/ambassador-pro-install.md
@@ -47,7 +47,7 @@ ambassador-pro-redis-dff565f78-88bl2   1/1       Running            0         1h
 By default, Ambassador Pro uses ports 8081 and 8082 for rate-limiting
 and filtering, respectively.  If for whatever reason those assignments
 are problematic (perhaps you [set
-`service_port`](/reference/running/#running-as-non-root) to one of
+`service_port`](/reference/modules#the-ambassador-module) to one of
 those), you can set adjust these by setting environment variables:
 
   - `GRPC_PORT`: Which port to serve the RateLimitService on; `8081`

--- a/docs/user-guide/bare-metal.md
+++ b/docs/user-guide/bare-metal.md
@@ -15,7 +15,7 @@ spec:
   ports:
   - name: http
     port: 8088
-    targetPort: 80
+    targetPort: 8080
     nodePort: 30036  # Optional: Define the port you would like exposed
     protocol: TCP
   selector:

--- a/docs/user-guide/getting-started.md
+++ b/docs/user-guide/getting-started.md
@@ -55,7 +55,9 @@ spec:
   type: LoadBalancer
   externalTrafficPolicy: Local
   ports:
-   - port: 80
+  - name: http
+    port: 80
+    targetPort: 8080
   selector:
     service: ambassador
 ```

--- a/docs/user-guide/tls-termination.md
+++ b/docs/user-guide/tls-termination.md
@@ -96,8 +96,8 @@ config:
 
     # If you set 'redirect_cleartext_from' to a port number, HTTP traffic
     # to that port will be redirected to HTTPS traffic. Typically you would
-    # use port 80, of course.
-    # redirect_cleartext_from: 80
+    # use port 8080, of course.
+    # redirect_cleartext_from: 8080
 
     # These are optional. They should not be present unless you are using
     # a custom Docker build to install certificates onto the container
@@ -139,7 +139,7 @@ name: tls
 config:
   server:
     enabled: True
-    redirect_cleartext_from: 80
+    redirect_cleartext_from: 8080
     secret: ambassador-certs
 ```
 
@@ -161,16 +161,18 @@ metadata:
       config:
         server:
           enabled: True
-          redirect_cleartext_from: 80
+          redirect_cleartext_from: 8080
           secret: ambassador-certs
 spec:
   ports:
     - name: http
       protocol: TCP
       port: 80
+      targetPort: 8080
     - name: https
       protocol: TCP
       port: 443
+      targetPort: 8443
   ...
 ```
 

--- a/docs/user-guide/with-istio.md
+++ b/docs/user-guide/with-istio.md
@@ -68,7 +68,7 @@ spec:
   ports:
   - name: ambassador
     port: 80
-    targetPort: 80
+    targetPort: 8080
   selector:
     service: ambassador
 ```
@@ -254,7 +254,7 @@ metadata:
       config:
         server:
           enabled: True
-          redirect_cleartext_from: 80
+          redirect_cleartext_from: 8080
         client:
           enabled: False
         upstream:
@@ -265,7 +265,7 @@ spec:
   ports:
   - name: ambassador
     port: 80
-    targetPort: 80
+    targetPort: 8080
   selector:
     service: ambassador
 ```

--- a/docs/yaml/ambassador/ambassador-no-rbac.yaml
+++ b/docs/yaml/ambassador/ambassador-no-rbac.yaml
@@ -45,9 +45,9 @@ spec:
               fieldPath: metadata.namespace
         ports:
         - name: http
-          containerPort: 80
+          containerPort: 8080
         - name: https
-          containerPort: 443
+          containerPort: 8443
         - name: admin
           containerPort: 8877
         livenessProbe:
@@ -63,3 +63,5 @@ spec:
           initialDelaySeconds: 30
           periodSeconds: 3
       restartPolicy: Always
+      securityContext:
+        runAsUser: 8888

--- a/docs/yaml/ambassador/ambassador-rbac-prometheus.yaml
+++ b/docs/yaml/ambassador/ambassador-rbac-prometheus.yaml
@@ -100,9 +100,9 @@ spec:
           value: "localhost"
         ports:
         - name: http
-          containerPort: 80
+          containerPort: 8080
         - name: https
-          containerPort: 443
+          containerPort: 8443
         - name: admin
           containerPort: 8877
         livenessProbe:
@@ -130,3 +130,5 @@ spec:
           mountPath: /statsd-exporter/
           readOnly: true
       restartPolicy: Always
+      securityContext:
+        runAsUser: 8888

--- a/docs/yaml/ambassador/ambassador-rbac.yaml
+++ b/docs/yaml/ambassador/ambassador-rbac.yaml
@@ -76,9 +76,9 @@ spec:
               fieldPath: metadata.namespace
         ports:
         - name: http
-          containerPort: 80
+          containerPort: 8080
         - name: https
-          containerPort: 443
+          containerPort: 8443
         - name: admin
           containerPort: 8877
         livenessProbe:
@@ -94,3 +94,5 @@ spec:
           initialDelaySeconds: 30
           periodSeconds: 3
       restartPolicy: Always
+      securityContext:
+        runAsUser: 8888

--- a/docs/yaml/ambassador/ambassador-service.yaml
+++ b/docs/yaml/ambassador/ambassador-service.yaml
@@ -7,6 +7,8 @@ spec:
   type: LoadBalancer
   externalTrafficPolicy: Local
   ports:
-   - port: 80
+  - name: http
+    port: 80
+    targetPort: 8080
   selector:
     service: ambassador


### PR DESCRIPTION
## Description

Documentation for https://github.com/datawire/ambassador/pull/1338. This changes documentation to assume Ambassador is running a non-root and listening on 8080 and 8443. 