### PR TITLE
Update podAntiAffinity settings

### DIFF
--- a/docs/yaml/ambassador/ambassador-rbac-prometheus.yaml
+++ b/docs/yaml/ambassador/ambassador-rbac-prometheus.yaml
@@ -81,6 +81,17 @@ spec:
                 values:
                 - ambassador
             topologyKey: kubernetes.io/hostname
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: service
+                  operator: In
+                  values:
+                  - ambassador
+              topologyKey: kubernetes.io/hostname
       serviceAccountName: ambassador
       volumes:
       - name: stats-exporter-mapping-config

--- a/docs/yaml/ambassador/ambassador-rbac-prometheus.yaml
+++ b/docs/yaml/ambassador/ambassador-rbac-prometheus.yaml
@@ -81,17 +81,6 @@ spec:
                 values:
                 - ambassador
             topologyKey: kubernetes.io/hostname
-        podAntiAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 100
-            podAffinityTerm:
-              labelSelector:
-                matchExpressions:
-                - key: service
-                  operator: In
-                  values:
-                  - ambassador
-              topologyKey: kubernetes.io/hostname
       serviceAccountName: ambassador
       volumes:
       - name: stats-exporter-mapping-config

--- a/docs/yaml/ambassador/ambassador-rbac-prometheus.yaml
+++ b/docs/yaml/ambassador/ambassador-rbac-prometheus.yaml
@@ -73,13 +73,14 @@ spec:
     spec:
       affinity:
         podAntiAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 100
-            podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  service: ambassador
-              topologyKey: kubernetes.io/hostname
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: service
+                operator: In
+                values:
+                - ambassador
+            topologyKey: kubernetes.io/hostname
       serviceAccountName: ambassador
       volumes:
       - name: stats-exporter-mapping-config

--- a/docs/yaml/ambassador/ambassador-rbac.yaml
+++ b/docs/yaml/ambassador/ambassador-rbac.yaml
@@ -61,13 +61,14 @@ spec:
     spec:
       affinity:
         podAntiAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 100
-            podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  service: ambassador
-              topologyKey: kubernetes.io/hostname
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: service
+                operator: In
+                values:
+                - ambassador
+            topologyKey: kubernetes.io/hostname
       serviceAccountName: ambassador
       containers:
       - name: ambassador

--- a/docs/yaml/ambassador/ambassador-rbac.yaml
+++ b/docs/yaml/ambassador/ambassador-rbac.yaml
@@ -69,6 +69,17 @@ spec:
                 values:
                 - ambassador
             topologyKey: kubernetes.io/hostname
+         podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: service
+                  operator: In
+                  values:
+                  - ambassador
+              topologyKey: kubernetes.io/hostname
       serviceAccountName: ambassador
       containers:
       - name: ambassador

--- a/docs/yaml/ambassador/ambassador-rbac.yaml
+++ b/docs/yaml/ambassador/ambassador-rbac.yaml
@@ -69,17 +69,6 @@ spec:
                 values:
                 - ambassador
             topologyKey: kubernetes.io/hostname
-         podAntiAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 100
-            podAffinityTerm:
-              labelSelector:
-                matchExpressions:
-                - key: service
-                  operator: In
-                  values:
-                  - ambassador
-              topologyKey: kubernetes.io/hostname
       serviceAccountName: ambassador
       containers:
       - name: ambassador


### PR DESCRIPTION
It is better to have the setting requiredDuringSchedulingIgnoredDuringExecution for the podAntiAffinity to ensure distribution of the Ambassador pods across different nodes, when also the externalTrafficPolicy is set to local.

If not intended to force pod distribution across nodes, then just close the PR and keep the configuration settings as they are.