### PR TITLE
Clean up yet more test stuff

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -30,11 +30,15 @@ If you're still reading, you must be at Datawire. Congrats, you picked a fine pl
 7. Now for the time-critical bit.
    - Tag `master` with a GA tag like `0.33.0` and let CI do its thing.
    - CI will retag the latest RC image as the GA image.
+
+8. _After the CI run finishes_:
    - `make push-docs` _after the retag_ to push new docs out to the website.
+   - Go to https://github.com/datawire/ambassador/releases and create a new release.
+      - `make release-prep` should've output the text to paste into the release description.
 
    **Note** that there must be at least one RC build before a GA, since the GA tag **does not** rebuild the docker images -- it retags the ones built by the RC build. This is intentional, to allow for testing to happen on the actual artifacts that will be released.
 
-8. Submit a PR into the `helm/charts` repo to update things in `stable/ambassador`:
+9. Submit a PR into the `helm/charts` repo to update things in `stable/ambassador`:
    - in `Chart.yaml`, update `appVersion` with the new Ambassador version, and bump `version`.
    - in `README.md`, update the default value of `image.tag`.
    - in `values.yaml`, update `tag`.
@@ -51,6 +55,6 @@ If you're still reading, you must be at Datawire. Congrats, you picked a fine pl
       - open a PR
     - Once your PR is merged, _delete the feature branch without merging it back to origin/master_.
 
-9. Additional updates:
+10. Additional updates:
    - Submit a PR to https://github.com/datawire/pro-ref-arch that updates the `env.sh.example` versions.
    - Submit a PR to the Ambassador website repository to update the version on the homepage.

--- a/ambassador/tests/t_consul.py
+++ b/ambassador/tests/t_consul.py
@@ -110,9 +110,9 @@ secret: {self.path.k8s}-client-cert-secret
                     body={
                         "Datacenter": "dc1",
                         "Node": self.format("{self.path.k8s}-consul-service"),
-                        "Address": "asdf.org",
+                        "Address": self.k8s_target.path.k8s,
                         "Service": {"Service": self.format("{self.path.k8s}-consul-service"),
-                                    "Address": "asdf.org",
+                                    "Address": self.k8s_target.path.k8s,
                                     "Port": 80}},
                     phase=2)
 

--- a/ambassador/tests/t_grpc_web.py
+++ b/ambassador/tests/t_grpc_web.py
@@ -5,7 +5,6 @@ from kat.harness import Query
 from abstract_tests import AmbassadorTest, ServiceType, EGRPC
 
 class AcceptanceGrpcWebTest(AmbassadorTest):
-    debug = True
 
     target: ServiceType
 

--- a/ambassador/tests/test_docker.py
+++ b/ambassador/tests/test_docker.py
@@ -35,18 +35,18 @@ def docker_kill(logfile):
 
     child.expect([ pexpect.EOF, pexpect.TIMEOUT ])
 
-def check_http() -> bool:
+def check_http(logfile) -> bool:
     try:
         response = requests.get('http://localhost:8888/qotm/?json=true', headers={ 'Host': 'localhost' })
         text = response.text
 
         if response.status_code != 200:
-            print(f'QotM: wanted 200 but got {response.status_code} {text}')
+            logfile.write(f'QotM: wanted 200 but got {response.status_code} {text}\n')
             return False
 
         return True
     except Exception as e:
-        print(f'Could not do HTTP: {e}')
+        logfile.write(f'Could not do HTTP: {e}\n')
 
         return False
 
@@ -58,20 +58,17 @@ def test_docker():
             logfile.write('No $AMBASSADOR_DOCKER_IMAGE??\n')
         else:
             if docker_start(logfile):
-                if check_http():
+                if check_http(logfile):
                     test_status = True
 
                 docker_kill(logfile)
 
-    with open('/tmp/test_docker_output', 'r') as logfile:
-        for line in logfile:
-            print(line.strip())
+    if not test_status:
+        with open('/tmp/test_docker_output', 'r') as logfile:
+            for line in logfile:
+                print(line.rstrip())
 
     assert test_status, 'test failed'
 
 if __name__ == '__main__':
     test_docker()
-
-
-
-

