### PR TITLE
Update dependencies for security vulns

### DIFF
--- a/end-to-end/auth-service/requirements.txt
+++ b/end-to-end/auth-service/requirements.txt
@@ -2,6 +2,6 @@ clize==4.0.1
 flask==0.12.3
 jinja2==2.9.6
 jsonschema==2.6.0
-pyyaml==4.2b1
+pyyaml==5.1
 scout.py==0.3.0
 semantic-version==2.6.0

--- a/end-to-end/auth-service/requirements.txt
+++ b/end-to-end/auth-service/requirements.txt
@@ -2,6 +2,6 @@ clize==4.0.1
 flask==0.12.3
 jinja2==2.9.6
 jsonschema==2.6.0
-pyyaml==3.12
+pyyaml==4.2b1
 scout.py==0.3.0
 semantic-version==2.6.0

--- a/end-to-end/demo-service/requirements.txt
+++ b/end-to-end/demo-service/requirements.txt
@@ -1,7 +1,7 @@
 clize==4.0.1
-flask==0.11.1
+flask==0.12.3
 jinja2==2.9.6
 jsonschema==2.6.0
-pyyaml==3.12
+pyyaml==4.2b1
 scout.py==0.3.0
 semantic-version==2.6.0

--- a/end-to-end/demo-service/requirements.txt
+++ b/end-to-end/demo-service/requirements.txt
@@ -2,6 +2,6 @@ clize==4.0.1
 flask==0.12.3
 jinja2==2.9.6
 jsonschema==2.6.0
-pyyaml==4.2b1
+pyyaml==5.1
 scout.py==0.3.0
 semantic-version==2.6.0


### PR DESCRIPTION
This updates some dependencies on Kat services. Technically, this isn't that important as these services are only used in tests, but it's not a hard fix.