### PR TITLE
Make the upgrade process for 0.71 a bit cleaner

### DIFF
--- a/ambassador/ambassador/config/resourcefetcher.py
+++ b/ambassador/ambassador/config/resourcefetcher.py
@@ -137,7 +137,10 @@ class ResourceFetcher:
     def parse_watt(self, serialization: str) -> None:
 
         if os.path.isfile(os.path.abspath('.ambassador_ignore_crds')):
-            self.aconf.post_error("Ambassador could not find all the required CRDs. Please visit https://www.getambassador.io/reference/core/crds/ for more information. You can continue using Ambassador via Kubernetes annotations, any configuration via CRDs will be ignored...")
+            self.aconf.post_error("Ambassador could not find core CRD definitions. Please visit https://www.getambassador.io/reference/core/crds/ for more information. You can continue using Ambassador via Kubernetes annotations, any configuration via CRDs will be ignored...")
+
+        if os.path.isfile(os.path.abspath('.ambassador_ignore_crds_2')):
+            self.aconf.post_error("Ambassador could not find Resolver type CRD definitions. Please visit https://www.getambassador.io/reference/core/crds/ for more information. You can continue using Ambassador via Kubernetes annotations, any configuration via CRDs will be ignored...")
 
         try:
             watt_dict = json.loads(serialization)

--- a/ambassador/ambassador/diagnostics/diagnostics.py
+++ b/ambassador/ambassador/diagnostics/diagnostics.py
@@ -366,6 +366,32 @@ class Diagnostics:
         self.ambassador_services: List[dict] = []
         self.ambassador_resolvers: List[dict] = []
 
+        # Warn people about upcoming deprecations.
+
+        warn_auth = False
+        warn_ratelimit = False
+
+        for filter in self.ir.filters:
+            if filter.kind == 'IRAuth':
+                proto = filter.get('proto') or 'http'
+
+                if proto.lower() != 'http':
+                    warn_auth = True
+
+            if filter.kind == 'IRRateLimit':
+                warn_ratelimit = True
+
+        things_to_warn = []
+
+        if warn_auth:
+            things_to_warn.append('AuthServices')
+
+        if warn_ratelimit:
+            things_to_warn.append('RateLimitServices')
+
+        if things_to_warn:
+            self.ir.aconf.post_notice(f'A future Ambassador version will change the GRPC protocol version for {" and ".join(things_to_warn)}. See the CHANGELOG for details.')
+
         # # Warn people about the default port change.
         # if self.ir.ambassador_module.service_port < 1024:
         #     # Does it look like they explicitly asked for this?

--- a/ambassador/entrypoint.sh
+++ b/ambassador/entrypoint.sh
@@ -183,8 +183,13 @@ fi
 ################################################################################
 if [[ -z "${AMBASSADOR_NO_KUBEWATCH}" ]]; then
     KUBEWATCH_SYNC_KINDS="-s service"
+
     if [ ! -f .ambassador_ignore_crds ]; then
-        KUBEWATCH_SYNC_KINDS="$KUBEWATCH_SYNC_KINDS -s AuthService -s ConsulResolver -s KubernetesEndpointResolver -s KubernetesServiceResolver -s Mapping -s Module -s RateLimitService -s TCPMapping -s TLSContext -s TracingService"
+        KUBEWATCH_SYNC_KINDS="$KUBEWATCH_SYNC_KINDS -s AuthService -s Mapping -s Module -s RateLimitService -s TCPMapping -s TLSContext -s TracingService"
+    fi
+
+    if [ ! -f .ambassador_ignore_crds_2 ]; then
+        KUBEWATCH_SYNC_KINDS="$KUBEWATCH_SYNC_KINDS -s ConsulResolver -s KubernetesEndpointResolver -s KubernetesServiceResolver"
     fi
 
     launch /ambassador/watt \

--- a/ambassador/tests/abstract_tests.py
+++ b/ambassador/tests/abstract_tests.py
@@ -34,6 +34,12 @@ type: kubernetes.io/service-account-token
 """
 
 
+DEFAULT_ERRORS = [
+    [ "", "Ambassador could not find core CRD definitions. Please visit https://www.getambassador.io/reference/core/crds/ for more information. You can continue using Ambassador via Kubernetes annotations, any configuration via CRDs will be ignored..." ],
+    [ "", "Ambassador could not find Resolver type CRD definitions. Please visit https://www.getambassador.io/reference/core/crds/ for more information. You can continue using Ambassador via Kubernetes annotations, any configuration via CRDs will be ignored..." ]
+]
+
+
 def run(*args, **kwargs):
     for arg in "stdout", "stderr":
         if arg not in kwargs:

--- a/ambassador/tests/t_basics.py
+++ b/ambassador/tests/t_basics.py
@@ -2,7 +2,7 @@ from typing import Tuple, Union
 
 from kat.harness import Query
 
-from abstract_tests import AmbassadorTest, HTTP, Node, ServiceType
+from abstract_tests import AmbassadorTest, DEFAULT_ERRORS, HTTP, Node, ServiceType
 
 
 class Empty(AmbassadorTest):
@@ -31,7 +31,7 @@ metadata:
     def check(self):
         # XXX Ew. If self.results[0].json is empty, the harness won't convert it to a response.
         errors = self.results[0].json
-        assert(len(errors) == 1)
+        assert(errors == DEFAULT_ERRORS)
 
 
 class AmbassadorIDTest(AmbassadorTest):

--- a/ambassador/tests/t_plain.py
+++ b/ambassador/tests/t_plain.py
@@ -2,7 +2,7 @@ from typing import Tuple, Union
 
 from kat.harness import variants, Query
 
-from abstract_tests import AmbassadorTest
+from abstract_tests import AmbassadorTest, DEFAULT_ERRORS
 from abstract_tests import MappingTest, Node
 
 # Plain is the place that all the MappingTests get pulled in.
@@ -74,4 +74,4 @@ config: {}
     def check(self):
         # XXX Ew. If self.results[0].json is empty, the harness won't convert it to a response.
         errors = self.results[0].json
-        assert(len(errors) == 1)
+        assert(errors == DEFAULT_ERRORS)

--- a/ambassador/tests/t_shadow.py
+++ b/ambassador/tests/t_shadow.py
@@ -7,7 +7,7 @@ from kat.harness import sanitize, variants, Query, Runner
 from kat import manifests
 
 from abstract_tests import AmbassadorTest, HTTP
-from abstract_tests import MappingTest, OptionTest, ServiceType, Node, Test
+from abstract_tests import DEFAULT_ERRORS, MappingTest, OptionTest, ServiceType, Node, Test
 
 
 class ShadowTest(MappingTest):
@@ -134,7 +134,7 @@ service: shadow.plain-namespace
     def check(self):
         # XXX Ew. If self.results[0].json is empty, the harness won't convert it to a response.
         errors = self.results[0].json or {}
-        assert(len(errors) == 1)
+        assert(errors == DEFAULT_ERRORS)
 
         for result in self.results:
             if "mark" in result.query.url:


### PR DESCRIPTION
- Handle upgrades from 0.70 that don't have the new Resolver CRDs in place
- Warn users about upcoming protocol changes
