### PR TITLE
Support selectors to filter which objects are processed by an Ambassador deployment.

### DIFF
--- a/ambassador/entrypoint.sh
+++ b/ambassador/entrypoint.sh
@@ -200,11 +200,23 @@ if [[ -z "${AMBASSADOR_NO_KUBEWATCH}" ]]; then
         KUBEWATCH_SYNC_KINDS="$KUBEWATCH_SYNC_KINDS -s ConsulResolver -s KubernetesEndpointResolver -s KubernetesServiceResolver"
     fi
 
+    AMBASSADOR_FIELD_SELECTOR_ARG=""
+    if [ -n "$AMBASSADOR_FIELD_SELECTOR" ] ; then
+	    AMBASSADOR_FIELD_SELECTOR_ARG="--fields $AMBASSADOR_FIELD_SELECTOR"
+    fi
+
+    AMBASSADOR_LABEL_SELECTOR_ARG=""
+    if [ -n "$AMBASSADOR_LABEL_SELECTOR" ] ; then
+	    AMBASSADOR_LABEL_SELECTOR_ARG="--labels $AMBASSADOR_LABEL_SELECTOR"
+    fi
+
     launch /ambassador/watt \
            --port 8002 \
            ${AMBASSADOR_SINGLE_NAMESPACE:+ --namespace "${AMBASSADOR_NAMESPACE}" } \
            --notify 'sh /ambassador/post_watt.sh' \
            ${KUBEWATCH_SYNC_KINDS} \
+           ${AMBASSADOR_FIELD_SELECTOR_ARG} \
+           ${AMBASSADOR_LABEL_SELECTOR_ARG} \
            --watch /ambassador/watch_hook.py
 fi
 

--- a/ambassador/watch_hook.py
+++ b/ambassador/watch_hook.py
@@ -222,6 +222,9 @@ kube_watches = []
 
 global_resolver = fake.ambassador_module.get('resolver', None)
 
+label_selector = os.environ.get('AMBASSADOR_LABEL_SELECTOR', '')
+logger.debug('label-selector: %s' % label_selector)
+
 for mname, mapping in mappings.items():
     res_name = mapping.get('resolver', None)
     res_source = 'mapping'
@@ -268,6 +271,7 @@ for mname, mapping in mappings.items():
                     {
                         "kind": "endpoints",
                         "namespace": namespace,
+                        "label-selector": label_selector,
                         "field-selector": f'metadata.name={host}'
                     }
                 )
@@ -279,6 +283,7 @@ for secret_key, secret_info in fake.secret_handler.needed.items():
         {
             "kind": "secret",
             "namespace": secret_info.namespace,
+            "label-selector": label_selector,
             "field-selector": f'metadata.name={secret_info.name}'
         }
     )


### PR DESCRIPTION
Support the ability to tell Watt which label selectors or field selectors to use. This can be used by an operator to cut down on the number of objects processed by an Ambassador deployment. 

## Related Issues
https://github.com/datawire/ambassador/issues/1292

## Testing
We use this for our testing environment use case to dramatically reduce the number of Service objects processed on a highly multi-tenant Kubernetes cluster. Each Ambassador deployment has a distinct ambassador_id, and they further provide Watt with a label selector such as `environment=someEnv` to limit Service results to only the set of things that can possibly contain mappings for that ambassador_id. Without this change, memory and CPU utilization on all Ambassadors is high.

## Todos
- [ ] Tests
- [ ] Documentation
This probably deserves to be mentioned in the documentation, especially near any existing documentation for running Ambassador in a multi-tenant cluster.
