### PR TITLE
More Resolver CRD tweaks

### DIFF
--- a/ambassador/ambassador/config/resourcefetcher.py
+++ b/ambassador/ambassador/config/resourcefetcher.py
@@ -210,7 +210,7 @@ class ResourceFetcher:
         metadata = obj.get('metadata') or {}
         name = metadata.get('name')
         namespace = metadata.get('namespace') or 'default'
-        spec = obj.get('spec')
+        spec = obj.get('spec') or {}
 
         if not name:
             self.logger.debug(f'{self.location}: ignoring K8s {kind} CRD, no name')
@@ -220,9 +220,9 @@ class ResourceFetcher:
             self.logger.debug(f'{self.location}: ignoring K8s {kind} CRD {name}: no apiVersion')
             return
 
-        if not spec:
-            self.logger.debug(f'{self.location}: ignoring K8s {kind} CRD {name}: no spec')
-            return
+        # if not spec:
+        #     self.logger.debug(f'{self.location}: ignoring K8s {kind} CRD {name}: no spec')
+        #     return
 
         # We use this resource identifier as a key into self.k8s_services, and of course for logging .
         resource_identifier = f'{name}.{namespace}'

--- a/ambassador/ambassador/ir/irhttpmappinggroup.py
+++ b/ambassador/ambassador/ir/irhttpmappinggroup.py
@@ -318,7 +318,7 @@ class IRHTTPMappingGroup (IRBaseMappingGroup):
                 mapping.cluster = self.add_cluster_for_mapping(ir, aconf, mapping)
 
                 # Next, does this mapping have a weight assigned?
-                if not mapping.get('weight', 0):
+                if 'weight' not in mapping:
                     unspecified_mappings += 1
                 else:
                     total_weight += mapping.weight
@@ -328,7 +328,7 @@ class IRHTTPMappingGroup (IRBaseMappingGroup):
             # sum to 100 exactly by doing this, so we'll need to fix that up later.
             if unspecified_mappings:
                 for mapping in self.mappings:
-                    if not mapping.get("weight", 0):
+                    if 'weight' not in mapping:
                         mapping.weight = round((100.0 - total_weight)/unspecified_mappings)
             elif total_weight != 100.0:
                 for mapping in self.mappings:

--- a/ambassador/tests/t_grpc.py
+++ b/ambassador/tests/t_grpc.py
@@ -70,6 +70,17 @@ class EndpointGrpcTest(AmbassadorTest):
     def init(self):
         self.target = EGRPC()
 
+    def manifests(self) -> str:
+        return super().manifests() + self.format('''
+---
+apiVersion: getambassador.io/v1
+kind: KubernetesEndpointResolver
+metadata:
+    name: my-endpoint
+spec:    
+    ambassador_id: endpointgrpctest 
+''')
+
     def config(self):
         yield self, self.format("""
 ---
@@ -80,7 +91,7 @@ prefix: /echo.EchoService/
 rewrite: /echo.EchoService/
 name:  {self.target.path.k8s}
 service: {self.target.path.k8s}
-resolver: endpoint
+resolver: my-endpoint
 load_balancer:
   policy: round_robin
 """)


### PR DESCRIPTION
- allow the `ResourceFetcher` to see resources with no `spec`, to allow for the simplest kind of resolver CRDs
- switch the `EndpointGRPCTest` to use a `KubernetesEndpointResolver` with a CRD and a custom name


