### PR TITLE
Remove x_forwarded_proto_redirect infinite loop

### DIFF
--- a/ambassador/ambassador/envoy/v2/v2listener.py
+++ b/ambassador/ambassador/envoy/v2/v2listener.py
@@ -467,49 +467,44 @@ class V2Listener(dict):
 
         self.routes: List[dict] = [ {
                 'match': {
-                    'prefix': '/',
-                },
-                'redirect': {
-                    'https_redirect': True
+                    'prefix': '/'
                 }
             } ]
 
-        if listener.redirect_listener:
-            self.http_filters = [{'name': 'envoy.router'}]
-        else:
-            # Use the actual listener name & port number
-            self.name = "ambassador-listener-%s" % listener.service_port
+        # Use the actual listener name & port number
+        self.name = "ambassador-listener-%s" % listener.service_port
 
-            # Use a sane access log spec
-            self.access_log = [ {
-                'name': 'envoy.file_access_log',
-                'config': {
-                    'path': '/dev/fd/1',
-                    'format': 'ACCESS [%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\"\n'
-                }
-            } ]
+        # Use a sane access log spec
+        self.access_log = [ {
+            'name': 'envoy.file_access_log',
+            'config': {
+                'path': '/dev/fd/1',
+                'format': 'ACCESS [%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\"\n'
+            }
+        } ]
 
-            # Assemble filters
-            for f in config.ir.filters:
-                v2f: dict = v2filter(f, config)
+        # Assemble filters
+        for f in config.ir.filters:
+            v2f: dict = v2filter(f, config)
 
-                if v2f:
-                    self.http_filters.append(v2f)
+            if v2f:
+                self.http_filters.append(v2f)
 
-            # Grab routes from the config (we do this as a shallow copy).
-            self.routes = [ dict(r) for r in config.routes ]
+        # Grab routes from the config (we do this as a shallow copy).
+        self.routes = [ dict(r) for r in config.routes ]
 
-            # Don't require TLS.
+        # Don't require TLS.
+        if not listener.redirect_listener:
             self.require_tls = None
 
-            # Save upgrade configs.
-            for group in config.ir.ordered_groups():
-                if group.get('use_websocket'):
-                    self.upgrade_configs = [{ 'upgrade_type': 'websocket' }]
-                    break
+        # Save upgrade configs.
+        for group in config.ir.ordered_groups():
+            if group.get('use_websocket'):
+                self.upgrade_configs = [{ 'upgrade_type': 'websocket' }]
+                break
 
-            # Let self.handle_sni do the heavy lifting for SNI.
-            self.handle_sni(config)
+        # Let self.handle_sni do the heavy lifting for SNI.
+        self.handle_sni(config)
 
         # If the filter chain is empty here, we had no contexts. Add a single empty element to
         # to filter chain to make the logic below a bit simpler.


### PR DESCRIPTION
## Description
I am not a Python developer this PR is more just a this is how I fixed the issue I was experiencing as I am not sure of the carry on consequences of these changes. No tests have been added or changed as I wasn't sure on how to do that. Hopefully this PR will help you solve the issue described.

This commit removes a bug where when you set the ambassador module config x_forwarded_proto_redirect to true it would generate a configuration that caused an infinite redirect loop.

The main cause of this issue was that the if you set the x_forwarded_proto_redirect to true it would only create an envoy listener with the default route rather than still appending the desired custom routes specified in the Kubernetes services annotations.

## Changes
The default route now doesn't contain a redirect that does a [https_redirect](https://www.envoyproxy.io/docs/envoy/latest/api-v2/api/v2/route/route.proto#route-redirectaction)
due to it causing an infinite loop of redirects as it would substitute the scheme portion of the URL for https and redirect to that URL even if that scheme was already https.

Removed the check for the `listener.redirect_listener` before building the routes so the routes would always be built and default route would be overwritten if routes have been defined whether or not
`listener.redirect_listener` had been set or not. Added a condition to set the `self.require_tls = None` only if `listener.redirect_listener` had not be set.

This change now means that Ambassador will add the `"require_tls": "EXTERNAL_ONLY"` configuration to the envoy virtual host if the Ambassador module `x_forwarded_proto_redirect` is set to true forcing all external requests to the gateway to use https and wont remove any routes.

## Related Issues
https://github.com/datawire/ambassador/issues/1571

## Testing
I have deployed this custom build to our systems and it works with our configuration with AWS and I have manually confirmed that the requests are redirected for the virtual host if x-forwarded-proto header is anything but `https`.

## Todos
- [ ] Tests
- [ ] Documentation
