### PR TITLE
Process-handling cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -159,8 +159,8 @@ SCOUT_APP_KEY=
 # Sets the kat-backend release which contains the kat-client use for E2e testing.
 # For details https://github.com/datawire/kat-backend
 #
-# Note that this needs to start with the 'v'.
-KAT_BACKEND_RELEASE = v1.5.0
+# Note that this must not start with the 'v'. Sigh.
+KAT_BACKEND_RELEASE = 1.5.0
 
 # Allow overriding which watt we use.
 WATT ?= watt
@@ -481,7 +481,7 @@ $(KUBERNAUT): $(var.)KUBERNAUT_VERSION $(var.)GOOS $(var.)GOARCH | venv/bin/acti
 KAT_CLIENT=venv/bin/kat_client
 
 venv/kat-backend-$(KAT_BACKEND_RELEASE).tar.gz: | venv/bin/activate
-	curl -L -o $@ https://github.com/datawire/kat-backend/archive/$(KAT_BACKEND_RELEASE).tar.gz
+	curl -L -o $@ https://github.com/datawire/kat-backend/archive/v$(KAT_BACKEND_RELEASE).tar.gz
 $(KAT_CLIENT): venv/kat-backend-$(KAT_BACKEND_RELEASE).tar.gz
 	cd venv && tar -xzf $(<F) kat-backend-$(KAT_BACKEND_RELEASE)/client/bin/client_$(GOOS)_$(GOARCH)
 	install -m0755 venv/kat-backend-$(KAT_BACKEND_RELEASE)/client/bin/client_$(GOOS)_$(GOARCH) $(CURDIR)/$(KAT_CLIENT)

--- a/Makefile
+++ b/Makefile
@@ -158,7 +158,7 @@ SCOUT_APP_KEY=
 
 # Sets the kat-backend release which contains the kat-client use for E2e testing.
 # For details https://github.com/datawire/kat-backend
-KAT_BACKEND_RELEASE = 1.4.4
+KAT_BACKEND_RELEASE = v1.5.0	# this needs to start with a 'v'
 
 # Allow overriding which watt we use.
 WATT ?= watt
@@ -479,7 +479,7 @@ $(KUBERNAUT): $(var.)KUBERNAUT_VERSION $(var.)GOOS $(var.)GOARCH | venv/bin/acti
 KAT_CLIENT=venv/bin/kat_client
 
 venv/kat-backend-$(KAT_BACKEND_RELEASE).tar.gz: | venv/bin/activate
-	curl -L -o $@ https://github.com/datawire/kat-backend/archive/v$(KAT_BACKEND_RELEASE).tar.gz
+	curl -L -o $@ https://github.com/datawire/kat-backend/archive/$(KAT_BACKEND_RELEASE).tar.gz
 $(KAT_CLIENT): venv/kat-backend-$(KAT_BACKEND_RELEASE).tar.gz
 	cd venv && tar -xzf $(<F) kat-backend-$(KAT_BACKEND_RELEASE)/client/bin/client_$(GOOS)_$(GOARCH)
 	install -m0755 venv/kat-backend-$(KAT_BACKEND_RELEASE)/client/bin/client_$(GOOS)_$(GOARCH) $(CURDIR)/$(KAT_CLIENT)

--- a/Makefile
+++ b/Makefile
@@ -158,7 +158,9 @@ SCOUT_APP_KEY=
 
 # Sets the kat-backend release which contains the kat-client use for E2e testing.
 # For details https://github.com/datawire/kat-backend
-KAT_BACKEND_RELEASE = v1.5.0	# this needs to start with a 'v'
+#
+# Note that this needs to start with the 'v'.
+KAT_BACKEND_RELEASE = v1.5.0
 
 # Allow overriding which watt we use.
 WATT ?= watt

--- a/ambassador/tests/t_retrypolicy.py
+++ b/ambassador/tests/t_retrypolicy.py
@@ -1,4 +1,7 @@
-from email.utils import parsedate_to_datetime
+# from email.utils import parsedate_to_datetime
+
+import re
+
 from datetime import datetime
 from kat.harness import Query
 
@@ -52,17 +55,49 @@ config:
         yield Query(self.url(self.name + '-retry/'), headers={"Requested-Status": "500", "Requested-Backend-Delay": "2000"}, expected=504)
         yield Query(self.url(self.name + '-normal/'), headers={"Requested-Status": "409", "Requested-Backend-Delay": "2000"}, expected=504)
 
+    def get_timestamp(self, hdr):
+        m = re.match(r'^(.*)\.(\d+)([-+]\d+:\d+)$', hdr)
+
+        if m:
+            date_and_time = m.group(1)
+            fractional_seconds = m.group(2)
+            tzone = m.group(3)
+
+            while len(fractional_seconds) < 6:
+                fractional_seconds += '0'
+
+            hdr = f'{date_and_time}.{fractional_seconds}{tzone}'
+
+        return datetime.fromisoformat(hdr).timestamp()
+
+    def get_duration(self, result):
+        start_time = self.get_timestamp(result.headers['Client-Start-Date'][0])
+        end_time = self.get_timestamp(result.headers['Client-End-Date'][0])
+
+        return end_time - start_time
+
     def check(self):
         ok_result = self.results[0]
         normal_result = self.results[1]
         retry_result = self.results[2]
         conflict_result = self.results[3]
 
