### PR TITLE
CRD support for Ambassador

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -159,7 +159,7 @@ KAT_BACKEND_RELEASE = 1.4.1
 
 # Allow overriding which watt we use.
 WATT ?= watt
-WATT_VERSION ?= 0.4.10
+WATT_VERSION ?= 0.4.12
 
 # "make" by itself doesn't make the website. It takes too long and it doesn't
 # belong in the inner dev loop.

--- a/ambassador/entrypoint.sh
+++ b/ambassador/entrypoint.sh
@@ -232,7 +232,7 @@ if [ -z "${AMBASSADOR_NO_KUBEWATCH}" ]; then
         KUBEWATCH_NAMESPACE_ARG="--namespace $AMBASSADOR_NAMESPACE"
     fi
 
-    KUBEWATCH_SYNC_KINDS="-s service"
+    KUBEWATCH_SYNC_KINDS="-s service -s AuthService -s Mapping -s Module -s RateLimitService -s TCPMapping -s TLSContext -s TracingService"
 
 #    if [ -n "$AMBASSADOR_NO_SECRETS" ]; then
 #        KUBEWATCH_SYNC_KINDS="-s service"

--- a/ambassador/tests/t_lua_scripts.py
+++ b/ambassador/tests/t_lua_scripts.py
@@ -8,31 +8,30 @@ class LuaTest(AmbassadorTest):
     def init(self):
         self.target = HTTP()
 
