### PR TITLE
Some startup tweaks around performance and debugging

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ script:
 
 after_script:
   # release the kubernaut claim
-  - make clean-test
+  - ./releng/travis-cleanup.sh
 
 deploy:
   # Set "GIT_BRANCH" to the value of "MAIN_BRANCH" because the branch a tag originates from is not preserved by Git.

--- a/Dockerfile
+++ b/Dockerfile
@@ -78,13 +78,14 @@ RUN chgrp -R 0 ${AMBASSADOR_ROOT} && \
     chmod -R g=u ${AMBASSADOR_ROOT} /etc/passwd
 
 # COPY the entrypoint and Python-kubewatch and make them runnable.
-COPY ambassador/kubewatch.py .
 COPY ambassador/entrypoint.sh .
+COPY ambassador/grab-snapshots.py .
 COPY ambassador/kick_ads.sh .
+COPY ambassador/kubewatch.py .
 COPY ambassador/post_update.py .
 COPY ambassador/post_watt.sh .
 COPY ambassador/watch_hook.py .
-RUN chmod 755 kubewatch.py entrypoint.sh kick_ads.sh post_update.py post_watt.sh watch_hook.py
+RUN chmod 755 entrypoint.sh grab-snapshots.py kick_ads.sh kubewatch.py post_update.py post_watt.sh watch_hook.py
 
 # XXX Move to base image
 COPY watt .

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License
 
+CI_DEBUG_KAT_BRANCH=flynn/dev/mypy-clean
+
 SHELL = bash
 
 # Welcome to the Ambassador Makefile...
@@ -181,6 +183,7 @@ print-vars:
 	@echo "AMBASSADOR_DOCKER_TAG            = $(AMBASSADOR_DOCKER_TAG)"
 	@echo "AMBASSADOR_EXTERNAL_DOCKER_IMAGE = $(AMBASSADOR_EXTERNAL_DOCKER_IMAGE)"
 	@echo "AMBASSADOR_EXTERNAL_DOCKER_REPO  = $(AMBASSADOR_EXTERNAL_DOCKER_REPO)"
+	@echo "CI_DEBUG_KAT_BRANCH              = $(CI_DEBUG_KAT_BRANCH)"
 	@echo "COMMIT_TYPE                      = $(COMMIT_TYPE)"
 	@echo "DOCKER_EPHEMERAL_REGISTRY        = $(DOCKER_EPHEMERAL_REGISTRY)"
 	@echo "DOCKER_EXTERNAL_REGISTRY         = $(DOCKER_EXTERNAL_REGISTRY)"
@@ -207,6 +210,7 @@ export-vars:
 	@echo "export AMBASSADOR_DOCKER_TAG='$(AMBASSADOR_DOCKER_TAG)'"
 	@echo "export AMBASSADOR_EXTERNAL_DOCKER_IMAGE='$(AMBASSADOR_EXTERNAL_DOCKER_IMAGE)'"
 	@echo "export AMBASSADOR_EXTERNAL_DOCKER_REPO='$(AMBASSADOR_EXTERNAL_DOCKER_REPO)'"
+	@echo "export CI_DEBUG_KAT_BRANCH='$(CI_DEBUG_KAT_BRANCH)'"
 	@echo "export COMMIT_TYPE='$(COMMIT_TYPE)'"
 	@echo "export DOCKER_EPHEMERAL_REGISTRY='$(DOCKER_EPHEMERAL_REGISTRY)'"
 	@echo "export DOCKER_EXTERNAL_REGISTRY='$(DOCKER_EXTERNAL_REGISTRY)'"

--- a/ambassador/entrypoint.sh
+++ b/ambassador/entrypoint.sh
@@ -61,6 +61,11 @@ export ENVOY_DEBUG
 
 DIAGD_CONFIGDIR=
 
+echo "AMBASSADOR STARTING with environment:"
+echo "===="
+env | grep AMBASSADOR | sort
+echo "===="
+
 if [ "$1" == "--demo" ]; then
     # This is _not_ meant to be overridden by AMBASSADOR_CONFIG_BASE_DIR.
     # It's baked into a specific location during the build process.

--- a/ambassador/entrypoint.sh
+++ b/ambassador/entrypoint.sh
@@ -227,11 +227,11 @@ if [ -z "${AMBASSADOR_NO_KUBEWATCH}" ]; then
         KUBEWATCH_NAMESPACE_ARG="--namespace $AMBASSADOR_NAMESPACE"
     fi
 
-    KUBEWATCH_SYNC_KINDS="-s secret -s service"
+    KUBEWATCH_SYNC_KINDS="-s service"
 
-    if [ -n "$AMBASSADOR_NO_SECRETS" ]; then
-        KUBEWATCH_SYNC_KINDS="-s service"
-    fi
+#    if [ -n "$AMBASSADOR_NO_SECRETS" ]; then
+#        KUBEWATCH_SYNC_KINDS="-s service"
+#    fi
 
     set -x
     /ambassador/watt ${KUBEWATCH_NAMESPACE_ARG} --notify "$KUBEWATCH_SYNC_CMD" $KUBEWATCH_SYNC_KINDS --watch "$WATCH_HOOK" &

