### PR TITLE
Default to endpoint routing

### DIFF
--- a/ambassador/ambassador/config/config.py
+++ b/ambassador/ambassador/config/config.py
@@ -49,7 +49,7 @@ class Config:
     ambassador_id: ClassVar[str] = os.environ.get('AMBASSADOR_ID', 'default')
     ambassador_namespace: ClassVar[str] = os.environ.get('AMBASSADOR_NAMESPACE', 'default')
     single_namespace: ClassVar[bool] = bool(os.environ.get('AMBASSADOR_SINGLE_NAMESPACE'))
-    enable_endpoints: ClassVar[bool] = bool(os.environ.get('AMBASSADOR_ENABLE_ENDPOINTS'))
+    enable_endpoints: ClassVar[bool] = not bool(os.environ.get('AMBASSADOR_DISABLE_ENDPOINTS'))
 
     StorageByKind: ClassVar[Dict[str, str]] = {
         'authservice': "auth_configs",

--- a/ambassador/ambassador/config/resourcefetcher.py
+++ b/ambassador/ambassador/config/resourcefetcher.py
@@ -430,10 +430,6 @@ class ResourceFetcher:
             except yaml.error.YAMLError as e:
                 self.logger.debug("could not parse YAML: %s" % e)
 
-        # # Don't include service_info unless endpoint routing is enabled.
-        # if Config.enable_endpoints:
-        #     objects.append(service_info)
-
         return resource_identifier, objects
 
     # Handler for K8s Secret resources.

--- a/ambassador/ambassador_diag/diagd.py
+++ b/ambassador/ambassador_diag/diagd.py
@@ -640,7 +640,7 @@ class AmbassadorEventWatcher(threading.Thread):
         else:
             self.logger.debug("no services loaded from snapshot %s" % snapshot)
 
-        if os.environ.get('AMBASSADOR_ENABLE_ENDPOINTS'):
+        if Config.enable_endpoints:
             serialization = load_url_contents(self.logger, "%s/endpoints" % url, stream2=open(ss_path, "a"))
 
             if serialization:

--- a/ambassador/tests/abstract_tests.py
+++ b/ambassador/tests/abstract_tests.py
@@ -57,7 +57,7 @@ class AmbassadorTest(Test):
     _index: Optional[int] = None
     _ambassador_id: Optional[str] = None
     single_namespace: bool = False
-    enable_endpoints: bool = False
+    disable_endpoints: bool = False
     name: Name
     path: Name
     extra_ports: Optional[List[int]] = None
@@ -75,9 +75,9 @@ class AmbassadorTest(Test):
 """
             rbac = manifests.RBAC_NAMESPACE_SCOPE
 
-        if self.enable_endpoints:
+        if self.disable_endpoints:
             envs += """
-    - name: AMBASSADOR_ENABLE_ENDPOINTS
+    - name: AMBASSADOR_DISABLE_ENDPOINTS
       value: "yes"
 """
 
@@ -191,8 +191,8 @@ class AmbassadorTest(Test):
         if self.single_namespace:
             envs.append("AMBASSADOR_SINGLE_NAMESPACE=yes")
 
-        if self.enable_endpoints:
-            envs.append("AMBASSADOR_ENABLE_ENDPOINTS=yes")
+        if self.disable_endpoints:
+            envs.append("AMBASSADOR_DISABLE_ENDPOINTS=yes")
 
         envs.extend(self.env)
         [command.extend(["-e", env]) for env in envs]

--- a/docs/reference/core/load-balancer.md
+++ b/docs/reference/core/load-balancer.md
@@ -1,8 +1,8 @@
 # Load Balancing in Ambassador
 
-Ambassador lets users control how it load balances between resulting endpoints for a given mapping. This feature ships in Early Access for Ambassador 0.52, and requires setting the environment variable `AMBASSADOR_ENABLE_ENDPOINTS` to `true` to enable this feature.
-
 Load balancing configuration can be set for all Ambassador mappings in the [ambassador](/reference/core/ambassador) module, or set per [mapping](https://www.getambassador.io/reference/mappings#configuring-mappings). If nothing is set, simple round robin balancing is used via Kubernetes services.
+
+(In Ambassador 0.60, you can disable advanced load balancing features by setting the environment variable `AMBASSADOR_DISABLE_ENDPOINTS` to any value. If you find that this is necessary, please reach out to us on [Slack](https://d6e.co/slack) so we can fix whatever is wrong!)
 
 The `load_balancer` attribute configures the load balancing. The following fields are supported:
 

--- a/flynn-devloop-stuff/yaml/ambassador.yaml
+++ b/flynn-devloop-stuff/yaml/ambassador.yaml
@@ -96,8 +96,6 @@ spec:
           fieldPath: metadata.namespace
     - name: AMBASSADOR_DEBUG
       value: "diagd"
-    - name: AMBASSADOR_ENABLE_ENDPOINTS
-      value: "true"
     livenessProbe:
       httpGet:
         path: /ambassador/v0/check_alive


### PR DESCRIPTION
Rather than setting `AMBASSADOR_ENABLE_ENDPOINTS` to enable endpoint routing if requested, set `AMBASSADOR_DISABLE_ENDPOINTS` to disable it.

Note that the default `Resolver` is still the `KubernetesServiceResolver`, so behavior won't change without deliberate action.