### PR TITLE
Add configuration option to enable HTTP/1.0 support

### DIFF
--- a/ambassador/ambassador/envoy/v2/v2listener.py
+++ b/ambassador/ambassador/envoy/v2/v2listener.py
@@ -104,7 +104,7 @@ def v2filter_buffer(buffer: IRBuffer, v2config: 'V2Config'):
         'name': 'envoy.buffer',
         'config': {
             "max_request_bytes": buffer.max_request_bytes
-        }  
+        }
     }
 
 @v2filter.when("ir.grpc_http1_bridge")
@@ -148,7 +148,7 @@ def v2filter_authv0(auth: IRAuth, v2config: 'V2Config'):
 
     assert auth.cluster
     cluster = typecast(IRCluster, auth.cluster)
-    
+
     assert auth.api_version == "ambassador/v0"
 
     # This preserves almost exactly the same logic prior to ambassador/v1 implementation.
@@ -167,8 +167,8 @@ def v2filter_authv0(auth: IRAuth, v2config: 'V2Config'):
 
     for key in sorted(hdrs):
         allowed_authorization_headers.append({"exact": key})
-    
-    allowed_request_headers = []  
+
+    allowed_request_headers = []
 
     for key in sorted(request_headers.keys()):
         allowed_request_headers.append({"exact": key})
@@ -228,7 +228,7 @@ def v2filter_authv1(auth: IRAuth, v2config: 'V2Config'):
 
         for key in list(set(auth.allowed_authorization_headers).union(AllowedAuthorizationHeaders)):
             allowed_authorization_headers.append({"exact": key})
-    
+
         allowed_request_headers = []
 
         for key in list(set(auth.allowed_request_headers).union(AllowedRequestHeaders)):
@@ -510,6 +510,9 @@ class V2Listener(dict):
 
         if 'server_name' in config.ir.ambassador_module:
             base_http_config["server_name"] = config.ir.ambassador_module.server_name
+
+        if 'enable_http10' in config.ir.ambassador_module:
+            base_http_config["http_protocol_options"] = { 'accept_http_10': config.ir.ambassador_module.enable_http10 }
 
         if config.ir.tracing:
             base_http_config["generate_request_id"] = True

--- a/ambassador/ambassador/ir/ir.py
+++ b/ambassador/ambassador/ir/ir.py
@@ -160,7 +160,7 @@ class IR:
 
         # After the Ambassador and TLS modules are done, we need to set up the
         # filter chains, which requires checking in on the auth, and
-        # ratelimit configuration. Note that order of the filters matter.        
+        # ratelimit configuration. Note that order of the filters matter.
         self.save_filter(IRAuth(self, aconf))
 
         # ...note that ratelimit is a filter too...
@@ -519,7 +519,7 @@ class IR:
         for key in [ 'diagnostics', 'liveness_probe', 'readiness_probe', 'statsd' ]:
             od[key] = self.ambassador_module.get(key, {}).get('enabled', False)
 
-        for key in [ 'use_proxy_proto', 'use_remote_address', 'x_forwarded_proto_redirect' ]:
+        for key in [ 'use_proxy_proto', 'use_remote_address', 'x_forwarded_proto_redirect', 'enable_http10' ]:
             od[key] = self.ambassador_module.get(key, False)
 
         od['xff_num_trusted_hops'] = self.ambassador_module.get('xff_num_trusted_hops', 0)

--- a/ambassador/ambassador/ir/irambassador.py
+++ b/ambassador/ambassador/ir/irambassador.py
@@ -80,13 +80,13 @@ class IRAmbassador (IRResource):
             readiness_probe={"enabled": True},
             diagnostics={"enabled": True},
             use_proxy_proto=False,
+            enable_http10=False,
             use_remote_address=use_remote_address,
             x_forwarded_proto_redirect=False,
             load_balancer=None,
             circuit_breakers=None,
             xff_num_trusted_hops=0,
             server_name="envoy",
-            enable_http10=False
             **kwargs
         )
 

--- a/ambassador/ambassador/ir/irambassador.py
+++ b/ambassador/ambassador/ir/irambassador.py
@@ -37,7 +37,8 @@ class IRAmbassador (IRResource):
         'use_proxy_proto',
         'use_remote_address',
         'x_forwarded_proto_redirect',
-        'xff_num_trusted_hops'
+        'xff_num_trusted_hops',
+        'enable_http10'
     ]
 
     service_port: int
@@ -85,6 +86,7 @@ class IRAmbassador (IRResource):
             circuit_breakers=None,
             xff_num_trusted_hops=0,
             server_name="envoy",
+            enable_http10=False
             **kwargs
         )
 
