### PR TITLE
Redirect path should not be set when client want to redirect to the path from the original request

### DIFF
--- a/ambassador/ambassador/envoy/v2/v2listener.py
+++ b/ambassador/ambassador/envoy/v2/v2listener.py
@@ -435,18 +435,17 @@ class V2Listener(dict):
         self.filter_chains: List[dict] = []
 
         self.upgrade_configs: Optional[List[dict]] = None
-
-        if listener.get('path_redirect'):
-            self.routes: List[dict] = [ {
+        self.routes: List[dict] = [ {
                 'match': {
                     'prefix': '/',
                 },
                 'redirect': {
                     'https_redirect': True,
-                    'path_redirect': listener.get('path_redirect')
+                    'path_redirect': '/'
                 }
-            } ]
-        else:
+            } ]    
+
+        if listener.redirect_listener:
             self.routes: List[dict] = [ {
                 'match': {
                     'prefix': '/',
@@ -455,8 +454,6 @@ class V2Listener(dict):
                     'https_redirect': True
                 }
             } ]
-
-        if listener.redirect_listener:
             self.http_filters = [{'name': 'envoy.router'}]
         else:
             # Use the actual listener name & port number

--- a/ambassador/ambassador/envoy/v2/v2listener.py
+++ b/ambassador/ambassador/envoy/v2/v2listener.py
@@ -441,8 +441,7 @@ class V2Listener(dict):
                 'prefix': '/',
             },
             'redirect': {
-                'https_redirect': True,
-                'path_redirect': '/'
+                'https_redirect': True
             }
         } ]
 

--- a/ambassador/ambassador/envoy/v2/v2listener.py
+++ b/ambassador/ambassador/envoy/v2/v2listener.py
@@ -436,7 +436,7 @@ class V2Listener(dict):
 
         self.upgrade_configs: Optional[List[dict]] = None
 
