### PR TITLE
Use an ephemeral Docker registry to (hopefully) allow non-Datawire contributions to run CI tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ env:
 
 before_install:
   - mkdir -p ~/bin
-  - make docker-login
+  # - make docker-login
 
 install:
   - ./releng/travis-install.sh

--- a/Makefile
+++ b/Makefile
@@ -167,52 +167,60 @@ print-%:
 	@printf "$($*)"
 
 print-vars:
-	@echo "MAIN_BRANCH             = $(MAIN_BRANCH)"
-	@echo "GIT_BRANCH              = $(GIT_BRANCH)"
-	@echo "GIT_BRANCH_SANITIZED    = $(GIT_BRANCH_SANITIZED)"
-	@echo "GIT_COMMIT              = $(GIT_COMMIT)"
-	@echo "GIT_DIRTY               = $(GIT_DIRTY)"
-	@echo "GIT_TAG                 = $(GIT_TAG)"
-	@echo "GIT_TAG_SANITIZED       = $(GIT_TAG_SANITIZED)"
-	@echo "GIT_VERSION             = $(GIT_VERSION)"
-	@echo "GIT_DESCRIPTION         = $(GIT_DESCRIPTION)"
-	@echo "IS_PULL_REQUEST         = $(IS_PULL_REQUEST)"
-	@echo "COMMIT_TYPE             = $(COMMIT_TYPE)"
-	@echo "VERSION                 = $(VERSION)"
-	@echo "LATEST_RC               = $(LATEST_RC)"
-	@echo "DOCKER_REGISTRY         = $(DOCKER_REGISTRY)"
-	@echo "DOCKER_OPTS             = $(DOCKER_OPTS)"
-	@echo "AMBASSADOR_DOCKER_REPO  = $(AMBASSADOR_DOCKER_REPO)"
-	@echo "AMBASSADOR_DOCKER_TAG   = $(AMBASSADOR_DOCKER_TAG)"
-	@echo "AMBASSADOR_DOCKER_IMAGE = $(AMBASSADOR_DOCKER_IMAGE)"
-	@echo "KAT_BACKEND_RELEASE     = $(KAT_BACKEND_RELEASE)"
-	@echo "KUBECONFIG =            = $(KUBECONFIG)"
+	@echo "AMBASSADOR_DOCKER_IMAGE          = $(AMBASSADOR_DOCKER_IMAGE)"
+	@echo "AMBASSADOR_DOCKER_REPO           = $(AMBASSADOR_DOCKER_REPO)"
+	@echo "AMBASSADOR_DOCKER_TAG            = $(AMBASSADOR_DOCKER_TAG)"
+	@echo "AMBASSADOR_EXTERNAL_DOCKER_IMAGE = $(AMBASSADOR_EXTERNAL_DOCKER_IMAGE)"
+	@echo "AMBASSADOR_EXTERNAL_DOCKER_REPO  = $(AMBASSADOR_EXTERNAL_DOCKER_REPO)"
+	@echo "COMMIT_TYPE                      = $(COMMIT_TYPE)"
+	@echo "DOCKER_EPHEMERAL_REGISTRY            = $(DOCKER_EPHEMERAL_REGISTRY)"
+	@echo "DOCKER_EXTERNAL_REGISTRY         = $(DOCKER_EXTERNAL_REGISTRY)"
+	@echo "DOCKER_OPTS                      = $(DOCKER_OPTS)"
+	@echo "DOCKER_REGISTRY                  = $(DOCKER_REGISTRY)"
+	@echo "GIT_BRANCH                       = $(GIT_BRANCH)"
+	@echo "GIT_BRANCH_SANITIZED             = $(GIT_BRANCH_SANITIZED)"
+	@echo "GIT_COMMIT                       = $(GIT_COMMIT)"
+	@echo "GIT_DESCRIPTION                  = $(GIT_DESCRIPTION)"
+	@echo "GIT_DIRTY                        = $(GIT_DIRTY)"
+	@echo "GIT_TAG                          = $(GIT_TAG)"
+	@echo "GIT_TAG_SANITIZED                = $(GIT_TAG_SANITIZED)"
+	@echo "GIT_VERSION                      = $(GIT_VERSION)"
+	@echo "IS_PULL_REQUEST                  = $(IS_PULL_REQUEST)"
+	@echo "KAT_BACKEND_RELEASE              = $(KAT_BACKEND_RELEASE)"
+	@echo "KUBECONFIG                       = $(KUBECONFIG)"
+	@echo "LATEST_RC                        = $(LATEST_RC)"
+	@echo "MAIN_BRANCH                      = $(MAIN_BRANCH)"
+	@echo "VERSION                          = $(VERSION)"
 
 export-vars:
