### PR TITLE
Resolver and loadbalancer cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -144,7 +144,7 @@ KAT_BACKEND_RELEASE = 1.4.0
 
 # Allow overriding which watt we use.
 WATT ?= watt
-WATT_VERSION ?= 0.4.1
+WATT_VERSION ?= 0.4.2
 
 # "make" by itself doesn't make the website. It takes too long and it doesn't
 # belong in the inner dev loop.

--- a/ambassador/ambassador/config/resourcefetcher.py
+++ b/ambassador/ambassador/config/resourcefetcher.py
@@ -511,15 +511,18 @@ class ResourceFetcher:
             self.logger.debug(f"ignoring Consul service {name} with no Endpoints")
             return None
 
-        # We can turn this directly into an Ambassador Service resource. (Why? because
-        # Consul keeps services and endpoints together, as it should!!)
+        # We can turn this directly into an Ambassador Service resource, since Consul keeps
+        # services and endpoints together (as it should!!).
+        #
+        # Note that we currently trust the association ID to contain the datacenter name.
+        # That's a function of the watch_hook putting it there.
 
         svc = {
             'apiVersion': 'ambassador/v1',
             'ambassador_id': Config.ambassador_id,
             'kind': 'Service',
             'name': name,
-            'datacenter': consul_object.get('datacenter') or 'dc1',
+            'datacenter': consul_object.get('id') or 'dc1',
             'endpoints': {}
         }
 

--- a/ambassador/ambassador/envoy/v2/v2cluster.py
+++ b/ambassador/ambassador/envoy/v2/v2cluster.py
@@ -74,8 +74,10 @@ class V2Cluster(dict):
     def get_endpoints(self, cluster: IRCluster):
         result = []
 
-        if cluster.enable_endpoints and len(cluster.targets) > 0:
-            for target in cluster.targets:
+        targetlist = cluster.get('targets', [])
+
+        if cluster.enable_endpoints and len(targetlist) > 0:
+            for target in targetlist:
                 address = {
                     'address': target['ip'],
                     'port_value': target['port']
@@ -98,6 +100,5 @@ class V2Cluster(dict):
         config.clusters = []
 
         for ircluster in sorted(config.ir.clusters.values(), key=lambda x: x.name):
-            if ircluster:
-                cluster = config.save_element('cluster', ircluster, V2Cluster(config, ircluster))
-                config.clusters.append(cluster)
+            cluster = config.save_element('cluster', ircluster, V2Cluster(config, ircluster))
+            config.clusters.append(cluster)

--- a/ambassador/ambassador/envoy/v2/v2cluster.py
+++ b/ambassador/ambassador/envoy/v2/v2cluster.py
@@ -98,6 +98,6 @@ class V2Cluster(dict):
         config.clusters = []
 
         for ircluster in sorted(config.ir.clusters.values(), key=lambda x: x.name):
-            cluster = config.save_element('cluster', ircluster, V2Cluster(config, ircluster))
-            config.clusters.append(cluster)
-
+            if ircluster:
+                cluster = config.save_element('cluster', ircluster, V2Cluster(config, ircluster))
+                config.clusters.append(cluster)

--- a/ambassador/ambassador/ir/irambassador.py
+++ b/ambassador/ambassador/ir/irambassador.py
@@ -27,15 +27,15 @@ class IRAmbassador (IRResource):
         'enable_ipv6',
         'enable_ipv4',
         'liveness_probe',
+        'load_balancer',
         'readiness_probe',
+        'server_name',
         'service_port',
         'statsd',
         'use_proxy_proto',
         'use_remote_address',
         'x_forwarded_proto_redirect',
-        'load_balancer',
         'xff_num_trusted_hops',
-        'server_name'
     ]
 
     service_port: int

--- a/ambassador/ambassador/ir/irambassador.py
+++ b/ambassador/ambassador/ir/irambassador.py
@@ -29,6 +29,7 @@ class IRAmbassador (IRResource):
         'liveness_probe',
         'load_balancer',
         'readiness_probe',
+        'resolver',
         'server_name',
         'service_port',
         'statsd',

--- a/ambassador/ambassador/ir/irbasemapping.py
+++ b/ambassador/ambassador/ir/irbasemapping.py
@@ -45,8 +45,15 @@ class IRBaseMapping (IRResource):
         if not self.get('resolver'):
             self.resolver = self.ir.ambassador_module.get('resolver', 'kubernetes-service')
 
-        if not self.ir.get_resolver(self.resolver):
+        resolver = self.ir.get_resolver(self.resolver)
+
+        if not resolver:
             self.post_error(f'resolver {self.resolver} is unknown!')
+            return False
+
+        # And, of course, we can make sure that the resolver thinks that this Mapping is OK.
+        if not resolver.valid_mapping(ir, self):
+            # If there's trouble, the resolver should've already posted about it.
             return False
 
         return True

