### PR TITLE
Small tweaks to watt, teleproxy, and tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -157,7 +157,7 @@ KAT_BACKEND_RELEASE = 1.4.0
 
 # Allow overriding which watt we use.
 WATT ?= watt
-WATT_VERSION ?= 0.4.7
+WATT_VERSION ?= 0.4.9
 
 # "make" by itself doesn't make the website. It takes too long and it doesn't
 # belong in the inner dev loop.
@@ -354,7 +354,7 @@ ambassador/ambassador/VERSION.py:
 version: ambassador/ambassador/VERSION.py
 
 TELEPROXY=venv/bin/teleproxy
-TELEPROXY_VERSION=0.4.6
+TELEPROXY_VERSION=0.4.9
 
 # This should maybe be replaced with a lighterweight dependency if we
 # don't currently depend on go

--- a/kat/kat/manifests.py
+++ b/kat/kat/manifests.py
@@ -312,13 +312,13 @@ spec:
       httpGet:
         path: /ambassador/v0/check_alive
         port: 8877
-      initialDelaySeconds: 120
+      initialDelaySeconds: 30
       periodSeconds: 3
     readinessProbe:
       httpGet:
         path: /ambassador/v0/check_ready
         port: 8877
-      initialDelaySeconds: 120
+      initialDelaySeconds: 30
       periodSeconds: 3
   restartPolicy: Always
 """


### PR DESCRIPTION
- Bump `watt` to version 0.4.9
- Bump `teleproxy` to version 0.4.9
- Drop the initial delays for Kube health checks from 120s to 30s

I raised the delays awhile ago while we were wrestling performance issues, but now they mostly force even a manual test run to take at least two minutes, even if you're only running one test.