-        ok_time = parsedate_to_datetime(ok_result.headers['Date'][0]).timestamp()
-        normal_time = parsedate_to_datetime(normal_result.headers['Date'][0]).timestamp()
-        retry_time = parsedate_to_datetime(retry_result.headers['Date'][0]).timestamp()
-        conflict_time = parsedate_to_datetime(conflict_result.headers['Date'][0]).timestamp()
+        ok_duration = self.get_duration(ok_result)
+        normal_duration = self.get_duration(normal_result)
+        retry_duration = self.get_duration(retry_result)
+        conflict_duration = self.get_duration(conflict_result)
 
-        assert abs(ok_time - normal_time) <= 1, "time to get 200 OK {} deviates more than a second from time to get a 500 {}".format(ok_time, normal_time)
-        assert retry_time - normal_time >= 2, "retry time {} should be at least 2 seconds slower than normal time {}".format(retry_time, normal_time)
-        assert conflict_time - ok_time >= 2, "conflict time {} should be at least 2 seconds slower than 200 OK time {}".format(conflict_time, ok_time)
+        assert retry_duration >= 2, f"retry time {retry_duration} must be at least 2 seconds"
+        assert conflict_duration >= 2, f"conflict time {conflict_duration} must be at least 2 seconds"
+
+        ok_vs_normal = abs(ok_duration - normal_duration)
+
+        assert ok_vs_normal <= 1, f"time to 200 OK {ok_duration} is more than 1 second different from time to 500 {normal_duration}"
+
+        retry_vs_normal = retry_duration - normal_duration
+
+        assert retry_vs_normal >= 2, f"retry time {retry_duration} is not at least 2 seconds slower than normal time {normal_duration}"
+
+        conflict_vs_ok = conflict_duration - ok_duration
+
+        assert conflict_vs_ok >= 2, f"conflict time {conflict_duration} is not at least 2 seconds slower than ok time {ok_duration}"

--- a/ambassador/tests/t_retrypolicy.py
+++ b/ambassador/tests/t_retrypolicy.py
@@ -56,19 +56,13 @@ config:
         yield Query(self.url(self.name + '-normal/'), headers={"Requested-Status": "409", "Requested-Backend-Delay": "2000"}, expected=504)
 
     def get_timestamp(self, hdr):
-        m = re.match(r'^(.*)\.(\d+)([-+]\d+:\d+)$', hdr)
+        m = re.match(r'^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{1,6})', hdr)
 
         if m:
-            date_and_time = m.group(1)
-            fractional_seconds = m.group(2)
-            tzone = m.group(3)
-
-            while len(fractional_seconds) < 6:
-                fractional_seconds += '0'
-
-            hdr = f'{date_and_time}.{fractional_seconds}{tzone}'
-
-        return datetime.fromisoformat(hdr).timestamp()
+            return datetime.strptime(m.group(1), '%Y-%m-%dT%H:%M:%S.%f').timestamp()
+        else:
+            assert False, f'header timestamp "{hdr}" is not parseable'
+            return None
 
     def get_duration(self, result):
         start_time = self.get_timestamp(result.headers['Client-Start-Date'][0])

--- a/kat/kat/manifests.py
+++ b/kat/kat/manifests.py
@@ -29,7 +29,7 @@ metadata:
 spec:
   containers:
   - name: backend
-    image: quay.io/datawire/kat-backend:15
+    image: quay.io/datawire/kat-backend:v1.5.0
     imagePullPolicy: Always
     ports:
     - containerPort: 8080
@@ -56,7 +56,7 @@ spec:
     spec:
       containers:
       - name: backend
-        image: quay.io/datawire/kat-backend:15
+        image: quay.io/datawire/kat-backend:v1.5.0
         imagePullPolicy: Always
         # ports:
         # {ports}
@@ -94,7 +94,7 @@ metadata:
 spec:
   containers:
   - name: backend
-    image: quay.io/datawire/kat-backend:15
+    image: quay.io/datawire/kat-backend:v1.5.0
     imagePullPolicy: Always
     ports:
     - containerPort: 8080
@@ -133,7 +133,7 @@ metadata:
 spec:
   containers:
   - name: backend
-    image: quay.io/datawire/kat-backend:15
+    image: quay.io/datawire/kat-backend:v1.5.0
     imagePullPolicy: Always
     ports:
     - containerPort: 8080
@@ -172,7 +172,7 @@ metadata:
 spec:
   containers:
   - name: backend
-    image: quay.io/datawire/kat-backend:15
+    image: quay.io/datawire/kat-backend:v1.5.0
     imagePullPolicy: Always
     ports:
     - containerPort: 8080


### PR DESCRIPTION
Sometimes `ambex` wasn't getting correctly triggered when an updated config arrives. This is because the `launch` function in `entrypoint.sh` was using `return` to hand off `ambex`'s PID... and `return` will truncate to 8 bits. Any startup sequence that results in `ambex` having a PID over 255 would cause problems.

This PR switches to an associative array for PID handling, so that we can let `launch` update the associative array easily, and the other elements of the `entrypoint` script can look into the associative array.

Fixes #1727.