### PR TITLE
Makefile base/cache image creation clean-up (part 2) (v2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ VERSION.py
 cluster.yaml
 watt
 kat/kat/client
+*.docker
 
 *.egg-info
 build

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -198,9 +198,7 @@ Ambassador currently relies on a custom Envoy build. This build lives in `https:
 
  6. Edit `ENVOY_COMMIT ?=` in the Makefile to point to your new Envoy commit.  Follow the instructions in the Makefile when doing so:
 
-    a. Also update the number in the `BASE_ENVOY_IMAGE`, `BASE_PY_IMAGE`, and `BASE_GO_IMAGE` variables.
-
-    b. Then run `make docker-update-base` to compile Envoy, and build+push new docker base images incorporating that Envoy binary.  This will also update the `go/apis/envoy/` directory if any of Envoy's protobuf definitions have changed; make sure to commit those changes when you commit the change to `ENVOY_COMMIT`.
+    a. Then run `make docker-update-base` to compile Envoy, and build+push new docker base images incorporating that Envoy binary.  This will also update the `go/apis/envoy/` directory if any of Envoy's protobuf definitions have changed; make sure to commit those changes when you commit the change to `ENVOY_COMMIT`.
 
 Version Numbering
 -----------------

--- a/Dockerfile.base-envoy
+++ b/Dockerfile.base-envoy
@@ -1,3 +1,23 @@
+# Copyright 2018 Datawire. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License
+
+################################################################
+# If you have to change this file, you _must_ update BASE_ENVOY_RELVER
+# in the Makefile, then run "make docker-update-base" to build and
+# push the new image.
+
 FROM frolvlad/alpine-glibc
 
-ADD envoy-bin/envoy-static-stripped /usr/local/bin/envoy
+ARG ENVOY_FILE
+ADD $ENVOY_FILE /usr/local/bin/envoy

--- a/Dockerfile.base-go
+++ b/Dockerfile.base-go
@@ -19,10 +19,10 @@
 # main Dockerfile, so that we can use the Docker cache to more
 # effectively dodge network issues re-downloading the Golang stuff.
 #
-# If you have to change this - notably, if you switch to a new rev of
-# either Golang dependency - you _must_ update BASE_GO_IMAGE
-# in the Makefile, then run "make docker-update-base" to build and push
-# the new image.
+# If you have to change this file (e.g. if you switch to a new rev of
+# a Golang dependency), you _must_ update BASE_GO_RELVER in the
+# Makefile, then run "make docker-update-base" to build and push the
+# new image.
 
 ARG BASE_ENVOY_IMAGE
 FROM $BASE_ENVOY_IMAGE

--- a/Dockerfile.base-py
+++ b/Dockerfile.base-py
@@ -19,10 +19,9 @@
 # to more effectively dodge network issues with APK repos or the Cheese
 # Shop.
 #
-# If you have to change this - including changing Ambassador's dependency
-# graph, including multi! - you _must_ update BASE_PY_IMAGE
-# in the Makefile, then run "make docker-update-base" to build and push the
-# new image.
+# If you have to change this file or any of the files that it COPYs
+# in, you _must_ update BASE_PY_RELVER in the Makefile, then run "make
+# docker-update-base" to build and push the new image.
 
 ARG BASE_ENVOY_IMAGE
 FROM $BASE_ENVOY_IMAGE

--- a/Makefile
+++ b/Makefile
@@ -140,7 +140,7 @@ AMBASSADOR_EXTERNAL_DOCKER_IMAGE ?= $(AMBASSADOR_EXTERNAL_DOCKER_REPO):$(AMBASSA
   ENVOY_FILE ?= envoy-bin/envoy-static-stripped
 
   # Increment BASE_ENVOY_RELVER on changes to `Dockerfile.base-envoy`, ENVOY_FILE, or Envoy recipes
-  BASE_ENVOY_RELVER ?= 2
+  BASE_ENVOY_RELVER ?= 3
   # Increment BASE_GO_RELVER on changes to `Dockerfile.base-go`
   BASE_GO_RELVER    ?= 1
   # Increment BASE_PY_RELVER on changes to `Dockerfile.base-py`, `releng/*`, `multi/requirements.txt`, `ambassador/requirements.txt`

--- a/Makefile
+++ b/Makefile
@@ -128,21 +128,29 @@ PULL_BRANCH ?= master
 
 NETLIFY_SITE=datawire-ambassador
 
-# IF YOU MESS WITH ANY OF THESE VALUES, YOU MUST UPDATE THE VERSION NUMBERS
-# BELOW AND THEN RUN make docker-update-base
-ENVOY_REPO ?= git://github.com/datawire/envoy.git
-ENVOY_COMMIT ?= 8f57f7d765939552a999721e8dac9b5a9a5cbb8b
-ENVOY_COMPILATION_MODE ?= dbg
 AMBASSADOR_DOCKER_TAG ?= $(GIT_VERSION)
 AMBASSADOR_DOCKER_IMAGE ?= $(AMBASSADOR_DOCKER_REPO):$(AMBASSADOR_DOCKER_TAG)
 AMBASSADOR_EXTERNAL_DOCKER_IMAGE ?= $(AMBASSADOR_EXTERNAL_DOCKER_REPO):$(AMBASSADOR_DOCKER_TAG)
 
-BASE_DOCKER_REPO ?= quay.io/datawire/ambassador-base
-# UPDATE THESE VERSION NUMBERS IF YOU UPDATE ANY OF THE VALUES ABOVE, THEN
-# RUN make docker-update-base.
-BASE_ENVOY_IMAGE ?= $(BASE_DOCKER_REPO):envoy-13
-BASE_PY_IMAGE    ?= $(BASE_DOCKER_REPO):go-14
-BASE_GO_IMAGE    ?= $(BASE_DOCKER_REPO):ambassador-14
+# IF YOU MESS WITH ANY OF THESE VALUES, YOU MUST RUN `make docker-update-base`.
+  ENVOY_REPO ?= git://github.com/datawire/envoy.git
+  ENVOY_COMMIT ?= 8f57f7d765939552a999721e8dac9b5a9a5cbb8b
+  ENVOY_COMPILATION_MODE ?= dbg
+
+  ENVOY_FILE ?= envoy-bin/envoy-static-stripped
+
+  # Increment BASE_ENVOY_RELVER on changes to `Dockerfile.base-envoy`, ENVOY_FILE, or Envoy recipes
+  BASE_ENVOY_RELVER ?= 2
+  # Increment BASE_GO_RELVER on changes to `Dockerfile.base-go`
+  BASE_GO_RELVER    ?= 1
+  # Increment BASE_PY_RELVER on changes to `Dockerfile.base-py`, `releng/*`, `multi/requirements.txt`, `ambassador/requirements.txt`
+  BASE_PY_RELVER    ?= 1
+
+  BASE_DOCKER_REPO ?= quay.io/datawire/ambassador-base
+  BASE_ENVOY_IMAGE ?= $(BASE_DOCKER_REPO):envoy-$(BASE_ENVOY_RELVER).$(ENVOY_COMMIT).$(ENVOY_COMPILATION_MODE)
+  BASE_GO_IMAGE    ?= $(BASE_DOCKER_REPO):go-$(BASE_ENVOY_RELVER).$(ENVOY_COMMIT).$(ENVOY_COMPILATION_MODE).$(BASE_GO_RELVER)
+  BASE_PY_IMAGE    ?= $(BASE_DOCKER_REPO):py-$(BASE_ENVOY_RELVER).$(ENVOY_COMMIT).$(ENVOY_COMPILATION_MODE).$(BASE_PY_RELVER)
+# END LIST OF VARIABLES REQUIRING `make docker-update-base`.
 
 # Default to _NOT_ using Kubernaut. At Datawire, we can set this to true,
 # but outside, it works much better to assume that user has set up something
@@ -180,6 +188,7 @@ clean: clean-test
 	rm -rf app.json
 	rm -rf venv/bin/ambassador
 	rm -rf ambassador/ambassador/VERSION.py*
+	rm -f *.docker
 	rm -rf ambassador/build ambassador/dist ambassador/ambassador.egg-info ambassador/__pycache__
 	find . \( -name .coverage -o -name .cache -o -name __pycache__ \) -print0 | xargs -0 rm -rf
 	find . \( -name *.log \) -print0 | xargs -0 rm -rf
@@ -341,22 +350,35 @@ envoy-shell: envoy-build-image.txt
 	$(ENVOY_SYNC_DOCKER_TO_HOST)
 .PHONY: envoy-shell
 
-docker-base-images:
+base-envoy.docker: Dockerfile.base-envoy $(var.)BASE_ENVOY_IMAGE
 	@if [ -n "$(AMBASSADOR_DEV)" ]; then echo "Do not run this from a dev shell" >&2; exit 1; fi
 	@if ! docker run --rm --entrypoint=true $(BASE_ENVOY_IMAGE); then \
 		echo "Building Envoy binary..." && \
-		$(MAKE) envoy-bin/envoy-static-stripped && \
+		$(MAKE) $(ENVOY_FILE) && \
 		echo "Building Envoy Docker image..." && \
-		docker build $(DOCKER_OPTS) -t $(BASE_ENVOY_IMAGE) -f Dockerfile.base-envoy .; \
+		docker build --build-arg ENVOY_FILE=$(ENVOY_FILE) $(DOCKER_OPTS) -t $(BASE_ENVOY_IMAGE) -f $< .; \
 	fi
+	@docker image inspect $(BASE_ENVOY_IMAGE) --format='{{.Id}}' | $(WRITE_IFCHANGED) $@
+
+base-py.docker: Dockerfile.base-py base-envoy.docker $(var.)BASE_PY_IMAGE
+	@if [ -n "$(AMBASSADOR_DEV)" ]; then echo "Do not run this from a dev shell" >&2; exit 1; fi
 	@if ! docker run --rm --entrypoint=true $(BASE_PY_IMAGE); then \
 		echo "Building $(BASE_PY_IMAGE)" && \
-		docker build --build-arg BASE_ENVOY_IMAGE=$(BASE_ENVOY_IMAGE) $(DOCKER_OPTS) -t $(BASE_PY_IMAGE) -f Dockerfile.base-py .; \
+		docker build --build-arg BASE_ENVOY_IMAGE=$(BASE_ENVOY_IMAGE) $(DOCKER_OPTS) -t $(BASE_PY_IMAGE) -f $< .; \
 	fi
+	@docker image inspect $(BASE_PY_IMAGE) --format='{{.Id}}' | $(WRITE_IFCHANGED) $@
+
+base-go.docker: Dockerfile.base-go base-envoy.docker $(var.)BASE_GO_IMAGE
+	@if [ -n "$(AMBASSADOR_DEV)" ]; then echo "Do not run this from a dev shell" >&2; exit 1; fi
 	@if ! docker run --rm --entrypoint=true $(BASE_GO_IMAGE); then \
 		echo "Building $(BASE_GO_IMAGE)" && \
-		docker build --build-arg BASE_ENVOY_IMAGE=$(BASE_ENVOY_IMAGE) $(DOCKER_OPTS) -t $(BASE_GO_IMAGE) -f Dockerfile.base-go .; \
+		docker build --build-arg BASE_ENVOY_IMAGE=$(BASE_ENVOY_IMAGE) $(DOCKER_OPTS) -t $(BASE_GO_IMAGE) -f $< .; \
 	fi
+	@docker image inspect $(BASE_GO_IMAGE) --format='{{.Id}}' | $(WRITE_IFCHANGED) $@
+
+docker-base-images:
+	@if [ -n "$(AMBASSADOR_DEV)" ]; then echo "Do not run this from a dev shell" >&2; exit 1; fi
+	$(MAKE) base-envoy.docker base-go.docker base-py.docker
 	@echo "RESTART ANY DEV SHELLS to make sure they use your new images."
 
 docker-push-base-images:
@@ -370,8 +392,10 @@ docker-update-base:
 	$(MAKE) docker-base-images go/apis/envoy
 	$(MAKE) docker-push-base-images
 
-ambassador-docker-image: version $(WATT)
+ambassador-docker-image: ambassador.docker
+ambassador.docker: Dockerfile base-go.docker base-py.docker $(WATT) ambassador/ambassador/VERSION.py FORCE
 	docker build --build-arg BASE_GO_IMAGE=$(BASE_GO_IMAGE) --build-arg BASE_PY_IMAGE=$(BASE_PY_IMAGE) $(DOCKER_OPTS) -t $(AMBASSADOR_DOCKER_IMAGE) .
+	@docker image inspect $(AMBASSADOR_DOCKER_IMAGE) --format='{{.Id}}' | $(WRITE_IFCHANGED) $@
 
 docker-login:
 ifeq ($(DOCKER_LOGIN_FAKE), true)
@@ -420,7 +444,7 @@ else
 endif
 
 # TODO: validate version is conformant to some set of rules might be a good idea to add here
-ambassador/ambassador/VERSION.py:
+ambassador/ambassador/VERSION.py: FORCE
 	$(call check_defined, VERSION, VERSION is not set)
 	$(call check_defined, GIT_BRANCH, GIT_BRANCH is not set)
 	$(call check_defined, GIT_COMMIT, GIT_COMMIT is not set)
@@ -432,7 +456,7 @@ ambassador/ambassador/VERSION.py:
 		-e 's!{{GITDIRTY}}!$(GIT_DIRTY)!g' \
 		-e 's!{{GITCOMMIT}}!$(GIT_COMMIT)!g' \
 		-e 's!{{GITDESCRIPTION}}!$(GIT_DESCRIPTION)!g' \
-		< VERSION-template.py > ambassador/ambassador/VERSION.py
+		< VERSION-template.py | $(WRITE_IFCHANGED) $@
 
 version: ambassador/ambassador/VERSION.py
 

--- a/Makefile
+++ b/Makefile
@@ -350,7 +350,7 @@ envoy-shell: envoy-build-image.txt
 	$(ENVOY_SYNC_DOCKER_TO_HOST)
 .PHONY: envoy-shell
 
-base-envoy.docker: Dockerfile.base-envoy $(var.)BASE_ENVOY_IMAGE
+base-envoy.docker: Dockerfile.base-envoy $(var.)BASE_ENVOY_IMAGE $(WRITE_IFCHANGED)
 	@if [ -n "$(AMBASSADOR_DEV)" ]; then echo "Do not run this from a dev shell" >&2; exit 1; fi
 	@if ! docker run --rm --entrypoint=true $(BASE_ENVOY_IMAGE); then \
 		echo "Building Envoy binary..." && \
@@ -360,7 +360,7 @@ base-envoy.docker: Dockerfile.base-envoy $(var.)BASE_ENVOY_IMAGE
 	fi
 	@docker image inspect $(BASE_ENVOY_IMAGE) --format='{{.Id}}' | $(WRITE_IFCHANGED) $@
 
-base-py.docker: Dockerfile.base-py base-envoy.docker $(var.)BASE_PY_IMAGE
+base-py.docker: Dockerfile.base-py base-envoy.docker $(var.)BASE_PY_IMAGE $(WRITE_IFCHANGED)
 	@if [ -n "$(AMBASSADOR_DEV)" ]; then echo "Do not run this from a dev shell" >&2; exit 1; fi
 	@if ! docker run --rm --entrypoint=true $(BASE_PY_IMAGE); then \
 		echo "Building $(BASE_PY_IMAGE)" && \
@@ -368,7 +368,7 @@ base-py.docker: Dockerfile.base-py base-envoy.docker $(var.)BASE_PY_IMAGE
 	fi
 	@docker image inspect $(BASE_PY_IMAGE) --format='{{.Id}}' | $(WRITE_IFCHANGED) $@
 
-base-go.docker: Dockerfile.base-go base-envoy.docker $(var.)BASE_GO_IMAGE
+base-go.docker: Dockerfile.base-go base-envoy.docker $(var.)BASE_GO_IMAGE $(WRITE_IFCHANGED)
 	@if [ -n "$(AMBASSADOR_DEV)" ]; then echo "Do not run this from a dev shell" >&2; exit 1; fi
 	@if ! docker run --rm --entrypoint=true $(BASE_GO_IMAGE); then \
 		echo "Building $(BASE_GO_IMAGE)" && \
@@ -393,7 +393,7 @@ docker-update-base:
 	$(MAKE) docker-push-base-images
 
 ambassador-docker-image: ambassador.docker
-ambassador.docker: Dockerfile base-go.docker base-py.docker $(WATT) ambassador/ambassador/VERSION.py FORCE
+ambassador.docker: Dockerfile base-go.docker base-py.docker $(WATT) $(WRITE_IFCHANGED) ambassador/ambassador/VERSION.py FORCE
 	docker build --build-arg BASE_GO_IMAGE=$(BASE_GO_IMAGE) --build-arg BASE_PY_IMAGE=$(BASE_PY_IMAGE) $(DOCKER_OPTS) -t $(AMBASSADOR_DOCKER_IMAGE) .
 	@docker image inspect $(AMBASSADOR_DOCKER_IMAGE) --format='{{.Id}}' | $(WRITE_IFCHANGED) $@
 
@@ -444,7 +444,7 @@ else
 endif
 
 # TODO: validate version is conformant to some set of rules might be a good idea to add here
-ambassador/ambassador/VERSION.py: FORCE
+ambassador/ambassador/VERSION.py: FORCE $(WRITE_IFCHANGED)
 	$(call check_defined, VERSION, VERSION is not set)
 	$(call check_defined, GIT_BRANCH, GIT_BRANCH is not set)
 	$(call check_defined, GIT_COMMIT, GIT_COMMIT is not set)


### PR DESCRIPTION
## Description

 - This un-reverts #1700
 - This bumps `BASE_ENVOY_RELVER`, because I had pushed broken images to quay.io while I was working on af8dd1f5ce33c185f29d0c0abb5ae86d253e5425. I've deleted them from quay.io, but developers may have cached copies sitting around.
 - This adds a `$(WRITE_IFCHANGED)` dependency to several targets for which I'd forgotten to declare that dependency, which lead to it maybe not yet being present depending on what order Make decided to do things in.

## Testing

I've run `make docker-update-base` and am counting on CI to tell me if I successfully fixed #1700's breakage.