### PR TITLE
Fix global overriding of load_balancer

### DIFF
--- a/ambassador/ambassador/ir/irhttpmappinggroup.py
+++ b/ambassador/ambassador/ir/irhttpmappinggroup.py
@@ -40,7 +40,8 @@ class IRHTTPMappingGroup (IRBaseMappingGroup):
         'prefix_regex': True,
         'rewrite': True,
         'timeout_ms': True,
-        'bypass_auth': True
+        'bypass_auth': True,
+        'load_balancer': True
     }
 
     DoNotFlattenKeys: ClassVar[Dict[str, bool]] = dict(CoreMappingKeys)
@@ -230,6 +231,8 @@ class IRHTTPMappingGroup (IRBaseMappingGroup):
             self.add_request_headers = add_request_headers
         if add_response_headers:
             self.add_response_headers = add_response_headers
+        if self.get('load_balancer', None) is None:
+            self['load_balancer'] = ir.ambassador_module.load_balancer
 
         # if verbose:
         #     self.ir.logger.debug("%s after flattening %s" % (self, self.as_json()))


### PR DESCRIPTION
Load balancing configuration for a given HTTPMappingGroup depends
on the load_balancer field that's assigned to it. This commit makes
sure that load_balancer is assigned correctly, such that -
- if all mappings in a group do not have the same load_balancer
  set, then disable endpoint routing
- if group's load_balancer can not be determined from the mappings,
  then pick the default from Ambassador module