### PR TITLE
Switch to watt 0.4.7

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -150,7 +150,7 @@ KAT_BACKEND_RELEASE = 1.4.0
 
 # Allow overriding which watt we use.
 WATT ?= watt
-WATT_VERSION ?= 0.4.2
+WATT_VERSION ?= 0.4.7
 
 # "make" by itself doesn't make the website. It takes too long and it doesn't
 # belong in the inner dev loop.

--- a/ambassador/grab-snapshots.py
+++ b/ambassador/grab-snapshots.py
@@ -36,10 +36,7 @@ def sanitize_snapshot(path: str):
 						data = secret["data"]
 
 						for k in data.keys():
-							if ((k == "token") or 
-								k.lower().endswith(".crt") or
-								k.lower().endswith(".key")):
-								data[k] = f'-sanitized-{k}-'
+							data[k] = f'-sanitized-{k}-'
 
 					metadata = secret.get('metadata', {})
 					annotations = metadata.get('annotations', {})


### PR DESCRIPTION
watt 0.4.7 fixes a memory leak in previous versions.

Also, let grab-snapshots sanitize all data keys. There's really no reason to let any of those pass through.