### PR TITLE
Improve gRPC tests (step 1)

### DIFF
--- a/ambassador/tests/t_grpc.py
+++ b/ambassador/tests/t_grpc.py
@@ -1,0 +1,51 @@
+from kat.harness import Query
+
+from abstract_tests import AmbassadorTest, ServiceType, EGRPC
+
+class AcceptanceGrpcTest(AmbassadorTest):
+
+    target: ServiceType
+
+    def init(self):
+        self.target = EGRPC()
+
+    def config(self):
+        yield self, self.format("""
+---
+apiVersion: ambassador/v0
+kind:  Module
+name:  ambassador
+""")
+
+        yield self, self.format("""
+---
+apiVersion: ambassador/v0
+kind:  Mapping
+grpc: True
+prefix: /echo.EchoService/
+rewrite: /echo.EchoService/
+name:  {self.target.path.k8s}
+service: {self.target.path.k8s}
+""")
+
+    def queries(self):
+        # [0]
+        yield Query(self.url("echo.EchoService/Echo"),
+                    headers={ "content-type": "application/grpc", "requested-status": "0" },
+                    expected=200,
+                    xfail="The kat client does not support real grpc (yet)",
+                    grpc_type="real")
+
+        # [1]
+        yield Query(self.url("echo.EchoService/Echo"),
+                    headers={ "content-type": "application/grpc", "requested-status": "7" },
+                    expected=200,
+                    xfail="The kat client does not support real grpc (yet)",
+                    grpc_type="real")
+
+    def check(self):
+        # [0]
+        assert self.results[0].headers["Grpc-Status"] == ["0"]
+
+        # [1]
+        assert self.results[1].headers["Grpc-Status"] == ["7"]

--- a/ambassador/tests/t_grpc_bridge.py
+++ b/ambassador/tests/t_grpc_bridge.py
@@ -34,12 +34,14 @@ service: {self.target.path.k8s}
         # [0]
         yield Query(self.url("echo.EchoService/Echo"),
                     headers={ "content-type": "application/grpc", "requested-status": "0" },
-                    expected=200)
+                    expected=200,
+                    grpc_type="bridge")
 
         # [1]
         yield Query(self.url("echo.EchoService/Echo"),
                     headers={ "content-type": "application/grpc", "requested-status": "7" },
-                    expected=200)
+                    expected=200,
+                    grpc_type="bridge")
 
     def check(self):
         # [0]

--- a/ambassador/tests/t_grpc_bridge.py
+++ b/ambassador/tests/t_grpc_bridge.py
@@ -1,5 +1,3 @@
-import json
-
 from kat.harness import Query
 
 from abstract_tests import AmbassadorTest, ServiceType, EGRPC
@@ -34,18 +32,18 @@ service: {self.target.path.k8s}
 
     def queries(self):
         # [0]
-        yield Query(self.url("echo.EchoService/Echo"), headers={ "content-type": "application/grpc", 
-                                                                    "requested-status": "0" }, expected=200)
+        yield Query(self.url("echo.EchoService/Echo"),
+                    headers={ "content-type": "application/grpc", "requested-status": "0" },
+                    expected=200)
 
-         # [1]
-        yield Query(self.url("echo.EchoService/Echo"),  headers={ "content-type": "application/grpc", 
-                                                                    "requested-status": "7" }, expected=200)
+        # [1]
+        yield Query(self.url("echo.EchoService/Echo"),
+                    headers={ "content-type": "application/grpc", "requested-status": "7" },
+                    expected=200)
 
     def check(self):
         # [0]
-        assert self.results[0].status == 200
         assert self.results[0].headers["Grpc-Status"] == ["0"]
 
-        # [0]
-        assert self.results[1].status == 200
+        # [1]
         assert self.results[1].headers["Grpc-Status"] == ["7"]

