### PR TITLE
Tests for first-time UX state machine

### DIFF
--- a/ambassador/entrypoint.sh
+++ b/ambassador/entrypoint.sh
@@ -47,6 +47,12 @@ export APPDIR="${APPDIR:-$ambassador_root}"
 export PYTHON_EGG_CACHE="${PYTHON_EGG_CACHE:-$AMBASSADOR_CONFIG_BASE_DIR}/.cache"
 export PYTHONUNBUFFERED=true
 
+if [[ "$1" == "--dev-magic" ]]; then
+    echo "AMBASSADOR: running with dev magic"
+    diagd --dev-magic
+    exit $?
+fi
+
 config_dir="${AMBASSADOR_CONFIG_BASE_DIR}/ambassador-config"
 snapshot_dir="${AMBASSADOR_CONFIG_BASE_DIR}/snapshots"
 diagd_flags=('--notices' "${AMBASSADOR_CONFIG_BASE_DIR}/notices.json")

--- a/ambassador/tests/test_docker.py
+++ b/ambassador/tests/test_docker.py
@@ -1,118 +1,69 @@
-import asyncio
+import sys
 import os
 
+import pexpect
+import requests
+
 DockerImage = os.environ["AMBASSADOR_DOCKER_IMAGE"]
+child = None    # see docker_start()
 
-@asyncio.coroutine
-def docker_ready():
-    cmd = [ 'docker', 'run', '--rm', '--name', 'ambassador', '-p8888:8080',
-            DockerImage, '--demo']
+def docker_start() -> bool:
+    # Use a global here so that the child process doesn't get killed
+    global child
 
-    subproc_future = asyncio.create_subprocess_exec(*cmd, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE)
+    cmd = f'docker run --rm --name ambassador -p8888:8080 {os.environ["AMBASSADOR_DOCKER_IMAGE"]} --demo'
 
-    subproc = yield from subproc_future
-    status = 0
+    child = pexpect.spawn(cmd, encoding='utf-8')
+    child.logfile = sys.stdout
 
-    while True:
-        data = yield from subproc.stdout.readline()
-        text = data.decode('utf-8').rstrip()
+    i = child.expect([ pexpect.EOF, pexpect.TIMEOUT, 'AMBASSADOR DEMO RUNNING' ])
 
-        if not text:
-            print("Ambassador died?")
-            status = subproc.returncode
-
-            stdout, stderr = yield from subproc.communicate()
-
-            if stderr:
-                print("stderr:")
-                print(stderr.decode('utf-8').rstrip())
-
-            break
-
-        if text.startswith('AMBASSADOR'):
-            print(f'<-- {text}')
-
-        if text == 'AMBASSADOR DEMO RUNNING':
-            print("Done!!")
-            break
-
-    return status
-
-@asyncio.coroutine
-def docker_kill():
-    cmd = [ 'docker', 'kill', 'ambassador' ]
-
-    subproc_future = asyncio.create_subprocess_exec(*cmd, stdout=asyncio.subprocess.PIPE)
-
-    subproc = yield from subproc_future
-
-    yield from subproc.communicate()
-
-async def do_http():
-    reader, writer = await asyncio.open_connection('127.0.0.1', 8888)
-
-    query = (
-        "GET /qotm/?json=true HTTP/1.1\r\n"
-        "Host: localhost\r\n"
-        "Connection: close\r\n"
-        "\r\n"
-    )
-
-    writer.write(query.encode('utf-8'))
-
-    in_headers = True
-
-    while True:
-        line = await reader.readline()
-
-        if line:
-            line = line.decode('utf-8').rstrip()
-
-        if line:
-            if in_headers:
-                print(f'HTTP header> {line}')
-            else:
-                print(f'HTTP body> {line}')
-        else:
-            if not in_headers:
-                break
-            else:
-                in_headers = False
-
-    writer.close()
-
-async def asynchronicity():
-    ready = False
-    succeeded = False
-
-    try:
-        returncode = await asyncio.wait_for(docker_ready(), timeout=10.0)
-
-        if returncode == 0:
-            ready = True
-    except asyncio.TimeoutError:
-        print('timeout')
-
-    if ready:
-        try:
-            await do_http()
-            succeeded = True
-        except Exception as e:
-            print(f'Could not do HTTP: {e}')
+    if i == 0:
+        print('ambassador died?')
+        return False
+    elif i == 1:
+        print('ambassador timed out?')
+        return False
     else:
-        print("Not ready in time")
+        return True
 
-    await asyncio.wait_for(docker_kill(), timeout=5.0)
+def docker_kill():
+    cmd = f'docker kill ambassador'
 