--- a/ambassador/tests/test_scout.py
+++ b/ambassador/tests/test_scout.py
@@ -37,14 +37,14 @@ SEQUENCES = [
     ),
 ]
 
-def docker_start() -> bool:
+def docker_start(logfile) -> bool:
     # Use a global here so that the child process doesn't get killed
     global child
 
     cmd = f'docker run --rm --name diagd -p9998:9998 {os.environ["AMBASSADOR_DOCKER_IMAGE"]} --dev-magic'
 
     child = pexpect.spawn(cmd, encoding='utf-8')
-    child.logfile = sys.stdout
+    child.logfile = logfile
 
     i = child.expect([ pexpect.EOF, pexpect.TIMEOUT, 'LocalScout: mode boot, action boot1' ])
 
@@ -57,69 +57,70 @@ def docker_start() -> bool:
     else:
         return True
 
-def docker_kill():
+def docker_kill(logfile):
     cmd = f'docker kill diagd'
 
     child = pexpect.spawn(cmd, encoding='utf-8')
-    child.logfile = sys.stdout
+    child.logfile = logfile
 
     child.expect([ pexpect.EOF, pexpect.TIMEOUT ])
 
-def wait_for_diagd() -> bool:
+def wait_for_diagd(logfile) -> bool:
     status = False
     tries_left = 5
 
     while tries_left >= 0:
-        print(f'...checking diagd ({tries_left})')
+        logfile.write(f'...checking diagd ({tries_left})\n')
 
         try:
             response = requests.get('http://localhost:9998/_internal/v0/ping')
 
             if response.status_code == 200:
+                logfile.write('   got it\n')
                 status = True
                 break
             else:
-                print(f'   failed {response.status_code}')
+                logfile.write(f'   failed {response.status_code}\n')
         except requests.exceptions.RequestException as e:
-            print(f'   failed {e}')
+            logfile.write(f'   failed {e}\n')
 
         tries_left -= 1
         time.sleep(2)
 
     return status
 
-def check_http(cmd: str) -> bool:
+def check_http(logfile, cmd: str) -> bool:
     try:
         response = requests.post('http://localhost:9998/_internal/v0/fs', params={ 'path': f'cmd:{cmd}' })
         text = response.text
 
         if response.status_code != 200:
-            print(f'{cmd}: wanted 200 but got {response.status_code} {text}')
+            logfile.write(f'{cmd}: wanted 200 but got {response.status_code} {text}\n')
             return False
 
         return True
     except Exception as e:
-        print(f'Could not do HTTP: {e}')
+        logfile.write(f'Could not do HTTP: {e}\n')
 
         return False
 
-def fetch_events() -> Any:
+def fetch_events(logfile) -> Any:
     try:
         response = requests.get('http://localhost:9998/_internal/v0/events')
 
         if response.status_code != 200:
-            print(f'events: wanted 200 but got {response.status_code} {response.text}')
-            return False
+            logfile.write(f'events: wanted 200 but got {response.status_code} {response.text}\n')
+            return None
 
         data = response.json()
 
         return data
     except Exception as e:
-        print(f'events: could not do HTTP: {e}')
+        logfile.write(f'events: could not do HTTP: {e}\n')
 
         return None
 
-def check_chimes() -> bool:
+def check_chimes(logfile) -> bool:
     result = True
 
     i = 0
@@ -137,19 +138,19 @@ def check_chimes() -> bool:
 
 
     for cmds, wanted_verdict in SEQUENCES:
-        print(f'RESETTING for sequence {i}')
+        logfile.write(f'RESETTING for sequence {i}\n')
 
-        if not check_http('chime_reset'):
-            print(f'could not reset for sequence {i}')
+        if not check_http(logfile, 'chime_reset'):
+            logfile.write(f'could not reset for sequence {i}\n')
             result = False
             continue
 
         j = 0
         for cmd in cmds:
-            print(f'   sending {cmd} for sequence {i}.{j}')
+            logfile.write(f'   sending {cmd} for sequence {i}.{j}\n')
 
-            if not check_http(cmd):
-                print(f'could not do {cmd} for sequence {i}.{j}')
+            if not check_http(logfile, cmd):
+                logfile.write(f'could not do {cmd} for sequence {i}.{j}\n')
                 result = False
                 break
 
