### PR TITLE
Tonkworks/1622 Support retry for AuthService

### DIFF
--- a/ambassador/ambassador/envoy/v2/v2listener.py
+++ b/ambassador/ambassador/envoy/v2/v2listener.py
@@ -238,9 +238,6 @@ def v2filter_authv1(auth: IRAuth, v2config: 'V2Config'):
             'allow_partial': True
         }
 
-    status_on_error =  auth.get('status_on_error', 403)
-    failure_mode_allow =  auth.get('failure_mode_allow', False)
-
     body_info: Optional[Dict[str, int]] = None
 
     if raw_body_info:
@@ -287,10 +284,8 @@ def v2filter_authv1(auth: IRAuth, v2config: 'V2Config'):
                         'allowed_client_headers': {
                             'patterns': allowed_authorization_headers
                         }
-                    },
-                    'status_on_error': status_on_error,
-                    'failure_mode_allow': failure_mode_allow
-                },
+                    }
+                }
             }
         }
 
@@ -304,15 +299,24 @@ def v2filter_authv1(auth: IRAuth, v2config: 'V2Config'):
                     },
                     'timeout': "%0.3fs" % (float(auth.timeout_ms) / 1000.0)
                 },
-                'use_alpha': True,
-                'status_on_error': status_on_error,
-                'failure_mode_allow': failure_mode_allow
+                'use_alpha': True
             }
         }
 
     if auth_info:
         if body_info:
             auth_info['config']['with_request_body'] = body_info
+
+        print(auth.status_on_error)
+        if auth.retry_policy:
+            auth_info['config']["retry_policy"] = auth.retry_policy.as_dict()
+
+        if auth.failure_mode_allow:
+            auth_info['config']["failure_mode_allow"] = auth.failure_mode_allow
+        
+        if auth.status_on_error:
+            status_on_error: Optional[Dict[str, int]] = auth.get('status_on_error')
+            auth_info['config']["status_on_error"] = status_on_error
 
         return auth_info
 

--- a/ambassador/ambassador/envoy/v2/v2listener.py
+++ b/ambassador/ambassador/envoy/v2/v2listener.py
@@ -285,7 +285,7 @@ def v2filter_authv1(auth: IRAuth, v2config: 'V2Config'):
                             'patterns': allowed_authorization_headers
                         }
                     }
-                }
+                },
             }
         }
 
@@ -307,7 +307,6 @@ def v2filter_authv1(auth: IRAuth, v2config: 'V2Config'):
         if body_info:
             auth_info['config']['with_request_body'] = body_info
 
-        print(auth.status_on_error)
         if auth.retry_policy:
             auth_info['config']["retry_policy"] = auth.retry_policy.as_dict()
 

--- a/ambassador/ambassador/envoy/v2/v2listener.py
+++ b/ambassador/ambassador/envoy/v2/v2listener.py
@@ -307,13 +307,13 @@ def v2filter_authv1(auth: IRAuth, v2config: 'V2Config'):
         if body_info:
             auth_info['config']['with_request_body'] = body_info
 
-        if auth.retry_policy:
+        if 'retry_policy' in auth:
             auth_info['config']["retry_policy"] = auth.retry_policy.as_dict()
 
-        if auth.failure_mode_allow:
+        if 'failure_mode_allow' in auth:
             auth_info['config']["failure_mode_allow"] = auth.failure_mode_allow
         
-        if auth.status_on_error:
+        if 'status_on_error' in auth:
             status_on_error: Optional[Dict[str, int]] = auth.get('status_on_error')
             auth_info['config']["status_on_error"] = status_on_error
 

--- a/ambassador/ambassador/envoy/v2/v2listener.py
+++ b/ambassador/ambassador/envoy/v2/v2listener.py
@@ -238,6 +238,9 @@ def v2filter_authv1(auth: IRAuth, v2config: 'V2Config'):
             'allow_partial': True
         }
 
+    status_on_error =  auth.get('status_on_error', 403)
+    failure_mode_allow =  auth.get('failure_mode_allow', False)
+
     body_info: Optional[Dict[str, int]] = None
 
     if raw_body_info:
@@ -284,7 +287,9 @@ def v2filter_authv1(auth: IRAuth, v2config: 'V2Config'):
                         'allowed_client_headers': {
                             'patterns': allowed_authorization_headers
                         }
