### PR TITLE
Improve gRPC tests (step 2)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -130,7 +130,7 @@ SCOUT_APP_KEY=
 
 # Sets the kat-backend release which contains the kat-client use for E2e testing.
 # For details https://github.com/datawire/kat-backend
-KAT_BACKEND_RELEASE = 1.1.0
+KAT_BACKEND_RELEASE = 1.2.1
 
 # "make" by itself doesn't make the website. It takes too long and it doesn't
 # belong in the inner dev loop.

--- a/ambassador/tests/t_grpc.py
+++ b/ambassador/tests/t_grpc.py
@@ -33,14 +33,12 @@ service: {self.target.path.k8s}
         yield Query(self.url("echo.EchoService/Echo"),
                     headers={ "content-type": "application/grpc", "requested-status": "0" },
                     expected=200,
-                    xfail="The kat client does not support real grpc (yet)",
                     grpc_type="real")
 
         # [1]
         yield Query(self.url("echo.EchoService/Echo"),
                     headers={ "content-type": "application/grpc", "requested-status": "7" },
                     expected=200,
-                    xfail="The kat client does not support real grpc (yet)",
                     grpc_type="real")
 
     def check(self):


### PR DESCRIPTION
## Description
Now that the kat backend client supports real gRPC, the xfail-ed real gRPC test added in #1364 no longer has to fail. This PR bumps Ambassador to the latest kat client and un-xfails that test.

## Next Steps

Still need to handle grpc-web.

- Either: Add smarts to `kat.harness.run_queries` to call the Node client (in datawire/kat-backend#3) for grpc-web queries.
- Or: Add grpc-web to the Go client. The goal is to test that we configured Envoy correctly, not to validate grpc-web functionality in Envoy, so using a hackish one-off test may be fine.
- Later: If we keep the Node client, update it to use improbable-eng/grpc-web, which seems to be newer and supports Node explicitly.