-	@echo "export MAIN_BRANCH='$(MAIN_BRANCH)'"
+	@echo "export AMBASSADOR_DOCKER_IMAGE='$(AMBASSADOR_DOCKER_IMAGE)'"
+	@echo "export AMBASSADOR_DOCKER_REPO='$(AMBASSADOR_DOCKER_REPO)'"
+	@echo "export AMBASSADOR_DOCKER_TAG='$(AMBASSADOR_DOCKER_TAG)'"
+	@echo "export AMBASSADOR_EXTERNAL_DOCKER_IMAGE='$(AMBASSADOR_EXTERNAL_DOCKER_IMAGE)'"
+	@echo "export AMBASSADOR_EXTERNAL_DOCKER_REPO='$(AMBASSADOR_EXTERNAL_DOCKER_REPO)'"
+	@echo "export COMMIT_TYPE='$(COMMIT_TYPE)'"
+	@echo "export DOCKER_EPHEMERAL_REGISTRY='$(DOCKER_EPHEMERAL_REGISTRY)'"
+	@echo "export DOCKER_EXTERNAL_REGISTRY='$(DOCKER_EXTERNAL_REGISTRY)'"
+	@echo "export DOCKER_OPTS='$(DOCKER_OPTS)'"
+	@echo "export DOCKER_REGISTRY='$(DOCKER_REGISTRY)'"
 	@echo "export GIT_BRANCH='$(GIT_BRANCH)'"
 	@echo "export GIT_BRANCH_SANITIZED='$(GIT_BRANCH_SANITIZED)'"
 	@echo "export GIT_COMMIT='$(GIT_COMMIT)'"
+	@echo "export GIT_DESCRIPTION='$(GIT_DESCRIPTION)'"
 	@echo "export GIT_DIRTY='$(GIT_DIRTY)'"
 	@echo "export GIT_TAG='$(GIT_TAG)'"
 	@echo "export GIT_TAG_SANITIZED='$(GIT_TAG_SANITIZED)'"
 	@echo "export GIT_VERSION='$(GIT_VERSION)'"
-	@echo "export GIT_DESCRIPTION='$(GIT_DESCRIPTION)'"
 	@echo "export IS_PULL_REQUEST='$(IS_PULL_REQUEST)'"
-	@echo "export COMMIT_TYPE='$(COMMIT_TYPE)'"
-	@echo "export VERSION='$(VERSION)'"
-	@echo "export LATEST_RC='$(LATEST_RC)'"
-	@echo "export DOCKER_REGISTRY='$(DOCKER_REGISTRY)'"
-	@echo "export DOCKER_OPTS='$(DOCKER_OPTS)'"
-	@echo "export AMBASSADOR_DOCKER_REPO='$(AMBASSADOR_DOCKER_REPO)'"
-	@echo "export AMBASSADOR_DOCKER_TAG='$(AMBASSADOR_DOCKER_TAG)'"
-	@echo "export AMBASSADOR_DOCKER_IMAGE='$(AMBASSADOR_DOCKER_IMAGE)'"
 	@echo "export KAT_BACKEND_RELEASE='$(KAT_BACKEND_RELEASE)'"
 	@echo "export KUBECONFIG='$(KUBECONFIG)'"
+	@echo "export LATEST_RC='$(LATEST_RC)'"
+	@echo "export MAIN_BRANCH='$(MAIN_BRANCH)'"
+	@echo "export VERSION='$(VERSION)'"
 
 # All of this will likely fail horribly outside of CI, for the record.
 docker-registry:
-ifneq ($(DOCKER_LOCAL_REGISTRY),)
+ifneq ($(DOCKER_EPHEMERAL_REGISTRY),)
 	@if [ "$(TRAVIS)" != "true" ]; then \
 		echo "make docker-registry is only for CI" >&2 ;\
 		exit 1 ;\
@@ -260,7 +268,7 @@ ambassador-docker-image: version
 	docker build --build-arg AMBASSADOR_BASE_IMAGE=$(AMBASSADOR_BASE_IMAGE) --build-arg CACHED_CONTAINER_IMAGE=$(AMBASSADOR_DOCKER_IMAGE_CACHED) $(DOCKER_OPTS) -t $(AMBASSADOR_DOCKER_IMAGE) .
 
 docker-login:
-ifneq ($(DOCKER_LOCAL_REGISTRY),)
+ifneq ($(DOCKER_EPHEMERAL_REGISTRY),)
 	@if [ -z $(DOCKER_USERNAME) ]; then echo 'DOCKER_USERNAME not defined'; exit 1; fi
 	@if [ -z $(DOCKER_PASSWORD) ]; then echo 'DOCKER_PASSWORD not defined'; exit 1; fi
 

