### PR TITLE
Better `make go/apis/envoy`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ dist
 
 *.out
 *.log
+*.tmp
 
 docs/_book
 docs/_site

--- a/Makefile
+++ b/Makefile
@@ -664,18 +664,24 @@ joinlist=$(if $(word 2,$2),$(firstword $2)$1$(call joinlist,$1,$(wordlist 2,$(wo
 comma = ,
 
 go/apis/envoy: envoy-src $(FLOCK) venv/bin/protoc venv/bin/protoc-gen-gogofast venv/bin/protoc-gen-validate
-	rm -rf $@
-	mkdir -p $@
-	set -e; find $(CURDIR)/envoy-src/api/envoy -type f -name '*.proto' | sed 's,/[^/]*$$,,' | uniq | while read -r dir; do \
+	rm -rf $@ $(@D).envoy.tmp
+	mkdir -p $(@D).envoy.tmp
+# go-control-plane `make generate`
+	@set -e; find $(CURDIR)/envoy-src/api/envoy -type f -name '*.proto' | sed 's,/[^/]*$$,,' | uniq | while read -r dir; do \
 		echo "Generating $$dir"; \
 		./venv/bin/protoc \
 			$(addprefix --proto_path=,$(imports))  \
-			--plugin=$(CURDIR)/venv/bin/protoc-gen-gogofast --gogofast_out='$(call joinlist,$(comma),plugins=grpc $(addprefix M,$(mappings))):$(@D)' \
-			--plugin=$(CURDIR)/venv/bin/protoc-gen-validate --validate_out='lang=gogo:$(@D)' \
+			--plugin=$(CURDIR)/venv/bin/protoc-gen-gogofast --gogofast_out='$(call joinlist,$(comma),plugins=grpc $(addprefix M,$(mappings))):$(@D).envoy.tmp' \
+			--plugin=$(CURDIR)/venv/bin/protoc-gen-validate --validate_out='lang=gogo:$(@D).envoy.tmp' \
 			"$$dir"/*.proto; \
 	done
+# go-control-plane `make generate-patch`
 # https://github.com/envoyproxy/go-control-plane/issues/173
-	find $@ -name '*.validate.go' -exec sed -E -i 's,"(envoy/.*)"$$,"github.com/datawire/ambassador/go/apis/\1",' {} +
+	find $(@D).envoy.tmp -name '*.validate.go' -exec sed -E -i 's,"(envoy/.*)"$$,"github.com/datawire/ambassador/go/apis/\1",' {} +
+# move things in to place
+	mkdir -p $(@D)
+	mv $(@D).envoy.tmp/envoy $@
+	rmdir $(@D).envoy.tmp
 
 # ------------------------------------------------------------------------------
 # Virtualenv

--- a/Makefile
+++ b/Makefile
@@ -679,7 +679,8 @@ go/apis/envoy: envoy-src $(FLOCK) venv/bin/protoc venv/bin/protoc-gen-gogofast v
 	done
 # go-control-plane `make generate-patch`
 # https://github.com/envoyproxy/go-control-plane/issues/173
-	find $(@D).envoy.tmp -name '*.validate.go' -exec sed -E -i 's,"(envoy/.*)"$$,"github.com/datawire/ambassador/go/apis/\1",' {} +
+	find $(@D).envoy.tmp -name '*.validate.go' -exec sed -E -i.bak 's,"(envoy/.*)"$$,"github.com/datawire/ambassador/go/apis/\1",' {} +
+	find $(@D).envoy.tmp -name '*.bak' -delete
 # move things in to place
 	mkdir -p $(@D)
 	mv $(@D).envoy.tmp/envoy $@


### PR DESCRIPTION
## Description

This improves the `make go/apis/envoy` target:
 - Don't spew a screen-full of mappings to stdout
 - Don't have `go/apis/envoy/` exist if the command fails; it makes it too easy to accidentally ignore an error
 - Add comments
 - Force a rebuild if the `$(imports)` or `$(mappings)` variables change
 - Fix it on macOS (cc: @gsagula)

## Testing

I've verified that `make go/apis/envoy` works as expected on my laptop (Parabola GNU/Linux-libre) and on the macincloud.