### PR TITLE
Flatten case_sensitive field when host_redirect is true

### DIFF
--- a/ambassador/ambassador/ir/irhttpmappinggroup.py
+++ b/ambassador/ambassador/ir/irhttpmappinggroup.py
@@ -325,4 +325,9 @@ class IRHTTPMappingGroup (IRBaseMappingGroup):
 
             return list([ mapping.cluster for mapping in self.mappings ])
         else:
+
+            # Flatten the case_sensitive field for host_redirect if it exists
+            if 'case_sensitive' in self.host_redirect:
+                self['case_sensitive'] = self.host_redirect['case_sensitive']
+
             return []


### PR DESCRIPTION
## Description
The `case_sensitive` field is ignored when `host_redirect` is set to true because no flattening occurs in `ambassador/ambassador/ir/irhttpmappinggroup.py`. To solve that, introduce another flattening step when `host_redirect` is there.

## Related Issues
https://github.com/datawire/ambassador/issues/699

## Testing
Simple manual tests-more to follow.

## Todos
- [ ] Tests
- [ ] Documentation