### PR TITLE
Add grpc=true when tracing driver is LightStep

### DIFF
--- a/ambassador/ambassador/ir/irtracing.py
+++ b/ambassador/ambassador/ir/irtracing.py
@@ -60,11 +60,16 @@ class IRTracing (IRResource):
             self.post_error(RichStatus.fromError("driver field is required in TracingService"))
             return False
 
+        grpc = False
+        if driver == "lightstep":
+            grpc = True
+
         # OK, we have a valid config.
         self.sourced_by(config)
 
         self.service = service
         self.driver = driver
+        self.grpc = grpc
         self.cluster = None
         self.driver_config = config.get("config", {})
         self.tag_headers = config.get('tag_headers', [])
@@ -85,7 +90,8 @@ class IRTracing (IRResource):
                 location=self.location,
                 service=self.service,
                 host_rewrite=self.get('host_rewrite', None),
-                marker='tracing'
+                marker='tracing',
+                grpc=self.grpc
             )
         )
 
@@ -97,4 +103,5 @@ class IRTracing (IRResource):
 
     def finalize(self):
         self.ir.logger.info("tracing cluster name: %s" % self.cluster.name)
+        self.ir.logger.info("tracing grpc: %s" % self.grpc)
         self.driver_config['collector_cluster'] = self.cluster.name

--- a/ambassador/ambassador/ir/irtracing.py
+++ b/ambassador/ambassador/ir/irtracing.py
@@ -103,5 +103,4 @@ class IRTracing (IRResource):
 
     def finalize(self):
         self.ir.logger.info("tracing cluster name: %s" % self.cluster.name)
-        self.ir.logger.info("tracing grpc: %s" % self.grpc)
         self.driver_config['collector_cluster'] = self.cluster.name

--- a/ambassador/schemas/v1/TracingService.schema
+++ b/ambassador/schemas/v1/TracingService.schema
@@ -20,6 +20,7 @@
             "type": "object",
             "properties": {
                 "access_token_file": { "type": "string" },
+                "collector_cluster": { "type": "string" },
                 "collector_endpoint": { "type": "string" },
                 "trace_id_128bit": { "type": "boolean" },
                 "shared_span_context": { "type": "boolean" }


### PR DESCRIPTION
## Description
LightStep tracing was recently broken due to the tracing cluster not being set to `grpc=true` (the LS tracer in Envoy uses grpc), this PR adds this setting so that the envoy.json renders correctly. The LS specific setting `collector_cluster` was also not in the Tracing.schema file.

## Related Issues
https://github.com/datawire/ambassador/issues/1189

## Testing
Tested manually with both LightStep SaaS and locally hosted collectors, process and kubernetes yamls can be found here:
https://github.com/sbaum1994/ambassador-lightstep-tracing-testing

## Todos
- [ ] Tests
- [ ] Documentation

## Other
* If this is a documentation change, please open the pull request at https://github.com/datawire/ambassador-docs instead.
* Code changes should occur against `master`.
