### PR TITLE
Add support for overriding server_name

### DIFF
--- a/ambassador/ambassador/envoy/v2/v2listener.py
+++ b/ambassador/ambassador/envoy/v2/v2listener.py
@@ -506,6 +506,9 @@ class V2Listener(dict):
         if 'xff_num_trusted_hops' in config.ir.ambassador_module:
             base_http_config["xff_num_trusted_hops"] = config.ir.ambassador_module.xff_num_trusted_hops
 
+        if 'server_name' in config.ir.ambassador_module:
+            base_http_config["server_name"] = config.ir.ambassador_module.server_name
+
         if config.ir.tracing:
             base_http_config["generate_request_id"] = True
 

--- a/ambassador/ambassador/ir/ir.py
+++ b/ambassador/ambassador/ir/ir.py
@@ -405,6 +405,7 @@ class IR:
             od[key] = self.ambassador_module.get(key, False)
 
         od['xff_num_trusted_hops'] = self.ambassador_module.get('xff_num_trusted_hops', 0)
+        od['server_name'] = bool(self.ambassador_module.server_name != '')
 
         od['custom_ambassador_id'] = bool(self.ambassador_id != 'default')
 

--- a/ambassador/ambassador/ir/irambassador.py
+++ b/ambassador/ambassador/ir/irambassador.py
@@ -35,7 +35,8 @@ class IRAmbassador (IRResource):
         'use_remote_address',
         'x_forwarded_proto_redirect',
         'load_balancer',
-        'xff_num_trusted_hops'
+        'xff_num_trusted_hops',
+        'server_name'
     ]
 
     service_port: int
@@ -81,6 +82,7 @@ class IRAmbassador (IRResource):
             x_forwarded_proto_redirect=False,
             load_balancer=None,
             xff_num_trusted_hops=0,
+            server_name="envoy",
             **kwargs
         )
 

--- a/ambassador/ambassador/ir/irlistener.py
+++ b/ambassador/ambassador/ir/irlistener.py
@@ -92,6 +92,9 @@ class ListenerFactory:
         if 'xff_num_trusted_hops' in amod:
             primary_listener.xff_num_trusted_hops = amod.xff_num_trusted_hops
 
+        if 'server_name' in amod:
+            primary_listener.server_name = amod.server_name
+
         ir.add_listener(primary_listener)
 
         if redirect_cleartext_from:
@@ -112,6 +115,9 @@ class ListenerFactory:
 
             if 'xff_num_trusted_hops' in amod:
                 new_listener.xff_num_trusted_hops = amod.xff_num_trusted_hops
+
+            if 'server_name' in amod:
+                new_listener.server_name = amod.server_name
 
             ir.add_listener(new_listener)
 

--- a/docs/reference/core/ambassador.md
+++ b/docs/reference/core/ambassador.md
@@ -57,6 +57,10 @@ config:
 # readiness_probe:
 #   enabled: true
 
+# By default Envoy sets server_name response header to 'envoy'
+# Override it with this variable
+# server_name: envoy
+
 # If present, service_port will be the port Ambassador listens
 # on for microservice access. If not present, Ambassador will
 # use 443 if TLS is configured, 80 otherwise. In future releases

--- a/docs/reference/running.md
+++ b/docs/reference/running.md
@@ -264,6 +264,7 @@ Unless disabled, Ambassador will also report the following anonymized informatio
 | `request_ok_count` | int | lower bound for how many requests have succeeded (not a 4xx or 5xx) | 
 | `request_total_count` | int | lower bound for how many requests were handled in total | 
 | `statsd` | bool | is statsd enabled? |
+| `server_name` | str | Overrides `server_name` response header |
 | `tls_origination_count` | int | count of TLS origination contexts |
 | `tls_termination_count` | int | count of TLS termination contexts |
 | `tls_using_contexts` | bool | is the old TLS module in use? |


### PR DESCRIPTION
## Description
Its useful to be able to override `server_name` for purposes like hiding what you are running or separating different instances based on it.

This PR adds support for setting `user_name` for the envoy config

## Testing
Seems trivial enough to not warrant a test (pretty much identical to `xff_num_trusted_hops` change), but I did test it out locally.

With:

```
    getambassador.io/config: |
      ---
      apiVersion: ambassador/v1
      kind: Module
      name: ambassador
      config:
        service_port: 8443
        use_proxy_proto: true
        server_name: "foobar"
        diagnostics:
          enabled: false
      ambassador_id: engineering
```

```
‽ curl -i https://<redacted>                                                                                                                
HTTP/1.1 302 Found
content-type: text/html; charset=utf-8
location: /graph
date: Fri, 29 Mar 2019 14:26:14 GMT
content-length: 29
x-envoy-upstream-service-time: 3
server: foobar

<a href="/graph">Found</a>.
```

Without `server_name`:

```
༶ curl -i https://<redacted>                                                                                                                  
HTTP/1.1 302 Found
content-type: text/html; charset=utf-8
location: /graph
date: Fri, 29 Mar 2019 14:32:08 GMT
content-length: 29
x-envoy-upstream-service-time: 0
server: envoy

<a href="/graph">Found</a>.
```

## Todos
- [/] Tests

## Other
* If this is a documentation change, please open the pull request at https://github.com/datawire/ambassador-docs instead.
* Code changes should occur against `master`.