--- a/ambassador/ambassador/ir/irbasemapping.py
+++ b/ambassador/ambassador/ir/irbasemapping.py
@@ -38,8 +38,6 @@ class IRBaseMapping (IRResource):
         # ...and the route weight.
         self.route_weight = self._route_weight()
 
-        self.ir.logger.debug("%s: GID %s route_weight %s" % (self, self.group_id, self.route_weight))
-
         # We can also default the resolver, and scream if it doesn't match a resolver we
         # know about.
         if not self.get('resolver'):
@@ -50,6 +48,9 @@ class IRBaseMapping (IRResource):
         if not resolver:
             self.post_error(f'resolver {self.resolver} is unknown!')
             return False
+
+        self.ir.logger.debug("%s: GID %s route_weight %s, resolver %s" %
+                             (self, self.group_id, self.route_weight, resolver))
 
         # And, of course, we can make sure that the resolver thinks that this Mapping is OK.
         if not resolver.valid_mapping(ir, self):

--- a/ambassador/tests/abstract_tests.py
+++ b/ambassador/tests/abstract_tests.py
@@ -61,7 +61,8 @@ class AmbassadorTest(Test):
     name: Name
     path: Name
     extra_ports: Optional[List[int]] = None
-
+    debug_diagd: bool = False
+    
     env = []
 
     def manifests(self) -> str:
@@ -193,6 +194,9 @@ class AmbassadorTest(Test):
 
         if self.disable_endpoints:
             envs.append("AMBASSADOR_DISABLE_ENDPOINTS=yes")
+
+        if self.debug_diagd:
+            envs.append("AMBASSADOR_DEBUG=diagd")
 
         envs.extend(self.env)
         [command.extend(["-e", env]) for env in envs]

--- a/ambassador/tests/t_loadbalancer.py
+++ b/ambassador/tests/t_loadbalancer.py
@@ -44,8 +44,8 @@ service: {self.target.path.fqdn}
 ---
 apiVersion: ambassador/v1
 kind:  Mapping
-name:  {self.name}-0
-prefix: /{self.name}-0/
+name:  {self.name}-1
+prefix: /{self.name}-1/
 service: {self.target.path.fqdn}
 resolver:  endpoint
 load_balancer:

--- a/ambassador/tests/t_loadbalancer.py
+++ b/ambassador/tests/t_loadbalancer.py
@@ -38,90 +38,86 @@ class LoadBalancerTest(AmbassadorTest):
 ---
 apiVersion: ambassador/v1
 kind:  Mapping
-name:  {self.name}-1
-prefix: /{self.name}-1/
+name:  {self.name}-0
+prefix: /{self.name}-0/
 service: {self.target.path.fqdn}
+---
+apiVersion: ambassador/v1
+kind:  Mapping
+name:  {self.name}-0
+prefix: /{self.name}-0/
+service: {self.target.path.fqdn}
+resolver:  endpoint
 load_balancer:
   policy: round_robin
-""")
-
-        yield self, self.format("""
 ---
 apiVersion: ambassador/v1
 kind:  Mapping
 name:  {self.name}-2
 prefix: /{self.name}-2/
 service: {self.target.path.fqdn}
+resolver: endpoint
 load_balancer:
   policy: ring_hash
   header: test-header
-""")
-
-        yield self, self.format("""
 ---
 apiVersion: ambassador/v1
 kind:  Mapping
 name:  {self.name}-3
 prefix: /{self.name}-3/
 service: {self.target.path.fqdn}
+resolver: endpoint
 load_balancer:
   policy: ring_hash
   source_ip: True
-""")
-
-        yield self, self.format("""
 ---
 apiVersion: ambassador/v1
 kind:  Mapping
 name:  {self.name}-4
 prefix: /{self.name}-4/
 service: {self.target.path.fqdn}
+resolver: endpoint
 load_balancer:
   policy: ring_hash
   cookie:
     name: test-cookie
-""")
-
-        yield self, self.format("""
 ---
 apiVersion: ambassador/v1
 kind:  Mapping
 name:  {self.name}-5
 prefix: /{self.name}-5/
 service: {self.target.path.fqdn}
+resolver: endpoint
 load_balancer:
   policy: ring_hash
   cookie:
     name: test-cookie
   header: test-header
   source_ip: True
-""")
-
-        yield self, self.format("""
 ---
 apiVersion: ambassador/v1
 kind:  Mapping
 name:  {self.name}-6
 prefix: /{self.name}-6/
 service: {self.target.path.fqdn}
+resolver: endpoint
 load_balancer:
   policy: round_robin
   cookie:
     name: test-cookie
-""")
-
-        yield self, self.format("""
 ---
 apiVersion: ambassador/v1
 kind:  Mapping
 name:  {self.name}-7
 prefix: /{self.name}-7/
 service: {self.target.path.fqdn}
