### PR TITLE
Avoid potential divison by zero

### DIFF
--- a/ambassador/ambassador/ir/irhttpmappinggroup.py
+++ b/ambassador/ambassador/ir/irhttpmappinggroup.py
@@ -332,7 +332,8 @@ class IRHTTPMappingGroup (IRBaseMappingGroup):
                 for mapping in self.mappings:
                     if 'weight' not in mapping:
                         mapping.weight = round((100.0 - total_weight)/unspecified_mappings)
-            elif 0 < total_weight < 100.0:
+            # Don't divide by zero if total_weight is zero
+            elif total_weight > 0 and total_weight != 100.0:
                 for mapping in self.mappings:
                     mapping.weight = round(mapping.weight * (100.0/total_weight))
 

--- a/ambassador/ambassador/ir/irhttpmappinggroup.py
+++ b/ambassador/ambassador/ir/irhttpmappinggroup.py
@@ -332,7 +332,7 @@ class IRHTTPMappingGroup (IRBaseMappingGroup):
                 for mapping in self.mappings:
                     if 'weight' not in mapping:
                         mapping.weight = round((100.0 - total_weight)/unspecified_mappings)
-            elif total_weight != 100.0:
+            elif 0 < total_weight < 100.0:
                 for mapping in self.mappings:
                     mapping.weight = round(mapping.weight * (100.0/total_weight))
 


### PR DESCRIPTION



## Description
If the total of all weights across mappings is zero, there's no need to
normalize weights against 100.

## Related Issues
Fixes #1663

## Testing
None, this absolutely needs testing; otoh this seems like a nondestructive change.

## Todos
- [ ] Tests
- [ ] Documentation

## Other
* If this is a documentation change, please open the pull request at https://github.com/datawire/ambassador-docs instead.
* Code changes should occur against `master`.
