### PR TITLE
Specify that statsd-exporter should use port 8125 rather than the default (9125)

### DIFF
--- a/statsd-sink/prometheus/prom-statsd-sink.yaml
+++ b/statsd-sink/prometheus/prom-statsd-sink.yaml
@@ -16,6 +16,8 @@ spec:
       containers:
       - name: statsd-sink
         image: prom/statsd-exporter:v0.8.1
+        args:
+        - --statsd.listen-udp=":8125"
         resources: {}
       restartPolicy: Always
 status: {}


### PR DESCRIPTION
## Description

By default, `prom/statsd-exporter` [uses port `:9125`](https://github.com/prometheus/statsd_exporter/tree/v0.8.1#building-and-running) as its `statsd` ingest port whereas the ambassador example configuration assumes that it is `8125`.

I have modified the example to specify port 8125 using the `--statsd.listen-udp` command-line flag. The other option is to specify a `targetPort` value of `9125` on the `Service`, but I opted for this route as it is adaptable to a sidecar-based deployment of the exporter. Please let me know if the `targetPort` on the service is more desirable.

## Testing
I have deployed this configuration within our own production cluster and metrics are exported properly where they were not without this change.
