### PR TITLE
Add a .editorconfig file with indentation settings

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,16 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+
+[*.py]
+indent_style = space
+indent_size = 4
+
+[*.sh]
+indent_style = space
+indent_size = 4
+
+[*.go]
+indent_style = tab


### PR DESCRIPTION
## Description

I got tired of having to type `M-x set-variable` for sh-basic-offset` and `indent-tabs-mode`.  ".editorconfig" is an editor-agnostic file-format for specifying indentation settings, that most editors support. https://editorconfig.org/
rall goals of the pull request's commits.

## Related Issues

None.

## Testing

None.