### PR TITLE
Support running with Diagd only

### DIFF
--- a/ambassador/entrypoint.sh
+++ b/ambassador/entrypoint.sh
@@ -180,7 +180,6 @@ if [ -z "${DIAGD_ONLY}" ]; then
     ambex "${ENVOY_DIR}" &
     AMBEX_PID="$!"
     pids="${pids:+${pids} }${AMBEX_PID}:ambex"
-    DIAGD_EXTRA="--kick \"sh /ambassador/kick_ads.sh $AMBEX_PID\""
 else
     DIAGD_EXTRA="--no-checks --no-envoy"
 fi
@@ -190,7 +189,7 @@ fi
 echo "AMBASSADOR: starting diagd"
 
 diagd "${SNAPSHOT_DIR}" "${ENVOY_BOOTSTRAP_FILE}" "${ENVOY_CONFIG_FILE}" $DIAGD_DEBUG $DIAGD_CONFIGDIR \
-       --notices "${AMBASSADOR_CONFIG_BASE_DIR}/notices.json" $DIAGD_EXTRA &
+      --kick "sh /ambassador/kick_ads.sh $AMBEX_PID" --notices "${AMBASSADOR_CONFIG_BASE_DIR}/notices.json" $DIAGD_EXTRA &
 pids="${pids:+${pids} }$!:diagd"
 
 # Wait for diagd to start

--- a/ambassador/kick_ads.sh
+++ b/ambassador/kick_ads.sh
@@ -1,5 +1,9 @@
 #!/bin/sh
 
+if [ -z "$DIAGD_ONLY" ]; then
+    exit 0
+fi
+
 # Is there an Envoy running?
 AMBEX_PID="$1"
 

--- a/ambassador/kick_ads.sh
+++ b/ambassador/kick_ads.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 
-if [ -z "$DIAGD_ONLY" ]; then
+if [ ! -z "$DIAGD_ONLY" ]; then
+    echo "Not starting, since in diagd-only mode."
     exit 0
 fi
 


### PR DESCRIPTION
## Description
In some cases we want to run diagd only. This enables it by setting DIAGD_ONLY env variable in the container.

## Related Issues
#1396 

## Testing
Manually tested that it runs when not set, and runs without envoy/ambex when set.

## Todos
- [ ] Tests
- [ ] Documentation

## Other
Is it worth documenting or testing beyond manual tests?