### PR TITLE
`case_sensitive` fix when `host_redirect` is true

### DIFF
--- a/ambassador/ambassador/ir/irhttpmappinggroup.py
+++ b/ambassador/ambassador/ir/irhttpmappinggroup.py
@@ -326,16 +326,8 @@ class IRHTTPMappingGroup (IRBaseMappingGroup):
             return list([ mapping.cluster for mapping in self.mappings ])
         else:
 
-            # There are still some things we want to flatten though, particularly the `case_sensitive` field
-            for k, v in self.host_redirect.items():
-                if k.startswith('_') or (k in ['apiVersion', 'host_redirect', 'path_redirect', 'ir', 'logger']) or (k in IRHTTPMappingGroup.DoNotFlattenKeys):
-                    # if verbose:
-                    #     self.ir.logger.debug("%s: don't flatten %s" % (self, k))
-                    continue
-
-                # if verbose:
-                #     self.ir.logger.debug("%s: flatten %s" % (self, k))
-
-                self[k] = v
+            # Flatten the case_sensitive field for host_redirect if it exists
+            if 'case_sensitive' in self.host_redirect:
+                self['case_sensitive'] = self.host_redirect['case_sensitive']
 
             return []

--- a/ambassador/ambassador/ir/irhttpmappinggroup.py
+++ b/ambassador/ambassador/ir/irhttpmappinggroup.py
@@ -325,4 +325,17 @@ class IRHTTPMappingGroup (IRBaseMappingGroup):
 
             return list([ mapping.cluster for mapping in self.mappings ])
         else:
+
+            # There are still some things we want to flatten though, particularly the `case_sensitive` field
+            for k, v in self.host_redirect.items():
+                if k.startswith('_') or (k in ['apiVersion', 'host_redirect', 'path_redirect', 'ir', 'logger']) or (k in IRHTTPMappingGroup.DoNotFlattenKeys):
+                    # if verbose:
+                    #     self.ir.logger.debug("%s: don't flatten %s" % (self, k))
+                    continue
+
+                # if verbose:
+                #     self.ir.logger.debug("%s: flatten %s" % (self, k))
+
+                self[k] = v
+
             return []


### PR DESCRIPTION
## Description
The `case_sensitive` field is ignored when `host_redirect` is set to true because no flattening occurs in `ambassador/ambassador/ir/irhttpmappinggroup.py`. To solve that, introduce another flattening step when `host_redirect` is there.

## Related Issues
https://github.com/datawire/ambassador/issues/699

## Testing
Simple manual tests-more to follow.

## Todos
- [ ] Tests
- [ ] Documentation

## Other
Work in progress. I would like to get that list coded out of there, something similar to `mapping.skip_key(k)` on L217.
