### PR TITLE
Clean up Ambassador's port usage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -407,7 +407,7 @@ ambassador/ambassador/VERSION.py:
 version: ambassador/ambassador/VERSION.py
 
 TELEPROXY=venv/bin/teleproxy
-TELEPROXY_VERSION=0.4.9
+TELEPROXY_VERSION=0.4.11
 
 # This should maybe be replaced with a lighterweight dependency if we
 # don't currently depend on go

--- a/ambassador/README.md
+++ b/ambassador/README.md
@@ -8,6 +8,31 @@ Ambassador sits between users and an Envoy. The primary job that an Ambassador d
 
 ```Ambassador config => IR => Envoy config```
 
+### Ambassador Components and Ports
+
+Ambassador comprises several different components:
+
+| Component                 | Type   | Function.                 |
+| :------------------------ | :----  | :------------------------ |
+| `diagd`                   | Python | Increasingly-misnamed core of the system; manages changing configurations and provides the diagnostics UI |
+| `ambex`                   | Go     | Envoy `go-control-plane` implementation; supplies Envoy with current configuration |
+| `watt`                    | Go     | Service/secret discovery; interface to Kubernetes and Consul |
+| `envoy`                   | C++    | The actual proxy process |
+| `kubewatch.py`            | Python | Used only to determine the cluster's installation ID; needs to be subsumed by `watt` |
+
+`diagd`, `ambex`, `watt`, and `envoy` are all long-running daemons. If any of them exit, the pod as a whole will exit.
+
+Ambassador uses several TCP ports while running. All but one of them are in the range 8000-8499, and any future assignments for Ambassador ports should come from this range.
+
+| Port | Process | Function |
+| :--- | :------ | :------- |
+| 8001 | `envoy` | Internal stats, logging, etc.; not exposed outside pod |
+| 8002 | `watt`  | Internal `watt` snapshot access; not exposed outside pod |
+| 8003 | `ambex` | Internal `ambex` snapshot access; not exposed outside pod |
+| 8080 | `envoy` | Default HTTP service port |
+| 8443 | `envoy` | Default HTTPS service port |
+| 8877 | `diagd` | Direct access to diagnostics UI |
+
 ### The Ambassador Configuration
 
 An Ambassador configuration is a collection of _Ambassador configuration resources_, which are represented by subclasses of `ambassador.config.ACResource`. The configuration as a whole is represented by an `ambassador.Config` object.

--- a/ambassador/ambassador/envoy/v2/v2bootstrap.py
+++ b/ambassador/ambassador/envoy/v2/v2bootstrap.py
@@ -40,7 +40,7 @@ class V2Bootstrap(dict):
             "hosts": [ {
                 "socket_address": {
                     "address": "127.0.0.1",
-                    "port_value": 18000
+                    "port_value": 8003
                 }
             } ],
             "http2_protocol_options": {},

--- a/ambassador/entrypoint.sh
+++ b/ambassador/entrypoint.sh
@@ -182,7 +182,7 @@ mkdir -p "${ENVOY_DIR}"
 
 if [ -z "${DIAGD_ONLY}" ]; then
     echo "AMBASSADOR: starting ads"
-    ambex "${ENVOY_DIR}" &
+    ambex -ads 8003 "${ENVOY_DIR}" &
     AMBEX_PID="$!"
     pids="${pids:+${pids} }${AMBEX_PID}:ambex"
 else
@@ -239,7 +239,7 @@ if [ -z "${AMBASSADOR_NO_KUBEWATCH}" ]; then
 #    fi
 
     set -x
-    /ambassador/watt ${KUBEWATCH_NAMESPACE_ARG} --notify "$KUBEWATCH_SYNC_CMD" $KUBEWATCH_SYNC_KINDS --watch "$WATCH_HOOK" &
+    /ambassador/watt ${KUBEWATCH_NAMESPACE_ARG} --port 8002 --notify "$KUBEWATCH_SYNC_CMD" $KUBEWATCH_SYNC_KINDS --watch "$WATCH_HOOK" &
     set +x
     pids="${pids:+${pids} }$!:watt"
 fi

--- a/docs/reference/running.md
+++ b/docs/reference/running.md
@@ -196,6 +196,10 @@ Ambassador and Ambassador Pro support more verbose debugging levels. If using Am
 
 If using Ambassador Pro, you can adjust the log level by setting the `APP_LOG_LEVEL` environment variable; from least verbose to most verbose, the valid values are `error`, `warn`/`warning`, `info`, `debug`, and `trace`; the default is `info`.
 
+## Port Assignments
+
+Ambassador uses some TCP ports in the range 8000-8499 internally, as well as port 8877. Third-party software integrating with Ambassador should not use ports in this range on the Ambassador pod.
+
 ## Ambassador Update Checks (Scout)
 
 Ambassador integrates Scout, a service that periodically checks with Datawire servers to advise of available updates. Scout also sends anonymized usage data and the Ambassador version. This information is important to us as we prioritize test coverage, bug fixes, and feature development. Note that Ambassador will run regardless of the status of Scout (i.e., our uptime has zero impact on your uptime.)


### PR DESCRIPTION
Ambassador OSS is claiming ports from 8000-8499, plus 8877. (Ambassador Pro is taking 8500-8999, except for 8877).

Document this, and move `ambex` and `watt`'s listen ports into that range.

Fixes #1526 
Fixes #1527 
