### PR TITLE
Resolver tweaks (CRDs, diagnostics)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -485,6 +485,13 @@ ifeq ($(USE_KUBERNAUT), true)
 	$(KUBERNAUT_DISCARD)
 	$(KUBERNAUT_CLAIM)
 	cp ~/.kube/$(CLAIM_NAME).yaml cluster.yaml
+else
+ifneq ($(USE_KUBERNAUT),)
+ifneq ($(USE_KUBERNAUT),false)
+	@echo "USE_KUBERNAUT must be true, false, or unset" >&2
+	false
+endif
+endif
 endif
 
 setup-test: cluster-and-teleproxy

--- a/ambassador/ambassador/config/resourcefetcher.py
+++ b/ambassador/ambassador/config/resourcefetcher.py
@@ -150,7 +150,9 @@ class ResourceFetcher:
                     self.handle_k8s(obj)
 
             # ...then handle Ambassador CRDs.
-            for key in [ 'AuthService', 'Mapping', 'Module', 'RateLimitService',
+            for key in [ 'AuthService', 'ConsulResolver',
+                         'KubernetesEndpointResolver', 'KubernetesServiceResolver',
+                         'Mapping', 'Module', 'RateLimitService',
                          'TCPMapping', 'TLSContext', 'TracingService']:
                 for obj in watt_k8s.get(key) or []:
                     self.handle_k8s_crd(obj)

--- a/ambassador/ambassador/diagnostics/diagnostics.py
+++ b/ambassador/ambassador/diagnostics/diagnostics.py
@@ -470,9 +470,17 @@ class Diagnostics:
             self.add_ambassador_service(self.ir.tracing, 'TracingService (%s)' % self.ir.tracing.driver)
 
         self.ambassador_resolvers = []
+        used_resolvers = {}
+
+        for group in self.groups.values():
+            for mapping in group.mappings:
+                resolver_name = mapping.resolver
+                group_list = used_resolvers.setdefault(resolver_name, [])
+                group_list.append(group)
 
         for name, resolver in sorted(self.ir.resolvers.items()):
-            self.add_ambassador_resolver(resolver)
+            if name in used_resolvers:
+                self.add_ambassador_resolver(resolver, used_resolvers[name])
 
     def add_ambassador_service(self, svc, type_name) -> None:
         """
@@ -496,17 +504,19 @@ class Diagnostics:
                 '_service_weight': svc_weight
             })
 
-    def add_ambassador_resolver(self, resolver) -> None:
+    def add_ambassador_resolver(self, resolver, group_list) -> None:
         """
         Remember information about a given Ambassador-wide resolver.
 
         :param resolver: resolver record
+        :param group_list: list of groups that use this resolver
         """
 
         self.ambassador_resolvers.append({
             'kind': resolver.kind,
             '_source': resolver.location,
-            'name': resolver.name
+            'name': resolver.name,
+            'groups': group_list
         })
 
     @staticmethod

--- a/ambassador/entrypoint.sh
+++ b/ambassador/entrypoint.sh
@@ -184,7 +184,7 @@ fi
 if [[ -z "${AMBASSADOR_NO_KUBEWATCH}" ]]; then
     KUBEWATCH_SYNC_KINDS="-s service"
     if [ ! -f .ambassador_ignore_crds ]; then
-        KUBEWATCH_SYNC_KINDS="$KUBEWATCH_SYNC_KINDS -s AuthService -s Mapping -s Module -s RateLimitService -s TCPMapping -s TLSContext -s TracingService"
+        KUBEWATCH_SYNC_KINDS="$KUBEWATCH_SYNC_KINDS -s AuthService -s ConsulResolver -s KubernetesEndpointResolver -s KubernetesServiceResolver -s Mapping -s Module -s RateLimitService -s TCPMapping -s TLSContext -s TracingService"
     fi
 
     launch /ambassador/watt \

--- a/ambassador/tests/t_consul.py
+++ b/ambassador/tests/t_consul.py
@@ -54,6 +54,15 @@ spec:
   - name: consul
     image: consul:1.4.3
   restartPolicy: Always
+---
+apiVersion: getambassador.io/v1
+kind: ConsulResolver
+metadata:
+  name: {self.path.k8s}-resolver
+spec:
+  ambassador_id: consultest
+  address: {self.path.k8s}-consul:8500
+  datacenter: dc1
 """ + SECRETS)
 
     def config(self):
