### PR TITLE
Be more careful about what we watch from Kubernetes

### DIFF
--- a/ambassador/ambassador/cli.py
+++ b/ambassador/ambassador/cli.py
@@ -114,7 +114,7 @@ class CLISecretHandler(SecretHandler):
 
 
 def dump(config_dir_path: Parameter.REQUIRED, *,
-         debug=False, debug_scout=False, k8s=False, recurse=False,
+         watt=False, debug=False, debug_scout=False, k8s=False, recurse=False,
          aconf=False, ir=False, v2=False, diag=False, features=False):
     """
     Dump various forms of an Ambassador configuration for debugging
@@ -123,6 +123,7 @@ def dump(config_dir_path: Parameter.REQUIRED, *,
     will be dumped.
 
     :param config_dir_path: Configuration directory to scan for Ambassador YAML files
+    :param watt: If set, input must be a WATT snapshot
     :param debug: If set, generate debugging output
     :param debug_scout: If set, generate debugging output
     :param k8s: If set, assume configuration files are annotated K8s manifests
@@ -159,7 +160,12 @@ def dump(config_dir_path: Parameter.REQUIRED, *,
     try:
         aconf = Config()
         fetcher = ResourceFetcher(logger, aconf)
-        fetcher.load_from_filesystem(config_dir_path, k8s=k8s, recurse=True)
+
+        if watt:
+            fetcher.parse_watt(open(config_dir_path, "r").read())
+        else:
+            fetcher.load_from_filesystem(config_dir_path, k8s=k8s, recurse=True)
+
         aconf.load_all(fetcher.sorted())
 
         # aconf.post_error("Error from string, boo yah")

--- a/ambassador/ambassador/ir/irserviceresolver.py
+++ b/ambassador/ambassador/ir/irserviceresolver.py
@@ -55,7 +55,7 @@ class IRServiceResolver(IRResource):
         if self.kind == 'ConsulResolver':
             self.resolve_with = 'consul'
 
-            if not self.datacenter:
+            if not self.get('datacenter'):
                 self.post_error("ConsulResolver is required to have a datacenter")
                 return False
         elif self.kind == 'KubernetesServiceResolver':

--- a/ambassador/tests/t_grpc.py
+++ b/ambassador/tests/t_grpc.py
@@ -81,6 +81,8 @@ rewrite: /echo.EchoService/
 name:  {self.target.path.k8s}
 service: {self.target.path.k8s}
 resolver: endpoint
+load_balancer:
+  policy: round_robin
 """)
 
     def queries(self):

--- a/ambassador/watch_hook.py
+++ b/ambassador/watch_hook.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python
 
-from typing import List, TYPE_CHECKING
+from typing import Dict, List, Optional, Tuple, TYPE_CHECKING
+from typing import cast as typecast
 
 import sys
 
@@ -11,21 +12,98 @@ import os
 from urllib.parse import urlparse
 
 logging.basicConfig(
-    level=logging.INFO,
+    level=logging.DEBUG,
     format="%(asctime)s watch-hook %(levelname)s: %(message)s",
     datefmt="%Y-%m-%d %H:%M:%S"
 )
 
-logger = logging.getLogger('ambassador')
+alogger = logging.getLogger('ambassador')
+alogger.setLevel(logging.INFO)
+
+logger = logging.getLogger('watch_hook')
 logger.setLevel(logging.INFO)
 
 from ambassador import Config, IR
 from ambassador.config.resourcefetcher import ResourceFetcher
+from ambassador.ir.irserviceresolver import IRServiceResolverFactory
+from ambassador.ir.irtls import TLSModuleFactory, IRAmbassadorTLS
+from ambassador.ir.irambassador import IRAmbassador
+from ambassador.utils import SecretInfo, SavedSecret, SecretHandler
 
 if TYPE_CHECKING:
     from ambassador.ir.irtlscontext import IRTLSContext
 
 
