### PR TITLE
Don't delete user created file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -191,7 +191,6 @@ clobber: clean
 	-rm -rf watt
 	-$(if $(filter-out -,$(ENVOY_COMMIT)),rm -rf envoy envoy-src)
 	-rm -rf docs/node_modules
-	-rm -rf .skip_test_warning	# reset the test warning too
 	-rm -rf venv && echo && echo "Deleted venv, run 'deactivate' command if your virtualenv is activated" || true
 
 print-%:


### PR DESCRIPTION
Since the user has explicitly created the file to state that they
are okay with Kubernetes cluster to be wiped out, we should not be
deleting this file.
