### PR TITLE
remove_request_headers feature

### DIFF
--- a/ambassador/ambassador/envoy/v2/v2route.py
+++ b/ambassador/ambassador/envoy/v2/v2route.py
@@ -58,8 +58,11 @@ class V2Route(dict):
         if response_headers_to_add:
             self['response_headers_to_add'] = self.generate_headers_to_add(response_headers_to_add)
 
-        response_headers_to_remove = group.get('remove_response_headers', None)
+        request_headers_to_remove = group.get('remove_request_headers', None)
+        if request_headers_to_remove:
+            self['request_headers_to_remove'] = request_headers_to_remove
 
+        response_headers_to_remove = group.get('remove_response_headers', None)
         if response_headers_to_remove:
             self['response_headers_to_remove'] = response_headers_to_remove
 

--- a/ambassador/ambassador/ir/irhttpmapping.py
+++ b/ambassador/ambassador/ir/irhttpmapping.py
@@ -80,6 +80,7 @@ class IRHTTPMapping (IRBaseMapping):
         "priority": True,
         "rate_limits": True,   # Only supported in v0, handled in setup
         "remove_response_headers": True,
+        "remove_request_headers": True,
         "resolver": True,
         # Do not include regex_headers.
         # Do not include rewrite.

--- a/ambassador/schemas/v1/Mapping.schema
+++ b/ambassador/schemas/v1/Mapping.schema
@@ -90,6 +90,12 @@
         "path_redirect": { "type": "string" },
         "priority": { "type": "string" },
         "precedence": { "type": "integer" },
+        "remove_request_headers": {
+            "anyOf": [
+                { "type": "string" },
+                { "type": "array", "items": { "type": "string" } }
+            ]
+        },
         "remove_response_headers": {
             "anyOf": [
                 { "type": "string" },

--- a/ambassador/tests/t_mappingtests.py
+++ b/ambassador/tests/t_mappingtests.py
@@ -377,6 +377,6 @@ remove_request_headers:
         for r in self.results:
             print(r.json)
             if 'headers' in r.json:
-            assert r.json['headers']['Foo'] == 'FooF'
-            assert 'Zoo' in r.json['headers']
-            assert 'Aoo' in r.json['headers']
+                assert r.json['headers']['Foo'] == 'FooF'
+                assert 'Zoo' in r.json['headers']
+                assert 'Aoo' in r.json['headers']

--- a/ambassador/tests/t_mappingtests.py
+++ b/ambassador/tests/t_mappingtests.py
@@ -343,3 +343,39 @@ add_response_headers:
                 assert r.headers['Zoo'] == ['Zoo', 'ZooZ']
                 assert r.headers['Test'] == ['Test', 'boo']
                 assert r.headers['Foo'] == ['Foo']
+
+class RemoveReqHeadersMapping(MappingTest):
+    parent: AmbassadorTest
+    target: ServiceType
+
+    @classmethod
+    def variants(cls):
+        for st in variants(ServiceType):
+            yield cls(st, name="{self.target.name}")
+
+    def config(self):
+        yield self, self.format("""
+---
+apiVersion: ambassador/v1
+kind:  Mapping
+name:  {self.name}
+prefix: /{self.name}/
+service: http://httpbin.org
+remove_request_headers:
+- zoo
+- aoo
+""")
+
+    def queries(self):
+        yield Query(self.parent.url(self.name + "/headers"), headers={
+            "zoo": "ZooZ",
+            "aoo": "AooA",
+            "foo": "FooF"
+        })
+
+    def check(self):
+        for r in self.results:
+            print(r.json)
+            assert r.json['headers']['Foo'] == 'FooF'
+            assert r.json['headers']['Zoo'] == None
+            assert r.json['headers']['Aoo'] == None

--- a/ambassador/tests/t_mappingtests.py
+++ b/ambassador/tests/t_mappingtests.py
@@ -376,6 +376,7 @@ remove_request_headers:
     def check(self):
         for r in self.results:
             print(r.json)
+            if 'headers' in r.json:
             assert r.json['headers']['Foo'] == 'FooF'
-            assert r.json['headers']['Zoo'] == None
-            assert r.json['headers']['Aoo'] == None
+            assert 'Zoo' in r.json['headers']
+            assert 'Aoo' in r.json['headers']

--- a/ambassador/tests/t_mappingtests.py
+++ b/ambassador/tests/t_mappingtests.py
@@ -378,5 +378,5 @@ remove_request_headers:
             print(r.json)
             if 'headers' in r.json:
                 assert r.json['headers']['Foo'] == 'FooF'
-                assert 'Zoo' in r.json['headers']
-                assert 'Aoo' in r.json['headers']
+                assert 'Zoo' not in r.json['headers']
+                assert 'Aoo' not in r.json['headers']

--- a/docs/reference/mappings.md
+++ b/docs/reference/mappings.md
@@ -38,7 +38,7 @@ Ambassador supports a number of attributes to configure and customize mappings.
 | `method_regex`            | if true, tells the system to interpret the `method` as a [regular expression](http://en.cppreference.com/w/cpp/regex/ecmascript) |
 | `prefix_regex`            | if true, tells the system to interpret the `prefix` as a [regular expression](http://en.cppreference.com/w/cpp/regex/ecmascript) |
 | [`rate_limits`](/reference/rate-limits) | specifies a list rate limit rules on a mapping |
-| [`remove_response_headers`](/reference/remove_response_headers) | specifies a list of HTTP headers that are dropped from the response before sending to client |  
+| [`remove_response_headers`](/reference/remove_response_headers) | specifies a list of HTTP headers that are dropped from the response before sending to client || [`remove_request_headers`](/reference/remove_request_headers) | specifies a list of HTTP headers that are dropped from the request before sending to upstream |    
 | [`regex_headers`](/reference/headers)           | specifies a list of HTTP headers and [regular expressions](http://en.cppreference.com/w/cpp/regex/ecmascript) which _must_ match for this mapping to be used to route the request |
 | [`rewrite`](/reference/rewrites)      | replaces the URL prefix with when talking to the service |
 | [`retry_policy`](/reference/retries) | performs automatic retries upon request failures |

--- a/docs/reference/remove_request_headers.md
+++ b/docs/reference/remove_request_headers.md
@@ -1,0 +1,22 @@
+# Remove request headers
+
+Ambassador can remove a list of HTTP headers that would be sent to the upstream from request.
+
+## The `remove_request_headers` annotation
+
+The `remove_request_headers` attribute takes a list of keys used to match to the header
+
+## A basic example
+
+```yaml
+---
+apiVersion: ambassador/v1
+kind:  Mapping
+name:  qotm_mapping
+prefix: /qotm/
+remove_request_headers:
+- authorization
+service: qotm
+```
+
+will drop header with key `authorization`.

--- a/docs/reference/remove_request_headers.md
+++ b/docs/reference/remove_request_headers.md
@@ -1,6 +1,6 @@
 # Remove request headers
 
-Ambassador can remove a list of HTTP headers that would be sent to the upstream from request.
+Ambassador can remove a list of HTTP headers that would be sent to the upstream from the request.
 
 ## The `remove_request_headers` annotation
 


### PR DESCRIPTION
## Description
Feature to support removing request headers before going upstream


## Testing
Added test cases which tests the scenario

## Todos
- [ ] Tests
- [ ] Documentation

## Other
* If this is a documentation change, please open the pull request at https://github.com/datawire/ambassador-docs instead.
* Code changes should occur against `master`.
