### PR TITLE
Remove response headers config

### DIFF
--- a/ambassador/ambassador/envoy/v2/v2route.py
+++ b/ambassador/ambassador/envoy/v2/v2route.py
@@ -76,6 +76,11 @@ class V2Route(dict):
                 } for k, v in response_headers_to_add.items()
             ]
 
+        response_headers_to_remove = group.get('remove_response_headers', None)
+
+        if response_headers_to_remove:
+            self['response_headers_to_remove'] = response_headers_to_remove
+
         # If a host_redirect is set, we won't do a 'route' entry.
         host_redirect = group.get('host_redirect', None)
 

--- a/ambassador/ambassador/ir/irhttpmapping.py
+++ b/ambassador/ambassador/ir/irhttpmapping.py
@@ -76,6 +76,7 @@ class IRHTTPMapping (IRBaseMapping):
         "prefix_regex": True,
         "priority": True,
         "rate_limits": True,   # Only supported in v0, handled in setup
+        "remove_response_headers": True,
         # Do not include regex_headers.
         # Do not include rewrite.
         "service": True,

--- a/ambassador/schemas/v1/Mapping.schema
+++ b/ambassador/schemas/v1/Mapping.schema
@@ -65,6 +65,12 @@
         "path_redirect": { "type": "string" },
         "priority": { "type": "string" },
         "precedence": { "type": "integer" },
+        "remove_response_headers": {
+            "anyOf": [
+                { "type": "string" },
+                { "type": "array", "items": { "type": "string" } }
+            ]
+        },
         "rewrite": { "type": "string" },
         "shadow": { "type": "boolean" },
         "cluster_timeout_ms": { "type": "integer" },

--- a/ambassador/tests/test_ambassador.py
+++ b/ambassador/tests/test_ambassador.py
@@ -792,6 +792,16 @@ class AddResponseHeaders(OptionTest):
                 actual = lowercased_headers.get(k.lower())
                 assert actual == [v], "expected %s: %s but got %s" % (k, v, lowercased_headers)
 
+class RemoveResponseHeaders(OptionTest):
+
+    parent: Test
+
+    def config(self):
+        yield "remove_response_headers: x-envoy-upstream-service-time"
+
+    def check(self):
+        for r in self.parent.results:
+            assert r.headers.get("x-envoy-upstream-service-time", None) == None, "x-envoy-upstream-service-time header was meant to be dropped but wasnt"
 
 class HostHeaderMapping(MappingTest):
 

--- a/docs/reference/mappings.md
+++ b/docs/reference/mappings.md
@@ -37,6 +37,7 @@ Ambassador supports a number of attributes to configure and customize mappings.
 | `method_regex`            | if true, tells the system to interpret the `method` as a [regular expression](http://en.cppreference.com/w/cpp/regex/ecmascript) |
 | `prefix_regex`            | if true, tells the system to interpret the `prefix` as a [regular expression](http://en.cppreference.com/w/cpp/regex/ecmascript) |
 | [`rate_limits`](/reference/rate-limits) | specifies a list rate limit rules on a mapping |
+| [`remove_response_headers`](/reference/remove_response_headers) | specifies a list of HTTP headers that are dropped from the response before sending to client |  
 | [`regex_headers`](/reference/headers)           | specifies a list of HTTP headers and [regular expressions](http://en.cppreference.com/w/cpp/regex/ecmascript) which _must_ match for this mapping to be used to route the request |
 | [`rewrite`](/reference/rewrites)      | replaces the URL prefix with when talking to the service |
 | `timeout_ms`              | the timeout, in milliseconds, for requests through this `Mapping`. Defaults to 3000. |

--- a/docs/reference/remove_response_headers.md
+++ b/docs/reference/remove_response_headers.md
@@ -1,0 +1,22 @@
+# Remove response headers
+
+Ambassador can remove a list of HTTP headers that would be sent to the client in the response (eg. default `x-envoy-upstream-service-time`)
+
+## The `remove_response_headers` annotation
+
+The `remove_response_headers` attribute takes a list of keys used to match to the header
+
+## A basic example
+
+```yaml
+---
+apiVersion: ambassador/v1
+kind:  Mapping
+name:  qotm_mapping
+prefix: /qotm/
+remove_response_headers:
+- x-envoy-upstream-service-time
+service: qotm
+```
+
+will drop header with key `x-envoy-upstream-service-time`.


### PR DESCRIPTION
## Description
Add configuration for dropping headers being replied to client. This is useful for masking details about `envoy` or eg. dropping headers that would had been added by upstream that you don't control.

## Related Issues
Will, kinda, help with https://github.com/datawire/ambassador/issues/843

## Testing
Tested locally, also added a test.
```
‽ curl -i https://<redacted>
HTTP/1.1 302 Found
location: /app
cache-control: no-cache
content-length: 0
date: Fri, 29 Mar 2019 15:41:22 GMT
x-envoy-upstream-service-time: 7
server: envoy
```

With:

```
    getambassador.io/config: |
      ---
      apiVersion: ambassador/v1
      kind: Mapping
      name: <redacted>
      host:<redacted>
      service: <redacted>
      prefix: /
      remove_response_headers: 
      - x-envoy-upstream-service-time
```

Goes to:

```
༶ curl -i https://<redacted>              
HTTP/1.1 302 Found
location: /app
cache-control: no-cache
content-length: 0
date: Fri, 29 Mar 2019 15:44:58 GMT
server: envoy
```
(missing `x-envoy-upstream-service-time: 7`)


