### PR TITLE
Loosen the constraints on the weighted shadow test.

### DIFF
--- a/ambassador/tests/t_shadow.py
+++ b/ambassador/tests/t_shadow.py
@@ -162,4 +162,9 @@ service: shadow.plain-namespace
 
                     weighted_total += value
 
-                assert abs(weighted_total - 50) <= 5, f'weighted buckets should have 50 total calls, got {weighted_total}'
+                # 20% margin of error is kind of absurd, but
+                #
+                # - small sample sizes kind of suck, and
+                # - we actually don't need to test Envoy's ability to generate random numbers, so meh.
+                
+                assert abs(weighted_total - 50) <= 10, f'weighted buckets should have 50 total calls, got {weighted_total}'


### PR DESCRIPTION
Giving this test a 10% margin is just not enough. We need to be testing that shadowing is happening, and that it's not at 100%, but we don't need to test Envoy's sampling ability, really.