--- a/ambassador/grab-snapshots.py
+++ b/ambassador/grab-snapshots.py
@@ -1,0 +1,82 @@
+#!python
+
+import sys
+
+import glob
+import json
+import os
+import tarfile
+
+def sanitize_snapshot(path: str):
+	watt_dict = json.loads(open(path, "r"). read())
+
+	sanitized = {}
+
+	# Consul is pretty easy. Just sort, using service-dc as the sort key.
+	consul_elements = watt_dict.get('Consul')
+
+	if consul_elements:
+		csorted = {}
+
+		for key, value in consul_elements.items():
+			csorted[key] = sorted(value, key=lambda x: f'{x["Service"]-x["Id"]}')
+
+		sanitized['Consul'] = csorted
+
+	# Kube is harder because we need to sanitize Kube secrets.
+	kube_elements = watt_dict.get('Kubernetes')
+
+	if kube_elements:
+		ksorted = {}
+
+		for key, value in kube_elements.items():
+			if key == 'secret':
+				for secret in value:
+					if "data" in secret:
+						data = secret["data"]
+
+						for k in data.keys():
+							if ((k == "token") or 
+								k.lower().endswith(".crt") or
+								k.lower().endswith(".key")):
+								data[k] = f'-sanitized-{k}-'
+
+					metadata = secret.get('metadata', {})
+					annotations = metadata.get('annotations', {})
+
+					# Wipe the last-applied-configuration annotation, too, because it 
+					# often contains the secret data.
+					if 'kubectl.kubernetes.io/last-applied-configuration' in annotations:
+						annotations['kubectl.kubernetes.io/last-applied-configuration'] = '--sanitized--'
+
+			# All the sanitization above happened in-place in value, so we can just
+			# sort it.
+			ksorted[key] = sorted(value, key=lambda x: x.get('metadata',{}).get('name'))
+
+		sanitized['Kubernetes'] = ksorted
+
+	return sanitized
+
+# Open a tarfile for output...
+tarfile = tarfile.open('sanitized.tgz', 'w:gz')
+
+# ...then iterate any snapshots, sanitize, and stuff 'em in the tarfile.
+# Note that the '.yaml' on the snapshot file name is a misnomer: when 
+# watt is involved, they're actually JSON. It's a long story.
+
+for path in glob.glob('snapshots/snap*.yaml'):
+	# The tarfile can be flat, rather than embedding everything
+	# in a directory with a fixed name.
+	b = os.path.basename(path)
+
+	sanitized = sanitize_snapshot(path)
+
+	if sanitized:
+		with open('sanitized.json', 'w') as tmp:
+			tmp.write(json.dumps(sanitized))
+
+		tarfile.add('sanitized.json', arcname=b)
+
+		os.unlink('sanitized.json')
+
+tarfile.close()

--- a/ambassador/watch_hook.py
+++ b/ambassador/watch_hook.py
@@ -12,7 +12,7 @@ from urllib.parse import urlparse
 
 logging.basicConfig(
     level=logging.INFO,
-    format="%(asctime)s test-dump %(levelname)s: %(message)s",
+    format="%(asctime)s watch-hook %(levelname)s: %(message)s",
     datefmt="%Y-%m-%d %H:%M:%S"
 )
 

--- a/ambassador/watch_hook.py
+++ b/ambassador/watch_hook.py
@@ -146,6 +146,11 @@ watchset = {
             "kind": "endpoints",
             "namespace": Config.ambassador_namespace if Config.single_namespace else "",
             "field-selector": "metadata.namespace!=kube-system"
+        },
+        {
+            "kind": "secret",
+            "namespace": Config.ambassador_namespace if Config.single_namespace else "",
+            "field-selector": "metadata.namespace!=kube-system,type!=kubernetes.io/service-account-token"
         }
     ],
     "consul-watches": consul_watches

--- a/releng/run-tests.sh
+++ b/releng/run-tests.sh
@@ -19,8 +19,8 @@ pytest ${TEST_ARGS}
 RESULT=$?
 
 if [ $RESULT -ne 0 ]; then
-    kubectl get pods
-    kubectl get svc
+    kubectl get pods --all-namespaces
+    kubectl get svc --all-namespaces
 
     if [ -n "${AMBASSADOR_DEV}" ]; then
         docker ps -a

--- a/releng/travis-cleanup.sh
+++ b/releng/travis-cleanup.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+# Copyright 2018 Datawire. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License
+
+set -o errexit
+set -o nounset
+
+printf "== Begin: travis-cleanup.sh ==\n"
+
+eval $(make export-vars)
+
+echo "GIT_BRANCH ${GIT_BRANCH}"
+echo "CI_DEBUG_KAT_BRANCH ${CI_DEBUG_KAT_BRANCH}"
+
+teardown=yes
+
+if [ \( -n "$CI_DEBUG_KAT_BRANCH" \) ]; then
+	if [ "$GIT_BRANCH" = "$CI_DEBUG_KAT_BRANCH" ]; then
+		echo "Leaving Kat cluster intact for debugging:"
+		kubectl cluster-info
+		teardown=
+	else
+		echo "Not running on debug branch ${CI_DEBUG_KAT_BRANCH}"
+	fi
+else
+	echo "No debug branch is set"
+fi
+
+if [ -n "$teardown" ]; then
+	make clean-test
+fi
+
+
+
+
+


### PR DESCRIPTION
- Don't ever look at secrets in the `kube-system` namespace, or secrets marked as service-account tokens.
- Log the startup environment early.
- Fix the !*@#&!*@&# name of `watch-hook` in the logs.
- Include the `grab-snapshots.py` script in the image.