--- a/ambassador/tests/t_grpc_web.py
+++ b/ambassador/tests/t_grpc_web.py
@@ -1,0 +1,53 @@
+from kat.harness import Query
+
+from abstract_tests import AmbassadorTest, ServiceType, EGRPC
+
+class AcceptanceGrpcWebTest(AmbassadorTest):
+
+    target: ServiceType
+
+    def init(self):
+        self.target = EGRPC()
+
+    def config(self):
+        yield self, self.format("""
+---
+apiVersion: ambassador/v0
+kind:  Module
+name:  ambassador
+config:
+    enable_grpc_web: True
+""")
+
+        yield self, self.format("""
+---
+apiVersion: ambassador/v0
+kind:  Mapping
+grpc: True
+prefix: /echo.EchoService/
+rewrite: /echo.EchoService/
+name:  {self.target.path.k8s}
+service: {self.target.path.k8s}
+""")
+
+    def queries(self):
+        # [0]
+        yield Query(self.url("echo.EchoService/Echo"),
+                    headers={ "content-type": "application/grpc-web-text", "requested-status": "0" },
+                    expected=200,
+                    xfail="The kat client does not support grpc-web (yet)",
+                    grpc_type="web")
+
+        # [1]
+        yield Query(self.url("echo.EchoService/Echo"),
+                    headers={ "content-type": "application/grpc-web-text", "requested-status": "7" },
+                    expected=200,
+                    xfail="The kat client does not support grpc-web (yet)",
+                    grpc_type="web")
+
+    def check(self):
+        # [0]
+        assert self.results[0].headers["Grpc-Status"] == ["0"]
+
+        # [1]
+        assert self.results[1].headers["Grpc-Status"] == ["7"]

--- a/ambassador/tests/test_ambassador.py
+++ b/ambassador/tests/test_ambassador.py
@@ -11,7 +11,9 @@ from kat.manifests import AMBASSADOR, RBAC_CLUSTER_SCOPE
 from abstract_tests import DEV, AmbassadorTest, HTTP
 from abstract_tests import MappingTest, OptionTest, ServiceType, Node
 
+from t_grpc import AcceptanceGrpcTest
 from t_grpc_bridge import AcceptanceGrpcBridgeTest
+from t_grpc_web import AcceptanceGrpcWebTest
 from t_tcpmapping import TCPMappingTest
 from t_headerrouting import HeaderRoutingTest
 from t_ratelimit import RateLimitTest

--- a/kat/kat/harness.py
+++ b/kat/kat/harness.py
@@ -278,7 +278,8 @@ class Test(Node):
 class Query:
 
     def __init__(self, url, expected=None, method="GET", headers=None, messages=None, insecure=False, skip=None,
-                 xfail=None, phase=1, debug=False, sni=False, error=None, client_crt=None, client_key=None, client_cert_required=False, ca_cert=None):
+                 xfail=None, phase=1, debug=False, sni=False, error=None, client_crt=None, client_key=None,
+                 client_cert_required=False, ca_cert=None, grpc_type=None):
         self.method = method
         self.url = url
         self.headers = headers
@@ -303,6 +304,8 @@ class Query:
         self.client_cert = client_crt
         self.client_key = client_key
         self.ca_cert = ca_cert
+        assert grpc_type in (None, "real", "bridge", "web"), grpc_type
+        self.grpc_type = grpc_type
 
     def as_json(self):
         result = {
@@ -326,6 +329,8 @@ class Query:
             result["ca_cert"] = self.ca_cert
         if self.client_cert_required:
             result["client_cert_required"] = self.client_cert_required
+        if self.grpc_type:
+            result["grpc_type"] = self.grpc_type
 
         return result
 


### PR DESCRIPTION
## Description

Add the ability to specify different kinds of gRPC tests to match the different kinds of gRPC support in Ambassador.

- HTTP/1.1-gRPC bridge (already tested)
- Real gRPC (not yet supported by the kat backend client, so marked as xfail)
- gRPC-web (not yet supported by the kat backend client, so marked as xfail)

## Next steps
- Add real gRPC support to the kat backend Go client
- Either support using the kat backend Node client for gRPC-web, or hack in gRPC-web support into the Go client
- Remove the xfail markers from the new tests