### PR TITLE
Configurable cluster_idle_timeout_ms to bound upstream keepalives

### DIFF
--- a/ambassador/ambassador/envoy/v2/v2cluster.py
+++ b/ambassador/ambassador/envoy/v2/v2cluster.py
@@ -35,11 +35,16 @@ class V2Cluster(dict):
             else:
                 dns_lookup_family = 'V6_ONLY'
 
+        cluster_idle_timeout_ms = cluster.ir.ambassador_module.get('cluster_idle_timeout_ms', 30000)
+
         fields = {
             'name': cluster.name,
             'type': cluster.type.upper(),
             'lb_policy': cluster.lb_type.upper(),
             'connect_timeout':"%0.3fs" % (float(cluster.connect_timeout_ms) / 1000.0),
+            'common_http_protocol_options': {
+                'idle_timeout': "%0.3fs" % (float(cluster_idle_timeout_ms) / 1000.0)
+            },
             'load_assignment': {
                 'cluster_name': cluster.name,
                 'endpoints': [

--- a/ambassador/ambassador/envoy/v2/v2cluster.py
+++ b/ambassador/ambassador/envoy/v2/v2cluster.py
@@ -35,16 +35,11 @@ class V2Cluster(dict):
             else:
                 dns_lookup_family = 'V6_ONLY'
 
-        cluster_idle_timeout_ms = cluster.ir.ambassador_module.get('cluster_idle_timeout_ms', 30000)
-
         fields = {
             'name': cluster.name,
             'type': cluster.type.upper(),
             'lb_policy': cluster.lb_type.upper(),
             'connect_timeout':"%0.3fs" % (float(cluster.connect_timeout_ms) / 1000.0),
-            'common_http_protocol_options': {
-                'idle_timeout': "%0.3fs" % (float(cluster_idle_timeout_ms) / 1000.0)
-            },
             'load_assignment': {
                 'cluster_name': cluster.name,
                 'endpoints': [
@@ -55,6 +50,16 @@ class V2Cluster(dict):
             },
             'dns_lookup_family': dns_lookup_family
         }
+
+        if cluster.cluster_idle_timeout_ms:
+            cluster_idle_timeout_ms = cluster.cluster_idle_timeout_ms
+        else:
+            cluster_idle_timeout_ms = cluster.ir.ambassador_module.get('cluster_idle_timeout_ms', None)
+        if cluster_idle_timeout_ms:
+            fields['common_http_protocol_options'] = {
+                'idle_timeout': "%0.3fs" % (float(cluster_idle_timeout_ms) / 1000.0)
+            }
+
         circuit_breakers = self.get_circuit_breakers(cluster)
         if circuit_breakers is not None:
             fields['circuit_breakers'] = circuit_breakers

--- a/ambassador/ambassador/ir/irambassador.py
+++ b/ambassador/ambassador/ir/irambassador.py
@@ -29,6 +29,7 @@ class IRAmbassador (IRResource):
         'diagnostics',
         'enable_ipv6',
         'enable_ipv4',
+        'cluster_idle_timeout_ms',
         'liveness_probe',
         'load_balancer',
         'readiness_probe',

--- a/ambassador/ambassador/ir/irauth.py
+++ b/ambassador/ambassador/ir/irauth.py
@@ -122,6 +122,7 @@ class IRAuth (IRFilter):
         self["proto"] = module.get("proto", "http")
         self["timeout_ms"] = module.get("timeout_ms", 5000)
         self["connect_timeout_ms"] = module.get("connect_timeout_ms", 3000)
+        self["cluster_idle_timeout_ms"] = module.get("cluster_idle_timeout_ms", None)
         self.__to_header_list('allowed_headers', module)
         self.__to_header_list('allowed_request_headers', module)
         self.__to_header_list('allowed_authorization_headers', module)
@@ -162,7 +163,7 @@ class IRAuth (IRFilter):
             "cluster": self.cluster.name
         }
 
-        for key in [ 'allowed_headers', 'path_prefix', 'timeout_ms', 'weight', 'connect_timeout_ms' ]:
+        for key in [ 'allowed_headers', 'path_prefix', 'timeout_ms', 'weight', 'connect_timeout_ms', 'cluster_idle_timeout_ms' ]:
             if self.get(key, None):
                 config[key] = self[key]
 

--- a/ambassador/ambassador/ir/ircluster.py
+++ b/ambassador/ambassador/ir/ircluster.py
@@ -44,6 +44,7 @@ class IRCluster (IRResource):
                  service: str,   # REQUIRED
                  resolver: Optional[str] = None,
                  connect_timeout_ms: Optional[int] = 3000,
+                 cluster_idle_timeout_ms: Optional[int] = None,
                  marker: Optional[str] = None,  # extra marker for this context name
 
                  ctx_name: Optional[Union[str, bool]]=None,
@@ -250,6 +251,7 @@ class IRCluster (IRResource):
             'enable_ipv6': enable_ipv6,
             'enable_endpoints': enable_endpoints,
             'connect_timeout_ms': connect_timeout_ms,
+            'cluster_idle_timeout_ms': cluster_idle_timeout_ms,
         }
 
         if grpc:
@@ -329,7 +331,7 @@ class IRCluster (IRResource):
         mismatches = []
 
         for key in [ 'type', 'lb_type', 'host_rewrite',
-                     'tls_context', 'originate_tls', 'grpc', 'connect_timeout_ms' ]:
+                     'tls_context', 'originate_tls', 'grpc', 'connect_timeout_ms', 'cluster_idle_timeout_ms' ]:
             if self.get(key, None) != other.get(key, None):
                 mismatches.append(key)
 

--- a/ambassador/ambassador/ir/irhttpmapping.py
+++ b/ambassador/ambassador/ir/irhttpmapping.py
@@ -87,6 +87,7 @@ class IRHTTPMapping (IRBaseMapping):
         "service": True,
         "shadow": True,
         "connect_timeout_ms": True,
+        "cluster_idle_timeout_ms": True,
         "timeout_ms": True,
         "idle_timeout_ms": True,
         "tls": True,

--- a/ambassador/ambassador/ir/irhttpmappinggroup.py
+++ b/ambassador/ambassador/ir/irhttpmappinggroup.py
@@ -33,6 +33,7 @@ class IRHTTPMappingGroup (IRBaseMappingGroup):
         'circuit_breakers': True,
         'cluster_timeout_ms': True,
         'connect_timeout_ms': True,
+        'cluster_idle_timeout_ms': True,
         'group_id': True,
         'headers': True,
         'host_rewrite': True,
@@ -195,6 +196,7 @@ class IRHTTPMappingGroup (IRBaseMappingGroup):
                             grpc=mapping.get('grpc', False),
                             load_balancer=mapping.get('load_balancer', None),
                             connect_timeout_ms=mapping.get('connect_timeout_ms', 3000),
+                            cluster_idle_timeout_ms=mapping.get('cluster_idle_timeout_ms', None),
                             circuit_breakers=mapping.get('circuit_breakers', None),
                             marker=marker)
 

--- a/ambassador/schemas/v1/Mapping.schema
+++ b/ambassador/schemas/v1/Mapping.schema
@@ -109,6 +109,7 @@
         "rewrite": { "type": "string" },
         "shadow": { "type": "boolean" },
         "connect_timeout_ms": { "type": "integer" },
+        "cluster_idle_timeout_ms": { "type": "integer" },
         "timeout_ms": { "type": "integer" },
         "idle_timeout_ms": { "type": "integer" },
         "tls": { "type": [ "string", "boolean" ] },


### PR DESCRIPTION
## Description
Add cluster_idle_timeout_ms to the ambassador module and Mapping schema, so that operators can set upstream keepalive timeouts.

## Related Issues
https://github.com/datawire/ambassador/issues/1542

## Testing
We use this for our use case. It ensures that Envoy times out idle connections before the typical upstream, to avoid the http1 race condition of missing an upstream close event at the moment a connection is chosen for proxying.

## Todos
- [ ] Tests
- [ ] Documentation

This needs some docs and probably a unit test.

Open question: should we allow this to be overriden per Mapping? Or does that make merging Mappings into a cluster more complicated?
