### PR TITLE
make push-docs: Allow PUSH_BRANCH to not exist yet

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -447,7 +447,7 @@ push-docs:
 		git fetch https://github.com/datawire/ambassador-docs master && \
 		docs_old=$$(git rev-parse FETCH_HEAD) && \
 		docs_new=$$(git subtree split --prefix=docs --rejoin --onto="$${docs_old}") && \
-		git push $(if $(GH_TOKEN),https://d6e-automaton:${GH_TOKEN}@github.com/,git@github.com:)datawire/ambassador-docs.git "$${docs_new}:$(or $(PUSH_BRANCH),master)"; \
+		git push $(if $(GH_TOKEN),https://d6e-automaton:${GH_TOKEN}@github.com/,git@github.com:)datawire/ambassador-docs.git "$${docs_new}:refs/heads/$(or $(PUSH_BRANCH),master)"; \
 	}
 .PHONY: pull-docs push-docs
 


### PR DESCRIPTION
Right now, `make push-docs PUSH_BRANCH=...` only works if the $(PUSH_BRANCH) already exists on the remote.  Fix that.