-                    }
+                    },
+                    'status_on_error': status_on_error,
+                    'failure_mode_allow': failure_mode_allow
                 },
             }
         }
@@ -299,7 +304,9 @@ def v2filter_authv1(auth: IRAuth, v2config: 'V2Config'):
                     },
                     'timeout': "%0.3fs" % (float(auth.timeout_ms) / 1000.0)
                 },
-                'use_alpha': True
+                'use_alpha': True,
+                'status_on_error': status_on_error,
+                'failure_mode_allow': failure_mode_allow
             }
         }
 

--- a/ambassador/ambassador/ir/irauth.py
+++ b/ambassador/ambassador/ir/irauth.py
@@ -121,6 +121,8 @@ class IRAuth (IRFilter):
         self["proto"] = module.get("proto", "http")
         self["timeout_ms"] = module.get("timeout_ms", 5000)
         self["connect_timeout_ms"] = module.get("connect_timeout_ms", 3000)
+        self["status_on_error"] = module.get("status_on_error", 403)
+        self["failure_mode_allow"] = module.get("failure_mode_allow", False)
         self.__to_header_list('allowed_headers', module)
         self.__to_header_list('allowed_request_headers', module)
         self.__to_header_list('allowed_authorization_headers', module)

--- a/ambassador/ambassador/ir/irauth.py
+++ b/ambassador/ambassador/ir/irauth.py
@@ -122,15 +122,21 @@ class IRAuth (IRFilter):
         self["proto"] = module.get("proto", "http")
         self["timeout_ms"] = module.get("timeout_ms", 5000)
         self["connect_timeout_ms"] = module.get("connect_timeout_ms", 3000)
-        self["status_on_error"] = module.get("status_on_error", None)
-        self["failure_mode_allow"] = module.get("failure_mode_allow", None)
-        self["retry_policy"] = module.get("retry_policy", None)
         self.__to_header_list('allowed_headers', module)
         self.__to_header_list('allowed_request_headers', module)
         self.__to_header_list('allowed_authorization_headers', module)
 
-        if not self["retry_policy"] == None:
-            self["retry_policy"] = IRRetryPolicy(ir=self.ir, aconf=self.ir.aconf, **self["retry_policy"])
+        status_on_error = module.get('status_on_error', None)
+        if status_on_error:
+            self['status_on_error'] = status_on_error
+        
+        failure_mode_allow = module.get('failure_mode_allow', None)
+        if failure_mode_allow:
+            self['failure_mode_allow'] = failure_mode_allow
+        
+        retry_policy = module.get('retry_policy', None)
+        if retry_policy:
+            self["retry_policy"] = IRRetryPolicy(ir=self.ir, aconf=self.ir.aconf, **retry_policy)
 
         # Required fields check.
         if self["api_version"] == None:

--- a/ambassador/ambassador/ir/irauth.py
+++ b/ambassador/ambassador/ir/irauth.py
@@ -7,6 +7,7 @@ from ..resource import Resource
 
 from .irfilter import IRFilter
 from .ircluster import IRCluster
+from .irretrypolicy import IRRetryPolicy
 
 if TYPE_CHECKING:
     from .ir import IR
@@ -121,11 +122,15 @@ class IRAuth (IRFilter):
         self["proto"] = module.get("proto", "http")
         self["timeout_ms"] = module.get("timeout_ms", 5000)
         self["connect_timeout_ms"] = module.get("connect_timeout_ms", 3000)
-        self["status_on_error"] = module.get("status_on_error", 403)
-        self["failure_mode_allow"] = module.get("failure_mode_allow", False)
+        self["status_on_error"] = module.get("status_on_error", None)
+        self["failure_mode_allow"] = module.get("failure_mode_allow", None)
+        self["retry_policy"] = module.get("retry_policy", None)
         self.__to_header_list('allowed_headers', module)
         self.__to_header_list('allowed_request_headers', module)
         self.__to_header_list('allowed_authorization_headers', module)
+
+        if not self["retry_policy"] == None:
+            self["retry_policy"] = IRRetryPolicy(ir=self.ir, aconf=self.ir.aconf, **self["retry_policy"])
 
         # Required fields check.
         if self["api_version"] == None:

--- a/ambassador/schemas/v1/AuthService.schema
+++ b/ambassador/schemas/v1/AuthService.schema
@@ -39,7 +39,9 @@
             },
             "required": [ "max_bytes", "allow_partial" ],
             "additionalProperties": false
