### PR TITLE
Make Tests Great Again!

### DIFF
--- a/ambassador/ambassador/config/resourcefetcher.py
+++ b/ambassador/ambassador/config/resourcefetcher.py
@@ -120,9 +120,23 @@ class ResourceFetcher:
 
         self.finalize()
 
+    def parse_json(self, serialization: Optional[str], k8s=False, rkey: Optional[str]=None,
+                   filename: Optional[str]=None) -> None:
+        # self.logger.debug("%s: parsing %d byte%s of YAML:\n%s" %
+        #                   (self.location, len(serialization), "" if (len(serialization) == 1) else "s",
+        #                    serialization))
+
+        try:
+            objects = json.loads(serialization)
+            self.parse_object(objects=objects, k8s=k8s, rkey=rkey, filename=filename)
+        except json.decoder.JSONDecodeError as e:
+            self.aconf.post_error("%s: could not parse YAML: %s" % (self.location, e))
+
+        self.finalize()
+
     def parse_watt(self, serialization: Optional[str]) -> None:
         try:
-            watt_dict = parse_yaml(serialization)[0]
+            watt_dict = json.loads(serialization)
 
             watt_k8s = watt_dict.get('Kubernetes', {})
 
@@ -141,7 +155,7 @@ class ResourceFetcher:
 
                     self.parse_object(parsed_objects, k8s=False,
                                       filename=self.filename, rkey=rkey)
-        except yaml.error.YAMLError as e:
+        except json.decoder.JSONDecodeError as e:
             self.aconf.post_error("%s: could not parse WATT: %s" % (self.location, e))
 
         self.finalize()

--- a/ambassador/ambassador_diag/diagd.py
+++ b/ambassador/ambassador_diag/diagd.py
@@ -728,23 +728,35 @@ class AmbassadorEventWatcher(threading.Thread):
             self._respond(rqueue, 500, 'ignoring: invalid Envoy configuration in snapshot %s' % snapshot)
             return
 
-        self.logger.info("rotating snapshots for snapshot %s" % snapshot)
+        snapcount = int(os.environ.get('AMBASSADOR_SNAPSHOT_COUNT', "4"))
+        snaplist: List[Tuple[str, str]] = []
 
-        for from_suffix, to_suffix in [
-            # ('-3', '-4'),
-            # ('-2', '-3'),
-            # ('-1', '-2'),
-            ('', '-1'),
-            ('-tmp', '') ]:
+        if snapcount > 0:
+            self.logger.debug("rotating snapshots for snapshot %s" % snapshot)
+
+            # If snapcount is 4, this range statement becomes range(-4, -1)
+            # which gives [ -4, -3, -2 ], which the list comprehension turns
+            # into [ ( "-3", "-4" ), ( "-2", "-3" ), ( "-1", "-2" ) ]...
+            # which is the list of suffixes to rename to rotate the snapshots.
+
+            snaplist += [ (str(x+1), str(x)) for x in range(-1 * snapcount, -1) ]
+
+            # After dealing with that, we need to rotate the current file into -1.
+            snaplist.append(( '', '-1' ))
+
+        # Whether or not we do any rotation, we need to cycle in the '-tmp' file.
+        snaplist.append(( '-tmp', '' ))
+
+        for from_suffix, to_suffix in snaplist:
             for fmt in [ "aconf{}.json", "econf{}.json", "ir{}.json", "snapshot{}.yaml" ]:
-                try:
-                    from_path = os.path.join(app.snapshot_path, fmt.format(from_suffix))
-                    to_path = os.path.join(app.snapshot_path, fmt.format(to_suffix))
+                from_path = os.path.join(app.snapshot_path, fmt.format(from_suffix))
+                to_path = os.path.join(app.snapshot_path, fmt.format(to_suffix))
 
-                    # self.logger.debug("rotate: %s -> %s" % (from_path, to_path))
+                try:
+                    self.logger.debug("rotate: %s -> %s" % (from_path, to_path))
                     os.rename(from_path, to_path)
                 except IOError as e:
-                    # self.logger.debug("skip %s -> %s: %s" % (from_path, to_path, e))
+                    self.logger.debug("skip %s -> %s: %s" % (from_path, to_path, e))
                     pass
                 except Exception as e:
                     self.logger.debug("could not rename %s -> %s: %s" % (from_path, to_path, e))

--- a/ambassador/ambassador_diag/diagd.py
+++ b/ambassador/ambassador_diag/diagd.py
@@ -730,7 +730,12 @@ class AmbassadorEventWatcher(threading.Thread):
 
         self.logger.info("rotating snapshots for snapshot %s" % snapshot)
 
