### PR TITLE
Update all uses of Jinja2 to 2.10.1 to clear security alert.

### DIFF
--- a/ambassador/requirements.txt
+++ b/ambassador/requirements.txt
@@ -2,7 +2,7 @@ requests==2.20.1
 clize==4.0.3
 flask==1.0.2
 gunicorn==19.9.0
-jinja2==2.10
+jinja2==2.10.1
 jsonschema==2.6.0
 jwt==0.5.4
 scout.py==0.5.0

--- a/unused-e2e/auth-service/requirements.txt
+++ b/unused-e2e/auth-service/requirements.txt
@@ -1,6 +1,6 @@
 clize==4.0.1
 flask==1.0.2
-jinja2==2.9.6
+jinja2==2.10.1
 jsonschema==2.6.0
 pyyaml==5.1
 scout.py==0.3.0

--- a/unused-e2e/demo-service/requirements.txt
+++ b/unused-e2e/demo-service/requirements.txt
@@ -1,6 +1,6 @@
 clize==4.0.1
 flask==1.0.2
-jinja2==2.9.6
+jinja2==2.10.1
 jsonschema==2.6.0
 pyyaml==5.1
 scout.py==0.3.0

--- a/unused-e2e/demo-test/requirements.txt
+++ b/unused-e2e/demo-test/requirements.txt
@@ -1,6 +1,6 @@
 clize==4.0.1
 flask==1.0.2
-jinja2==2.9.6
+jinja2==2.10.1
 jsonschema==2.6.0
 pyyaml==5.1
 scout.py==0.3.0

--- a/unused-e2e/shadow-service/requirements.txt
+++ b/unused-e2e/shadow-service/requirements.txt
@@ -1,6 +1,6 @@
 clize==4.0.1
 flask==1.0.2
-jinja2==2.9.6
+jinja2==2.10.1
 jsonschema==2.6.0
 pyyaml==5.1
 scout.py==0.3.0

--- a/unused-e2e/stats-test-service/requirements.txt
+++ b/unused-e2e/stats-test-service/requirements.txt
@@ -1,6 +1,6 @@
 clize==4.0.1
 flask==1.0.2
-jinja2==2.9.6
+jinja2==2.10.1
 jsonschema==2.6.0
 pyyaml==5.1
 scout.py==0.3.0


### PR DESCRIPTION
We actually need to delete some of these entirely, but let's get the alert cleared anyway.