### PR TITLE
handle TimeoutExpired on envoy validation, to keep receiving config updates

### DIFF
--- a/ambassador/ambassador_diag/diagd.py
+++ b/ambassador/ambassador_diag/diagd.py
@@ -906,7 +906,7 @@ class AmbassadorEventWatcher(threading.Thread):
                 odict['output'] = e.output
                 break
             except subprocess.TimeoutExpired as e:
-                odict['exit_code'] = e.returncode
+                odict['exit_code'] = 1
                 odict['output'] = e.output
                 self.logger.warn("envoy configuration validation timed out after {} seconds{}\n{}",
                     timeout, ', retrying...' if retry < retries - 1 else '', e.output)


### PR DESCRIPTION
 ## Description
When `envoy --mode validate` fails, Ambassador receives an unhandled `subprocess.TimeoutExpired` and stops picking up all future configuration changes.

This adds retries to Envoy config validation, in the fervent hope that a subsequent validation will not time out.

## Related Issues
#1478

## Testing
We were hitting `TimeoutExpired` a few times per day. We're running this branch in production, and are waiting for the timeout case to hit to make sure the updates handle it correctly.

## Todos
- [ ] Tests -- not sure if there are any automated tests for this. I'm not too familiar with Ambassador's code base, but looking at previous revisions that touched this code, it doesn't look like there are any tests to be updated.
- [X] Documentation -- think this change is pretty transparent, having Ambassador DTRT.
