### PR TITLE
auth-service: automatically include the l5d-dst-override header

### DIFF
--- a/ambassador/ambassador/envoy/v2/v2listener.py
+++ b/ambassador/ambassador/envoy/v2/v2listener.py
@@ -265,7 +265,7 @@ def v2filter_authv1(auth: IRAuth, v2config: 'V2Config'):
 
         if auth.get('add_linkerd_headers', False):
             headers_to_add.append({
-                'key' : 'l5d-dst-override' 
+                'key' : 'l5d-dst-override', 
                 'value': auth_cluster_uri(auth, cluster)
             })
 
@@ -280,11 +280,11 @@ def v2filter_authv1(auth: IRAuth, v2config: 'V2Config'):
                     },
                     'path_prefix': auth.path_prefix,
                     'authorization_request': {
-                    'allowed_headers': {
+                        'allowed_headers': {
                             'patterns': allowed_request_headers
-                        }
+                        },
+                        'headers_to_add' : headers_to_add
                     },
-                    'headers_to_add' : headers_to_add,
                     'authorization_response' : {
                         'allowed_upstream_headers': {
                             'patterns': allowed_authorization_headers

--- a/ambassador/ambassador/envoy/v2/v2listener.py
+++ b/ambassador/ambassador/envoy/v2/v2listener.py
@@ -253,6 +253,7 @@ def v2filter_authv1(auth: IRAuth, v2config: 'V2Config'):
 
     if auth.proto == "http":
         allowed_authorization_headers = []
+        headers_to_add = []
 
         for key in list(set(auth.allowed_authorization_headers).union(AllowedAuthorizationHeaders)):
             allowed_authorization_headers.append({"exact": key})
@@ -261,6 +262,12 @@ def v2filter_authv1(auth: IRAuth, v2config: 'V2Config'):
 
         for key in list(set(auth.allowed_request_headers).union(AllowedRequestHeaders)):
             allowed_request_headers.append({"exact": key})
+
+        if auth.get('add_linkerd_headers', False):
+            headers_to_add.append({
+                'key' : 'l5d-dst-override' 
+                'value': auth_cluster_uri(auth, cluster)
+            })
 
         auth_info = {
             'name': 'envoy.ext_authz',
@@ -277,6 +284,7 @@ def v2filter_authv1(auth: IRAuth, v2config: 'V2Config'):
                             'patterns': allowed_request_headers
                         }
                     },
+                    'headers_to_add' : headers_to_add,
                     'authorization_response' : {
                         'allowed_upstream_headers': {
                             'patterns': allowed_authorization_headers

--- a/ambassador/ambassador/ir/irauth.py
+++ b/ambassador/ambassador/ir/irauth.py
@@ -116,7 +116,11 @@ class IRAuth (IRFilter):
 
             self.referenced_by(module)
 
-        self["add_linkerd_headers"] = module.get("add_linkerd_headers", False)
+        if module.get("add_linkerd_headers") not None:
+            self["add_linkerd_headers"] = module.get("add_linkerd_headers")
+        else:
+            self["add_linkerd_headers"] = 'add_linkerd_headers' in self.ir.ambassador_module and self.ir.ambassador_module.add_linkerd_headers is True
+        
         self["allow_request_body"] = module.get("allow_request_body", False)
         self["include_body"] = module.get("include_body", None)
         self["api_version"] = module.get("apiVersion", None)

--- a/ambassador/ambassador/ir/irauth.py
+++ b/ambassador/ambassador/ir/irauth.py
@@ -115,6 +115,7 @@ class IRAuth (IRFilter):
 
             self.referenced_by(module)
 
+        self["add_linkerd_headers"] = module.get("add_linkerd_headers", False)
         self["allow_request_body"] = module.get("allow_request_body", False)
         self["include_body"] = module.get("include_body", None)
         self["api_version"] = module.get("apiVersion", None)

--- a/ambassador/ambassador/ir/irauth.py
+++ b/ambassador/ambassador/ir/irauth.py
@@ -116,10 +116,10 @@ class IRAuth (IRFilter):
 
             self.referenced_by(module)
 
-        if module.get("add_linkerd_headers") not None:
-            self["add_linkerd_headers"] = module.get("add_linkerd_headers")
+        if module.get('add_linkerd_headers', None):
+            self["add_linkerd_headers"] = module.get("add_linkerd_headers", False)
         else:
-            self["add_linkerd_headers"] = 'add_linkerd_headers' in self.ir.ambassador_module and self.ir.ambassador_module.add_linkerd_headers is True
+            self["add_linkerd_headers"] = 'add_linkerd_headers' in self.ir.ambassador_module and self.ir.ambassador_module.add_linkerd_headers
         
         self["allow_request_body"] = module.get("allow_request_body", False)
         self["include_body"] = module.get("include_body", None)

--- a/ambassador/schemas/v1/AuthService.schema
+++ b/ambassador/schemas/v1/AuthService.schema
@@ -31,6 +31,7 @@
             "items": { "type": "string" }
         },
         "allow_request_body": { "type": "boolean" },
+        "add_linkerd_headers": { "type": "boolean" },
         "include_body": {
             "type": "object",
             "properties": {

--- a/ambassador/tests/t_extauth.py
+++ b/ambassador/tests/t_extauth.py
@@ -331,6 +331,7 @@ auth_service: "{self.auth2.path.fqdn}"
 proto: http
 path_prefix: "/extauth"
 timeout_ms: 5000
+add_linkerd_headers: true
 
 allowed_request_headers:
 - X-Foo
@@ -442,6 +443,10 @@ bypass_auth: true
         assert self.results[4].status == 200
         assert self.results[4].headers["Server"] == ["envoy"]
         assert self.results[4].headers["Authorization"] == ["foo-11111"]
+
+        extauth_res = json.loads(self.results[4].headers["Extauth"][0])
+        assert extauth_res["request"]["headers"]["l5d-dst-override"] ==  [ self.url ]
+
 
         # [5] Verify that X-Forwarded-Proto makes it to the auth service.
         #

--- a/ambassador/tests/t_extauth.py
+++ b/ambassador/tests/t_extauth.py
@@ -444,8 +444,8 @@ bypass_auth: true
         assert self.results[4].headers["Server"] == ["envoy"]
         assert self.results[4].headers["Authorization"] == ["foo-11111"]
 
-        extauth_res = json.loads(self.results[4].headers["Extauth"][0])
-        assert extauth_res["request"]["headers"]["l5d-dst-override"] ==  [ self.url ]
+        extauth_req = json.loads(self.results[4].backend.request.headers["extauth"][0])
+        assert extauth_req["request"]["headers"]["l5d-dst-override"] ==  [ 'http://extauth' ]
 
 
         # [5] Verify that X-Forwarded-Proto makes it to the auth service.

--- a/ambassador/tests/t_extauth.py
+++ b/ambassador/tests/t_extauth.py
@@ -313,7 +313,7 @@ name:  {self.auth.path.k8s}
 auth_service: "{self.auth.path.fqdn}"
 path_prefix: "/extauth"
 timeout_ms: 5000
-tls: {self.name}-same-context-1
+tls: {self.name}-same-context-1 
 
 allowed_request_headers:
 - Requested-Status
@@ -332,7 +332,7 @@ service: {self.target.path.fqdn}
 
     def queries(self):
         # [0]
-        yield Query(self.url("target/"), headers={"Requested-Status": "200"}, expected=200)
+        yield Query(self.url("target/"), headers={"Requested-Status": "200"}, expected=200, debug=True)
         
         # [1]
         yield Query(self.url("target/"), headers={"Requested-Status": "503"}, expected=503)

--- a/docs/reference/services/auth-service.md
+++ b/docs/reference/services/auth-service.md
@@ -25,6 +25,7 @@ allowed_authorization_headers:
 include_body:
   max_bytes: 4096
   allow_partial: true
+add_linkerd_headers: true
 ```
 
 - `proto` (optional) specifies the protocol to use when communicating with the auth service. Valid options are `http` (default) or `grpc`.
@@ -53,6 +54,8 @@ include_body:
        * if false, the message is rejected. 
 
 - `allow_request_body` is deprecated. It is exactly equivalent to `include_body` with `max_bytes` 4096 and `allow_partial` true.
+
+- `add_linkerd_headers` (optional) when true, adds `l5d-dst-override` to the authorization request and set the hostname of the authorization server as the header value. 
 
 ### v0 (Ambassador versions prior to 0.50.0)
 


### PR DESCRIPTION
## Description
Adds support for automatically include the `l5d-dst-override` header to all authorization requests (when configured).

## Related Issues
Fixes https://github.com/datawire/ambassador/issues/1578

## Testing
KAT tests

## Todos
- n/a