### PR TITLE
External auth bug-fix and new Envoy image update

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -137,9 +137,9 @@ AMBASSADOR_EXTERNAL_DOCKER_IMAGE ?= $(AMBASSADOR_EXTERNAL_DOCKER_REPO):$(AMBASSA
 
 # UPDATE THESE VERSION NUMBERS IF YOU UPDATE ANY OF THE VALUES ABOVE, THEN
 # RUN make docker-update-base.
-ENVOY_BASE_IMAGE ?= quay.io/datawire/ambassador-base:envoy-12-rc1
-AMBASSADOR_DOCKER_IMAGE_CACHED ?= quay.io/datawire/ambassador-base:go-13-rc1
-AMBASSADOR_BASE_IMAGE ?= quay.io/datawire/ambassador-base:ambassador-13-rc1
+ENVOY_BASE_IMAGE ?= quay.io/datawire/ambassador-base:envoy-12
+AMBASSADOR_DOCKER_IMAGE_CACHED ?= quay.io/datawire/ambassador-base:go-13
+AMBASSADOR_BASE_IMAGE ?= quay.io/datawire/ambassador-base:ambassador-13
 
 # Default to _NOT_ using Kubernaut. At Datawire, we can set this to true,
 # but outside, it works much better to assume that user has set up something

--- a/Makefile
+++ b/Makefile
@@ -130,16 +130,16 @@ NETLIFY_SITE=datawire-ambassador
 # IF YOU MESS WITH ANY OF THESE VALUES, YOU MUST UPDATE THE VERSION NUMBERS
 # BELOW AND THEN RUN make docker-update-base
 ENVOY_REPO ?= git://github.com/datawire/envoy.git
-ENVOY_COMMIT ?= a484da25f765a28546b0f312115a8a346959f15c
+ENVOY_COMMIT ?= c0fd0ba40979158b96b5173724d6b3a92614ffd2
 AMBASSADOR_DOCKER_TAG ?= $(GIT_VERSION)
 AMBASSADOR_DOCKER_IMAGE ?= $(AMBASSADOR_DOCKER_REPO):$(AMBASSADOR_DOCKER_TAG)
 AMBASSADOR_EXTERNAL_DOCKER_IMAGE ?= $(AMBASSADOR_EXTERNAL_DOCKER_REPO):$(AMBASSADOR_DOCKER_TAG)
 
 # UPDATE THESE VERSION NUMBERS IF YOU UPDATE ANY OF THE VALUES ABOVE, THEN
 # RUN make docker-update-base.
-ENVOY_BASE_IMAGE ?= quay.io/datawire/ambassador-base:envoy-11
-AMBASSADOR_DOCKER_IMAGE_CACHED ?= quay.io/datawire/ambassador-base:go-12
-AMBASSADOR_BASE_IMAGE ?= quay.io/datawire/ambassador-base:ambassador-12
+ENVOY_BASE_IMAGE ?= quay.io/datawire/ambassador-base:envoy-12-rc
+AMBASSADOR_DOCKER_IMAGE_CACHED ?= quay.io/datawire/ambassador-base:go-13-rc
+AMBASSADOR_BASE_IMAGE ?= quay.io/datawire/ambassador-base:ambassador-13-rc
 
 # Default to _NOT_ using Kubernaut. At Datawire, we can set this to true,
 # but outside, it works much better to assume that user has set up something

--- a/Makefile
+++ b/Makefile
@@ -137,9 +137,9 @@ AMBASSADOR_EXTERNAL_DOCKER_IMAGE ?= $(AMBASSADOR_EXTERNAL_DOCKER_REPO):$(AMBASSA
 
 # UPDATE THESE VERSION NUMBERS IF YOU UPDATE ANY OF THE VALUES ABOVE, THEN
 # RUN make docker-update-base.
-ENVOY_BASE_IMAGE ?= quay.io/datawire/ambassador-base:envoy-12
-AMBASSADOR_DOCKER_IMAGE_CACHED ?= quay.io/datawire/ambassador-base:go-13
-AMBASSADOR_BASE_IMAGE ?= quay.io/datawire/ambassador-base:ambassador-13
+ENVOY_BASE_IMAGE ?= quay.io/datawire/ambassador-base:envoy-13
+AMBASSADOR_DOCKER_IMAGE_CACHED ?= quay.io/datawire/ambassador-base:go-14
+AMBASSADOR_BASE_IMAGE ?= quay.io/datawire/ambassador-base:ambassador-14
 
 # Default to _NOT_ using Kubernaut. At Datawire, we can set this to true,
 # but outside, it works much better to assume that user has set up something

--- a/Makefile
+++ b/Makefile
@@ -130,16 +130,16 @@ NETLIFY_SITE=datawire-ambassador
 # IF YOU MESS WITH ANY OF THESE VALUES, YOU MUST UPDATE THE VERSION NUMBERS
 # BELOW AND THEN RUN make docker-update-base
 ENVOY_REPO ?= git://github.com/datawire/envoy.git
-ENVOY_COMMIT ?= c0fd0ba40979158b96b5173724d6b3a92614ffd2
+ENVOY_COMMIT ?= 59b502c0a8e723aa262335de49f737c305eb1521
 AMBASSADOR_DOCKER_TAG ?= $(GIT_VERSION)
 AMBASSADOR_DOCKER_IMAGE ?= $(AMBASSADOR_DOCKER_REPO):$(AMBASSADOR_DOCKER_TAG)
 AMBASSADOR_EXTERNAL_DOCKER_IMAGE ?= $(AMBASSADOR_EXTERNAL_DOCKER_REPO):$(AMBASSADOR_DOCKER_TAG)
 
 # UPDATE THESE VERSION NUMBERS IF YOU UPDATE ANY OF THE VALUES ABOVE, THEN
 # RUN make docker-update-base.
-ENVOY_BASE_IMAGE ?= quay.io/datawire/ambassador-base:envoy-12-rc
-AMBASSADOR_DOCKER_IMAGE_CACHED ?= quay.io/datawire/ambassador-base:go-13-rc
-AMBASSADOR_BASE_IMAGE ?= quay.io/datawire/ambassador-base:ambassador-13-rc
+ENVOY_BASE_IMAGE ?= quay.io/datawire/ambassador-base:envoy-12-rc1
+AMBASSADOR_DOCKER_IMAGE_CACHED ?= quay.io/datawire/ambassador-base:go-13-rc1
+AMBASSADOR_BASE_IMAGE ?= quay.io/datawire/ambassador-base:ambassador-13-rc1
 
 # Default to _NOT_ using Kubernaut. At Datawire, we can set this to true,
 # but outside, it works much better to assume that user has set up something

--- a/Makefile
+++ b/Makefile
@@ -137,9 +137,9 @@ AMBASSADOR_EXTERNAL_DOCKER_IMAGE ?= $(AMBASSADOR_EXTERNAL_DOCKER_REPO):$(AMBASSA
 
 # UPDATE THESE VERSION NUMBERS IF YOU UPDATE ANY OF THE VALUES ABOVE, THEN
 # RUN make docker-update-base.
-ENVOY_BASE_IMAGE ?= quay.io/datawire/ambassador-base:envoy-13
-AMBASSADOR_DOCKER_IMAGE_CACHED ?= quay.io/datawire/ambassador-base:go-14
-AMBASSADOR_BASE_IMAGE ?= quay.io/datawire/ambassador-base:ambassador-14
+ENVOY_BASE_IMAGE ?= quay.io/datawire/ambassador-base:envoy-12
+AMBASSADOR_DOCKER_IMAGE_CACHED ?= quay.io/datawire/ambassador-base:go-13
+AMBASSADOR_BASE_IMAGE ?= quay.io/datawire/ambassador-base:ambassador-13
 
 # Default to _NOT_ using Kubernaut. At Datawire, we can set this to true,
 # but outside, it works much better to assume that user has set up something

--- a/kat/kat/manifests.py
+++ b/kat/kat/manifests.py
@@ -29,7 +29,7 @@ metadata:
 spec:
   containers:
   - name: backend
-    image: quay.io/datawire/kat-backend:12
+    image: quay.io/datawire/kat-backend:13
     imagePullPolicy: Always
     ports:
     - containerPort: 8080
@@ -56,7 +56,7 @@ spec:
     spec:
       containers:
       - name: backend
-        image: quay.io/datawire/kat-backend:12
+        image: quay.io/datawire/kat-backend:13
         imagePullPolicy: Always
         # ports:
         # {ports}
@@ -94,7 +94,7 @@ metadata:
 spec:
   containers:
   - name: backend
-    image: quay.io/datawire/kat-backend:12
+    image: quay.io/datawire/kat-backend:13
     imagePullPolicy: Always
     ports:
     - containerPort: 8080
@@ -133,7 +133,7 @@ metadata:
 spec:
   containers:
   - name: backend
-    image: quay.io/datawire/kat-backend:12
+    image: quay.io/datawire/kat-backend:13
     imagePullPolicy: Always
     ports:
     - containerPort: 8080
@@ -172,7 +172,7 @@ metadata:
 spec:
   containers:
   - name: backend
-    image: quay.io/datawire/kat-backend:12
+    image: quay.io/datawire/kat-backend:13
     imagePullPolicy: Always
     ports:
     - containerPort: 8080


### PR DESCRIPTION
## Description
This PR fixes https://github.com/datawire/ambassador/issues/1595 and also updates Envoy image with the Envoy upstream. The updated was needed in order to fix a problem with premature end of stream when the external authorization filter was configured to accept partial messages during auth. 

Note that many Envoy deprecation flags where removed.

## Related Issues
https://github.com/datawire/ambassador/issues/1595
https://github.com/datawire/ambassador/issues/1523

## Testing
Add KAT test coverage for authorization involving message body.