### PR TITLE
Add snapshot ID to on disk certificate path

### DIFF
--- a/ambassador/ambassador_diag/diagd.py
+++ b/ambassador/ambassador_diag/diagd.py
@@ -586,7 +586,7 @@ class AmbassadorEventWatcher(threading.Thread):
         self.logger.info("loading configuration from disk: %s" % path)
 
         snapshot = re.sub(r'[^A-Za-z0-9_-]', '_', path)
-        scc = SecretSaver(app.logger, path, "%s" % (app.snapshot_path))
+        scc = SecretSaver(app.logger, path, "%s/%s" % (app.snapshot_path, snapshot))
 
         aconf = Config()
         fetcher = ResourceFetcher(app.logger, aconf)

--- a/ambassador/ambassador_diag/diagd.py
+++ b/ambassador/ambassador_diag/diagd.py
@@ -586,7 +586,7 @@ class AmbassadorEventWatcher(threading.Thread):
         self.logger.info("loading configuration from disk: %s" % path)
 
         snapshot = re.sub(r'[^A-Za-z0-9_-]', '_', path)
-        scc = SecretSaver(app.logger, path, "%s/%s" % (app.snapshot_path, snapshot))
+        scc = SecretSaver(app.logger, path, "%s" % (app.snapshot_path))
 
         aconf = Config()
         fetcher = ResourceFetcher(app.logger, aconf)

--- a/ambassador/ambassador_diag/diagd.py
+++ b/ambassador/ambassador_diag/diagd.py
@@ -257,7 +257,7 @@ def td_format(td_object):
         if seconds > period_seconds:
             period_value, seconds = divmod(seconds, period_seconds)
 
-            strings.append("%d %s%s" % 
+            strings.append("%d %s%s" %
                            (period_value, period_name, "" if (period_value == 1) else "s"))
 
     formatted = ", ".join(strings)
@@ -390,7 +390,7 @@ def show_overview(reqid=None):
     ddict = collect_errors_and_notices(request, reqid, "overview", diag)
 
     tvars = dict(system=system_info(),
-                 envoy_status=envoy_status(app.estats), 
+                 envoy_status=envoy_status(app.estats),
                  loginfo=app.estats.loginfo,
                  notices=app.notices.notices,
                  **ov, **ddict)
@@ -586,7 +586,7 @@ class AmbassadorEventWatcher(threading.Thread):
         self.logger.info("loading configuration from disk: %s" % path)
 
         snapshot = re.sub(r'[^A-Za-z0-9_-]', '_', path)
-        scc = SecretSaver(app.logger, path, app.snapshot_path)
+        scc = SecretSaver(app.logger, path, "%s/%s" % (app.snapshot_path, snapshot))
 
         aconf = Config()
         fetcher = ResourceFetcher(app.logger, aconf)
@@ -618,7 +618,7 @@ class AmbassadorEventWatcher(threading.Thread):
             # self._respond(rqueue, 204, 'ignoring: no data loaded from snapshot %s' % snapshot)
             # return
 
-        scc = SecretSaver(app.logger, url, app.snapshot_path)
+        scc = SecretSaver(app.logger, url, "%s/%s" % (app.snapshot_path, snapshot))
 
         aconf = Config()
         fetcher = ResourceFetcher(app.logger, aconf)


### PR DESCRIPTION
## Description

Envoy won't reload dynamic configuration if it doesn't change. When rotating certificates the on disk contents change by the listener configuration simply points at those files so from Envoy perspective nothing has changed.

This causes Envoy to continue to serve the old certificates until it is restarted.

## Related Issues

https://github.com/datawire/ambassador/issues/1416

## Testing

Loaded a certificate on initial deploy and verified that this was served by Envoy. I then updated the secret with a new certificate. At this point Ambassador noticed the secret change, wrote the new contents to snapshot/#/ directory and pushed a new config to Envoy. As the path differed, Envoy reloaded the config. Verified this new certificate was served.

## Todos
- [x] Tests
- [ ] Documentation

## Other
* If this is a documentation change, please open the pull request at https://github.com/datawire/ambassador-docs instead.
* Code changes should occur against `master`.
