### PR TITLE
Fix grammar in configuration docs

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -2,13 +2,13 @@
 
 Ambassador is configured in a declarative fashion, using YAML manifests to describe the state of the world. As with Kubernetes, Ambassador's manifests are identified with `apiVersion`, `kind`, and `name`. The current `apiVersion` is `getambassador.io/v1`; currently-supported `kind`s are:
 
-- [`Module`](/reference/modules) manifests configure things with can apply to Ambassador as a whole. For example, the `ambassador` module can define listener ports, and the `tls` module can configure TLS termination for Ambassador.
+- [`Module`](/reference/modules) manifests configure things that apply to Ambassador as a whole. For example, the `ambassador` module can define listener ports, and the `tls` module can configure TLS termination for Ambassador.
 
-- [`AuthService`](/reference/services/auth-service) manifests configures the external authentication service[s] that Ambassador will use.
+- [`AuthService`](/reference/services/auth-service) manifests configure the external authentication service[s] that Ambassador will use.
 
-- [`RateLimitService`](/reference/services/rate-limit-service) manifests configures the external rate limiting service that Ambassador will use.
+- [`RateLimitService`](/reference/services/rate-limit-service) manifests configure the external rate limiting service that Ambassador will use.
 
-- [`TracingService`](/reference/services/tracing-service) manifests configures the external tracing service that Ambassador will use.
+- [`TracingService`](/reference/services/tracing-service) manifests configure the external tracing service that Ambassador will use.
 
 - [`Mapping`](/reference/mappings) manifests associate REST _resources_ with Kubernetes _services_. Ambassador _must_ have one or more mappings defined to provide access to any services at all.
 


### PR DESCRIPTION
I am not sure what was the intention of the first phrase, but it doesn't sound right.

## Description
Fix in documentation
