### PR TITLE
Fix run-tests.sh and other woes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -369,10 +369,6 @@ docker-push: docker-images
 ifeq ($(DOCKER_PUSH_AS),)
 	@echo "No DOCKER_PUSH_AS set"
 else
-	@if [ "$(GIT_DIRTY)" = "dirty" ]; then \
-		printf "Git tree is dirty and therefore 'docker push' is not allowed!\n"; \
-		exit 1; \
-	fi
 	@echo 'PUSH $(AMBASSADOR_DOCKER_IMAGE) as $(DOCKER_PUSH_AS)'
 ifneq ($(DOCKER_PUSH_AS),$(AMBASSADOR_DOCKER_IMAGE))
 	@docker tag $(AMBASSADOR_DOCKER_IMAGE) $(DOCKER_PUSH_AS)

--- a/releng/run-tests.sh
+++ b/releng/run-tests.sh
@@ -29,7 +29,11 @@ fi
 
 TEST_ARGS="--tb=short -s"
 
-seq=('Plain' 'not Plain and (A or C)' 'not Plain and not (A or C)')
+seq=(
+    'Plain'
+    'not Plain and (A or C)'
+    'not Plain and not (A or C)'
+)
 
 if [[ -n "${TEST_NAME}" ]]; then
     case "${TEST_NAME}" in

--- a/releng/run-tests.sh
+++ b/releng/run-tests.sh
@@ -52,11 +52,7 @@ for el in "${seq[@]}"; do
 #    kubectl delete namespaces -l scope=AmbassadorTest
 #    kubectl delete all -l scope=AmbassadorTest
 
-    pytest ${TEST_ARGS} -k "$el"
-    true
-    RESULT=$?
-
-    if [ $RESULT -ne 0 ]; then
+    if ! pytest ${TEST_ARGS} -k "$el"; then
         FULL_RESULT=1
 
         kubectl get pods --all-namespaces


### PR DESCRIPTION
## Description

 - Don't prohibit `make docker-push` if the tree is dirty
 - Fix `releng/run-tests.sh` bailing before it could print diagnostic output (because `set -e`)
 - Other minor touch-up to `run-tests.sh`

## Related Issues

None.

## Testing

This was a substantial workflow improvement for me.