### PR TITLE
tls-context: added logic to bypass secret validation when tls context has no hostnames

### DIFF
--- a/ambassador/ambassador/ir/irtlscontext.py
+++ b/ambassador/ambassador/ir/irtlscontext.py
@@ -231,7 +231,7 @@ class IRTLSContext(IRResource):
         errors = 0
 
         # self.ir.logger.debug("resolve_secrets before path checks: %s" % self.as_json())
-        if not self.hosts is None:
+        if len(self.hosts) > 0:
             for key in [ 'cert_chain_file', 'private_key_file', 'cacert_chain_file' ]:
                 path = self.secret_info.get(key, None)
 

--- a/ambassador/ambassador/ir/irtlscontext.py
+++ b/ambassador/ambassador/ir/irtlscontext.py
@@ -140,7 +140,7 @@ class IRTLSContext(IRResource):
             is_valid = True
 
         # If we don't have secret info, it's worth logging.
-        if not self.secret_info and not self.hosts is None:
+        if not self.secret_info and self.hosts:
             self.logger.info("TLSContext %s has no certificate information at all?" % self.name)
 
         self.ir.logger.debug("resolve_secrets working on: %s" % self.as_json())
@@ -230,18 +230,19 @@ class IRTLSContext(IRResource):
         # OK. Check paths.
         errors = 0
 
-        # self.ir.logger.debug("resolve_secrets before path checks: %s" % self.as_json())
-        for key in [ 'cert_chain_file', 'private_key_file', 'cacert_chain_file' ]:
-            path = self.secret_info.get(key, None)
+        if self.hosts:
+            # self.ir.logger.debug("resolve_secrets before path checks: %s" % self.as_json())
+            for key in [ 'cert_chain_file', 'private_key_file', 'cacert_chain_file' ]:
+                path = self.secret_info.get(key, None)
 
-            if path:
-                fc = getattr(self.ir, 'file_checker')
-                if not fc(path):
-                    self.post_error("TLSContext %s found no %s '%s'" % (self.name, key, path))
+                if path:
+                    fc = getattr(self.ir, 'file_checker')
+                    if not fc(path):
+                        self.post_error("TLSContext %s found no %s '%s'" % (self.name, key, path))
+                        errors += 1
+                elif key != 'cacert_chain_file':
+                    self.post_error("TLSContext %s is missing %s" % (self.name, key))
                     errors += 1
-            elif key != 'cacert_chain_file':
-                self.post_error("TLSContext %s is missing %s" % (self.name, key))
-                errors += 1
     
         if errors > 0:
             return False

--- a/ambassador/ambassador/ir/irtlscontext.py
+++ b/ambassador/ambassador/ir/irtlscontext.py
@@ -140,7 +140,7 @@ class IRTLSContext(IRResource):
             is_valid = True
 
         # If we don't have secret info, it's worth logging.
-        if not self.secret_info and self.hosts:
+        if not self.secret_info and not self.hosts is None:
             self.logger.info("TLSContext %s has no certificate information at all?" % self.name)
 
         self.ir.logger.debug("resolve_secrets working on: %s" % self.as_json())
@@ -230,8 +230,8 @@ class IRTLSContext(IRResource):
         # OK. Check paths.
         errors = 0
 
-        if self.hosts:
-            # self.ir.logger.debug("resolve_secrets before path checks: %s" % self.as_json())
+        # self.ir.logger.debug("resolve_secrets before path checks: %s" % self.as_json())
+        if not self.hosts is None:
             for key in [ 'cert_chain_file', 'private_key_file', 'cacert_chain_file' ]:
                 path = self.secret_info.get(key, None)
 
@@ -243,7 +243,7 @@ class IRTLSContext(IRResource):
                 elif key != 'cacert_chain_file':
                     self.post_error("TLSContext %s is missing %s" % (self.name, key))
                     errors += 1
-    
+
         if errors > 0:
             return False
 

--- a/ambassador/ambassador/ir/irtlscontext.py
+++ b/ambassador/ambassador/ir/irtlscontext.py
@@ -231,19 +231,18 @@ class IRTLSContext(IRResource):
         errors = 0
 
         # self.ir.logger.debug("resolve_secrets before path checks: %s" % self.as_json())
-        if len(self.hosts) > 0:
-            for key in [ 'cert_chain_file', 'private_key_file', 'cacert_chain_file' ]:
-                path = self.secret_info.get(key, None)
+        for key in [ 'cert_chain_file', 'private_key_file', 'cacert_chain_file' ]:
+            path = self.secret_info.get(key, None)
 
