### PR TITLE
Allow DNS resolvable names for endpoint routing

### DIFF
--- a/ambassador/ambassador/config/resourcefetcher.py
+++ b/ambassador/ambassador/config/resourcefetcher.py
@@ -308,6 +308,7 @@ class ServiceKind(ObjectKind):
                 service_info['ports'] = []
                 for port in ports:
                     service_info['ports'].append(port)
+        service_info['clusterIP'] = spec.get('clusterIP', None)
 
         metadata = self.object.get('metadata', None)
         resource_name = metadata.get('name') if metadata else None


### PR DESCRIPTION
Before this commit, if an Ambassador Mapping has a service set as
`qotm.default.svc.cluster.local`, then it is not resolved to
endpoints. This is an issue in cases where long resolvable
hostnames are used which span namespaces instead of short namespace
specific names.

This commit tries to resolve such a name and then does a reverse
lookup in Kubernetes services for the resolved IP to allow for
endpoint routing.