@@ -82,12 +91,6 @@ service: {self.path.k8s}-consul-service
 resolver: {self.path.k8s}-resolver
 load_balancer:
   policy: round_robin
----
-apiVersion: ambassador/v1
-kind: ConsulResolver
-name: {self.path.k8s}-resolver
-address: {self.path.k8s}-consul:8500
-datacenter: dc1
 ---
 apiVersion: ambassador/v1
 kind:  TLSContext

--- a/docs/reference/core/crds.md
+++ b/docs/reference/core/crds.md
@@ -42,6 +42,9 @@ The full set of CRDs supported by Ambassador in 0.70.0:
 | `Kind` | Kubernetes singular | Kubernetes plural |
 | :----- | :------------------ | :---------------- |
 | `AuthService` | `authservice` | `authservices` |
+| `ConsulResolver` | `consulresolver` | `consulresolvers` |
+| `KubernetesEndpointResolver` | `kubernetesendpointresolver` | `kubernetesendpointresolvers` |
+| `KubernetesServiceResolver` | `kubernetesserviceresolver` | `kubernetesserviceresolvers` |
 | `Mapping` | `mapping` | `mappings` |
 | `Module` | `module` | `modules` |
 | `RateLimitService` | `ratelimitservice` | `ratelimitservices` |
@@ -91,6 +94,57 @@ spec:
     plural: authservices
     singular: authservice
     kind: AuthService
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: consulresolvers.getambassador.io
+spec:
+  group: getambassador.io
+  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true
+  scope: Namespaced
+  names:
+    plural: consulresolvers
+    singular: consulresolver
+    kind: ConsulResolver
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: kubernetesendpointresolvers.getambassador.io
+spec:
+  group: getambassador.io
+  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true
+  scope: Namespaced
+  names:
+    plural: kubernetesendpointresolvers
+    singular: kubernetesendpointresolver
+    kind: KubernetesEndpointResolver
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: kubernetesserviceresolvers.getambassador.io
+spec:
+  group: getambassador.io
+  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true
+  scope: Namespaced
+  names:
+    plural: kubernetesserviceresolvers
+    singular: kubernetesserviceresolver  
+    kind: KubernetesServiceResolver
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition

--- a/docs/yaml/ambassador/ambassador-crds.yaml
+++ b/docs/yaml/ambassador/ambassador-crds.yaml
@@ -19,6 +19,57 @@ spec:
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
+  name: consulresolvers.getambassador.io
+spec:
+  group: getambassador.io
+  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true
+  scope: Namespaced
+  names:
+    plural: consulresolvers
+    singular: consulresolver
+    kind: ConsulResolver
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: kubernetesendpointresolvers.getambassador.io
+spec:
+  group: getambassador.io
+  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true
+  scope: Namespaced
+  names:
+    plural: kubernetesendpointresolvers
+    singular: kubernetesendpointresolver
+    kind: KubernetesEndpointResolver
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: kubernetesserviceresolvers.getambassador.io
+spec:
+  group: getambassador.io
+  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true
+  scope: Namespaced
+  names:
+    plural: kubernetesserviceresolvers
+    singular: kubernetesserviceresolver
+    kind: KubernetesServiceResolver
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
   name: mappings.getambassador.io
 spec:
   group: getambassador.io

--- a/kat/kat/manifests.py
+++ b/kat/kat/manifests.py
@@ -205,6 +205,57 @@ spec:
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
+  name: consulresolvers.getambassador.io
+spec:
+  group: getambassador.io
+  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true
+  scope: Namespaced
+  names:
+    plural: consulresolvers
+    singular: consulresolver
+    kind: ConsulResolver
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: kubernetesendpointresolvers.getambassador.io
+spec:
+  group: getambassador.io
+  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true
+  scope: Namespaced
+  names:
+    plural: kubernetesendpointresolvers
+    singular: kubernetesendpointresolver
+    kind: KubernetesEndpointResolver
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: kubernetesserviceresolvers.getambassador.io
+spec:
+  group: getambassador.io
+  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true
+  scope: Namespaced
+  names:
+    plural: kubernetesserviceresolvers
+    singular: kubernetesserviceresolver
+    kind: KubernetesServiceResolver
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
   name: mappings.getambassador.io
 spec:
   group: getambassador.io


### PR DESCRIPTION
- Have CRDs for `ConsulResolver`, `KubernetesEndpointResolver`, and `KubernetesServiceResolver`.
- Switch the `ConsulTest` to use the `ConsulResolver` CRD.
- Only show resolvers that are actually being used in the diagnostics service.