-        }
+        },
+        "status_on_error": { "type": "string" },
+        "failure_mode_allow": { "type": "string", "boolean" }
     },
     "required": [ "apiVersion", "kind", "name", "auth_service" ],
     "additionalProperties": false

--- a/ambassador/schemas/v1/AuthService.schema
+++ b/ambassador/schemas/v1/AuthService.schema
@@ -46,7 +46,7 @@
                 "code": { "type": "int" }
             }
         },
-        "failure_mode_allow": { "type": "string", "boolean" }
+        "failure_mode_allow": { "type": "boolean" },
         "retry_policy": {
             "type": "object",
             "properties": {

--- a/ambassador/schemas/v1/AuthService.schema
+++ b/ambassador/schemas/v1/AuthService.schema
@@ -43,7 +43,7 @@
         "status_on_error": { 
             "type": "object",
             "properties": {
-                "code": { "type": "int" }
+                "code": { "type": "integer" }
             }
         },
         "failure_mode_allow": { "type": "boolean" },

--- a/ambassador/schemas/v1/AuthService.schema
+++ b/ambassador/schemas/v1/AuthService.schema
@@ -40,8 +40,25 @@
             "required": [ "max_bytes", "allow_partial" ],
             "additionalProperties": false
         },
-        "status_on_error": { "type": "string" },
+        "status_on_error": { 
+            "type": "object",
+            "properties": {
+                "code": { "type": "int" }
+            }
+        },
         "failure_mode_allow": { "type": "string", "boolean" }
+        "retry_policy": {
+            "type": "object",
+            "properties": {
+                "retry_on":  {
+                    "type": "string",
+                    "enum": ["5xx", "gateway-error", "connect-failure", "retriable-4xx", "refused-stream", "retriable-status-codes"]
+                },
+                "num_retries": { "type": "integer" },
+                "per_try_timeout": { "type": "string" }
+            },
+            "additionalProperties": false
+        }
     },
     "required": [ "apiVersion", "kind", "name", "auth_service" ],
     "additionalProperties": false

--- a/ambassador/tests/t_extauth.py
+++ b/ambassador/tests/t_extauth.py
@@ -335,7 +335,7 @@ service: {self.target.path.fqdn}
         yield Query(self.url("target/"), headers={"Requested-Status": "200"}, expected=200)
         
         # [1]
-        yield Query(self.url("target/"), headers={"Requested-Status": "401"}, expected=200)
+        yield Query(self.url("target/"), headers={"Requested-Status": "503"}, expected=200)
 
     def check(self):
         # [0] Verifies that the authorization server received the partial message body.
@@ -346,7 +346,7 @@ service: {self.target.path.fqdn}
         
         # [1] Verifies that the authorization server received the full message body.
         extauth_res2 = json.loads(self.results[1].headers["Extauth"][0])
-        assert self.results[1].backend.request.headers["requested-status"] == ["401"]
+        assert self.results[1].backend.request.headers["requested-status"] == ["503"]
         assert self.results[1].status == 200
         assert self.results[1].headers["Server"] == ["envoy"]
 
@@ -382,6 +382,13 @@ allowed_request_headers:
 allowed_authorization_headers:
 - X-Foo
 - Extauth
+
+status_on_error:
+- code: 503
+
+retry_policy:
+  retry_on: "5xx"
+  num_retries: 2
 
 ---
 apiVersion: ambassador/v1

--- a/ambassador/tests/t_extauth.py
+++ b/ambassador/tests/t_extauth.py
@@ -383,7 +383,7 @@ allowed_authorization_headers:
 - Extauth
 
 status_on_error:
-- code: 503
+  code: 503
 
 retry_policy:
   retry_on: "5xx"
@@ -410,7 +410,7 @@ allowed_authorization_headers:
 - Extauth
 
 status_on_error:
-- code: 503
+  code: 503
 
 retry_policy:
   retry_on: "5xx"

--- a/ambassador/tests/t_extauth.py
+++ b/ambassador/tests/t_extauth.py
@@ -335,7 +335,7 @@ service: {self.target.path.fqdn}
         yield Query(self.url("target/"), headers={"Requested-Status": "200"}, expected=200)
         
         # [1]