@@ -158,15 +159,15 @@ def check_chimes() -> bool:
         if not result:
             continue
 
-        events = fetch_events()
+        events = fetch_events(logfile)
 
         if not events:
             result = False
             continue
 
-        # print(json.dumps(events, sort_keys=True, indent=4))
+        # logfile.write(json.dumps(events, sort_keys=True, indent=4))
 
-        print('   ----')
+        logfile.write('   ----\n')
         verdict = []
 
         for timestamp, mode, action, data in events:
@@ -177,40 +178,43 @@ def check_chimes() -> bool:
             if action_key:
                 covered[action_key] = True
 
-            print(f'     {action} - {action_key}')
+            logfile.write(f'     {action} - {action_key}\n')
 
-        # print(json.dumps(verdict, sort_keys=True, indent=4))
+        # logfile.write(json.dumps(verdict, sort_keys=True, indent=4\n))
 
         if verdict != wanted_verdict:
-            print(f'verdict mismatch for sequence {i}:')
-            print(f'  wanted {" ".join(wanted_verdict)}')
-            print(f'  got    {" ".join(verdict)}')
+            logfile.write(f'verdict mismatch for sequence {i}:\n')
+            logfile.write(f'  wanted {" ".join(wanted_verdict)}\n')
+            logfile.write(f'  got    {" ".join(verdict)}\n')
 
         i += 1
 
     for key in sorted(covered.keys()):
         if not covered[key]:
-            print(f'missing coverage for {key}')
+            logfile.write(f'missing coverage for {key}\n')
             result = False
 
     return result
 
 def test_scout():
-    test_status = True
+    test_status = False
 
-    if not DockerImage:
-        assert False, f'You must set $AMBASSADOR_DOCKER_IMAGE'
-    else:
-        assert docker_start(), 'diagd could not start'
+    with open('/tmp/test_scout_output', 'w') as logfile:
+        if not DockerImage:
+            logfile.write('No $AMBASSADOR_DOCKER_IMAGE??\n')
+        else:
+            if docker_start(logfile):
+                if wait_for_diagd(logfile) and check_chimes(logfile):
+                    test_status = True
 
-        if not wait_for_diagd():
-            test_status = False
-        elif not check_chimes():
-            test_status = False
+                docker_kill(logfile)
 
-        docker_kill()
+    if not test_status:
+        with open('/tmp/test_scout_output', 'r') as logfile:
+            for line in logfile:
+                print(line.rstrip())
 
-        assert test_status, 'test failed'
+    assert test_status, 'test failed'
 
 if __name__ == '__main__':
     test_scout()

--- a/releng/run-tests.sh
+++ b/releng/run-tests.sh
@@ -44,8 +44,10 @@ FULL_RESULT=0
 
 ( cd "$ROOT" ; make cluster-and-teleproxy )
 
+echo "==== [$(date)] ==== STARTING TESTS"
+
 for el in "${seq[@]}"; do
-    echo "==== running $el"
+    echo "==== [$(date)] ==== running $el"
 
 #    kubectl delete namespaces -l scope=AmbassadorTest
 #    kubectl delete all -l scope=AmbassadorTest
@@ -76,5 +78,7 @@ for el in "${seq[@]}"; do
         mv /tmp/k8s-AmbassadorTest.yaml /tmp/k8s-$el-AmbassadorTest.yaml
     fi
 done
+
+echo "==== [$(date)] ==== FINISHED TESTS ($FULL_RESULT)"
 
 exit $FULL_RESULT

--- a/releng/travis-install.sh
+++ b/releng/travis-install.sh
@@ -28,7 +28,7 @@ mv kubectl ~/bin/kubectl
 
 pip install -q -r dev-requirements.txt
 pip install -q -r ambassador/requirements.txt
-npm install gitbook-cli netlify-cli
+#npm install gitbook-cli netlify-cli
 
 if [[ `which helm` == "" ]]; then
   curl https://storage.googleapis.com/kubernetes-helm/helm-v2.9.1-linux-amd64.tar.gz | tar xz


### PR DESCRIPTION
- Ambassador tests should never rely on external hosts!
- I don't think we need to install `npm` any more
- Arrange for the docker & scout tests to collect their output all at once on failure
- Drop the debug output from the gRPC-Web test