-        if listener.get('path_redirect') is not None:
+        if listener.get('path_redirect'):
             self.routes: List[dict] = [ {
                 'match': {
                     'prefix': '/',

--- a/ambassador/ambassador/envoy/v2/v2listener.py
+++ b/ambassador/ambassador/envoy/v2/v2listener.py
@@ -432,21 +432,11 @@ class V2Listener(dict):
 
         self.http_filters: List[dict] = []
         self.listener_filters: List[dict] = []
-        self.filter_chains: List[dict] = []
+        self.filter_chains: List[dict] = []    
 
         self.upgrade_configs: Optional[List[dict]] = None
-        self.routes: List[dict] = [ {
-                'match': {
-                    'prefix': '/',
-                },
-                'redirect': {
-                    'https_redirect': True,
-                    'path_redirect': '/'
-                }
-            } ]    
 
-        if listener.redirect_listener:
-            self.routes: List[dict] = [ {
+        self.routes: List[dict] = [ {
                 'match': {
                     'prefix': '/',
                 },
@@ -454,6 +444,8 @@ class V2Listener(dict):
                     'https_redirect': True
                 }
             } ]
+
+        if listener.redirect_listener:
             self.http_filters = [{'name': 'envoy.router'}]
         else:
             # Use the actual listener name & port number

--- a/ambassador/ambassador/envoy/v2/v2listener.py
+++ b/ambassador/ambassador/envoy/v2/v2listener.py
@@ -436,14 +436,25 @@ class V2Listener(dict):
 
         self.upgrade_configs: Optional[List[dict]] = None
 
-        self.routes: List[dict] = [ {
-            'match': {
-                'prefix': '/',
-            },
-            'redirect': {
-                'https_redirect': True
-            }
-        } ]
+        if listener.get('path_redirect') is not None:
+            self.routes: List[dict] = [ {
+                'match': {
+                    'prefix': '/',
+                },
+                'redirect': {
+                    'https_redirect': True,
+                    'path_redirect': listener.get('path_redirect')
+                }
+            } ]
+        else:
+            self.routes: List[dict] = [ {
+                'match': {
+                    'prefix': '/',
+                },
+                'redirect': {
+                    'https_redirect': True
+                }
+            } ]
 
         if listener.redirect_listener:
             self.http_filters = [{'name': 'envoy.router'}]

--- a/ambassador/ambassador/envoy/v2/v2listener.py
+++ b/ambassador/ambassador/envoy/v2/v2listener.py
@@ -432,7 +432,7 @@ class V2Listener(dict):
 
         self.http_filters: List[dict] = []
         self.listener_filters: List[dict] = []
-        self.filter_chains: List[dict] = []    
+        self.filter_chains: List[dict] = []
 
         self.upgrade_configs: Optional[List[dict]] = None
 

--- a/ambassador/ambassador/ir/irlistener.py
+++ b/ambassador/ambassador/ir/irlistener.py
@@ -118,9 +118,6 @@ class ListenerFactory:
 
             if 'server_name' in amod:
                 new_listener.server_name = amod.server_name
-            
-            if 'path_redirect' in amod:
-                new_listener.path_redirect = amod.path_redirect
 
             ir.add_listener(new_listener)
 

--- a/ambassador/ambassador/ir/irlistener.py
+++ b/ambassador/ambassador/ir/irlistener.py
@@ -118,6 +118,9 @@ class ListenerFactory:
 
             if 'server_name' in amod:
                 new_listener.server_name = amod.server_name
+            
+            if 'path_redirect' in amod:
+                new_listener.path_redirect = amod.path_redirect
 
             ir.add_listener(new_listener)
 

--- a/ambassador/tests/t_redirect.py
+++ b/ambassador/tests/t_redirect.py
@@ -61,6 +61,7 @@ config:
     enabled: True
     secret: redirect-cert
     redirect_cleartext_from: 8080
+    path_redirect: /
 """)
 
         yield self.target, self.format("""

--- a/ambassador/tests/t_redirect.py
+++ b/ambassador/tests/t_redirect.py
@@ -61,7 +61,6 @@ config:
     enabled: True
     secret: redirect-cert
     redirect_cleartext_from: 8080
-    path_redirect: /
 """)
 
         yield self.target, self.format("""

--- a/ambassador/tests/t_redirect.py
+++ b/ambassador/tests/t_redirect.py
@@ -81,6 +81,9 @@ service: {self.target.path.fqdn}
                              scheme="https"),
                     insecure=True,
                     phase=2)
+        
+        # [2]
+        yield Query(self.parent.url("http://%s" % self.name + "/target/"), expected=301)
 
     def check(self):
         # We don't have to check anything about query 0, the "expected" clause is enough.
@@ -90,6 +93,9 @@ service: {self.target.path.fqdn}
         errors = self.results[1].json
         assert(len(errors) == 0)
 
+        assert self.results[2].headers['Location'] == [
+            self.format("http://%s" % self.name + "/target/")
+        ]
 
 class RedirectTestsWithProxyProto(AmbassadorTest):
 

--- a/ambassador/tests/t_redirect.py
+++ b/ambassador/tests/t_redirect.py
@@ -14,7 +14,6 @@ from abstract_tests import ServiceType, TLSRedirect
 # what I wanted here. Sigh.
 
 class RedirectTests(AmbassadorTest):
-
     target: ServiceType
 
     def init(self):
@@ -91,9 +90,6 @@ service: {self.target.path.fqdn}
         # XXX Ew. If self.results[1].json is empty, the harness won't convert it to a response.
         errors = self.results[1].json
         assert(len(errors) == 0)
-
-        
-
 
 class RedirectTestsWithProxyProto(AmbassadorTest):
 


### PR DESCRIPTION
## Description
This PR adds logic to removed `redirect_path` from v2listener when `redirect_cleartext` is configured. Previously, `redirect_path` had a hardcoded value `/` which was causing problems for clients to redirect to the path from the original request.

## Related Issues
https://github.com/datawire/ambassador/issues/1463