-                if path:
-                    fc = getattr(self.ir, 'file_checker')
-                    if not fc(path):
-                        self.post_error("TLSContext %s found no %s '%s'" % (self.name, key, path))
-                        errors += 1
-                elif key != 'cacert_chain_file':
-                    self.post_error("TLSContext %s is missing %s" % (self.name, key))
+            if path:
+                fc = getattr(self.ir, 'file_checker')
+                if not fc(path):
+                    self.post_error("TLSContext %s found no %s '%s'" % (self.name, key, path))
                     errors += 1
-
+            elif key != 'cacert_chain_file':
+                self.post_error("TLSContext %s is missing %s" % (self.name, key))
+                errors += 1
+    
         if errors > 0:
             return False
 

--- a/ambassador/ambassador/ir/irtlscontext.py
+++ b/ambassador/ambassador/ir/irtlscontext.py
@@ -140,11 +140,10 @@ class IRTLSContext(IRResource):
             is_valid = True
 
         # If we don't have secret info, it's worth logging.
-        if not self.secret_info and not self.hosts is None:
+        if not self.secret_info:
             self.logger.info("TLSContext %s has no certificate information at all?" % self.name)
 
         self.ir.logger.debug("resolve_secrets working on: %s" % self.as_json())
-
 
         # OK. Do we have a secret name?
         secret_name = self.secret_info.get('secret')
@@ -231,18 +230,17 @@ class IRTLSContext(IRResource):
         errors = 0
 
         # self.ir.logger.debug("resolve_secrets before path checks: %s" % self.as_json())
-        if not self.hosts is None:
-            for key in [ 'cert_chain_file', 'private_key_file', 'cacert_chain_file' ]:
-                path = self.secret_info.get(key, None)
+        for key in [ 'cert_chain_file', 'private_key_file', 'cacert_chain_file' ]:
+            path = self.secret_info.get(key, None)
 
-                if path:
-                    fc = getattr(self.ir, 'file_checker')
-                    if not fc(path):
-                        self.post_error("TLSContext %s found no %s '%s'" % (self.name, key, path))
-                        errors += 1
-                elif key != 'cacert_chain_file':
-                    self.post_error("TLSContext %s is missing %s" % (self.name, key))
+            if path:
+                fc = getattr(self.ir, 'file_checker')
+                if not fc(path):
+                    self.post_error("TLSContext %s found no %s '%s'" % (self.name, key, path))
                     errors += 1
+            elif key != 'cacert_chain_file' and self.hosts:
+                self.post_error("TLSContext %s is missing %s" % (self.name, key))
+                errors += 1
 
         if errors > 0:
             return False

--- a/ambassador/tests/t_tls.py
+++ b/ambassador/tests/t_tls.py
@@ -370,6 +370,7 @@ config:
     hosts: ["*"]
     cert_chain_file: /nonesuch
   bad-path-info:
+    hosts: ["*"]
     cert_chain_file: /nonesuch 
     private_key_file: /nonesuch
   validation-without-termination:  

--- a/ambassador/tests/t_tls.py
+++ b/ambassador/tests/t_tls.py
@@ -414,7 +414,7 @@ service: {self.target.path.fqdn}
         assert found == len(errors), "unexpected errors in list"
 
 
-class TLSContext(AmbassadorTest):
+class TLSContextABCTest(AmbassadorTest):
     # debug = True
 
     def init(self):
@@ -513,7 +513,6 @@ config:
     enabled: True
     secret: test-tlscontext-secret-0 
 """)
-
         yield self, self.format("""
 ---
 apiVersion: ambassador/v1
@@ -521,6 +520,15 @@ kind:  Mapping
 name:  {self.name}-other-mapping
 prefix: /{self.name}/
 service: https://{self.target.path.fqdn}
+""")
+        # Ambassador should not return an error when hostname is not present.
+        yield self, self.format("""
+---
+apiVersion: ambassador/v1
+kind: TLSContext
+name: {self.name}-no-secret
+min_tls_version: v1.0
+max_tls_version: v1.3
 """)
 
     def scheme(self) -> str:

--- a/ambassador/tests/t_tls.py
+++ b/ambassador/tests/t_tls.py
@@ -365,18 +365,14 @@ config:
   server:
     enabled: True
     secret: test-certs-secret-invalid
-    hosts: ["*"]
   missing-secret-key:
-    hosts: ["*"]
     cert_chain_file: /nonesuch
   bad-path-info:
-    hosts: ["*"]
     cert_chain_file: /nonesuch 
     private_key_file: /nonesuch
   validation-without-termination:  
     enabled: True
     secret: test-certs-secret-invalid
-    hosts: ["*"]
     ca_secret: ambassador-certs
 """)
 


### PR DESCRIPTION
Signed-off-by: Gabriel Linden Sagula <gsagula@gmail.com>

## Description
This PR modifies the TLS context object to not run certificate validation on contexts that do not contain a hostname.  

## Related Issues
https://github.com/datawire/ambassador/issues/1708

## Testing
Add one test that asserts not TLS error and another test that check validation errors.

## Todos
- Documentation