### PR TITLE
Add IRResource.lookup method

### DIFF
--- a/ambassador/ambassador/cli.py
+++ b/ambassador/ambassador/cli.py
@@ -29,9 +29,8 @@ from clize import Parameter
 from . import Scout, Config, IR, Diagnostics, Version
 from .config.resourcefetcher import ResourceFetcher
 from .envoy import EnvoyConfig, V2Config
-from .ir.irtlscontext import IRTLSContext
 
-from .utils import RichStatus, SecretInfo, SecretHandler
+from .utils import RichStatus, NullSecretHandler
 
 __version__ = Version
 
@@ -105,14 +104,6 @@ def file_checker(path: str) -> bool:
     return True
 
 
-class CLISecretHandler(SecretHandler):
-    def load_secret(self, context: 'IRTLSContext', secret_name: str, namespace: str) -> Optional[SecretInfo]:
-        # In the Real World, the secret loader should, y'know, load secrets..
-        # Here we're just gonna fake it.
-
-        return SecretInfo(secret_name, namespace, "fake-tls-crt", "fake-tls-key")
-
-
 def dump(config_dir_path: Parameter.REQUIRED, *,
          secret_dir_path=None, watt=False, debug=False, debug_scout=False, k8s=False, recurse=False,
          aconf=False, ir=False, v2=False, diag=False, features=False):
