### PR TITLE
TLS certificate tweaks

### DIFF
--- a/ambassador/ambassador/cli.py
+++ b/ambassador/ambassador/cli.py
@@ -168,7 +168,7 @@ def dump(config_dir_path: Parameter.REQUIRED, *,
         if dump_aconf:
             od['aconf'] = aconf.as_dict()
 
-        secret_handler = CLISecretHandler(logger, config_dir_path, config_dir_path)
+        secret_handler = CLISecretHandler(logger, config_dir_path, config_dir_path, 0)
 
         ir = IR(aconf, file_checker=file_checker, secret_handler=secret_handler)
 
@@ -296,7 +296,7 @@ def config(config_dir_path: Parameter.REQUIRED, output_json_path: Parameter.REQU
             if exit_on_error and aconf.errors:
                 raise Exception("errors in: {0}".format(', '.join(aconf.errors.keys())))
 
-            secret_handler = CLISecretHandler(logger, config_dir_path, config_dir_path)
+            secret_handler = CLISecretHandler(logger, config_dir_path, config_dir_path, 0)
 
             ir = IR(aconf, file_checker=file_checker, secret_handler=secret_handler)
 

--- a/ambassador/ambassador/ir/ir.py
+++ b/ambassador/ambassador/ir/ir.py
@@ -241,14 +241,15 @@ class IR:
 
     # Save secrets from our aconf.
     def save_secret_info(self, aconf):
-        # ...but we may be able to probably do have secret_info that we'll need to use to locate saved secrets.
         aconf_secrets = aconf.get_config("secret") or {}
 
         for secret_name, aconf_secret in aconf_secrets.items():
-            secret_info = SecretInfo.from_aconf_secret(aconf_secret)
-            secret_namespace = secret_info.namespace
+            # Ignore anything that doesn't at least have a public half.
+            if aconf_secret.get('tls_crt'):
+                secret_info = SecretInfo.from_aconf_secret(aconf_secret)
+                secret_namespace = secret_info.namespace
 
-            self.secret_info[f'{secret_name}.{secret_namespace}'] = secret_info
+                self.secret_info[f'{secret_name}.{secret_namespace}'] = secret_info
 
     # Save TLS contexts from the aconf into the IR. Note that the contexts in the aconf
     # are just ACResources; they need to be turned into IRTLSContexts.

--- a/ambassador/ambassador/utils.py
+++ b/ambassador/ambassador/utils.py
@@ -379,7 +379,16 @@ class SecretHandler:
         key_path = None
         cert_data = None
 
+        h = hashlib.new('sha1')
+
         if cert:
+            h.update(cert.encode('utf-8'))
+
+            if key:
+                h.update(key.encode('utf-8'))
+
+            hd = h.hexdigest().upper()
+
             secret_dir = os.path.join(self.cache_dir, namespace, "secrets-decoded", name)
 
             try:
@@ -387,11 +396,11 @@ class SecretHandler:
             except FileExistsError:
                 pass
 
-            cert_path = os.path.join(secret_dir, f'tls-{self.version}.crt')
+            cert_path = os.path.join(secret_dir, f'{hd}.crt')
             open(cert_path, "w").write(cert)
 
             if key:
-                key_path = os.path.join(secret_dir, f'tls-{self.version}.key')
+                key_path = os.path.join(secret_dir, f'{hd}.key')
                 open(key_path, "w").write(key)
 
             cert_data = {

--- a/ambassador/ambassador/utils.py
+++ b/ambassador/ambassador/utils.py
@@ -354,10 +354,11 @@ class SecretHandler:
     source_root: str
     cache_dir: str
 
-    def __init__(self, logger: logging.Logger, source_root: str, cache_dir: str) -> None:
+    def __init__(self, logger: logging.Logger, source_root: str, cache_dir: str, version: str) -> None:
         self.logger = logger
         self.source_root = source_root
         self.cache_dir = cache_dir
+        self.version = version
 
     def load_secret(self, context: 'IRTLSContext',
                     secret_name: str, namespace: str) -> Optional[SecretInfo]:
@@ -386,11 +387,11 @@ class SecretHandler:
             except FileExistsError:
                 pass
 
-            cert_path = os.path.join(secret_dir, "tls.crt")
+            cert_path = os.path.join(secret_dir, f'tls-{self.version}.crt')
             open(cert_path, "w").write(cert)
 
             if key:
-                key_path = os.path.join(secret_dir, "tls.key")
+                key_path = os.path.join(secret_dir, f'tls-{self.version}.key')
                 open(key_path, "w").write(key)
 
             cert_data = {

--- a/ambassador/ambassador_diag/diagd.py
+++ b/ambassador/ambassador_diag/diagd.py
@@ -611,7 +611,7 @@ class AmbassadorEventWatcher(threading.Thread):
         self.logger.info("loading configuration from disk: %s" % path)
 
         snapshot = re.sub(r'[^A-Za-z0-9_-]', '_', path)
-        scc = FSSecretHandler(app.logger, path, app.snapshot_path)
+        scc = FSSecretHandler(app.logger, path, app.snapshot_path, 0)
 
         aconf = Config()
         fetcher = ResourceFetcher(app.logger, aconf)
@@ -656,7 +656,7 @@ class AmbassadorEventWatcher(threading.Thread):
             # self._respond(rqueue, 204, 'ignoring: no data loaded from snapshot %s' % snapshot)
             # return
 
-        scc = KubewatchSecretHandler(app.logger, url, app.snapshot_path)
+        scc = KubewatchSecretHandler(app.logger, url, app.snapshot_path, snapshot)
 
         aconf = Config()
         fetcher = ResourceFetcher(app.logger, aconf)
@@ -689,7 +689,7 @@ class AmbassadorEventWatcher(threading.Thread):
 
         # Weirdly, we don't need a special WattSecretHandler: parse_watt knows how to handle
         # the secrets that watt sends.
-        scc = SecretHandler(app.logger, url, app.snapshot_path)
+        scc = SecretHandler(app.logger, url, app.snapshot_path, snapshot)
 
         aconf = Config()
         fetcher = ResourceFetcher(app.logger, aconf)

--- a/ambassador/tests/t_tls.py
+++ b/ambassador/tests/t_tls.py
@@ -209,8 +209,8 @@ config:
   upstream:
     secret: test-certs-secret
   upstream-files:
-    cert_chain_file: /ambassador/snapshots/default/secrets-decoded/test-certs-secret/tls.crt
-    private_key_file: /ambassador/snapshots/default/secrets-decoded/test-certs-secret/tls.key
+    cert_chain_file: /ambassador/snapshots/default/secrets-decoded/test-certs-secret/tls-1.crt
+    private_key_file: /ambassador/snapshots/default/secrets-decoded/test-certs-secret/tls-1.key
 """)
 
         yield self, self.format("""

--- a/ambassador/tests/t_tls.py
+++ b/ambassador/tests/t_tls.py
@@ -209,8 +209,8 @@ config:
   upstream:
     secret: test-certs-secret
   upstream-files:
-    cert_chain_file: /ambassador/snapshots/default/secrets-decoded/test-certs-secret/tls-1.crt
-    private_key_file: /ambassador/snapshots/default/secrets-decoded/test-certs-secret/tls-1.key
+    cert_chain_file: /ambassador/snapshots/default/secrets-decoded/test-certs-secret/F94E4DCF30ABC50DEF240AA8024599B67CC03991.crt
+    private_key_file: /ambassador/snapshots/default/secrets-decoded/test-certs-secret/F94E4DCF30ABC50DEF240AA8024599B67CC03991.key
 """)
 
         yield self, self.format("""

--- a/releng/run-tests.sh
+++ b/releng/run-tests.sh
@@ -13,45 +13,52 @@ TEST_ARGS="--tb=short"
 
 if [ -n "${TEST_NAME}" ]; then
     TEST_ARGS+=" -k ${TEST_NAME}"
-    pytest ${TEST_ARGS}
-    RESULT=$?
-else
-    # Split up the tests so we don't run them all at once. This is an
-    # eggregious hack that depends on the "main[...]" syntax of the
-    # pytest parameterized test notation.
-
-    # make sure we include non parameterized tests, but they don't
-    # seem to exist in CI, so we need to check (running an empty set
-    # of tests counts as a failure)
-    UNPARAM="not ["
-    if pytest -qq --collect-only -k "${UNPARAM}"; then
-        PATTERNS=("${UNPARAM}")
-    else
-        PATTERNS=()
-    fi
-
-    # split up the parameterized tests by starting letter
-    for T in {A..Z}; do
-        # we need to check if the pattern actually matches any tests,
-        # because running an empty set of tests counts as a failure
-        if pytest -qq --collect-only -k "[${T}"; then
-            PATTERNS+=("[${T}")
-        fi
-    done
-
-    # actually run the tests in each pattern
-    for P in "${PATTERNS[@]}"; do
-        set -x
-        pytest ${TEST_ARGS} -k "$P"
-        RESULT=$?
-        set +x
-        if [ $RESULT -ne 0 ] ; then
-            # we could try again on failure, but lets see if we can
-            # keep things non-flakey enough that it isn't necessary
-            break
-        fi
-    done
 fi
+
+pytest ${TEST_ARGS}
+RESULT=$?
+
+#if [ -n "${TEST_NAME}" ]; then
+#    TEST_ARGS+=" -k ${TEST_NAME}"
+#    pytest ${TEST_ARGS}
+#    RESULT=$?
+#else
+#    # Split up the tests so we don't run them all at once. This is an
+#    # eggregious hack that depends on the "main[...]" syntax of the
+#    # pytest parameterized test notation.
+#
+#    # make sure we include non parameterized tests, but they don't
+#    # seem to exist in CI, so we need to check (running an empty set
+#    # of tests counts as a failure)
+#    UNPARAM="not ["
+#    if pytest -qq --collect-only -k "${UNPARAM}"; then
+#        PATTERNS=("${UNPARAM}")
+#    else
+#        PATTERNS=()
+#    fi
+#
+#    # split up the parameterized tests by starting letter
+#    for T in {A..Z}; do
+#        # we need to check if the pattern actually matches any tests,
+#        # because running an empty set of tests counts as a failure
+#        if pytest -qq --collect-only -k "[${T}"; then
+#            PATTERNS+=("[${T}")
+#        fi
+#    done
+#
+#    # actually run the tests in each pattern
+#    for P in "${PATTERNS[@]}"; do
+#        set -x
+#        pytest ${TEST_ARGS} -k "$P"
+#        RESULT=$?
+#        set +x
+#        if [ $RESULT -ne 0 ] ; then
+#            # we could try again on failure, but lets see if we can
+#            # keep things non-flakey enough that it isn't necessary
+#            break
+#        fi
+#    done
+#fi
 
 if [ $RESULT -ne 0 ]; then
     kubectl get pods

--- a/releng/run-tests.sh
+++ b/releng/run-tests.sh
@@ -13,52 +13,45 @@ TEST_ARGS="--tb=short"
 
 if [ -n "${TEST_NAME}" ]; then
     TEST_ARGS+=" -k ${TEST_NAME}"
+    pytest ${TEST_ARGS}
+    RESULT=$?
+else
+    # Split up the tests so we don't run them all at once. This is an
+    # eggregious hack that depends on the "main[...]" syntax of the
+    # pytest parameterized test notation.
+
+    # make sure we include non parameterized tests, but they don't
+    # seem to exist in CI, so we need to check (running an empty set
+    # of tests counts as a failure)
+    UNPARAM="not ["
+    if pytest -qq --collect-only -k "${UNPARAM}"; then
+        PATTERNS=("${UNPARAM}")
+    else
+        PATTERNS=()
+    fi
+
+    # split up the parameterized tests by starting letter
+    for T in {A..Z}; do
+        # we need to check if the pattern actually matches any tests,
+        # because running an empty set of tests counts as a failure
+        if pytest -qq --collect-only -k "[${T}"; then
+            PATTERNS+=("[${T}")
+        fi
+    done
+
+    # actually run the tests in each pattern
+    for P in "${PATTERNS[@]}"; do
+        set -x
+        pytest ${TEST_ARGS} -k "$P"
+        RESULT=$?
+        set +x
+        if [ $RESULT -ne 0 ] ; then
+            # we could try again on failure, but lets see if we can
+            # keep things non-flakey enough that it isn't necessary
+            break
+        fi
+    done
 fi
-
-pytest ${TEST_ARGS}
-RESULT=$?
-
-#if [ -n "${TEST_NAME}" ]; then
-#    TEST_ARGS+=" -k ${TEST_NAME}"
-#    pytest ${TEST_ARGS}
-#    RESULT=$?
-#else
-#    # Split up the tests so we don't run them all at once. This is an
-#    # eggregious hack that depends on the "main[...]" syntax of the
-#    # pytest parameterized test notation.
-#
-#    # make sure we include non parameterized tests, but they don't
-#    # seem to exist in CI, so we need to check (running an empty set
-#    # of tests counts as a failure)
-#    UNPARAM="not ["
-#    if pytest -qq --collect-only -k "${UNPARAM}"; then
-#        PATTERNS=("${UNPARAM}")
-#    else
-#        PATTERNS=()
-#    fi
-#
-#    # split up the parameterized tests by starting letter
-#    for T in {A..Z}; do
-#        # we need to check if the pattern actually matches any tests,
-#        # because running an empty set of tests counts as a failure
-#        if pytest -qq --collect-only -k "[${T}"; then
-#            PATTERNS+=("[${T}")
-#        fi
-#    done
-#
-#    # actually run the tests in each pattern
-#    for P in "${PATTERNS[@]}"; do
-#        set -x
-#        pytest ${TEST_ARGS} -k "$P"
-#        RESULT=$?
-#        set +x
-#        if [ $RESULT -ne 0 ] ; then
-#            # we could try again on failure, but lets see if we can
-#            # keep things non-flakey enough that it isn't necessary
-#            break
-#        fi
-#    done
-#fi
 
 if [ $RESULT -ne 0 ]; then
     kubectl get pods


### PR DESCRIPTION
When saving certs for Envoy to work with, write them to disk using a hash of the key contents so that if the secret is updated, the filename will change, to make it easier for Envoy to notice.

Also, if we run across a secret with no public half, skip it rather than crashing. Sigh.

Thanks to @matthewce for work debugging both of these!