### PR TITLE
Fix documentation example with TLS context

### DIFF
--- a/docs/user-guide/with-istio.md
+++ b/docs/user-guide/with-istio.md
@@ -223,7 +223,7 @@ Istio can be configured to require TLS on connections to APIs in the service mes
           name: productpage_mapping
           prefix: /productpage/
           rewrite: /productpage
-          tls: upstream
+          tls: istio-upstream
           service: https://productpage:9080
     spec:
       ports:


### PR DESCRIPTION
Fix documentation example related to ambassador integration with istio when using mutual TLS. The name created to the example doesn't match with the name used to the mapping.