-        yield Query(self.url("target/"), headers={"Requested-Status": "503"}, expected=200)
+        yield Query(self.url("target/"), headers={"Requested-Status": "503"}, expected=503)
 
     def check(self):
         # [0] Verifies that the authorization server received the partial message body.
@@ -347,7 +347,6 @@ service: {self.target.path.fqdn}
         # [1] Verifies that the authorization server received the full message body.
         extauth_res2 = json.loads(self.results[1].headers["Extauth"][0])
         assert self.results[1].backend.request.headers["requested-status"] == ["503"]
-        assert self.results[1].status == 200
         assert self.results[1].headers["Server"] == ["envoy"]
 
 class AuthenticationTestV1(AmbassadorTest):

--- a/ambassador/tests/t_extauth.py
+++ b/ambassador/tests/t_extauth.py
@@ -462,7 +462,7 @@ bypass_auth: true
         yield Query(self.url("target/unauthed/"), headers={"Requested-Status": "200"}, expected=200)
 
         # [7]
-        yield Query(self.url("target/"), headers={"Requested-Status": "503"}, expected=503)
+        yield Query(self.url("target/"), headers={"Requested-Status": "500"}, expected=503)
 
     def check_backend_name(self, result) -> bool:
         backend_name = result.backend.name
@@ -555,8 +555,6 @@ bypass_auth: true
         assert self.backend_counts.get(self.auth2.path.k8s, 0) > 0, "auth2 got no requests"
 
         # [7] Verifies that envoy returns customized status_on_error code.
-        assert self.check_backend_name(self.results[7])
-        assert self.results[7].backend.request.headers["requested-status"] == ["503"]
         assert self.results[7].status == 503
 
         # TODO(gsagula): Write tests for all UCs which request header headers

--- a/docs/reference/services/auth-service.md
+++ b/docs/reference/services/auth-service.md
@@ -25,6 +25,8 @@ allowed_authorization_headers:
 include_body:
   max_bytes: 4096
   allow_partial: true
+status_on_error: 403
+failure_mode_allow: false
 ```
 
 - `proto` (optional) specifies the protocol to use when communicating with the auth service. Valid options are `http` (default) or `grpc`.
@@ -53,6 +55,10 @@ include_body:
        * if false, the message is rejected. 
 
 - `allow_request_body` is deprecated. It is exactly equivalent to `include_body` with `max_bytes` 4096 and `allow_partial` true.
+
+- `status_on_error` (optional) status code returned when unable to communicate with auth service. Defaults to 403
+
+- `failure_mode_allow` (optional) if requests should be allowed on auth service failure. Defaults to false
 
 ### v0 (Ambassador versions prior to 0.50.0)
 

--- a/docs/reference/services/auth-service.md
+++ b/docs/reference/services/auth-service.md
@@ -25,8 +25,12 @@ allowed_authorization_headers:
 include_body:
   max_bytes: 4096
   allow_partial: true
-status_on_error: 403
+status_on_error: 
+  code: 503
 failure_mode_allow: false
+retry_policy:
+  retry_on: "5xx"
+  num_retries: 2
 ```
 
 - `proto` (optional) specifies the protocol to use when communicating with the auth service. Valid options are `http` (default) or `grpc`.
@@ -56,7 +60,8 @@ failure_mode_allow: false
 
 - `allow_request_body` is deprecated. It is exactly equivalent to `include_body` with `max_bytes` 4096 and `allow_partial` true.
 
-- `status_on_error` (optional) status code returned when unable to communicate with auth service. Defaults to 403
+- `status_on_error` (optional) status code returned when unable to communicate with auth service. 
+    * `code` Defaults to 403
 
 - `failure_mode_allow` (optional) if requests should be allowed on auth service failure. Defaults to false
 


### PR DESCRIPTION
## Description
This pull request adds support to set authservice config status_on_error, failure_mode_allow, and retry_policy and external auth

## Related Issues
List related issues.

https://github.com/datawire/ambassador/issues/1622
https://github.com/datawire/ambassador/issues/1461

## Testing
A few sentences describing what testing you've done, e.g., manual tests, automated tests, deployed in production, etc.
Built the docker containers using make docker-images
Ran using docker-compose

## Todos
- [x] Tests
- [x] Documentation

## Other
* If this is a documentation change, please open the pull request at https://github.com/datawire/ambassador-docs instead.
* Code changes should occur against `master`.
