### PR TITLE
Allow defining Service records directly, as well as synthesizing them from K8s services

### DIFF
--- a/ambassador/ambassador/config/config.py
+++ b/ambassador/ambassador/config/config.py
@@ -538,4 +538,7 @@ class Config:
                             (resource, resource.kind, key, storage[key].location),
                             resource=resource)
 
+        self.logger.debug("%s: saving %s %s" %
+                          (resource, resource.kind, key))
+
         storage[key] = resource

--- a/ambassador/ambassador/config/resourcefetcher.py
+++ b/ambassador/ambassador/config/resourcefetcher.py
@@ -304,13 +304,18 @@ class ResourceFetcher:
 
         # self.logger.debug("%s PROCESS %s updated rkey to %s" % (self.location, obj['kind'], rkey))
 
-        # Fine. Fine fine fine.
-        serialization = dump_yaml(obj, default_flow_style=False)
+        # Brutal hackery.
+        if obj['kind'] == 'Service':
+            self.logger.debug("%s PROCESS saving service %s" % (self.location, obj['name']))
+            self.services[obj['name']] = obj
+        else:
+            # Fine. Fine fine fine.
+            serialization = dump_yaml(obj, default_flow_style=False)
 
-        r = ACResource.from_dict(rkey, rkey, serialization, obj)
-        self.elements.append(r)
+            r = ACResource.from_dict(rkey, rkey, serialization, obj)
+            self.elements.append(r)
 
-        # self.logger.debug("%s PROCESS %s save %s: %s" % (self.location, obj['kind'], rkey, serialization))
+            self.logger.debug("%s PROCESS %s save %s: %s" % (self.location, obj['kind'], rkey, serialization))
 
     def sorted(self, key=lambda x: x.rkey):  # returns an iterator, probably
         return sorted(self.elements, key=key)


### PR DESCRIPTION
Internally, a Kubernetes or Consul service gets turned into an Ambassador record of type `Service`. This PR allows defining `Service` resources directly.

This is mostly useful for some testing scenarios I'm working on, but since this is common code across them I decided to land it early.