### PR TITLE
Support AMBASSADOR_NO_SECRETS to prevent Ambassador from reading secrets objects

### DIFF
--- a/ambassador/entrypoint.sh
+++ b/ambassador/entrypoint.sh
@@ -224,8 +224,14 @@ if [ -z "${AMBASSADOR_NO_KUBEWATCH}" ]; then
         KUBEWATCH_ENDPOINTS_ARG="endpoints"
     fi
 
+    KUBEWATCH_SYNC_KINDS="secrets services"
+
+    if [ -n "$AMBASSADOR_NO_SECRETS" ]; then
+        KUBEWATCH_SYNC_KINDS="services"
+    fi
+
     set -x
-    "kubewatch" ${KUBEWATCH_NAMESPACE_ARG} --sync "$KUBEWATCH_SYNC_CMD" --warmup-delay 10s secrets services $KUBEWATCH_ENDPOINTS_ARG &
+    "kubewatch" ${KUBEWATCH_NAMESPACE_ARG} --sync "$KUBEWATCH_SYNC_CMD" --warmup-delay 10s $KUBEWATCH_SYNC_KINDS $KUBEWATCH_ENDPOINTS_ARG &
     set +x
     pids="${pids:+${pids} }$!:kubewatch"
 fi


### PR DESCRIPTION
## Description
Add AMBASSADOR_NO_SECRETS to entrypoint.sh. When set, Ambassador will only read Services. 

This helps organizations adopt ambassador when running on infrastructure that tightly access controls secrets.

## Related Issues
https://github.com/datawire/ambassador/issues/1293

## Testing
Manually tested. We are using a similar patch for our Ambassador evaluation and it works as expected.

## Todos
- [ ] Tests
- [ ] Documentation

## Other
* If this is a documentation change, please open the pull request at https://github.com/datawire/ambassador-docs instead.
* Code changes should occur against `master`.
