### PR TITLE
Do not deadlock on check_scout after observing an invalid envoy configuration

### DIFF
--- a/ambassador/ambassador_diag/diagd.py
+++ b/ambassador/ambassador_diag/diagd.py
@@ -726,7 +726,8 @@ class AmbassadorEventWatcher(threading.Thread):
 
         if not self.validate_envoy_config(config=ads_config):
             self.logger.info("no updates were performed due to invalid envoy configuration, continuing with current configuration...")
-            app.check_scout("attempted bad update")
+            # Don't use app.check_scout; it will deadlock.
+            self.check_scout("attempted bad update")
             self._respond(rqueue, 500, 'ignoring: invalid Envoy configuration in snapshot %s' % snapshot)
             return
 


### PR DESCRIPTION
## Description
Fixes an `app.check_scout` call to `self.check_scout` to avoid deadlocks on invalid envoy configuration.

## Related Issues
https://github.com/datawire/ambassador/issues/1491

## Testing
Manually tested by generating an invalid envoy configuration and observing that scout code gets called, instead of stopping just before the deadlock line of code.
