### PR TITLE
added weighting to mirror feature in envoy

### DIFF
--- a/ambassador/ambassador/envoy/v2/v2route.py
+++ b/ambassador/ambassador/envoy/v2/v2route.py
@@ -146,8 +146,16 @@ class V2Route(dict):
             if shadow:
                 shadow = shadow[0]
 
+                weight = shadow.get('weight', 100)
+
                 route['request_mirror_policy'] = {
-                    'cluster': shadow.cluster.name
+                    'cluster': shadow.cluster.name,
+                    'runtime_fraction': {
+                        'default_value': {
+                            'numerator': weight,
+                            'denominator': 'HUNDRED'
+                        }
+                    }
                 }
 
             # Is RateLimit a thing?

--- a/docs/reference/shadowing.md
+++ b/docs/reference/shadowing.md
@@ -55,7 +55,7 @@ The `prefix` is set to be the same as the first annotation, which tells Ambassad
 
 ### Shadow traffic weighting
 
-It is possible shadowing only a portion of the traffic specifying the `weight` in the mapping. Eg.
+It is possible to shadow a portion of the traffic by specifying the `weight` in the mapping. Eg.
 
 ```yaml
   getambassador.io/config: |

--- a/docs/reference/shadowing.md
+++ b/docs/reference/shadowing.md
@@ -53,3 +53,20 @@ What if we want to shadow the traffic to `myservice`, and send that exact same t
 
 The `prefix` is set to be the same as the first annotation, which tells Ambassador which production traffic to shadow. The destination service, where the shadow traffic is routed, is a *different* Kubernetes service, `myservice-shadow`. Finally, the `shadow: true` annotation actually enables shadowing.
 
+### Shadow traffic weighting
+
+It is possible shadowing only a portion of the traffic specifying the `weight` in the mapping. Eg.
+
+```yaml
+  getambassador.io/config: |
+      ---
+      apiVersion: ambassador/v1
+      kind: Mapping
+      name: myservice-shadow-mapping
+      prefix: /myservice/
+      service: myservice-shadow.default
+      shadow: true
+      weight: 10
+```
+
+In the example above, only the 10% of the traffic will be forwarded to the shadowing service.


### PR DESCRIPTION
## Description
Shadowing traffic is a great feature, but not being able to select only a percentage of the traffic, forces the ghost service to be able to hold the full production traffic.

Envoy supports mirror traffic control via the [runtime_fraction](https://www.envoyproxy.io/docs/envoy/latest/api-v2/api/v2/route/route.proto.html?highlight=request_mirror_policy#route-routeaction-requestmirrorpolicy) property.

## Related Issues
N/A

## Testing
Manual testing done locally

## Todos
Added a couple of lines of documentation and one example.

## Other
* If this is a documentation change, please open the pull request at https://github.com/datawire/ambassador-docs instead.
* Code changes should occur against `master`.
