### PR TITLE
Clean up teleproxy usage to better support Darwin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -357,7 +357,7 @@ endif
 kill_teleproxy = curl -s --connect-timeout 5 127.254.254.254/api/shutdown || true
 
 ifeq ($(shell uname -s), Darwin)
-run_teleproxy = sudo $(TELEPROXY)
+run_teleproxy = sudo id; sudo $(TELEPROXY)
 else
 run_teleproxy = $(TELEPROXY)
 endif


### PR DESCRIPTION
MacOS Mojave has some issues with `networksetup` when the ruid and euid don't match. (C'mon, Apple, WTF?)

So. For Darwin, don't install teleproxy setuid root: instead, run it with sudo.