@@ -181,7 +172,7 @@ def dump(config_dir_path: Parameter.REQUIRED, *,
         if dump_aconf:
             od['aconf'] = aconf.as_dict()
 
-        secret_handler = CLISecretHandler(logger, config_dir_path, secret_dir_path, "0")
+        secret_handler = NullSecretHandler(logger, config_dir_path, secret_dir_path, "0")
 
         ir = IR(aconf, file_checker=file_checker, secret_handler=secret_handler)
 
@@ -309,7 +300,7 @@ def config(config_dir_path: Parameter.REQUIRED, output_json_path: Parameter.REQU
             if exit_on_error and aconf.errors:
                 raise Exception("errors in: {0}".format(', '.join(aconf.errors.keys())))
 
-            secret_handler = CLISecretHandler(logger, config_dir_path, config_dir_path, "0")
+            secret_handler = NullSecretHandler(logger, config_dir_path, config_dir_path, "0")
 
             ir = IR(aconf, file_checker=file_checker, secret_handler=secret_handler)
 

--- a/ambassador/ambassador/config/__init__.py
+++ b/ambassador/ambassador/config/__init__.py
@@ -16,3 +16,4 @@ from .acresource import ACResource
 from .acmapping import ACMapping
 from .acpragma import ACPragma
 from .config import Config
+from .resourcefetcher import ResourceFetcher

--- a/ambassador/ambassador/ir/irambassador.py
+++ b/ambassador/ambassador/ir/irambassador.py
@@ -92,7 +92,12 @@ class IRAmbassador (IRResource):
             **kwargs
         )
 
-    def setup(self, ir: 'IR', aconf: Config) -> bool:
+    # We allow 'setup' to just return True for the Ambassador module, and do the heavy lifting
+    # in 'finalize', so that we can do fallback lookups for TLS configuration stuff during
+    # finalize. As it happens, finalize is called _immediately_ after setup finishes, from
+    # ir.py.
+
+    def finalize(self, ir: 'IR', aconf: Config) -> bool:
         # We're interested in the 'ambassador' module from the Config, if any...
         amod = aconf.get_module("ambassador")
 
@@ -234,7 +239,6 @@ class IRAmbassador (IRResource):
                 ir.save_filter(self.gzip)
             else:
                 return False
-
 
          # Buffer.
         if amod and ('buffer' in amod):

--- a/ambassador/ambassador/ir/irambassador.py
+++ b/ambassador/ambassador/ir/irambassador.py
@@ -25,6 +25,7 @@ class IRAmbassador (IRResource):
         'circuit_breakers',
         'default_label_domain',
         'default_labels',
+        'defaults',
         'diag_port',
         'diagnostics',
         'enable_ipv6',

--- a/ambassador/ambassador/ir/irresource.py
+++ b/ambassador/ambassador/ir/irresource.py
@@ -62,6 +62,61 @@ class IRResource (Resource):
         # ...before we override it with the setup results.
         self.set_active(self.setup(ir, aconf))
 
+    def lookup(self, key: str, *args, default_class: str=None, default_key: str=None) -> Any:
+        """
+        Look up a key in this IRResource, with a fallback to the Ambassador module's "defaults"
+        element.
+
+        Here's the resolution order:
+
+        - if key is present in self, use its value.
+        - if not, we'll try to look up a fallback value in the Ambassador module:
+            - the key for the lookup will be the value of "default_key" if that's set,
+              otherwise the same key we just tried in self.
+            - if "default_class" wasn't passed in, and self.default_class isn't set, just
+              look up a fallback value from the "defaults" dict in the Ambassador module.
+            - otherwise, look up the default class in Ambassador's "defaults", then look up
+              the fallback value from that dict (the passed in "default_class" wins if both
+              are set).
+        - if no key is present in self, and no fallback is found, but a default value was passed
+          in as *args[0], return that.
+        - if all else fails, return None.
+
+        :param key: the key to look up
+        :param default_class: the default class for the fallback lookup (optional, see above)
+        :param default_key: the key for the fallback lookup (optional, defaults to key)
+        :param args: an all-else-fails default value can go here, see above
+        :return: Any
+        """
+
+        value = self.get(key, None)
+
+        default_value = None
+
+        if len(args) > 0:
+            default_value = args[0]
+
+        if value is None:
+            get_from = self.ir.ambassador_module
+
+            dfl_class = default_class
+
+            if not dfl_class:
+                dfl_class = self.get('default_class', None)
+
+            if dfl_class:
+                get_from = self.ir.ambassador_module.get(dfl_class)
+
+            if get_from:
+                if not default_key:
+                    default_key = key
+
+                value = get_from.get(default_key, default_value)
+            else:
+                value = default_value
+
+        return value
+
     def add_dict_helper(self, key: str, helper) -> None:
         self.__as_dict_helpers[key] = helper
 

--- a/ambassador/ambassador/utils.py
+++ b/ambassador/ambassador/utils.py
@@ -25,6 +25,7 @@ import time
 import os
 import logging
 import requests
+import tempfile
 import yaml
 
 from .VERSION import Version
@@ -466,6 +467,32 @@ class SecretHandler:
             return None
 
         return SecretInfo.from_dict(context, secret_name, source, namespace, cert_data)
+
+
+class NullSecretHandler(SecretHandler):
+    def __init__(self, logger: logging.Logger, source_root: Optional[str], cache_dir: Optional[str], version: str) -> None:
+        """
+        Returns a valid SecretInfo (with fake keys) for any requested secret. Also, you can pass
+        None for source_root and cache_dir to use random temporary directories for them.
+        """
+
+        if not source_root:
+            self.tempdir_source = tempfile.TemporaryDirectory(prefix="null-secret-", suffix="-source")
+            source_root = self.tempdir_source.name
+
+        if not cache_dir:
+            self.tempdir_cache = tempfile.TemporaryDirectory(prefix="null-secret-", suffix="-cache")
+            cache_dir = self.tempdir_cache.name
+
+        logger.info(f'NullSecretHandler using source_root {source_root}, cache_dir {cache_dir}')
+
+        super().__init__(logger, source_root, cache_dir, version)
+
+    def load_secret(self, context: 'IRTLSContext', secret_name: str, namespace: str) -> Optional[SecretInfo]:
+        # In the Real World, the secret loader should, y'know, load secrets..
+        # Here we're just gonna fake it.
+
+        return SecretInfo(secret_name, namespace, "fake-tls-crt", "fake-tls-key")
 
 
 class FSSecretHandler(SecretHandler):

--- a/ambassador/tests/test_lookup.py
+++ b/ambassador/tests/test_lookup.py
@@ -1,0 +1,108 @@
+from typing import Optional
+
+import logging
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s test %(levelname)s: %(message)s",
+    datefmt='%Y-%m-%d %H:%M:%S'
+)
+
+logger = logging.getLogger("ambassador")
+
+from ambassador import Config, IR
+from ambassador.config import ResourceFetcher
+from ambassador.utils import NullSecretHandler
+from ambassador.ir import IRResource
+from ambassador.ir.irbuffer import IRBuffer
+
+yaml = '''
+---
+apiVersion: getambassador.io/v1
+kind: Module
+name: ambassador
+config:
+    defaults:
+        max_request_words: 1
+        altered: 2
+        test_resource:
+            max_request_words: 3
+            altered: 4
+---
+apiVersion: getambassador.io/v1
+kind: Mapping
+name: test_mapping
+prefix: /test/
+service: test:9999
+'''
+
+
+class IRTestResource(IRBuffer):
+    def __init__(self, ir: 'IR', aconf: Config,
+                 rkey: str="ir.testresource",
+                 name: str="ir.testresource",
+                 kind: str="IRTestResource",
+                 **kwargs) -> None:
+
+        super().__init__(ir=ir, aconf=aconf, rkey=rkey, kind=kind, name=name, **kwargs)
+
+        self.default_class = 'test_resource'
+
+
+def test_lookup():
+    aconf = Config()
+
+    fetcher = ResourceFetcher(logger, aconf)
+    fetcher.parse_yaml(yaml)
+
+    aconf.load_all(fetcher.sorted())
+
+    secret_handler = NullSecretHandler(logger, None, None, "0")
+
+    ir = IR(aconf, file_checker=lambda path: True, secret_handler=secret_handler)
+
+    t1 = IRBuffer(ir, aconf, rkey='-foo-', name='buffer', max_request_bytes=4096)
+
+    t2 = IRTestResource(ir, aconf, rkey='-foo-', name='buffer', max_request_bytes=8192)
+
+    assert t1.lookup('max_request_bytes') == 4096
+    assert t1.lookup('max_request_bytes', 57) == 4096
+    assert t1.lookup('max_request_bytes2', 57) == 57
+
+    assert t1.lookup('max_request_words') == 1
+    assert t1.lookup('max_request_words', 77) == 1
+    assert t1.lookup('max_request_words', default_key='altered') == 2
+    assert t1.lookup('max_request_words', 77, default_key='altered') == 2
+    assert t1.lookup('max_request_words', default_key='altered2') == None
+    assert t1.lookup('max_request_words', 77, default_key='altered2') == 77
+
+    assert t1.lookup('max_request_words', default_class='test_resource') == 3
+    assert t1.lookup('max_request_words', 77, default_class='test_resource') == 3
+    assert t1.lookup('max_request_words', 77, default_class='test_resource2') == 77
+    assert t1.lookup('max_request_words', default_key='altered', default_class='test_resource') == 4
+    assert t1.lookup('max_request_words', 77, default_key='altered', default_class='test_resource') == 4
+    assert t1.lookup('max_request_words', default_key='altered2', default_class='test_resource') == None
+    assert t1.lookup('max_request_words', 77, default_key='altered2', default_class='test_resource') == 77
+
+    assert t2.lookup('max_request_bytes') == 8192
+    assert t2.lookup('max_request_bytes', 57) == 8192
+    assert t2.lookup('max_request_bytes2', 57) == 57
+
+    assert t2.lookup('max_request_words') == 3
+    assert t2.lookup('max_request_words', 77) == 3
+    assert t2.lookup('max_request_words', default_key='altered') == 4
+    assert t2.lookup('max_request_words', 77, default_key='altered') == 4
+    assert t2.lookup('max_request_words', default_key='altered2') == None
+    assert t2.lookup('max_request_words', 77, default_key='altered2') == 77
+
+    assert t2.lookup('max_request_words', default_class='/') == 1
+    assert t2.lookup('max_request_words', 77, default_class='/') == 1
+    assert t2.lookup('max_request_words', 77, default_class='/2') == 77
+    assert t2.lookup('max_request_words', default_key='altered', default_class='/') == 2
+    assert t2.lookup('max_request_words', 77, default_key='altered', default_class='/') == 2
+    assert t2.lookup('max_request_words', default_key='altered2', default_class='/') == None
+    assert t2.lookup('max_request_words', 77, default_key='altered2', default_class='/') == 77
+
+if __name__ == '__main__':
+    test_lookup()
+

