### PR TITLE
Support, and test, canary weights of 0 and 100.

### DIFF
--- a/ambassador/ambassador/ir/irhttpmappinggroup.py
+++ b/ambassador/ambassador/ir/irhttpmappinggroup.py
@@ -318,7 +318,7 @@ class IRHTTPMappingGroup (IRBaseMappingGroup):
                 mapping.cluster = self.add_cluster_for_mapping(ir, aconf, mapping)
 
                 # Next, does this mapping have a weight assigned?
-                if not mapping.get('weight', 0):
+                if 'weight' not in mapping:
                     unspecified_mappings += 1
                 else:
                     total_weight += mapping.weight
@@ -328,7 +328,7 @@ class IRHTTPMappingGroup (IRBaseMappingGroup):
             # sum to 100 exactly by doing this, so we'll need to fix that up later.
             if unspecified_mappings:
                 for mapping in self.mappings:
-                    if not mapping.get("weight", 0):
+                    if 'weight' not in mapping:
                         mapping.weight = round((100.0 - total_weight)/unspecified_mappings)
             elif total_weight != 100.0:
                 for mapping in self.mappings:


### PR DESCRIPTION
Previously we were treating a `weight` of 0 in exactly the same way as not having a `weight` at all. This meant that setting up a canary with a `weight` of 1 would result in 99% of your traffic going to the main service and 1% to the canary (good), but that if you then switched the `weight` to 0 to turn off canarying, you'd suddenly get a 50/50 split (not good!!).

This PR arranges to treat a `weight` of 0 correctly, and to test that it works.
