### PR TITLE
Makefile: Remove more left-over website stuff

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,8 +101,6 @@ else
 COMMIT_TYPE=random
 endif
 
-DOC_RELEASE_TYPE?=unstable
-
 ifndef DOCKER_REGISTRY
 $(error DOCKER_REGISTRY must be set. Use make DOCKER_REGISTRY=- for a purely local build.)
 endif
@@ -406,7 +404,6 @@ release:
 		docker pull $(AMBASSADOR_DOCKER_REPO):$(LATEST_RC); \
 		docker tag $(AMBASSADOR_DOCKER_REPO):$(LATEST_RC) $(AMBASSADOR_DOCKER_REPO):$(VERSION); \
 		docker push $(AMBASSADOR_DOCKER_REPO):$(VERSION); \
-		DOC_RELEASE_TYPE=stable make website; \
 		make SCOUT_APP_KEY=app.json STABLE_TXT_KEY=stable.txt update-aws; \
 		set +x; \
 	else \


### PR DESCRIPTION
## Description

Apparently, I "broke" the 0.52.0 release <https://travis-ci.org/datawire/ambassador/builds/509610026>.  I think this should fix it.

Even though it did create and publish most of the release artifacts, it did exit before it got to run:
```
make SCOUT_APP_KEY=app.json STABLE_TXT_KEY=stable.txt update-aws
```
IDK if you want to run that manually.