### PR TITLE
Add the ability to skip child span creation

### DIFF
--- a/ambassador/ambassador/envoy/v2/v2listener.py
+++ b/ambassador/ambassador/envoy/v2/v2listener.py
@@ -16,6 +16,7 @@ from typing import Any, Dict, List, Optional, Tuple, TYPE_CHECKING
 from typing import cast as typecast
 
 import json
+import os
 
 # from copy import deepcopy
 
@@ -251,7 +252,8 @@ def v2filter_router(router: IRFilter):
     od: Dict[str, Any] = { 'name': 'envoy.router' }
 
     if router.ir.tracing:
-        od['config'] = { 'start_child_span': True }
+        no_child_span = os.environ.get('AMBASSADOR_NO_CHILD_SPAN', "")
+        od['config'] = { 'start_child_span': True if not no_child_span else False }
 
     return od
 

--- a/ambassador/ambassador/ir/ir.py
+++ b/ambassador/ambassador/ir/ir.py
@@ -162,7 +162,8 @@ class IR:
         router_config = {}
 
         if self.tracing:
-            router_config['start_child_span'] = True
+            no_child_span = os.environ.get('AMBASSADOR_NO_CHILD_SPAN', "")
+            router_config['start_child_span'] = True if not no_child_span else False
 
         self.save_filter(IRFilter(ir=self, aconf=aconf,
                                   rkey="ir.router", kind="ir.router", name="router", type="decoder",


### PR DESCRIPTION
## Description
Allows an operator to disable child span creation for traces, which in practice prevents extra X-B3-* trace header values from propagating upstream.

## Related Issues
https://github.com/datawire/ambassador/issues/1344

## Testing
Manual testing. We use this patch for our internal use case and it works well.

## Todos
- [ ] Tests
- [ ] Documentation

## Other
* If this is a documentation change, please open the pull request at https://github.com/datawire/ambassador-docs instead.
* Code changes should occur against `master`.