--- a/ambassador/watch_hook.py
+++ b/ambassador/watch_hook.py
@@ -108,11 +108,13 @@ class FakeIR(IR):
         self.saved_secrets = {}
         self.secret_info = {}
 
+        self.ambassador_module = IRAmbassador(self, aconf)
+
         IRServiceResolverFactory.load_all(self, aconf)
         TLSModuleFactory.load_all(self, aconf)
         self.save_tls_contexts(aconf)
 
-        self.ambassador_module = IRAmbassador(self, aconf)
+        self.ambassador_module.finalize(self, aconf)
 
     # Don't bother actually saving resources that come up when working with
     # the faked modules.


### PR DESCRIPTION
Add `IRResource.lookup` method, to allow easily looking something up in an `IRResource` with a fallback to the `defaults` dict of the `ambassador` `Module`.

Here's how it works.

```
def lookup(self, key: str, *args, default_class: Optional[str]=None, default_key: Optional[str]=None) -> Any:
```

- If `key` is present in `self`, return `self[key]`.

- If not, we'll try to look up a fallback value in the `defaults` dict of the `ambassador` `Module`:
   - the key for the lookup will be the value of `default_key` if that's set, otherwise the same key we just tried in self.
   - if `default_class` wasn't passed in, and `self.default_class` isn't set, just look up a fallback value directly from the `defaults` dict in the `ambassador` `Module`.
   - otherwise, look up the default class in `defaults` dict in the `ambassador` `Module`, then look up the fallback value from that dict (the passed in `default_class` wins if both are set, and a default class of `'/'` means to skip descending into the subdict entirely).
   - if `key` is not present in self, and no fallback is found, but a default value was passed in as `*args[0]`, return that.
- if all else fails, return `None`.

This required some larger changes to the Ambassador-module handling in `IR.__init__` than I was expecting. Also, while I'm not a huge fan of the call signature (it requires that the default value come _before_ any overrides to `default_class` and `default_key`), I expect that overriding the class or the key will be rare.
