### PR TITLE
Basic feature reporting of request volume

### DIFF
--- a/ambassador/ambassador_diag/diagd.py
+++ b/ambassador/ambassador_diag/diagd.py
@@ -103,6 +103,8 @@ class DiagApp (Flask):
     # scout_result: Dict[str, Any]
     watcher: 'AmbassadorEventWatcher'
     stats_updater: Optional[PeriodicTrigger]
+    last_request_info: Dict[str, int]
+    last_request_time: Optional[datetime.datetime]
 
     def setup(self, snapshot_path: str, bootstrap_path: str, ads_path: str,
               config_path: Optional[str], ambex_pid: int, kick: Optional[str],
@@ -138,7 +140,10 @@ class DiagApp (Flask):
         self.ir = None
         self.stats_updater = None
 
-        # self.scout = Scout(update_frequency=datetime.timedelta(seconds=30))
+        self.last_request_info = {}
+        self.last_request_time = None
+
+        # self.scout = Scout(update_frequency=datetime.timedelta(seconds=10))
         self.scout = Scout()
 
     def check_scout(self, what: str) -> None:
@@ -694,14 +699,19 @@ class AmbassadorEventWatcher(threading.Thread):
         if app.health_checks and not app.stats_updater:
             app.logger.info("starting Envoy status updater")
             app.stats_updater = PeriodicTrigger(app.watcher.update_estats, period=5)
+            # app.scout_updater = PeriodicTrigger(lambda: app.watcher.check_scout("30s"), period=30)
 
         # Don't use app.check_scout; it will deadlock. And don't bother doing the Scout
         # update until after we've taken care of Envoy.
         self.check_scout("update")
 
     def check_scout(self, what: str, ir: Optional[IR] = None) -> None:
-        uptime = datetime.datetime.now() - boot_time
+        now = datetime.datetime.now()
+        uptime = now - boot_time
         hr_uptime = td_format(uptime)
+
+        if not ir:
+            ir = app.ir
 
         self.app.notices.reset()
 
@@ -710,8 +720,35 @@ class AmbassadorEventWatcher(threading.Thread):
             "hr_uptime": hr_uptime
         }
 
-        if ir and not os.environ.get("AMBASSADOR_DISABLE_FEATURES", None):
-            scout_args["features"] = ir.features()
+        if ir:
+            self.app.logger.debug("check_scout: we have an IR")
+
+            if not os.environ.get("AMBASSADOR_DISABLE_FEATURES", None):
+                self.app.logger.debug("check_scout: including features")
+                feat = ir.features()
+
+                request_data = app.estats.stats.get('requests', None)
+
+                if request_data:
+                    self.app.logger.debug("check_scout: including requests")
+
+                    for rkey in request_data.keys():
+                        cur = request_data[rkey]
+                        prev = app.last_request_info.get(rkey, 0)
+                        feat[f'request_{rkey}_count'] = max(cur - prev, 0)
+
+                    lrt = app.last_request_time or boot_time
+                    since_lrt = now - lrt
+                    elapsed = since_lrt.total_seconds()
+                    hr_elapsed = td_format(since_lrt)
+
+                    app.last_request_time = now
+                    app.last_request_info = request_data
+
+                    feat['request_elapsed'] = elapsed
+                    feat['request_hr_elapsed'] = hr_elapsed
+
+                scout_args["features"] = feat
 
         scout_result = self.app.scout.report(mode="diagd", action=what, **scout_args)
         scout_notices = scout_result.pop('notices', [])

--- a/ambassador/ambassador_diag/diagd.py
+++ b/ambassador/ambassador_diag/diagd.py
@@ -666,10 +666,11 @@ class AmbassadorEventWatcher(threading.Thread):
                     from_path = os.path.join(app.snapshot_path, fmt.format(from_suffix))
                     to_path = os.path.join(app.snapshot_path, fmt.format(to_suffix))
 
-                    self.logger.debug("rotate: %s -> %s" % (from_path, to_path))
+                    # self.logger.debug("rotate: %s -> %s" % (from_path, to_path))
                     os.rename(from_path, to_path)
                 except IOError as e:
-                    self.logger.debug("skip %s -> %s: %s" % (from_path, to_path, e))
+                    # self.logger.debug("skip %s -> %s: %s" % (from_path, to_path, e))
+                    pass
                 except Exception as e:
                     self.logger.debug("could not rename %s -> %s: %s" % (from_path, to_path, e))
 

--- a/docs/reference/running.md
+++ b/docs/reference/running.md
@@ -254,6 +254,13 @@ Unless disabled, Ambassador will also report the following anonymized informatio
 | `ratelimit_custom_domain` | bool | has the rate limiting domain been changed from 'ambassador'? |
 | `ratelimit_data_plane_proto` | bool | is rate limiting using the data plane proto? |
 | `readiness_probe` | bool | are readiness probes enabled? |
+| `request_4xx_count` | int | lower bound for how many requests have gotten a 4xx response | 
+| `request_5xx_count` | int | lower bound for how many requests have gotten a 5xx response | 
+| `request_bad_count` | int | lower bound for how many requests have failed (either 4xx or 5xx) | 
+| `request_elapsed` | float | seconds over which the request_ counts are valid | 
+| `request_hr_elapsed` | string | human-readable version of `request_elapsed` (e.g. "3 hours 35 minutes 20 seconds" | 
+| `request_ok_count` | int | lower bound for how many requests have succeeded (not a 4xx or 5xx) | 
+| `request_total_count` | int | lower bound for how many requests were handled in total | 
 | `statsd` | bool | is statsd enabled? |
 | `tls_origination_count` | int | count of TLS origination contexts |
 | `tls_termination_count` | int | count of TLS termination contexts |
@@ -265,6 +272,10 @@ Unless disabled, Ambassador will also report the following anonymized informatio
 | `use_remote_address` | bool | is Ambassador honoring remote addresses? |
 | `x_forwarded_proto_redirect` | bool | is Ambassador redirecting based on `X-Forwarded-Proto`? |
 | `xff_num_trusted_hops` | int | what is the count of trusted hops for `X-Forwarded-For`? | 
+
+The `request_*` counts are always incremental: they contain only information about the last `request_elapsed` seconds.
+Additionally, they only provide a lower bound -- notably, if an Ambassador pod crashes or exits, no effort is made to
+ship out a final update, so it's very easy for counts to never be reported.   
 
 To completely disable feature reporting, set the environment variable `AMBASSADOR_DISABLE_FEATURES` to any non-empty
 value.


### PR DESCRIPTION
Allow Ambassador to use the feature-reporting mechanism to report on the total volume of requests being handled, and the split between success and failure.

This will only give a lower bound, and provides no information at all about any specific request.