### PR TITLE
Dockerfile.base-envoy: Pin to Alpine 3.9

### DIFF
--- a/Dockerfile.base-envoy
+++ b/Dockerfile.base-envoy
@@ -17,7 +17,7 @@
 # in the Makefile, then run "make docker-update-base" to build and
 # push the new image.
 
-FROM frolvlad/alpine-glibc
+FROM frolvlad/alpine-glibc:alpine-3.9
 
 ARG ENVOY_FILE
 ADD $ENVOY_FILE /usr/local/bin/envoy

--- a/Makefile
+++ b/Makefile
@@ -129,7 +129,7 @@ AMBASSADOR_EXTERNAL_DOCKER_IMAGE ?= $(AMBASSADOR_EXTERNAL_DOCKER_REPO):$(AMBASSA
   ENVOY_FILE ?= envoy-bin/envoy-static-stripped
 
   # Increment BASE_ENVOY_RELVER on changes to `Dockerfile.base-envoy`, ENVOY_FILE, or Envoy recipes
-  BASE_ENVOY_RELVER ?= 3
+  BASE_ENVOY_RELVER ?= 4
   # Increment BASE_GO_RELVER on changes to `Dockerfile.base-go`
   BASE_GO_RELVER    ?= 1
   # Increment BASE_PY_RELVER on changes to `Dockerfile.base-py`, `releng/*`, `multi/requirements.txt`, `ambassador/requirements.txt`


### PR DESCRIPTION
## Description

The Alpine 3.9→2.10 update brings in the Python 3.6→3.7 update, which breaks us.  Pin to Alpine 3.9 for now.

Accordingly, this increments `BASE_ENVOY_RELVER`, so I've run `make docker-update-base`, which pushed the following images:
 - `quay.io/datawire/ambassador-base:envoy-4.8f57f7d765939552a999721e8dac9b5a9a5cbb8b.dbg`
 - `quay.io/datawire/ambassador-base:go-4.8f57f7d765939552a999721e8dac9b5a9a5cbb8b.dbg.1`
 - `quay.io/datawire/ambassador-base:py-4.8f57f7d765939552a999721e8dac9b5a9a5cbb8b.dbg.1`

## Related Issues

None.

## Testing

I've verified that the the images look sane (specifically the `/usr/local/bin/envoy` file).