+# Fake SecretHandler for our fake IR, below.
+
+class SecretRecorder(SecretHandler):
+    def __init__(self, logger: logging.Logger) -> None:
+        super().__init__(logger, "-source_root-", "-cache_dir-", "0")
+        self.needed: Dict[Tuple[str, str], SecretInfo] = {}
+
+    # Record what was requested, and always return True.
+    def load_secret(self, context: 'IRTLSContext',
+                    secret_name: str, namespace: str) -> Optional[SecretInfo]:
+        secret_key = ( secret_name, namespace )
+
+        if secret_key not in self.needed:
+            self.needed[secret_key] = SecretInfo(secret_name, namespace, '-crt-', '-key-', decode_b64=False)
+
+        return self.needed[secret_key]
+
+    # Never cache anything.
+    def cache_secret(self, context: 'IRTLSContext', secret_info: SecretInfo):
+        return SavedSecret(secret_info.name, secret_info.namespace, '-crt-path-', '-key-path-',
+                           { 'tls_crt': '-crt-', 'tls_key': '-key-' })
+
+
+# XXX Sooooo there's some ugly stuff here.
+#
+# We need to do a little bit of the same work that the IR does for things like
+# managing Resolvers and parsing service names. However, we really don't want to
+# do all the work of instantiating an IR.
+#
+# So we kinda fake it. And yeah, it's kind of disgusting.
+
+class FakeIR(IR):
+    def __init__(self, logger, aconf):
+        self.ambassador_id = Config.ambassador_id
+        self.ambassador_namespace = Config.ambassador_namespace
+        self.ambassador_nodename = aconf.ambassador_nodename
+
+        self.logger = logger
+        self.aconf = aconf
+
+        # If we're asked about a secret, record interest in that secret.
+        self.secret_handler = SecretRecorder(self.logger)
+
+        # If we're asked about a file, it's good.
+        self.file_checker = lambda path: True
+
+        self.clusters = {}
+        self.grpc_services = {}
+        self.filters = []
+        self.tls_contexts = {}
+        self.tls_module = None
+        self.listeners = []
+        self.groups = {}
+        self.resolvers = {}
+        self.breakers = {}
+        self.outliers = {}
+        self.services = {}
+        self.tracing = None
+        self.ratelimit = None
+        self.saved_secrets = {}
+        self.secret_info = {}
+
+        IRServiceResolverFactory.load_all(self, aconf)
+        TLSModuleFactory.load_all(self, aconf)
+        self.save_tls_contexts(aconf)
+
+        self.ambassador_module = IRAmbassador(self, aconf)
+
+
+# XXX More fakery here. This duplicates code from ircluster.py.
 class Service:
     def __init__(self, logger, service: str, allow_scheme=True, ctx_name: str=None) -> None:
         original_service = service
@@ -94,6 +172,9 @@ class Service:
         if not self.port:
             self.port = 443 if originate_tls else 80
 
+
+#### Mainline.
+
 yaml_stream = sys.stdin
 
 if len(sys.argv) > 1:
@@ -105,25 +186,39 @@ fetcher.parse_watt(yaml_stream.read())
 
 aconf.load_all(fetcher.sorted())
 
+# We can lift mappings straight from the aconf...
 mappings = aconf.get_config('mappings') or {}
-resolvers = aconf.get_config('resolvers') or {}
-contexts = aconf.get_config('tls_contexts') or {}
-secrets = aconf.get_config('secret') or {}  # 'secret', singular, is not a typo
+
+# ...but we need the fake IR to deal with resolvers and TLS contexts.
+fake = FakeIR(logger, aconf)
+
+logger.debug("FakeIR: %s" % fake.as_json())
+
+resolvers = fake.resolvers
+contexts = fake.tls_contexts
+
+logger.debug(f'mappings: {len(mappings)}')
+logger.debug(f'resolvers: {len(resolvers)}')
+logger.debug(f'contexts: {len(contexts)}')
 
 consul_watches = []
+kube_watches = []
 
 for mname, mapping in mappings.items():
     res_name = mapping.get('resolver', None)
     ctx_name = mapping.get('tls', None)
 
     if res_name:
+        logger.debug(f'Mapping {mname}: resolver {res_name}, service {mapping.service}, tls {ctx_name}')
+
         resolver = resolvers.get(res_name, None)
+        logger.debug(f'-> resolver {resolver}')
 
         if resolver:
+            svc = Service(logger, mapping.service, ctx_name)
+
             if resolver.kind == 'ConsulResolver':
                 logger.debug(f'Mapping {mname} uses Consul resolver {res_name}')
-
-                svc = Service(logger, mapping.service, ctx_name)
 
                 # At the moment, we stuff the resolver's datacenter into the association
                 # ID for this watch. The ResourceFetcher relies on that.
@@ -136,26 +231,50 @@ for mname, mapping in mappings.items():
                         "service-name": svc.hostname
                     }
                 )
+            elif resolver.kind == 'KubernetesEndpointResolver':
+                host = svc.hostname
+                namespace = Config.ambassador_namespace
 
