### PR TITLE
Drop the generated Resolvers back to apiVersion v1

### DIFF
--- a/ambassador/ambassador/ir/irserviceresolver.py
+++ b/ambassador/ambassador/ir/irserviceresolver.py
@@ -209,7 +209,7 @@ class IRServiceResolverFactory:
         if not ir.get_resolver('kubernetes-service'):
             # Default the K8s service resolver.
             config = {
-                'apiVersion': 'getambassador.io/v2',
+                'apiVersion': 'getambassador.io/v1',
                 'kind': 'KubernetesServiceResolver',
                 'name': 'kubernetes-service'
             }
@@ -227,7 +227,7 @@ class IRServiceResolverFactory:
             # Neither exists. Create them from scratch.
 
             config = {
-                'apiVersion': 'getambassador.io/v2',
+                'apiVersion': 'getambassador.io/v1',
                 'kind': 'KubernetesEndpointResolver',
                 'name': 'kubernetes-endpoint'
             }
@@ -250,7 +250,7 @@ class IRServiceResolverFactory:
             # Neither exists. Create them from scratch.
 
             config = {
-                'apiVersion': 'getambassador.io/v2',
+                'apiVersion': 'getambassador.io/v1',
                 'kind': 'ConsulResolver',
                 'name': 'consul-endpoint',
                 'datacenter': 'dc1'

--- a/ambassador/tests/t_consul.py
+++ b/ambassador/tests/t_consul.py
@@ -65,11 +65,11 @@ name:  {self.path.k8s}_k8s_mapping
 prefix: /{self.path.k8s}_k8s/
 service: {self.k8s_target.path.k8s}
 ---
-apiVersion: getambassador.io/v2
+apiVersion: getambassador.io/v1
 kind: KubernetesServiceResolver
 name: kubernetes-service
 ---
-apiVersion: getambassador.io/v2
+apiVersion: getambassador.io/v1
 kind: KubernetesEndpointResolver
 name: endpoint
 ---
@@ -83,7 +83,7 @@ resolver: {self.path.k8s}-resolver
 load_balancer:
   policy: round_robin
 ---
-apiVersion: ambassador/v2
+apiVersion: ambassador/v1
 kind: ConsulResolver
 name: {self.path.k8s}-resolver
 address: {self.path.k8s}-consul:8500

--- a/ambassador/tests/t_grpc.py
+++ b/ambassador/tests/t_grpc.py
@@ -50,10 +50,10 @@ service: {self.target.path.k8s}
 
     def check(self):
         # [0]
-        assert self.results[0].headers["Grpc-Status"] == ["0"]
+        assert self.results[0].headers["Grpc-Status"] == ["0"], f'0 expected ["0"], got {self.results[0].headers["Grpc-Status"]}'
 
         # [1]
-        assert self.results[1].headers["Grpc-Status"] == ["7"]
+        assert self.results[1].headers["Grpc-Status"] == ["7"], f'0 expected ["0"], got {self.results[0].headers["Grpc-Status"]}'
 
         # [2]
         # XXX Ew. If self.results[2].json is empty, the harness won't convert it to a response.
@@ -101,10 +101,10 @@ resolver: endpoint
 
     def check(self):
         # [0]
-        assert self.results[0].headers["Grpc-Status"] == ["0"]
+        assert self.results[0].headers["Grpc-Status"] == ["0"], f'0 expected ["0"], got {self.results[0].headers["Grpc-Status"]}'
 
         # [1]
-        assert self.results[1].headers["Grpc-Status"] == ["7"]
+        assert self.results[1].headers["Grpc-Status"] == ["7"], f'0 expected ["0"], got {self.results[0].headers["Grpc-Status"]}'
 
         # [2]
         # XXX Ew. If self.results[2].json is empty, the harness won't convert it to a response.


### PR DESCRIPTION
Also, have some better messages for failures in the gRPC tests.