### PR TITLE
Add Success rate Legend to overview html

### DIFF
--- a/ambassador/templates/overview.html
+++ b/ambassador/templates/overview.html
@@ -308,6 +308,42 @@ limitations under the License
         </div>
       </div>
 
+      <div class="row">
+        <div class="col-12">
+          Color Legend
+          <div class="row">
+            <div class="col-12">
+              <table cellpadding="2em" width="100%">
+                <thead>
+                  <tr>
+                    <td>Color</td>
+                    <td>Success Rate</td>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr style="background: rgba(86,61,124,.05)">
+                    <td style="color:red">Red</td>
+                    <td>0% - 70%</td>
+                  </tr>
+                  <tr>
+                    <td style="color:yellow">Yellow</td>
+                    <td>70% - 90%</td>
+                  </tr>
+                  <tr style="background: rgba(86,61,124,.05)">
+                    <td style="color:green">Green</td>
+                    <td>90% - 100%</td>
+                  </tr>
+                  <tr>
+                    <td style="color:gray">Gray</td>
+                    <td>Unknown</td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </div>
+      </div>
+
     </div> <!-- /container -->
   </body>
 </html>


### PR DESCRIPTION
## Description
Adds a legend to the bottom of the overview template so that it's more obvious what the colors of the service row in the Route Table mean.

## Testing
Open overview page, view new legend table below Route Table.