--- a/releng/docker-registry.yaml
+++ b/releng/docker-registry.yaml
@@ -1,0 +1,49 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: docker-registry
+---
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: docker-registry
+  name: registry
+spec:
+  type: NodePort
+  selector:
+    app: registry
+  ports:
+    - port: 5000
+      nodePort: 31000
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: docker-registry
+  name: registry
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: registry
+  template:
+    metadata:
+      name: registry
+      labels:
+        app: registry
+    spec:
+      containers:
+        - name: registry
+          image: docker.io/library/registry:2
+          ports:
+            - containerPort: 5000
+          volumeMounts:
+            - mountPath: /var/lib/registry
+              name: registry-data
+      volumes:
+        - name: registry-data
+          # On kubernaut.io clusters, there is only 1 node, so a
+          # hostPath is fine.
+          hostPath:
+            path: /var/lib/registry

--- a/releng/travis-script.sh
+++ b/releng/travis-script.sh
@@ -45,9 +45,20 @@ if [ "${COMMIT_TYPE}" != "GA" ]; then
     export DOCKER_EXTERNAL_REGISTRY=$DOCKER_REGISTRY
     export DOCKER_REGISTRY=localhost:31000
 
-    make setup-develop cluster.yaml docker-registry
-    make docker-push
-    make KAT_REQ_LIMIT=900 test
+    make DOCKER_LOCAL_REGISTRY=true \
+         DOCKER_EXTERNAL_REGISTRY=$DOCKER_REGISTRY \
+         DOCKER_REGISTRY=localhost:31000 \
+         setup-develop cluster.yaml docker-registry
+
+    make DOCKER_LOCAL_REGISTRY=true \
+         DOCKER_EXTERNAL_REGISTRY=$DOCKER_REGISTRY \
+         DOCKER_REGISTRY=localhost:31000 \
+         docker-push
+
+    make DOCKER_LOCAL_REGISTRY=true \
+         DOCKER_EXTERNAL_REGISTRY=$DOCKER_REGISTRY \
+         DOCKER_REGISTRY=localhost:31000 \
+         KAT_REQ_LIMIT=900 test
 
     if [[ ${GIT_BRANCH} = ${MAIN_BRANCH} ]]; then
         # By fiat, _any commit_ on the main branch pushes production docs.

--- a/releng/travis-script.sh
+++ b/releng/travis-script.sh
@@ -45,12 +45,7 @@ if [ "${COMMIT_TYPE}" != "GA" ]; then
     export DOCKER_EXTERNAL_REGISTRY=$DOCKER_REGISTRY
     export DOCKER_REGISTRY=localhost:31000
 
-    echo "========"
-    env | sort
-    echo "========"
-    echo
-    
-    make docker-registry
+    make setup-develop cluster.yaml docker-registry
     make docker-push
     make KAT_REQ_LIMIT=900 test
 

--- a/releng/travis-script.sh
+++ b/releng/travis-script.sh
@@ -42,14 +42,13 @@ if [ "${COMMIT_TYPE}" != "GA" ]; then
     # the ephemeral Docker registry.
     printf "========\nSetting up environment...\n"
 
-    eval $(make DOCKER_LOCAL_REGISTRY=true \
+    eval $(make DOCKER_EPHEMERAL_REGISTRY=true \
                 DOCKER_EXTERNAL_REGISTRY=$DOCKER_REGISTRY \
                 DOCKER_REGISTRY=localhost:31000 \
                 export-vars)
 
     # Makes it much easier to actually debug when you see what the Makefile sees
     make print-vars
-    git status
 
     printf "========\nStarting build...\n"
 

--- a/releng/travis-script.sh
+++ b/releng/travis-script.sh
@@ -41,6 +41,16 @@ printf "== Begin: travis-script.sh ==\n"
 
 # Basically everything for a GA commit happens from the deploy target.
 if [ "${COMMIT_TYPE}" != "GA" ]; then
+    export DOCKER_LOCAL_REGISTRY=true
+    export DOCKER_EXTERNAL_REGISTRY=$DOCKER_REGISTRY
+    export DOCKER_REGISTRY=localhost:31000
+
+    echo "========"
+    env | sort
+    echo "========"
+    echo
+    
+    make docker-registry
     make docker-push
     make KAT_REQ_LIMIT=900 test
 


### PR DESCRIPTION
Rather than require Docker credentials to push to quay.io for most builds, use an ephemeral Docker registry running in the Kubernaut cluster. We still push to quay.io for more permanent things (RC, EA, GA).