### PR TITLE
Avoid Python warning on single-backslash-dot

### DIFF
--- a/kat/kat/manifests.py
+++ b/kat/kat/manifests.py
@@ -800,7 +800,7 @@ spec:
   - JSONPath: .status.serviceName
     name: Service Name
     type: string
-  - JSONPath: .metadata.labels['serving\.knative\.dev/configurationGeneration']
+  - JSONPath: .metadata.labels['serving\\.knative\\.dev/configurationGeneration']
     name: Generation
     type: string
   - JSONPath: .status.conditions[?(@.type=='Ready')].status


### PR DESCRIPTION
I haven't gotten CI to pass yet...