### PR TITLE
Arrange for the docker commands in Kat to show output when they fail

### DIFF
--- a/ambassador/tests/abstract_tests.py
+++ b/ambassador/tests/abstract_tests.py
@@ -134,11 +134,21 @@ class AmbassadorTest(Test):
         if not AmbassadorTest.IMAGE_BUILT:
             AmbassadorTest.IMAGE_BUILT = True
 
-            print("Killing old containers...")
-            ShellCommand.run("kill old containers",
-                             "bash", "-c", 'docker kill $(docker ps -a -f \'label=kat-family=ambassador\' --format \'{{.ID}}\')')
-            ShellCommand.run("rm old containers",
-                             "bash", "-c", 'docker rm $(docker ps -a -f \'label=kat-family=ambassador\' --format \'{{.ID}}\')')
+            cmd = ShellCommand('docker', 'ps', '-a', '-f', 'label=kat-family=ambassador', '--format', '{{.ID}}')
+
+            if cmd.check('find old docker container IDs'):
+                ids = cmd.stdout.split('\n')
+
+                while ids:
+                    if ids[-1]:
+                        break
+
+                    ids.pop()
+
+                if ids:
+                    print("Killing old containers...")
+                    ShellCommand.run('kill old containers', 'docker', 'kill', *ids, verbose=True)
+                    ShellCommand.run('rm old containers', 'docker', 'rm', *ids, verbose=True)
 
             context = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
 

--- a/ambassador/tests/abstract_tests.py
+++ b/ambassador/tests/abstract_tests.py
@@ -306,13 +306,7 @@ class ServiceType(Node):
     use_superpod: bool = True
  
     def __init__(self, service_manifests: str=None, namespace: str=None, *args, **kwargs) -> None:
-        if namespace is not None:
-            print("%s init %s" % (type(self), namespace))
-
         super().__init__(namespace=namespace, *args, **kwargs)
-
-        if namespace is not None:
-            print("%s %s after super %s" % (type(self), self.name, self.namespace))
 
         self._manifests = service_manifests
 

--- a/kat/kat/utils.py
+++ b/kat/kat/utils.py
@@ -1,0 +1,63 @@
+import re
+import subprocess
+
+
+_quote_pos = re.compile('(?=[^-0-9a-zA-Z_./\n])')
+
+def quote(arg):
+    r"""
+    >>> quote('\t')
+    '\\\t'
+    >>> quote('foo bar')
+    'foo\\ bar'
+    """
+
+    # This is the logic emacs uses
+    if arg:
+        return _quote_pos.sub('\\\\', arg).replace('\n', "'\n'")
+    else:
+        return "''"
+
+
+class ShellCommand:
+    def __init__(self, *args, **kwargs) -> None:
+        self.verbose = kwargs.pop('verbose', False)
+
+        for arg in "stdout", "stderr":
+            if arg not in kwargs:
+                kwargs[arg] = subprocess.PIPE
+
+        self.cmdline = " ".join([quote(x) for x in args])
+
+        if self.verbose:
+            print(f'---- running: {self.cmdline}')
+
+        self.proc = subprocess.run(args, **kwargs)
+
+    def check(self, what: str) -> bool:
+        try:
+            self.proc.check_returncode()
+            return True
+        except Exception as e:
+            print(f"==== COMMAND FAILED: {what}")
+            print("---- command line ----")
+            print(self.cmdline)
+            print("---- stdout ----")
+            print(self.stdout)
+            print("")
+            print("---- stderr ----")
+            print(self.stderr)
+
+            return False
+
+    @property
+    def stdout(self) -> str:
+        return self.proc.stdout.decode("utf-8")
+
+    @property
+    def stderr(self) -> str:
+        return self.proc.stderr.decode("utf-8")
+
+    @classmethod
+    def run(cls, what: str, *args, **kwargs) -> None:
+        ShellCommand(*args, **kwargs).check(what)


### PR DESCRIPTION
I've been sick of the lack of output on failures for awhile. This PR probably makes the initial cleanup of dead Docker containers too verbose, actually, but I'll tweak that later.