### PR TITLE
envoy-image: updated Envoy image with a fix for auth tracing and lates upstream code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -130,16 +130,16 @@ NETLIFY_SITE=datawire-ambassador
 # IF YOU MESS WITH ANY OF THESE VALUES, YOU MUST UPDATE THE VERSION NUMBERS
 # BELOW AND THEN RUN make docker-update-base
 ENVOY_REPO ?= git://github.com/datawire/envoy.git
-ENVOY_COMMIT ?= 59b502c0a8e723aa262335de49f737c305eb1521
+ENVOY_COMMIT ?= 8f57f7d765939552a999721e8dac9b5a9a5cbb8b
 AMBASSADOR_DOCKER_TAG ?= $(GIT_VERSION)
 AMBASSADOR_DOCKER_IMAGE ?= $(AMBASSADOR_DOCKER_REPO):$(AMBASSADOR_DOCKER_TAG)
 AMBASSADOR_EXTERNAL_DOCKER_IMAGE ?= $(AMBASSADOR_EXTERNAL_DOCKER_REPO):$(AMBASSADOR_DOCKER_TAG)
 
 # UPDATE THESE VERSION NUMBERS IF YOU UPDATE ANY OF THE VALUES ABOVE, THEN
 # RUN make docker-update-base.
-ENVOY_BASE_IMAGE ?= quay.io/datawire/ambassador-base:envoy-12
-AMBASSADOR_DOCKER_IMAGE_CACHED ?= quay.io/datawire/ambassador-base:go-13
-AMBASSADOR_BASE_IMAGE ?= quay.io/datawire/ambassador-base:ambassador-13
+ENVOY_BASE_IMAGE ?= quay.io/datawire/ambassador-base:envoy-13-rc
+AMBASSADOR_DOCKER_IMAGE_CACHED ?= quay.io/datawire/ambassador-base:go-14-rc
+AMBASSADOR_BASE_IMAGE ?= quay.io/datawire/ambassador-base:ambassador-14-rc
 
 # Default to _NOT_ using Kubernaut. At Datawire, we can set this to true,
 # but outside, it works much better to assume that user has set up something

--- a/Makefile
+++ b/Makefile
@@ -137,9 +137,9 @@ AMBASSADOR_EXTERNAL_DOCKER_IMAGE ?= $(AMBASSADOR_EXTERNAL_DOCKER_REPO):$(AMBASSA
 
 # UPDATE THESE VERSION NUMBERS IF YOU UPDATE ANY OF THE VALUES ABOVE, THEN
 # RUN make docker-update-base.
-ENVOY_BASE_IMAGE ?= quay.io/datawire/ambassador-base:envoy-13-rc
-AMBASSADOR_DOCKER_IMAGE_CACHED ?= quay.io/datawire/ambassador-base:go-14-rc
-AMBASSADOR_BASE_IMAGE ?= quay.io/datawire/ambassador-base:ambassador-14-rc
+ENVOY_BASE_IMAGE ?= quay.io/datawire/ambassador-base:envoy-13
+AMBASSADOR_DOCKER_IMAGE_CACHED ?= quay.io/datawire/ambassador-base:go-14
+AMBASSADOR_BASE_IMAGE ?= quay.io/datawire/ambassador-base:ambassador-14
 
 # Default to _NOT_ using Kubernaut. At Datawire, we can set this to true,
 # but outside, it works much better to assume that user has set up something


### PR DESCRIPTION
## Description
This PR updates Ambassador with a new Envoy image that contains a bug fix for `ext-authz` tracing as well as the latest Envoy upstream code.  

## Related Issues
https://github.com/datawire/ambassador/issues/1414

## Testing
I performed a manual test for the bug fix. HTTP auth tracing works exactly like the gRPC auth which already has tracing built into the client.

## Todos
- [ ] KAT test