-        for from_suffix, to_suffix in [ ('-3', '-4'), ('-2', '-3'), ('-1', '-2'), ('', '-1'), ('-tmp', '') ]:
+        for from_suffix, to_suffix in [
+            # ('-3', '-4'),
+            # ('-2', '-3'),
+            # ('-1', '-2'),
+            ('', '-1'),
+            ('-tmp', '') ]:
             for fmt in [ "aconf{}.json", "econf{}.json", "ir{}.json", "snapshot{}.yaml" ]:
                 try:
                     from_path = os.path.join(app.snapshot_path, fmt.format(from_suffix))

--- a/ambassador/tests/abstract_tests.py
+++ b/ambassador/tests/abstract_tests.py
@@ -184,7 +184,7 @@ class AmbassadorTest(Test):
         command = ["docker", "run", "-d", "-l", "kat-family=ambassador", "--name", self.path.k8s]
 
         envs = ["KUBERNETES_SERVICE_HOST=kubernetes", "KUBERNETES_SERVICE_PORT=443",
-                "AMBASSADOR_ID=%s" % self.ambassador_id]
+                "AMBASSADOR_SNAPSHOT_COUNT=1", "AMBASSADOR_ID=%s" % self.ambassador_id]
 
         if self.namespace:
             envs.append("AMBASSADOR_NAMESPACE=%s" % self.namespace)

--- a/kat/kat/manifests.py
+++ b/kat/kat/manifests.py
@@ -306,6 +306,8 @@ spec:
           fieldPath: metadata.namespace
     - name: AMBASSADOR_ID
       value: {self.path.k8s}
+    - name: AMBASSADOR_SNAPSHOT_COUNT
+      value: 1
     livenessProbe:
       httpGet:
         path: /ambassador/v0/check_alive

--- a/kat/kat/manifests.py
+++ b/kat/kat/manifests.py
@@ -307,7 +307,7 @@ spec:
     - name: AMBASSADOR_ID
       value: {self.path.k8s}
     - name: AMBASSADOR_SNAPSHOT_COUNT
-      value: 1
+      value: "1"
     livenessProbe:
       httpGet:
         path: /ambassador/v0/check_alive

--- a/releng/run-tests.sh
+++ b/releng/run-tests.sh
@@ -9,56 +9,16 @@
 # to the pytest line, and, uh, I guess recover and merge all the .coverage 
 # files from the containers??
 
-GLOBAL_RESULT=0
-
 TEST_ARGS="--tb=short"
 
 if [ -n "${TEST_NAME}" ]; then
     TEST_ARGS+=" -k ${TEST_NAME}"
-    pytest ${TEST_ARGS}
-    RESULT=$?
-else
-    # Split up the tests so we don't run them all at once. This is an
-    # eggregious hack that depends on the "main[...]" syntax of the
-    # pytest parameterized test notation.
-
-    # make sure we include non parameterized tests, but they don't
-    # seem to exist in CI, so we need to check (running an empty set
-    # of tests counts as a failure)
-    UNPARAM="not ["
-    if pytest -qq --collect-only -k "${UNPARAM}"; then
-        PATTERNS=("${UNPARAM}")
-    else
-        PATTERNS=()
-    fi
-
-    # split up the parameterized tests by starting letter
-    for T in {A..Z}; do
-        # we need to check if the pattern actually matches any tests,
-        # because running an empty set of tests counts as a failure
-        if pytest -qq --collect-only -k "[${T}"; then
-            PATTERNS+=("[${T}")
-        fi
-    done
-
-    # actually run the tests in each pattern
-    for P in "${PATTERNS[@]}"; do
-        set -x
-        pytest ${TEST_ARGS} -k "$P"
-        RESULT=$?
-        set +x
-        if [ $RESULT -ne 0 ] ; then
-            # we could try again on failure, but lets see if we can
-            # keep things non-flakey enough that it isn't necessary
-
-            # Do remember that we had failures, but don't bail yet.
-            GLOBAL_RESULT=$RESULT
-#            break
-        fi
-    done
 fi
 
-if [ $GLOBAL_RESULT -ne 0 ]; then
+pytest ${TEST_ARGS}
+RESULT=$?
+
+if [ $RESULT -ne 0 ]; then
     kubectl get pods
     kubectl get svc
 


### PR DESCRIPTION
Well, OK, maybe that's a bit strong. :wink: But:

- Instead of parsing the outer JSON container that comes from `watt` using the Python YAML parser, use the JSON parser.
   - A YAML parser can always parse JSON, since YAML is a superset, so using the YAML parser made it faster to get things running, but
   - even using the C YAML parser, the YAML parser is on the order of _20x_ slower than the JSON parser. That is not a typo.
   - I don't know why this is so. I haven't really gotten past boggling at it.

- Make the number of configuration snapshots we keep tunable with the `AMBASSADOR_SNAPSHOT_COUNT` environment variable, and have the tests cut it to 1 instead of 4.
   - Turns out the Kubernaut cluster is _severely_ disk-constrained, and the accumulation of snapshots was eating all the disk and causing pods to be evicted. Sigh.
   - This doesn't happen if we clamp to one snapshot.

So this brings us back to one test pass that's quick enough to succeed.
