### PR TITLE
Update Python requirements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -130,8 +130,8 @@ AMBASSADOR_EXTERNAL_DOCKER_IMAGE ?= $(AMBASSADOR_EXTERNAL_DOCKER_REPO):$(AMBASSA
 
 # UPDATE THESE VERSION NUMBERS IF YOU UPDATE ANY OF THE VALUES ABOVE, THEN
 # RUN make docker-update-base.
-AMBASSADOR_DOCKER_IMAGE_CACHED ?= quay.io/datawire/ambassador-base:go-7
-AMBASSADOR_BASE_IMAGE ?= quay.io/datawire/ambassador-base:ambassador-7
+AMBASSADOR_DOCKER_IMAGE_CACHED ?= quay.io/datawire/ambassador-base:go-8
+AMBASSADOR_BASE_IMAGE ?= quay.io/datawire/ambassador-base:ambassador-8
 
 KUBECONFIG ?= $(shell pwd)/cluster.yaml
 USE_KUBERNAUT ?= true

--- a/kat/requirements.txt
+++ b/kat/requirements.txt
@@ -1,2 +1,2 @@
 pytest
-pyyaml
+pyyaml>=5.1

--- a/unused-e2e/auth-service/requirements.txt
+++ b/unused-e2e/auth-service/requirements.txt
@@ -1,7 +1,7 @@
 clize==4.0.1
-flask==0.12.3
+flask==1.0.2
 jinja2==2.9.6
 jsonschema==2.6.0
-pyyaml==3.12
+pyyaml==5.1
 scout.py==0.3.0
 semantic-version==2.6.0

--- a/unused-e2e/demo-service/requirements.txt
+++ b/unused-e2e/demo-service/requirements.txt
@@ -1,7 +1,7 @@
 clize==4.0.1
-flask==0.11.1
+flask==1.0.2
 jinja2==2.9.6
 jsonschema==2.6.0
-pyyaml==3.12
+pyyaml==5.1
 scout.py==0.3.0
 semantic-version==2.6.0

--- a/unused-e2e/demo-test/requirements.txt
+++ b/unused-e2e/demo-test/requirements.txt
@@ -1,7 +1,7 @@
 clize==4.0.1
-flask==0.11.1
+flask==1.0.2
 jinja2==2.9.6
 jsonschema==2.6.0
-pyyaml==3.12
+pyyaml==5.1
 scout.py==0.3.0
 semantic-version==2.6.0

--- a/unused-e2e/shadow-service/requirements.txt
+++ b/unused-e2e/shadow-service/requirements.txt
@@ -1,7 +1,7 @@
 clize==4.0.1
-flask==0.11.1
+flask==1.0.2
 jinja2==2.9.6
 jsonschema==2.6.0
-pyyaml==3.12
+pyyaml==5.1
 scout.py==0.3.0
 semantic-version==2.6.0

--- a/unused-e2e/stats-test-service/requirements.txt
+++ b/unused-e2e/stats-test-service/requirements.txt
@@ -1,7 +1,7 @@
 clize==4.0.1
-flask==0.11.1
+flask==1.0.2
 jinja2==2.9.6
 jsonschema==2.6.0
-pyyaml==3.12
+pyyaml==5.1
 scout.py==0.3.0
 semantic-version==2.6.0


### PR DESCRIPTION
Bump Flask & PyYAML versions to deal with security issues found by the GitHub scanner. These are unlikely to be terribly relevant for Ambassador, but dealing with them definitely can't hurt.