-    assert succeeded
+    child = pexpect.spawn(cmd, encoding='utf-8')
+    child.logfile = sys.stdout
+
+    child.expect([ pexpect.EOF, pexpect.TIMEOUT ])
+
+def check_http() -> bool:
+    try:
+        response = requests.get('http://localhost:8888/qotm/?json=true', headers={ 'Host': 'localhost' })
+        text = response.text
+
+        if response.status_code != 200:
+            print(f'QotM: wanted 200 but got {response.status_code} {text}')
+            return False
+
+        return True
+    except Exception as e:
+        print(f'Could not do HTTP: {e}')
+
+        return False
 
 def test_docker():
+    test_status = True
+
     if not DockerImage:
         assert False, f'You must set $AMBASSADOR_DOCKER_IMAGE'
     else:
-        loop = asyncio.get_event_loop()
-        loop.run_until_complete(asynchronicity())
-        loop.close()
+        assert docker_start(), 'ambassador could not start'
+
+        if not check_http():
+            test_status = False
+
+        docker_kill()
+
+        assert test_status, 'test failed'
 
 if __name__ == '__main__':
     test_docker()

--- a/ambassador/tests/test_scout.py
+++ b/ambassador/tests/test_scout.py
@@ -1,0 +1,253 @@
+from typing import Any, Dict, List, Optional
+
+import asyncio
+import json
+import os
+import time
+
+import requests
+
+DockerImage = os.environ["AMBASSADOR_DOCKER_IMAGE"]
+
+SEQUENCES = [
+    (
+        [ 'env_ok', 'chime' ],
+        [ 'boot1', 'now-healthy' ]
+    ),
+    (
+        [ 'env_ok', 'chime', 'scout_cache_reset', 'chime' ],
+        [ 'boot1', 'now-healthy', 'healthy' ]
+    ),
+    (
+        [ 'env_ok', 'chime', 'env_bad', 'chime' ],
+        [ 'boot1', 'now-healthy', 'now-unhealthy' ]
+    ),
+    (
+        [ 'env_bad', 'chime' ],
+        [ 'boot1', 'unhealthy' ]
+    ),
+    (
+        [ 'env_bad', 'chime', 'chime', 'scout_cache_reset', 'chime' ],
+        [ 'boot1', 'unhealthy', 'unhealthy' ]
+    ),
+    (
+        [ 'chime', 'chime', 'chime', 'env_ok', 'chime', 'chime' ],
+        [ 'boot1', 'unhealthy', 'now-healthy' ]
+    ),
+]
+
+@asyncio.coroutine
+def docker_start():
+    cmd = [ 'docker', 'run', '--rm', '--name', 'diagd', '-p9998:9998', DockerImage, '--dev-magic' ]
+
+    subproc_future = asyncio.create_subprocess_exec(*cmd, stdout=asyncio.subprocess.PIPE,
+                                                    stderr=asyncio.subprocess.PIPE)
+
+    subproc = yield from subproc_future
+    status = 0
+
+    while True:
+        data = yield from subproc.stdout.readline()
+        text = data.decode('utf-8').rstrip()
+
+        if not text:
+            print("Diagd died?")
+            status = subproc.returncode
+
+            stdout, stderr = yield from subproc.communicate()
+
+            if stderr:
+                print("stderr:")
+                print(stderr.decode('utf-8').rstrip())
+
+            break
+
+        print(f'<-- {text}')
+
+        if (('AMBASSADOR: running with dev magic' in text) or
+            ('LocalScout: mode boot, action boot1' in text)):
+            print("Ready!")
+            break
+
+    return status
+
+@asyncio.coroutine
+def docker_kill():
+    cmd = [ 'docker', 'kill', 'diagd' ]
+
+    subproc_future = asyncio.create_subprocess_exec(*cmd, stdout=asyncio.subprocess.PIPE)
+
+    subproc = yield from subproc_future
+
+    yield from subproc.communicate()
+
+async def timed_wait(coro, timeout=10.0) -> bool:
+    print(f'TIMED WAIT {coro}')
+
+    status = False
+
+    try:
+        returncode = await asyncio.wait_for(coro(), timeout=timeout)
+
+        if returncode == 0:
+            status = True
+    except asyncio.TimeoutError:
+        print('timeout')
+
+    return status
+
+def wait_for_diagd() -> bool:
+    status = False
+    tries_left = 5
+
+    while tries_left >= 0:
+        print(f'...checking diagd ({tries_left})')
+
+        try:
+            response = requests.get('http://localhost:9998/_internal/v0/ping')
+
+            if response.status_code == 200:
+                status = True
+                break
+            else:
+                print(f'   failed {response.status_code}')
+        except requests.exceptions.RequestException as e:
+            print(f'   failed {e}')
+
+        tries_left -= 1
+        time.sleep(2)
+
+    return status
+
+def check_http(cmd: str) -> bool:
+    try:
+        response = requests.post('http://localhost:9998/_internal/v0/fs', params={ 'path': f'cmd:{cmd}' })
+        text = response.text
+
+        if response.status_code != 200:
+            print(f'{cmd}: wanted 200 but got {response.status_code} {text}')
+            return False
+
+        return True
+    except Exception as e:
+        print(f'Could not do HTTP: {e}')
+
+        return False
+
+def fetch_events() -> Any:
+    try:
+        response = requests.get('http://localhost:9998/_internal/v0/events')
+
+        if response.status_code != 200:
+            print(f'events: wanted 200 but got {response.status_code} {response.text}')
+            return False
+
+        data = response.json()
+
+        return data
+    except Exception as e:
+        print(f'events: could not do HTTP: {e}')
+
+        return None
+
+def check_chimes() -> bool:
+    result = True
+
+    i = 0
+
+    covered = {
+        'F-F-F': False,
+        'F-F-T': False,
+        # 'F-T-F': False,   # This particular key can never be generated
+        # 'F-T-T': False,   # This particular key can never be generated
+        'T-F-F': False,
+        'T-F-T': False,
+        'T-T-F': False,
+        'T-T-T': False,
+    }
+
+
+    for cmds, wanted_verdict in SEQUENCES:
+        print(f'RESETTING for sequence {i}')
+
+        if not check_http('chime_reset'):
+            print(f'could not reset for sequence {i}')
+            result = False
+            continue
+
+        j = 0
+        for cmd in cmds:
+            print(f'   sending {cmd} for sequence {i}.{j}')
+
+            if not check_http(cmd):
+                print(f'could not do {cmd} for sequence {i}.{j}')
+                result = False
+                break
+
+            j += 1
+
+        if not result:
+            continue
+
+        events = fetch_events()
+
+        if not events:
+            result = False
+            continue
+
+        # print(json.dumps(events, sort_keys=True, indent=4))
+
+        print('   ----')
+        verdict = []
+
+        for timestamp, mode, action, data in events:
+            verdict.append(action)
+
+            action_key = data.get('action_key', None)
+
+            if action_key:
+                covered[action_key] = True
+
+            print(f'     {action} - {action_key}')
+
+        # print(json.dumps(verdict, sort_keys=True, indent=4))
+
+        if verdict != wanted_verdict:
+            print(f'verdict mismatch for sequence {i}:')
+            print(f'  wanted {" ".join(wanted_verdict)}')
+            print(f'  got    {" ".join(verdict)}')
+
+        i += 1
+
+    for key in sorted(covered.keys()):
+        if not covered[key]:
+            print(f'missing coverage for {key}')
+            result = False
+
+    return result
+
+def test_scout():
+    test_status = True
+
+    if not DockerImage:
+        assert False, f'You must set $AMBASSADOR_DOCKER_IMAGE'
+    else:
+        loop = asyncio.get_event_loop()
+        status = loop.run_until_complete(timed_wait(docker_start))
+
+        if not status:
+            print('Timed out waiting for output, but continuing anyway')
+
+        if not wait_for_diagd():
+            test_status = False
+        elif not check_chimes():
+            test_status = False
+
+        loop.run_until_complete(timed_wait(docker_kill, timeout=1.0))
+        loop.close()
+
+        assert test_status
+
+if __name__ == '__main__':
+    test_scout()
+

--- a/ambassador/tests/test_scout.py
+++ b/ambassador/tests/test_scout.py
@@ -8,6 +8,7 @@ import pexpect
 import requests
 
 DockerImage = os.environ["AMBASSADOR_DOCKER_IMAGE"]
+child = None    # see docker_start()
 
 SEQUENCES = [
     (
@@ -37,6 +38,9 @@ SEQUENCES = [
 ]
 
 def docker_start() -> bool:
+    # Use a global here so that the child process doesn't get killed
+    global child
+
     cmd = f'docker run --rm --name diagd -p9998:9998 {os.environ["AMBASSADOR_DOCKER_IMAGE"]} --dev-magic'
 
     child = pexpect.spawn(cmd, encoding='utf-8')

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -6,3 +6,4 @@ pytest
 pytest-cov
 dpath
 mypy
+pexpect


### PR DESCRIPTION
This should've been easier than it was. Sigh. But here we have:

- an easy way to run `diagd` locally or within Docker for develop and testing (just pass `--dev-magic`, see the code for more)
- a test that walks the environment state machine through its paces to make sure it's working
- a refactored `test_docker.py` that relies on `pexpect` instead of `asyncio`