### PR TITLE
Be more careful about where we write things on disk

### DIFF
--- a/ambassador/ambassador/config/resourcefetcher.py
+++ b/ambassador/ambassador/config/resourcefetcher.py
@@ -135,11 +135,12 @@ class ResourceFetcher:
         self.finalize()
 
     def parse_watt(self, serialization: str) -> None:
+        basedir = os.environ.get('AMBASSADOR_CONFIG_BASE_DIR', '/ambassador')
 
-        if os.path.isfile(os.path.abspath('.ambassador_ignore_crds')):
+        if os.path.isfile(os.path.join(basedir, '.ambassador_ignore_crds')):
             self.aconf.post_error("Ambassador could not find core CRD definitions. Please visit https://www.getambassador.io/reference/core/crds/ for more information. You can continue using Ambassador via Kubernetes annotations, any configuration via CRDs will be ignored...")
 
-        if os.path.isfile(os.path.abspath('.ambassador_ignore_crds_2')):
+        if os.path.isfile(os.path.join(basedir, '.ambassador_ignore_crds_2')):
             self.aconf.post_error("Ambassador could not find Resolver type CRD definitions. Please visit https://www.getambassador.io/reference/core/crds/ for more information. You can continue using Ambassador via Kubernetes annotations, any configuration via CRDs will be ignored...")
 
         try:

--- a/ambassador/entrypoint.sh
+++ b/ambassador/entrypoint.sh
@@ -44,12 +44,20 @@ export APPDIR="${APPDIR:-$ambassador_root}"
 
 # If we don't set PYTHON_EGG_CACHE explicitly, /.cache is set by
 # default, which fails when running as a non-privileged user
-export PYTHON_EGG_CACHE="${PYTHON_EGG_CACHE:-$APPDIR}/.cache"
+export PYTHON_EGG_CACHE="${PYTHON_EGG_CACHE:-$AMBASSADOR_CONFIG_BASE_DIR}/.cache"
 export PYTHONUNBUFFERED=true
 
 config_dir="${AMBASSADOR_CONFIG_BASE_DIR}/ambassador-config"
 snapshot_dir="${AMBASSADOR_CONFIG_BASE_DIR}/snapshots"
 diagd_flags=('--notices' "${AMBASSADOR_CONFIG_BASE_DIR}/notices.json")
+
+# Make sure that base dir exists.
+if [[ ! -d "$AMBASSADOR_CONFIG_BASE_DIR" ]]; then
+    if ! mkdir -p "$AMBASSADOR_CONFIG_BASE_DIR"; then
+        echo "Could not create $AMBASSADOR_CONFIG_BASE_DIR" >&2
+        exit 1
+    fi
+fi
 
 # Note that the envoy_config_file really is in ENVOY_DIR, rather than
 # being in AMBASSADOR_CONFIG_BASE_DIR.
@@ -184,11 +192,11 @@ fi
 if [[ -z "${AMBASSADOR_NO_KUBEWATCH}" ]]; then
     KUBEWATCH_SYNC_KINDS="-s service"
 
-    if [ ! -f .ambassador_ignore_crds ]; then
+    if [ ! -f "${AMBASSADOR_CONFIG_BASE_DIR}/.ambassador_ignore_crds" ]; then
         KUBEWATCH_SYNC_KINDS="$KUBEWATCH_SYNC_KINDS -s AuthService -s Mapping -s Module -s RateLimitService -s TCPMapping -s TLSContext -s TracingService"
     fi
 
-    if [ ! -f .ambassador_ignore_crds_2 ]; then
+    if [ ! -f "${AMBASSADOR_CONFIG_BASE_DIR}/.ambassador_ignore_crds_2" ]; then
         KUBEWATCH_SYNC_KINDS="$KUBEWATCH_SYNC_KINDS -s ConsulResolver -s KubernetesEndpointResolver -s KubernetesServiceResolver"
     fi
 

--- a/ambassador/kubewatch.py
+++ b/ambassador/kubewatch.py
@@ -193,10 +193,14 @@ def main(debug):
                         logger.debug(f'CRD type definition unreadable for {crd}: {e.reason}')
 
                 if crd_errors:
-                    Path(touchfile).touch()
+                    basedir = os.environ.get('AMBASSADOR_CONFIG_BASE_DIR', '/ambassador')
+                    touchpath = Path(basedir, touchfile)
+                    touchpath.touch()
+
                     logger.debug(f'{description} are not available.' +
                                  ' To enable CRD support, configure the Ambassador CRD type definitions and RBAC,' +
                                  ' then restart the Ambassador pod.')
+                    # logger.debug(f'touched {touchpath}')
     else:
         # If we couldn't talk to Kube, log that, but broadly we'll expect our caller
         # to DTRT around CRDs.

--- a/ambassador/tests/t_tls.py
+++ b/ambassador/tests/t_tls.py
@@ -209,8 +209,8 @@ config:
   upstream:
     secret: test-certs-secret
   upstream-files:
-    cert_chain_file: /ambassador/snapshots/default/secrets-decoded/test-certs-secret/F94E4DCF30ABC50DEF240AA8024599B67CC03991.crt
-    private_key_file: /ambassador/snapshots/default/secrets-decoded/test-certs-secret/F94E4DCF30ABC50DEF240AA8024599B67CC03991.key
+    cert_chain_file: /tmp/ambassador/snapshots/default/secrets-decoded/test-certs-secret/F94E4DCF30ABC50DEF240AA8024599B67CC03991.crt
+    private_key_file: /tmp/ambassador/snapshots/default/secrets-decoded/test-certs-secret/F94E4DCF30ABC50DEF240AA8024599B67CC03991.key
 """)
 
         yield self, self.format("""

--- a/kat/kat/manifests.py
+++ b/kat/kat/manifests.py
@@ -474,7 +474,15 @@ metadata:
   labels:
     service: {self.path.k8s}
 spec:
+  securityContext:
+    runAsUser: 8888
   serviceAccountName: {self.path.k8s}
+  restartPolicy: Always
+  volumes:
+    - name: scratchpad
+      emptyDir:
+        medium: Memory
+        sizeLimit: "45Mi"
   containers:
   - name: ambassador
     image: {image}
@@ -488,6 +496,11 @@ spec:
       value: {self.path.k8s}
     - name: AMBASSADOR_SNAPSHOT_COUNT
       value: "0"
+    - name: AMBASSADOR_CONFIG_BASE_DIR
+      value: "/tmp/ambassador"
+    securityContext:
+      allowPrivilegeEscalation: false
+      readOnlyRootFilesystem: true  
     livenessProbe:
       httpGet:
         path: /ambassador/v0/check_alive
@@ -500,7 +513,9 @@ spec:
         port: 8877
       initialDelaySeconds: 30
       periodSeconds: 3
-  restartPolicy: Always
+    volumeMounts:
+      - mountPath: /tmp/
+        name: scratchpad
 """
 
 HTTPBIN = """


### PR DESCRIPTION
Several things were getting written outside of `AMBASSADOR_CONFIG_BASE_DIR`. We can't do that.

This PR fixes the places I found where we wrote to the wrong place, and updates the test suite to run as non-root with a read-only root filesystem by default.
