### PR TITLE
Support reading idle_timeout_ms on the Ambassador module

### DIFF
--- a/ambassador/ambassador/envoy/v2/v2route.py
+++ b/ambassador/ambassador/envoy/v2/v2route.py
@@ -91,10 +91,10 @@ class V2Route(dict):
                 }
             }
 
-            idle_timeout_ms = group.get('idle_timeout_ms', None)
-
-            if idle_timeout_ms is not None:
-                route['idle_timeout'] = "%0.3fs" % (idle_timeout_ms / 1000.0)
+            if 'idle_timeout_ms' in group:
+                route['idle_timeout'] = "%0.3fs" % (group['idle_timeout_ms']/ 1000.0)
+            elif 'idle_timeout_ms' in config.ir.ambassador_module:
+                route['idle_timeout'] = "%0.3fs" % (config.ir.ambassador_module['idle_timeout_ms'] / 1000.0)
 
             if group.get('rewrite', None):
                 route['prefix_rewrite'] = group['rewrite']


### PR DESCRIPTION
## Description
Allow an operator to set a default idle_timeout_ms on the Ambassador module that applies to all Mappings, except for those with an explicit override.

## Related Issues
-
## Testing
Tested manually, works for my use case so far.

## Todos
- [ ] Tests
- [ ] Documentation