@@ -210,7 +212,7 @@ class IRAmbassador (IRResource):
                                                config=dict())
             self.grpc_http11_bridge.sourced_by(amod)
             ir.save_filter(self.grpc_http11_bridge)
-            
+
         if amod and ('enable_grpc_web' in amod):
             self.grpc_web = IRFilter(ir=ir, aconf=aconf, kind='ir.grpc_web', name='grpc_web', config=dict())
             self.grpc_web.sourced_by(amod)

--- a/docs/reference/core/ambassador.md
+++ b/docs/reference/core/ambassador.md
@@ -174,7 +174,7 @@ gRPC-Web is a protocol built on gRPC that extends the benefits of gRPC to the br
 
 ### HTTP/1.0 support (`enable_http10`)
 
-Enabled/disable handling of incoming HTTP/1.0 and HTTP 0.9 requests.
+Enable/disable handling of incoming HTTP/1.0 and HTTP 0.9 requests.
 
 ### `enable_ivp4` and `enable_ipv6`
 

--- a/docs/reference/core/ambassador.md
+++ b/docs/reference/core/ambassador.md
@@ -36,6 +36,9 @@ config:
 # Should we enable the grpc-Web protocol?
 # enable_grpc_web: false
 
+# Should we enable http/1.0 protocol?
+# enable_http10: false
+
 # Should we do IPv4 DNS lookups when contacting services? Defaults to true,
 # but can be overridden in a [`Mapping`](/reference/mappings).
 # enable_ipv4: true
@@ -75,11 +78,11 @@ config:
 # use_proxy_proto: false
 
 # use_remote_address controls whether Envoy will trust the remote
-# address of incoming connections or rely exclusively on the 
-# X-Forwarded_For header. 
+# address of incoming connections or rely exclusively on the
+# X-Forwarded_For header.
 # use_remote_address: true
 
-# xff_num_trusted_hops controls the how Envoy sets the trusted 
+# xff_num_trusted_hops controls the how Envoy sets the trusted
 # client IP address of a request. If you have a proxy in front
 # of Ambassador, Envoy will set the trusted client IP to the
 # address of that proxy. To preserve the orginal client IP address,
@@ -90,7 +93,7 @@ config:
 
 # Ambassador lets through only the HTTP requests with
 # `X-FORWARDED-PROTO: https` header set, and redirects all the other
-# requests to HTTPS if this field is set to true. Note that `use_remote_address` 
+# requests to HTTPS if this field is set to true. Note that `use_remote_address`
 # must be set to false for this feature to work as expected.
 # x_forwarded_proto_redirect: false
 
@@ -111,7 +114,7 @@ config:
 #   ...
 
 
-# Set default CORS configuration for all mappings in the cluster. See 
+# Set default CORS configuration for all mappings in the cluster. See
 # CORS syntax at https://www.getambassador.io/reference/cors.html
 # cors:
 #   origins: http://foo.example,http://bar.example
@@ -169,6 +172,10 @@ Ambassador supports bridging HTTP/1.1 clients to backend gRPC servers. When an H
 
 gRPC-Web is a protocol built on gRPC that extends the benefits of gRPC to the browser. The gRPC-Web specification requires a server-side proxy to translate between gRPC-Web requests and gRPC backend services. Ambassador can serve as the service-side proxy for gRPC-Web when `enable_grpc_web: true` is set.
 
+### HTTP/1.0 support (`enable_http10`)
+
+Enabled/disable handling of incoming HTTP/1.0 and HTTP 0.9 requests.
+
 ### `enable_ivp4` and `enable_ipv6`
 
 If both IPv4 and IPv6 are enabled, Ambassador will prefer IPv6. This can have strange effects if Ambassador receives