-watchset = {
-    "kubernetes-watches": [
-        {
-            "kind": "endpoints",
-            "namespace": Config.ambassador_namespace if Config.single_namespace else "",
-            "field-selector": "metadata.namespace!=kube-system"
-        },
+                if "." in host:
+                    (host, namespace) = host.split(".", 2)[0:2]
+
+                logger.debug(f'...kube endpoints: svc {svc.hostname} -> host {host} namespace {namespace}')
+
+                kube_watches.append(
+                    {
+                        "kind": "endpoints",
+                        "namespace": namespace,
+                        "field-selector": f'metadata.name={host}'
+                    }
+                )
+
+for secret_key, secret_info in fake.secret_handler.needed.items():
+    logger.debug(f'need secret {secret_info.name}.{secret_info.namespace}')
+
+    kube_watches.append(
         {
             "kind": "secret",
-            "namespace": Config.ambassador_namespace if Config.single_namespace else "",
-            "field-selector": "metadata.namespace!=kube-system,type!=kubernetes.io/service-account-token"
+            "namespace": secret_info.namespace,
+            "field-selector": f'metadata.name={secret_info.name}'
         }
-    ],
+    )
+
+# kube_watches.append(
+#     {
+#         "kind": "secret",
+#         "namespace": Config.ambassador_namespace if Config.single_namespace else "",
+#         "field-selector": "metadata.namespace!=kube-system,type!=kubernetes.io/service-account-token"
+#     }
+# )
+
+watchset = {
+    "kubernetes-watches": kube_watches,
     "consul-watches": consul_watches
 }
 
-save_dir = os.environ.get('AMBASSADOR_WATCH_DIR', None)
+save_dir = os.environ.get('AMBASSADOR_WATCH_DIR', '/tmp')
 
 if save_dir:
-    json.dump(watchset, open(os.path.join(save_dir, 'watch.yaml'), "w"))
+    json.dump(watchset, open(os.path.join(save_dir, 'watch.json'), "w"))
 
 json.dump(watchset, sys.stdout)

--- a/ambassador/watch_hook.py
+++ b/ambassador/watch_hook.py
@@ -11,17 +11,28 @@ import os
 
 from urllib.parse import urlparse
 
+loglevel = logging.INFO
+
+args = sys.argv[1:]
+
+if args:
+    if args[0] == '--debug':
+        loglevel = logging.DEBUG
+        args.pop(0)
+    elif args[0].startswith('--'):
+        raise Exception(f'Usage: {os.path.basename(sys.argv[0])} [--debug] [path]')
+
 logging.basicConfig(
-    level=logging.DEBUG,
+    level=loglevel,
     format="%(asctime)s watch-hook %(levelname)s: %(message)s",
     datefmt="%Y-%m-%d %H:%M:%S"
 )
 
 alogger = logging.getLogger('ambassador')
-alogger.setLevel(logging.INFO)
+alogger.setLevel(loglevel)
 
 logger = logging.getLogger('watch_hook')
-logger.setLevel(logging.INFO)
+logger.setLevel(loglevel)
 
 from ambassador import Config, IR
 from ambassador.config.resourcefetcher import ResourceFetcher
@@ -177,8 +188,8 @@ class Service:
 
 yaml_stream = sys.stdin
 
-if len(sys.argv) > 1:
-    yaml_stream = open(sys.argv[1], "r")
+if args:
+    yaml_stream = open(args[0], "r")
 
 aconf = Config()
 fetcher = ResourceFetcher(logger, aconf)

--- a/ambassador/watch_hook.py
+++ b/ambassador/watch_hook.py
@@ -215,13 +215,21 @@ logger.debug(f'contexts: {len(contexts)}')
 consul_watches = []
 kube_watches = []
 
+global_resolver = fake.ambassador_module.get('resolver', None)
+
 for mname, mapping in mappings.items():
     res_name = mapping.get('resolver', None)
+    res_source = 'mapping'
+
+    if not res_name:
+        res_name = global_resolver
+        res_source = 'defaults'
+
     ctx_name = mapping.get('tls', None)
 
-    if res_name:
-        logger.debug(f'Mapping {mname}: resolver {res_name}, service {mapping.service}, tls {ctx_name}')
+    logger.debug(f'Mapping {mname}: resolver {res_name} from {res_source}, service {mapping.service}, tls {ctx_name}')
 
+    if res_name:
         resolver = resolvers.get(res_name, None)
         logger.debug(f'-> resolver {resolver}')
 


### PR DESCRIPTION
`watt` has the ability to use filters to watch only endpoints and secrets that we think we need to pay attention to. This PR leans heavily on that ability to try to only reconfigure Ambassador when it's necessary.

(Note that there's some pretty ugly code in here that we'll need to clean up later.)