-    def config(self):
-        # Use self here, not self.target, so that the Ambassador module is
-        # be annotated on the Ambassador itself.
-        yield self, self.format("""
+    def manifests(self) -> str:
+        return super().manifests() + self.format('''
 ---
-apiVersion: ambassador/v1
+apiVersion: getambassador.io/v1
 kind: Module
-name: ambassador
-config:
-  lua_scripts: |
-    function envoy_on_response(response_handle)
-      response_handle:headers():add("Lua-Scripts-Enabled", "Processed")
-    end
-""")
-
-        # Use self.target _here_, because we want the mapping to be annotated
-        # on the service, not the Ambassador.
-        yield self.target, self.format("""
+metadata:
+  name: ambassador
+spec:
+  ambassador_id: {self.ambassador_id}
+  config:
+    lua_scripts: |
+      function envoy_on_response(response_handle)
+        response_handle: headers():add("Lua-Scripts-Enabled", "Processed")
+      end
 ---
-apiVersion: ambassador/v1
-kind:  Mapping
-name:  lua-target-mapping
-prefix: /target/
-service: {self.target.path.fqdn}
-""")
+apiVersion: getambassador.io/v1
+kind: Mapping
+metadata:
+  name: lua-target-mapping
+spec:
+  ambassador_id: {self.ambassador_id}
+  prefix: /target/
+  service: {self.target.path.fqdn}
+''')
 
     def queries(self):
         yield Query(self.url("target/"))

--- a/docs/reference/core/crds.md
+++ b/docs/reference/core/crds.md
@@ -1,0 +1,182 @@
+# Using CRDs with Ambassador
+
+As of Ambassador 0.70, any Ambassador resource can be expressed as a CRD in the `getambassador.io` API group:
+
+- use `apiVersion: getambassador.io/v1`
+- use the same `kind` as you would in an annotation
+- put the resource name in `metadata.name`
+- put everything else in `spec`
+
+As an example, you could use the following CRDs for a very simple Lua test:
+
+```yaml
+---
+apiVersion: getambassador.io/v1
+kind: Module
+metadata:
+  name: ambassador
+  namespace: default
+spec:
+  config:
+    lua_scripts: |
+      function envoy_on_response(response_handle)
+        response_handle: headers():add("Lua-Scripts-Enabled", "Processed")
+      end
+---
+apiVersion: getambassador.io/v1
+kind: Mapping
+metadata:
+  name: lua-target-mapping
+  namespace: default
+spec:
+  prefix: /target/
+  service: luatest-http
+```
+
+(Note that the `namespace` must be declared in the `metadata`, but if needed, `ambassador_id` must be declared in the `spec`.)
+
+## CRDs supported by Ambassador
+
+The full set of CRDs supported by Ambassador in 0.70.0:
+
+| `Kind` | Kubernetes singular | Kubernetes plural |
+| :----- | :------------------ | :---------------- |
+| `AuthService` | `authservice` | `authservices` |
+| `Mapping` | `mapping` | `mappings` |
+| `Module` | `module` | `modules` |
+| `RateLimitService` | `ratelimitservice` | `ratelimitservices` |
+| `TCPMapping` | `tcpmapping` | `tcpmappings` |
+| `TLSContext` | `tlscontext` | `tlscontexts` |
+| `TracingService` | `tracingservice` | `tracingservices` |
+
+So, for example, if you're using CRDs then 
+
+```kubectl get mappings```
+
+should show all your `Mapping` CRDs.
+
+## Creating the CRD types within Kubernetes
+
+Before using the CRD types, you must add them to the Kubernetes API server. This is most easily done with the following YAML:
+
+```yaml
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: authservices.getambassador.io
+spec:
+  group: getambassador.io
+  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true
+  scope: Namespaced
+  names:
+    plural: authservices
+    singular: authservice
+    kind: AuthService
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: mappings.getambassador.io
+spec:
+  group: getambassador.io
+  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true
+  scope: Namespaced
+  names:
+    plural: mappings
+    singular: mapping
+    kind: Mapping
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: modules.getambassador.io
+spec:
+  group: getambassador.io
+  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true
+  scope: Namespaced
+  names:
+    plural: modules
+    singular: module
+    kind: Module
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: ratelimitservices.getambassador.io
+spec:
+  group: getambassador.io
+  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true
+  scope: Namespaced
+  names:
+    plural: ratelimitservices
+    singular: ratelimitservice
+    kind: RateLimitService
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: tcpmappings.getambassador.io
+spec:
+  group: getambassador.io
+  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true
+  scope: Namespaced
+  names:
+    plural: tcpmappings
+    singular: tcpmapping
+    kind: TCPMapping
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: tlscontexts.getambassador.io
+spec:
+  group: getambassador.io
+  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true
+  scope: Namespaced
+  names:
+    plural: tlscontexts
+    singular: tlscontext
+    kind: TLSContext
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: tracingservices.getambassador.io
+spec:
+  group: getambassador.io
+  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true
+  scope: Namespaced
+  names:
+    plural: tracingservices
+    singular: tracingservice
+    kind: TracingService
+```

--- a/docs/reference/core/crds.md
+++ b/docs/reference/core/crds.md
@@ -55,9 +55,22 @@ So, for example, if you're using CRDs then
 
 should show all your `Mapping` CRDs.
 
+## CRDs and RBAC
+
+You will need to grant your Kubernetes service appropriate RBAC permissions to use CRDs. The default Ambassador RBAC examples have been updated, but the appropriate rules are
+
+```yaml
+rules:
+- apiGroups: [""]
+  resources: [ "endpoints", "namespaces", "secrets", "services" ]
+  verbs: ["get", "list", "watch"]
+- apiGroups: [ "getambassador.io" ]
+  verbs: ["get", "list", "watch"]
+```
+
 ## Creating the CRD types within Kubernetes
 
-Before using the CRD types, you must add them to the Kubernetes API server. This is most easily done with the following YAML:
+Before using the CRD types, you must add them to the Kubernetes API server. This is most easily done with the following YAML (which you can find in `docs/yaml/ambassador-crds.yaml`)
 
 ```yaml
 ---

--- a/docs/yaml/ambassador/ambassador-crds.yaml
+++ b/docs/yaml/ambassador/ambassador-crds.yaml
@@ -1,0 +1,119 @@
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: authservices.getambassador.io
+spec:
+  group: getambassador.io
+  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true
+  scope: Namespaced
+  names:
+    plural: authservices
+    singular: authservice
+    kind: AuthService
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: mappings.getambassador.io
+spec:
+  group: getambassador.io
+  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true
+  scope: Namespaced
+  names:
+    plural: mappings
+    singular: mapping
+    kind: Mapping
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: modules.getambassador.io
+spec:
+  group: getambassador.io
+  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true
+  scope: Namespaced
+  names:
+    plural: modules
+    singular: module
+    kind: Module
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: ratelimitservices.getambassador.io
+spec:
+  group: getambassador.io
+  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true
+  scope: Namespaced
+  names:
+    plural: ratelimitservices
+    singular: ratelimitservice
+    kind: RateLimitService
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: tcpmappings.getambassador.io
+spec:
+  group: getambassador.io
+  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true
+  scope: Namespaced
+  names:
+    plural: tcpmappings
+    singular: tcpmapping
+    kind: TCPMapping
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: tlscontexts.getambassador.io
+spec:
+  group: getambassador.io
+  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true
+  scope: Namespaced
+  names:
+    plural: tlscontexts
+    singular: tlscontext
+    kind: TLSContext
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: tracingservices.getambassador.io
+spec:
+  group: getambassador.io
+  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true
+  scope: Namespaced
+  names:
+    plural: tracingservices
+    singular: tracingservice
+    kind: TracingService

--- a/docs/yaml/ambassador/ambassador-rbac-prometheus.yaml
+++ b/docs/yaml/ambassador/ambassador-rbac-prometheus.yaml
@@ -18,18 +18,11 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
   name: ambassador
-rules:
 - apiGroups: [""]
-  resources:
-  - services
+  resources: [ "endpoints", "namespaces", "secrets", "services" ]
   verbs: ["get", "list", "watch"]
-- apiGroups: [""]
-  resources:
-  - configmaps
-  verbs: ["create", "update", "patch", "get", "list", "watch"]
-- apiGroups: [""]
-  resources:
-  - secrets
+- apiGroups: [ "getambassador.io" ]
+  resources: [ "*" ]
   verbs: ["get", "list", "watch"]
 ---
 apiVersion: v1

--- a/docs/yaml/ambassador/ambassador-rbac.yaml
+++ b/docs/yaml/ambassador/ambassador-rbac.yaml
@@ -19,12 +19,12 @@ kind: ClusterRole
 metadata:
   name: ambassador
 rules:
+rules:
 - apiGroups: [""]
-  resources:
-  - namespaces
-  - services
-  - secrets
-  - endpoints
+  resources: [ "endpoints", "namespaces", "secrets", "services" ]
+  verbs: ["get", "list", "watch"]
+- apiGroups: [ "getambassador.io" ]
+  resources: [ "*" ]
   verbs: ["get", "list", "watch"]
 ---
 apiVersion: v1

--- a/kat/kat/harness.py
+++ b/kat/kat/harness.py
@@ -2,6 +2,7 @@ import sys
 
 from abc import ABC
 from collections import OrderedDict
+from hashlib import sha256
 from typing import Any, Callable, Dict, List, Sequence, Tuple, Type, Union
 
 import base64
@@ -27,6 +28,49 @@ def run(cmd):
     status = os.system(cmd)
     if status != 0:
         raise RuntimeError("command failed[%s]: %s" % (status, cmd))
+
+
+def get_digest(data: str) -> str:
+    s = sha256()
+    s.update(data.encode('utf-8'))
+    return s.hexdigest()
+
+
+def has_changed(data: str, path: str) -> Tuple[bool, str]:
+    cur_size = len(data.strip()) if data else 0
+    cur_hash = get_digest(data)
+
+    print(f'has_changed: data size {cur_size} - {cur_hash}')
+
+    prev_data = None
+    changed = True
+    reason = f'no {path} present'
+
+    if os.path.exists(path):
+        with open(path) as f:
+            prev_data = f.read()
+
+    prev_size = len(prev_data.strip()) if prev_data else 0
+    prev_hash = None
+
+    if prev_data:
+        prev_hash = get_digest(prev_data)
+
+    print(f'has_changed: prev_data size {prev_size} - {prev_hash}')
+
+    if data:
+        if data != prev_data:
+            reason = f'different data in {path}'
+        else:
+            changed = False
+            reason = f'same data in {path}'
+
+        if changed:
+            print(f'has_changed: updating {path}')
+            with open(path, "w") as f:
+                f.write(data)
+
+    return (changed, reason)
 
 
 COUNTERS: Dict[Type, int] = {}
@@ -834,35 +878,24 @@ class Runner:
 
     def _setup_k8s(self, selected):
         # First up: CRDs.
-        fname = "/tmp/k8s-CRDs.yaml"
-        prev_yaml = None
+        changed, reason = has_changed(CRDS, "/tmp/k8s-CRDs.yaml")
 
-        if os.path.exists(fname):
-            with open(fname) as f:
-                prev_yaml = f.read()
+        if changed:
+            print(f'CRDS changed ({reason}), applying.')
+            run(f'kubectl apply -f /tmp/k8s-CRDs.yaml')
 
-        yaml = CRDS
+            tries_left = 10
 
-        if yaml.strip():
-            if yaml != prev_yaml:
-                print("CRDS changed, applying.")
-                with open(fname, "w") as f:
-                    f.write(yaml)
+            while os.system('kubectl get crd mappings.getambassador.io > /dev/null 2>&1') != 0:
+                tries_left -= 1
 
-                run(f'kubectl apply -f {fname}')
+                if tries_left <= 0:
+                    raise RuntimeError("CRDs never became available")
 
-                tries_left = 10
-
-                while os.system('kubectl get crd mappings.getambassador.io > /dev/null 2>&1') != 0:
-                    tries_left -= 1
-
-                    if tries_left <= 0:
-                        raise RuntimeError("CRDs never became available")
-
-                    print("sleeping for CRDs... (%d)" % tries_left)
-                    time.sleep(5)
-            else:
-                print("CRDS unchanged, skipping apply.")
+                print("sleeping for CRDs... (%d)" % tries_left)
+                time.sleep(5)
+        else:
+            print(f'CRDS unchanged {reason}, skipping apply.')
 
         manifests = self.get_manifests(selected)
 
@@ -924,22 +957,18 @@ class Runner:
 
         fname = "/tmp/k8s-%s.yaml" % self.scope
 
-        if os.path.exists(fname):
-            with open(fname) as f:
-                prev_yaml = f.read()
-        else:
-            prev_yaml = None
+        self.applied_manifests = False
 
-        if yaml.strip() and (yaml != prev_yaml or DOCTEST):
-            print("Manifests changed, applying.")
-            with open(fname, "w") as f:
-                f.write(yaml)
+        changed, reason = has_changed(yaml, fname)
+
+        if changed:
+            print(f'Manifests changed ({reason}), applying.')
+
             # XXX: better prune selector label
             run("kubectl apply --prune -l scope=%s -f %s" % (self.scope, fname))
             self.applied_manifests = True
-        elif yaml.strip():
-            self.applied_manifests = False
-            print("Manifests unchanged, skipping apply.")
+        else:
+            print(f'Manifests unchanged ({reason}), applying.')
 
         for n in self.nodes:
             if n in selected:

--- a/kat/kat/manifests.py
+++ b/kat/kat/manifests.py
@@ -342,12 +342,10 @@ metadata:
   name: {self.path.k8s}
 rules:
 - apiGroups: [""]
-  resources:
-  - configmaps
-  - services
-  - secrets
-  - namespaces
-  - endpoints
+  resources: [ "configmaps", "services", "secrets", "namespaces", "endpoints" ]
+  verbs: ["get", "list", "watch"]
+- apiGroups: [ "getambassador.io" ]
+  resources: [ "*" ]
   verbs: ["get", "list", "watch"]
 ---
 apiVersion: v1

--- a/kat/kat/manifests.py
+++ b/kat/kat/manifests.py
@@ -178,6 +178,128 @@ spec:
       value: grpc_echo
 """
 
+CRDS = """
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: authservices.getambassador.io
+spec:
+  group: getambassador.io
+  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true
+  scope: Namespaced
+  names:
+    plural: authservices
+    singular: authservice
+    kind: AuthService
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: mappings.getambassador.io
+spec:
+  group: getambassador.io
+  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true
+  scope: Namespaced
+  names:
+    plural: mappings
+    singular: mapping
+    kind: Mapping
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: modules.getambassador.io
+spec:
+  group: getambassador.io
+  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true
+  scope: Namespaced
+  names:
+    plural: modules
+    singular: module
+    kind: Module
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: ratelimitservices.getambassador.io
+spec:
+  group: getambassador.io
+  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true
+  scope: Namespaced
+  names:
+    plural: ratelimitservices
+    singular: ratelimitservice
+    kind: RateLimitService
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: tcpmappings.getambassador.io
+spec:
+  group: getambassador.io
+  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true
+  scope: Namespaced
+  names:
+    plural: tcpmappings
+    singular: tcpmapping
+    kind: TCPMapping
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: tlscontexts.getambassador.io
+spec:
+  group: getambassador.io
+  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true
+  scope: Namespaced
+  names:
+    plural: tlscontexts
+    singular: tlscontext
+    kind: TLSContext
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: tracingservices.getambassador.io
+spec:
+  group: getambassador.io
+  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true
+  scope: Namespaced
+  names:
+    plural: tracingservices
+    singular: tracingservice
+    kind: TracingService
+"""
+
 RBAC_CLUSTER_SCOPE = """
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
@@ -186,12 +308,10 @@ metadata:
   name: {self.path.k8s}
 rules:
 - apiGroups: [""]
-  resources:
-  - configmaps
-  - services
-  - secrets
-  - namespaces
-  - endpoints
+  resources: [ "configmaps", "services", "secrets", "namespaces", "endpoints" ]
+  verbs: ["get", "list", "watch"]
+- apiGroups: [ "getambassador.io" ]
+  resources: [ "*" ]
   verbs: ["get", "list", "watch"]
 ---
 apiVersion: v1


### PR DESCRIPTION
This change supports using CRDs to configure Ambassador, as follows:

- Ambassador CRDs live in the `getambassador.io` API group and use the `getambassador.io/v1` API version.
- We support all the same `kind`s as the existing Ambassador resources.
- `name` and `namespace` are (of course) set in the CRD `metadata`.
- *Everything else* (including `ambassador_id` goes into the CRD `spec`.

The full supported set:

| `kind` | Kubernetes singular | Kubernetes plural |
| :----- | :------------------ | :---------------- |
| `AuthService` | `authservice` | `authservices` |
| `Mapping` | `mapping` | `mappings` |
| `Module` | `module` | `modules` |
| `RateLimitService` | `ratelimitservice` | `ratelimitservices` |
| `TCPMapping` | `tcpmapping` | `tcpmappings` |
| `TLSContext` | `tlscontext` | `tlscontexts` |
| `TracingService` | `tracingservice` | `tracingservices` |

The Lua test (in `ambassador/tests/t_lua_scripts.py`) has been converted to use CRDs for configuration. The YAML for creating the CRD types themselves is currently in `docs/ambassador/ambassador-crds.yaml` (or in `kat/kat/manifests.py`). The example Ambassador RBAC rules have been updated. Whew.