@@ -204,7 +211,7 @@ Many load balancers can use the [PROXY protocol](https://www.haproxy.org/downloa
 
 ### `xff_num_trusted_hops`
 
-The value of `xff_num_trusted_hops` indicates the number of trusted proxies in front of Ambassador. The default setting is 0 which tells Envoy to use the immediate downstream connection's IP address as the trusted client address. The trusted client address is used to populate the `remote_address` field used for rate limiting and can affect which IP address Envoy will set as `X-Envoy-External-Address`. 
+The value of `xff_num_trusted_hops` indicates the number of trusted proxies in front of Ambassador. The default setting is 0 which tells Envoy to use the immediate downstream connection's IP address as the trusted client address. The trusted client address is used to populate the `remote_address` field used for rate limiting and can affect which IP address Envoy will set as `X-Envoy-External-Address`.
 
 `xff_num_trusted_hops` behavior is determined by the value of `use_remote_address` (which defaults to `true` in Ambassador).
 


### PR DESCRIPTION
## Description

Envoy supports HTTP/1.0 (https://www.envoyproxy.io/docs/envoy/latest/api-v2/api/v2/core/protocol.proto#envoy-api-msg-core-http1protocoloptions). 

This PR exposes a configuration option via Ambassador module to enable/disable support.

## Testing

With enable_http10 not set or set to false:

```
› curl --insecure -vvv --http1.0 https://localhost:8443
* Rebuilt URL to: https://localhost:8443/
*   Trying ::1...
* TCP_NODELAY set
* Connected to localhost (::1) port 8443 (#0)
* ALPN, offering http/1.1
* Cipher selection: ALL:!EXPORT:!EXPORT40:!EXPORT56:!aNULL:!LOW:!RC4:@STRENGTH
* successfully set certificate verify locations:
*   CAfile: /etc/ssl/cert.pem
  CApath: none
* TLSv1.2 (OUT), TLS handshake, Client hello (1):
* TLSv1.2 (IN), TLS handshake, Server hello (2):
* TLSv1.2 (IN), TLS handshake, Certificate (11):
* TLSv1.2 (IN), TLS handshake, Server key exchange (12):
* TLSv1.2 (IN), TLS handshake, Server finished (14):
* TLSv1.2 (OUT), TLS handshake, Client key exchange (16):
* TLSv1.2 (OUT), TLS change cipher, Client hello (1):
* TLSv1.2 (OUT), TLS handshake, Finished (20):
* TLSv1.2 (IN), TLS change cipher, Client hello (1):
* TLSv1.2 (IN), TLS handshake, Finished (20):
* SSL connection using TLSv1.2 / ECDHE-RSA-CHACHA20-POLY1305
* ALPN, server accepted to use http/1.1
* Server certificate:
*  subject: C=US; ST=Oregon; L=beaverton; CN=localhost; emailAddress=xxxx
*  start date: Apr  2 22:31:09 2019 GMT
*  expire date: May  2 22:31:09 2019 GMT
*  issuer: C=US; ST=Oregon; L=beaverton; CN=localhost; emailAddress=xxxx
*  SSL certificate verify result: self signed certificate (18), continuing anyway.
> GET / HTTP/1.0
> Host: localhost:8443
> User-Agent: curl/7.54.0
> Accept: */*
>
< HTTP/1.1 426 Upgrade Required
< date: Tue, 30 Apr 2019 22:49:24 GMT
< server: envoy
< content-length: 0
<
* Connection #0 to host localhost left intact
```

With enable_http10 set to true:

```
› curl --insecure -vvv --http1.0 https://localhost:8443
* Rebuilt URL to: https://localhost:8443/
*   Trying ::1...
* TCP_NODELAY set
* Connected to localhost (::1) port 8443 (#0)
* ALPN, offering http/1.1
* Cipher selection: ALL:!EXPORT:!EXPORT40:!EXPORT56:!aNULL:!LOW:!RC4:@STRENGTH
* successfully set certificate verify locations:
*   CAfile: /etc/ssl/cert.pem
  CApath: none
* TLSv1.2 (OUT), TLS handshake, Client hello (1):
* TLSv1.2 (IN), TLS handshake, Server hello (2):
* TLSv1.2 (IN), TLS handshake, Certificate (11):
* TLSv1.2 (IN), TLS handshake, Server key exchange (12):
* TLSv1.2 (IN), TLS handshake, Server finished (14):
* TLSv1.2 (OUT), TLS handshake, Client key exchange (16):
* TLSv1.2 (OUT), TLS change cipher, Client hello (1):
* TLSv1.2 (OUT), TLS handshake, Finished (20):
* TLSv1.2 (IN), TLS change cipher, Client hello (1):
* TLSv1.2 (IN), TLS handshake, Finished (20):
* SSL connection using TLSv1.2 / ECDHE-RSA-CHACHA20-POLY1305
* ALPN, server accepted to use http/1.1
* Server certificate:
*  subject: C=US; ST=Oregon; L=beaverton; CN=localhost; emailAddress=xxxx
*  start date: Apr  2 22:31:09 2019 GMT
*  expire date: May  2 22:31:09 2019 GMT
*  issuer: C=US; ST=Oregon; L=beaverton; CN=localhost; emailAddress=xxxx
*  SSL certificate verify result: self signed certificate (18), continuing anyway.
> GET / HTTP/1.0
> Host: localhost:8443
> User-Agent: curl/7.54.0
> Accept: */*
>
* HTTP 1.0, assume close after body
< HTTP/1.0 404 Not Found
< date: Tue, 30 Apr 2019 22:50:29 GMT
< server: envoy
< connection: close
< content-length: 0
<
* Closing connection 0
* TLSv1.2 (OUT), TLS alert, Client hello (1):
```

## Todos
- [X] Tests
- [X] Documentation

