### PR TITLE
Warn people about the upcoming default-port change

### DIFF
--- a/ambassador/ambassador/config/resourcefetcher.py
+++ b/ambassador/ambassador/config/resourcefetcher.py
@@ -110,21 +110,25 @@ class ResourceFetcher:
             self.aconf.post_error("%s: could not parse YAML: %s" % (self.location, e))
 
     def extract_k8s(self, obj: dict) -> None:
-        self.logger.debug("extract_k8s obj %s" % json.dumps(obj, indent=4, sort_keys=True))
+        # self.logger.debug("extract_k8s obj %s" % json.dumps(obj, indent=4, sort_keys=True))
 
         k8s_object = ObjectKind(obj=obj, filename=self.filename, logger=self.logger, ambassador_namespace=self.aconf.ambassador_namespace)
         parsed, resource_identifier = k8s_object.parse()
         if parsed is None:
-            self.logger.debug(
-                "%s: ignoring K8s object, unable to parse kind %s" % (self.location, k8s_object.get_kind()))
+            # self.logger.debug("%s: ignoring K8s object, unable to parse kind %s" %
+            #                   (self.location, k8s_object.get_kind()))
             return
 
-        self.parse_object(parsed, filename=self.filename, rkey=resource_identifier)
+        self.parse_object(parsed, k8s=False, filename=self.filename, rkey=resource_identifier)
 
     def parse_object(self, objects, k8s=False, rkey: Optional[str]=None, filename: Optional[str]=None):
         self.push_location(filename, 1)
 
+        # self.logger.debug("PARSE_OBJECT: incoming %d" % len(objects))
+
         for obj in objects:
+            self.logger.debug("PARSE_OBJECT: checking %s" % obj)
+
             if k8s:
                 self.extract_k8s(obj)
             else:
@@ -185,7 +189,7 @@ class ResourceFetcher:
         r = ACResource.from_dict(rkey, rkey, serialization, obj)
         self.elements.append(r)
 
-        self.logger.debug("%s PROCESS %s save %s" % (self.location, obj['kind'], rkey))
+        # self.logger.debug("%s PROCESS %s save %s: %s" % (self.location, obj['kind'], rkey, serialization))
 
     def sorted(self, key=lambda x: x.rkey): # returns an iterator, probably
         return sorted(self.elements, key=key)
@@ -311,7 +315,7 @@ class ServiceKind(ObjectKind):
             skip = True
 
         if not annotations:
-            self.logger.debug("ignoring K8s %s %s without Ambassador annotation" % (kind, resource_name))
+            # self.logger.debug("ignoring K8s %s %s without Ambassador annotation" % (kind, resource_name))
             skip = True
 
         if not skip and (Config.single_namespace and (resource_namespace != self.ambassador_namespace)):

--- a/ambassador/ambassador/diagnostics/diagnostics.py
+++ b/ambassador/ambassador/diagnostics/diagnostics.py
@@ -365,6 +365,40 @@ class Diagnostics:
         self.envoy_elements: Dict[str, dict] = {}
         self.ambassador_services: List[dict] = []
 
+        # Warn people about the default port change.
+        if self.ir.ambassador_module.service_port < 1024:
+            # Does it look like they explicitly asked for this?
+            amod = self.ir.aconf.get_module('ambassador')
+
+            if not (amod and amod.get('service_port')):
+                # They did not explictly set the port. Warn them about the
+                # port change.
+                new_defaults = [ "port 8080 for HTTP" ]
+
+                if self.ir.get('tls_contexts', None):
+                    new_defaults.append("port 8443 for HTTPS")
+
+                default_ports = " and ".join(new_defaults)
+
+                listen_ports = [ str(l.service_port) for l in self.ir.listeners ]
+                self.ir.logger.info("listen_ports %s" % listen_ports)
+
+                port_or_ports = "port" if (len(listen_ports) == 1) else "ports"
+
+                last_port = listen_ports.pop()
+
+                els = [ last_port ]
+
+                if len(listen_ports) > 0:
+                    els.insert(0, ", ".join(listen_ports))
+
+                port_nums = " and ".join(els)
+
+                m1 = f'Ambassador 0.60 will default to listening on {default_ports}.'
+                m2 = f'You will need to change your configuration to continue using {port_or_ports} {port_nums}.'
+
+                self.ir.aconf.post_notice(f'{m1} {m2}')
+
         # Copy in the toplevel error and notice sets.
         self.errors = self.ir.aconf.errors
         self.notices = self.ir.aconf.notices

--- a/ambassador/ambassador/diagnostics/diagnostics.py
+++ b/ambassador/ambassador/diagnostics/diagnostics.py
@@ -375,7 +375,7 @@ class Diagnostics:
                 # port change.
                 new_defaults = [ "port 8080 for HTTP" ]
 
-                if self.ir.get('tls_contexts', None):
+                if self.ir.tls_contexts:
                     new_defaults.append("port 8443 for HTTPS")
 
                 default_ports = " and ".join(new_defaults)


### PR DESCRIPTION
In 0.60 (which will probably be the next release after 0.52) we'll change Ambassador's default ports from 80/443 to 8080/8443 to facilitate running as non-root. The diag service can now warn people about that.

This PR also includes some changes to make it simpler to just run diagd locally for testing.