### PR TITLE
Fix grab-snapshots for 0.70+

### DIFF
--- a/ambassador/grab-snapshots.py
+++ b/ambassador/grab-snapshots.py
@@ -30,6 +30,9 @@ def sanitize_snapshot(path: str):
 		ksorted = {}
 
 		for key, value in kube_elements.items():
+			if not value:
+				continue
+
 			if key == 'secret':
 				for secret in value:
 					if "data" in secret:


### PR DESCRIPTION
Let grab-snapshots work in the face of Kubernetes keys with empty values (which are likely with CRDs).
