### PR TITLE
adding /metrics endpoint to ambassador diag svc, reverse proxying to …

### DIFF
--- a/ambassador/ambassador/diagnostics/envoy_stats.py
+++ b/ambassador/ambassador/diagnostics/envoy_stats.py
@@ -182,6 +182,19 @@ class EnvoyStats (object):
 
         # logging.info("loginfo: %s" % self.loginfo)
         return True
+
+    def get_prometheus_state(self):
+        try:
+            r = requests.get("http://127.0.0.1:8001/stats/prometheus")
+        except OSError as e:
+            logging.warning("EnvoyStats.get_prometheus_state failed: %s" % e)
+            return
+
+        if r.status_code != 200:
+            logging.warning("EnvoyStats.get_prometheus_state failed: %s" % r.text)
+            return
+        else:
+            return r.text
         
     def update_envoy_stats(self, last_attempt):
         # logging.info("updating stats")

--- a/ambassador/ambassador_diag/diagd.py
+++ b/ambassador/ambassador_diag/diagd.py
@@ -542,6 +542,11 @@ def source_lookup(name, sources):
     return source.get('_source', name)
 
 
+@app.route('/metrics', methods=['GET'])
+@standard_handler
+def get_prometheus_metrics(*args, **kwargs):
+    return app.estats.get_prometheus_state()
+
 class AmbassadorEventWatcher(threading.Thread):
     def __init__(self, app: DiagApp) -> None:
         super().__init__(name="AmbassadorEventWatcher", daemon=True)


### PR DESCRIPTION
…envoy /stats/prometheus

## Description
Adding /metrics endpoint on the diag service that reverse proxies to envoy /stats/admin. This is intended to make it easier to expose envoy stats to prometheus, essentially deprecating the current statsd-exporter setup which is cumbersome to configure. 

## Related Issues
https://github.com/datawire/ambassador/issues/989

## Testing
`PrometheusTest` makes 1000 calls then asserts that the metric is available vs /metrics.

## Todos
- [V ] Tests
- [ ] Documentation

## Other
* If this is a documentation change, please open the pull request at https://github.com/datawire/ambassador-docs instead.
* Code changes should occur against `master`.
