### PR TITLE
Fix process management to make sure we notice when Envoy dies

### DIFF
--- a/ambassador/entrypoint.sh
+++ b/ambassador/entrypoint.sh
@@ -215,7 +215,7 @@ kick_ads() {
     if [ -n "$DIAGD_ONLY" ]; then
         echo "kick_ads: ignoring kick since in diagd-only mode."
     else
-        echo "KICK: my PID is $$"
+#        echo "KICK: my PID is $$"
 
         if [ -n "${envoy_pid}" ]; then
             if ! kill -0 "${envoy_pid}"; then
@@ -234,13 +234,13 @@ kick_ads() {
         fi
 
         # Once envoy is running, poke Ambex.
-        echo "KICK: kicking ambex"
+#        echo "KICK: kicking ambex"
         kill -HUP "$ambex_pid"
 
 #        jobs -l
 #        sleep 30
 
-        echo "KICK: done"
+#        echo "KICK: done"
     fi
 }
 

--- a/ambassador/entrypoint.sh
+++ b/ambassador/entrypoint.sh
@@ -361,31 +361,6 @@ fi
 # Wait for one worker to quit, then kill the others                            #
 ################################################################################
 
-#echo "==== PS"
-#ps -o pid,ppid,args
-#
-#jobs -p
-#
-#wait -n
-#r=$?
-#
-#echo "AMBASSADOR: one of the worker processes has exited ($r); shutting down the others"
-#jobs -p
-#
-#while test -n "$(jobs -p)"; do
-#    jobs -p | xargs -r kill --
-#    wait -n
-#done
-#
-#echo 'AMBASSADOR: all worker processes have exited'
-#
-#if [[ -n "$AMBASSADOR_EXIT_DELAY" ]]; then
-#    echo "AMBASSADOR: sleeping for debug"
-#    sleep $AMBASSADOR_EXIT_DELAY
-#fi
-#
-#exit $r
-
 echo "AMBASSADOR: waiting"
 echo "PIDS: $pids"
 

--- a/ambassador/tests/t_circuitbreaker.py
+++ b/ambassador/tests/t_circuitbreaker.py
@@ -40,7 +40,7 @@ spec:
     service: {0}
 """
 
-class CircuitBreakingTest(AmbassadorTest):
+class CircuitBreakingTestCANFLAKE(AmbassadorTest):
     target: ServiceType
 
     def init(self):
@@ -90,7 +90,7 @@ circuit_breakers:
         for result in pending_results:
             if 'X-Envoy-Overloaded' in result.headers:
                 pending_overloaded += 1
-        assert 450 < pending_overloaded < 500
+        assert 450 < pending_overloaded < 500, f'[CF] expected 450-500 pending_overloaded, got {pending_overloaded}'
 
         pending_datapoints = 0
         for stat in pending_stats:
@@ -98,7 +98,7 @@ circuit_breakers:
                 pending_datapoints = stat.json[0]['datapoints'][0][0]
                 break
         assert pending_datapoints > 0
-        assert 450 < pending_datapoints*10 <= 500
+        assert 450 < pending_datapoints*10 <= 500, f'[CF] expected 45-50 pending_datapoints, got {pending_datapoints}'
 
         assert abs(pending_overloaded-(pending_datapoints*10)) < 10
 

--- a/ambassador/tests/t_shadow.py
+++ b/ambassador/tests/t_shadow.py
@@ -10,7 +10,7 @@ from abstract_tests import AmbassadorTest, HTTP
 from abstract_tests import assert_default_errors, MappingTest, OptionTest, ServiceType, Node, Test
 
 
-class ShadowTest(MappingTest):
+class ShadowTestCANFLAKE(MappingTest):
     parent: AmbassadorTest
     target: ServiceType
     shadow: ServiceType

--- a/releng/run-tests.sh
+++ b/releng/run-tests.sh
@@ -29,7 +29,12 @@ TEST_ARGS="--tb=short -s"
 seq=('Plain' 'not Plain and (A or C)' 'not Plain and not (A or C)')
 
 if [[ -n "${TEST_NAME}" ]]; then
-    seq=("$TEST_NAME")
+    case "${TEST_NAME}" in
+    group1) seq=('Plain') ;;
+    group2) seq=('not Plain and (A or C)') ;;
+    group3) seq=('not Plain and not (A or C)') ;;
+    *) seq=("$TEST_NAME") ;;
+    esac
 fi
 
 FULL_RESULT=0


### PR DESCRIPTION
As of about 0.71, `entrypoint.sh` forked `diagd`, which called `kick_ads.sh` to trigger Envoy reloads, and which would start Envoy if no Envoy was running. This was a problem, because Envoy was no longer being started by `entrypoint.sh`, so job control in `entrypoint.sh` wouldn't realize that Envoy dying was a bad thing.

This PR changes the world so that we have `diagd` send a `SIGHUP` directly to `entrypoint.sh`, so that Envoy can be started as a child of `entrypoint.sh` and things work better. Turns out there needed to be several other changes as well:

1. Job control generates a lot more `SIGCHLD`s than I would've expected when signal-handling is in play, so we need to carefully track which PIDs are relevant.

2. Of course, the `SIGCHLD` won't actually tell you which PID died, so you have to do a bunch of junk around that to make sure of what's going on.

3. When running with `--demo`, we need to only signal that the demo is running _after_ Envoy is responding to requests (in Kubernetes, this is what the liveness/readiness checks are for).

This PR also includes some small test things, too, which were relevant while testing this.