### PR TITLE
Strip the old "reconfiguration timing" stuff

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -407,7 +407,7 @@ ambassador/ambassador/VERSION.py:
 version: ambassador/ambassador/VERSION.py
 
 TELEPROXY=venv/bin/teleproxy
-TELEPROXY_VERSION=0.4.9
+TELEPROXY_VERSION=0.4.11
 
 # This should maybe be replaced with a lighterweight dependency if we
 # don't currently depend on go

--- a/ambassador/entrypoint.sh
+++ b/ambassador/entrypoint.sh
@@ -93,8 +93,6 @@ fi
 mkdir -p "${SNAPSHOT_DIR}"
 mkdir -p "${ENVOY_DIR}"
 
-DELAY=${AMBASSADOR_RESTART_TIME:-1}
-
 APPDIR=${APPDIR:-"$AMBASSADOR_ROOT"}
 
 # If we don't set PYTHON_EGG_CACHE explicitly, /.cache is set by default, which fails when running as a non-privileged

--- a/docs/reference/running.md
+++ b/docs/reference/running.md
@@ -170,18 +170,6 @@ If no `AMBASSADOR_ID` is assigned to an Ambassador, it will use the ID `default`
 
 By default, Ambassador will verify the TLS certificates provided by the Kubernetes API. In some situations, the cluster may be deployed with self-signed certificates. In this case, set `AMBASSADOR_VERIFY_SSL_FALSE` to `true` to disable verifying the TLS certificates.
 
-## Reconfiguration Timing Configuration
-
-Ambassador is constantly watching for changes to the service annotations. When changes are observed, Ambassador generates a new Envoy configuration and restarts the Envoy handling the heavy lifting of routing. Three environment variables provide control over the timing of this reconfiguration:
-
-- `AMBASSADOR_RESTART_TIME` (default 15) sets the minimum number of seconds between restarts. No matter how often services are changed, Ambassador will never restart Envoy more frequently than this.
-
-- `AMBASSADOR_DRAIN_TIME` (default 5) sets the number of seconds that the Envoy will wait for open connections to drain on a restart. Connections still open at the end of this time will be summarily dropped.
-
-- `AMBASSADOR_SHUTDOWN_TIME` (default 10) sets the number of seconds that Ambassador will wait for the old Envoy to clean up and exit on a restart. **If Envoy is not able to shut down in this time, the Ambassador pod will exit.** If this happens, it is generally indicative of issues with restarts being attempted too often.
-
-These environment variables can be set much like `AMBASSADOR_NAMESPACE`, above.
-
 ## Configuration From the Filesystem
 
 If desired, Ambassador can be configured from YAML files in the directory `$AMBASSADOR_CONFIG_BASE_DIR/ambassador-config` (by default, `/ambassador/ambassador-config`, which is empty in the images built by Datawire). You could volume mount an external configuration directory here, for example, or use a custom Dockerfile to build configuration directly into a Docker image.


### PR DESCRIPTION
This is from the days of hot restart (wow) and has no relevance to the ADS world.

There's one small code change in here, as well as the doc change, so I'm making it against `master`.