+resolver: endpoint
 load_balancer:
   policy: rr
 """)
 
     def queries(self):
+        yield Query(self.url(self.name + "-0/"))
         yield Query(self.url(self.name + "-1/"))
         yield Query(self.url(self.name + "-2/"))
         yield Query(self.url(self.name + "-3/"))
@@ -166,12 +162,10 @@ apiVersion: ambassador/v0
 kind:  Module
 name:  ambassador
 config:
+  resolver: endpoint
   load_balancer:
     policy: ring_hash
     header: LB-HEADER
-""")
-
-        yield self, self.format("""
 ---
 apiVersion: ambassador/v1
 kind:  Mapping
@@ -182,9 +176,6 @@ load_balancer:
   policy: ring_hash
   cookie:
     name: lb-cookie
-""")
-
-        yield self, self.format("""
 ---
 apiVersion: ambassador/v1
 kind:  Mapping

--- a/ambassador/tests/t_loadbalancer.py
+++ b/ambassador/tests/t_loadbalancer.py
@@ -313,45 +313,40 @@ kind:  Mapping
 name:  {self.name}-header-{self.policy}
 prefix: /{self.name}-header-{self.policy}/
 service: permappingloadbalancing-service
+resolver: endpoint
 load_balancer:
   policy: {self.policy}
   header: LB-HEADER
-""")
-
-            yield self, self.format("""
 ---
 apiVersion: ambassador/v1
 kind:  Mapping
 name:  {self.name}-sourceip-{self.policy}
 prefix: /{self.name}-sourceip-{self.policy}/
 service: permappingloadbalancing-service
+resolver: endpoint
 load_balancer:
   policy: {self.policy}
   source_ip: true
-""")
-
-            yield self, self.format("""
 ---
 apiVersion: ambassador/v1
 kind:  Mapping
 name:  {self.name}-cookie-{self.policy}
 prefix: /{self.name}-cookie-{self.policy}/
 service: permappingloadbalancing-service
+resolver: endpoint
 load_balancer:
   policy: {self.policy}
   cookie:
     name: lb-cookie
     ttl: 125s
     path: /foo
-""")
-
-            yield self, self.format("""
 ---
 apiVersion: ambassador/v1
 kind:  Mapping
 name:  {self.name}-cookie-no-ttl-{self.policy}
 prefix: /{self.name}-cookie-no-ttl-{self.policy}/
 service: permappingloadbalancing-service
+resolver: endpoint
 load_balancer:
   policy: {self.policy}
   cookie:

--- a/ambassador/watch_hook.py
+++ b/ambassador/watch_hook.py
@@ -128,9 +128,12 @@ for mname, mapping in mappings.items():
 
                 svc = Service(logger, mapping.service, ctx_name)
 
+                # At the moment, we stuff the resolver's datacenter into the association
+                # ID for this watch. The ResourceFetcher relies on that.
+
                 consul_watches.append(
                     {
-                        "id": res_name,
+                        "id": resolver.datacenter,
                         "consul-address": resolver.address,
                         "datacenter": resolver.datacenter,
                         "service-name": svc.hostname

--- a/ambassador/watch_hook.py
+++ b/ambassador/watch_hook.py
@@ -1,38 +1,51 @@
 #!/usr/bin/python3
-from typing import Dict, Optional, Tuple, TYPE_CHECKING
+from typing import Any, Dict
 
-import logging
 import sys
+
+import json
+import logging
+import traceback
+
+from collections import OrderedDict
+
+from multi import multi
+
+from ambassador.utils import parse_yaml
+from ambassador.config import Config
+
+
+########
+# This is the quick-and-dirty approach to the watch hook. It needs to be rewritten to use
+# the ResourceFetcher and friends...
+
 
 logging.basicConfig(
     level=logging.DEBUG,
-    format="%(asctime)s test-dump %(levelname)s: %(message)s",
+    format="%(asctime)s watch_hook %(levelname)s: %(message)s",
     datefmt="%Y-%m-%d %H:%M:%S"
 )
 
 logger = logging.getLogger('ambassador')
 logger.setLevel(logging.DEBUG)
 
-import json, traceback, urllib
-from collections import OrderedDict
-from ambassador.utils import parse_yaml
-from ambassador.config import Config
-from multi import multi
 
 class ConsulResolver:
 
-    def __init__(self, source, address, datacenter):
+    def __init__(self, source: str, address: str, datacenter: str) -> None:
         self.source = source
         self.address = address
         self.datacenter = datacenter
 
+
 class Mapping:
 
-    def __init__(self, source, namespace, service, resolver):
+    def __init__(self, source: str, namespace: str, service: str, resolver: str) -> None:
         self.source = source
         self.namespace = namespace
         self.service = service
         self.resolver = resolver
+
 
 class Loader:
 
@@ -45,65 +58,89 @@ class Loader:
         self.services.add(f"{name}.{namespace}")
 
     @multi
-    def load(self, source, namespace, obj):
+    def load(self, source: str, namespace: str, obj: Any) -> None:
+        del source      # silence warnings
+        del namespace
+
         yield obj["kind"]
 
     @load.when("Mapping", "TCPMapping")
-    def load(self, source, namespace, m):
+    def load(self, source: str, namespace: str, m: Dict[str, Any]) -> None:
         self.mappings.append(Mapping(source, namespace, m["service"], m.get("resolver")))
 
     @load.when("ConsulResolver")
-    def load(self, source, namespace, r):
+    def load(self, source: str, namespace: str, r: Dict[str, Any]) -> None:
+        del namespace   # silence warning
+
         self.resolvers[r["name"]] = ConsulResolver(source, r["address"], r["datacenter"])
 
     @load.when("Module", "AuthService", "TLSContext", "KubernetesServiceResolver", "KubernetesEndpointResolver",
                "RateLimitService", "TracingService")
-    def load(self, *args):
+    def load(self, *args) -> None:
         pass
 
     def print_watches(self):
         # we just watch all the endpoints for now because for some
         # reason it is slow to watch individual ones
-        k8s_watches = [{"kind": "endpoints",
-                        "namespace": Config.ambassador_namespace if Config.single_namespace else "",
-                        "field-selector": "metadata.namespace!=kube-system"}]
+        k8s_watches = [
+            {
+                "kind": "endpoints",
+                "namespace": Config.ambassador_namespace if Config.single_namespace else "",
+                "field-selector": "metadata.namespace!=kube-system"
+            }
+        ]
+
         consul_watches = []
+
         for m in self.mappings:
             if m.resolver is not None:
                 r = self.resolvers.get(m.resolver)
+
                 if r is None:
                     logger.error(f"mapping {m.source} has unknown resolver: {m.resolver}")
                 else:
-                    consul_watches.append({"consul-address": r.address,
-                                           "datacenter": r.datacenter,
-                                           "service-name": f"{m.service}"})
+                    consul_watches.append(
+                        {
+                            "consul-address": r.address,
+                            "datacenter": r.datacenter,
+                            "service-name": m.service
+                        }
+                    )
 
         watchset = {
             "kubernetes-watches": k8s_watches,
             "consul-watches": consul_watches
         }
+
         json.dump(watchset, sys.stdout)
 
-snapshot = json.load(sys.stdin)
-# XXX: should make everything lowercase in watt
-services = snapshot.get("Kubernetes", {}).get("service") or []
 
-loader = Loader()
+def main(stream) -> None:
+    snapshot = json.load(stream)
 
-for svc in services:
-    metadata = svc.get("metadata", {})
-    namespace = metadata.get("namespace", "default")
-    name = metadata["name"]
-    loader.service(name, namespace)
-    annotations = metadata.get("annotations", {})
-    config = annotations.get("getambassador.io/config")
-    if config:
-        objs = parse_yaml(config)
-        for idx, obj in enumerate(objs):
-            source = metadata["name"] + "." + namespace + f".{idx}"
-            try:
-                loader.load(source, namespace, obj)
-            except:
-                logger.error("error loading object from %s: %s", source, traceback.format_exc())
+    # XXX: should make everything lowercase in watt
+    services = snapshot.get("Kubernetes", {}).get("service") or []
 
-loader.print_watches()
+    loader = Loader()
+
+    for svc in services:
+        metadata = svc.get("metadata", {})
+        namespace = metadata.get("namespace", "default")
+        name = metadata["name"]
+        loader.service(name, namespace)
+        annotations = metadata.get("annotations", {})
+        config = annotations.get("getambassador.io/config")
+        if config:
+            objs = parse_yaml(config)
+            for idx, obj in enumerate(objs):
+                source = metadata["name"] + "." + namespace + f".{idx}"
+                try:
+                    loader.load(source, namespace, obj)
+                except:
+                    logger.error("error loading object from %s: %s", source, traceback.format_exc())
+
+    loader.print_watches()
+
+
+if __name__ == "__main__":
+    main(sys.stdin)


### PR DESCRIPTION
This is basically a pass over the Resolver implementation, cleaning up and formalizing things:

- you're no longer allowed to set a `load_balancer` when using a `KubernetesServiceResolver`
- the `ConsulResolver` ignores attempts to override the ports returned from Consul
- Kubernetes `Service`s with no ports specified can still carry Ambassador annotations (thanks to @patricksanders for the report here!)
- `watt` and `diagd` correctly cooperate to get datacenter information from Consul
- problems resolving services to endpoints should show up in the diagnostics service
- tests have been brought in line with everything above
