### PR TITLE
Much test tweaking

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -245,7 +245,7 @@ ifneq ($(DOCKER_EPHEMERAL_REGISTRY),)
 		echo "Starting local Docker registry in Kubernetes" ;\
 		kubectl apply -f releng/docker-registry.yaml ;\
 		while [ -z "$$(kubectl get pods -n docker-registry -ojsonpath='{.items[0].status.containerStatuses[0].state.running}')" ]; do echo pod wait...; sleep 1; done ;\
-		sh -c 'kubectl port-forward --namespace=docker-registry deployment/registry 31000:5000 & echo $$! > .docker_port_forward' ;\
+		sh -c 'kubectl port-forward --namespace=docker-registry deployment/registry 31000:5000 > /tmp/port-forward-log & echo $$! > .docker_port_forward' ;\
 	else \
 		echo "Local Docker registry should be already running" ;\
 	fi

--- a/ambassador/ambassador/ir/irambassador.py
+++ b/ambassador/ambassador/ir/irambassador.py
@@ -235,7 +235,7 @@ class IRAmbassador (IRResource):
                 return False
 
         if self.get('circuit_breakers', None) is not None:
-            if not IRHTTPMapping.validate_circuit_breakers(self['circuit_breakers']):
+            if not IRHTTPMapping.validate_circuit_breakers(self.ir, self['circuit_breakers']):
                 self.post_error("Invalid circuit_breakers specified: {}".format(self['circuit_breakers']))
                 return False
 

--- a/ambassador/ambassador/ir/ircluster.py
+++ b/ambassador/ambassador/ir/ircluster.py
@@ -88,6 +88,7 @@ class IRCluster (IRResource):
         name_fields: List[str] = [ 'cluster' ]
         ctx: Optional[IRTLSContext] = None
         errors: List[str] = []
+        unknown_breakers = 0
 
         # Do we have a marker?
         if marker:
@@ -188,6 +189,19 @@ class IRCluster (IRResource):
         # (Yes, really, TCP. Envoy uses the TLS context to determine whether to originate
         # TLS. Kind of odd, but there we go.)
         url = "tcp://%s:%d" % (hostname, port)
+
+        # Is there a circuit breaker involved here?
+        if circuit_breakers:
+            for breaker in circuit_breakers:
+                name = breaker.get('_name', None)
+
+                if name:
+                    name_fields.append(name)
+                else:
+                    # This is "impossible", but... let it go I guess?
+                    errors.append(f"{service}: unvalidated circuit breaker {breaker}!")
+                    name_fields.append(f'cbu{unknown_breakers}')
+                    unknown_breakers += 1
 
         # The Ambassador module will always have a load_balancer (which may be None).
         global_load_balancer = ir.ambassador_module.load_balancer

--- a/ambassador/ambassador/ir/ircluster.py
+++ b/ambassador/ambassador/ir/ircluster.py
@@ -59,9 +59,6 @@ class IRCluster (IRResource):
                  load_balancer: Optional[dict] = None,
                  circuit_breakers: Optional[list] = None,
 
-                 cb_name: Optional[str]=None,
-                 od_name: Optional[str]=None,
-
                  rkey: str="-override-",
                  kind: str="IRCluster",
                  apiVersion: str="ambassador/v0",   # Not a typo! See below.

--- a/ambassador/ambassador_diag/diagd.py
+++ b/ambassador/ambassador_diag/diagd.py
@@ -148,6 +148,9 @@ class DiagApp (Flask):
         self.snapshot_path = snapshot_path
 
         self.ir = None
+        self.econf = None
+        self.diag = None
+
         self.stats_updater = None
         self.scout_checker = None
 
@@ -397,7 +400,7 @@ def check_alive():
 
 @app.route('/ambassador/v0/check_ready', methods=[ 'GET' ])
 def check_ready():
-    if not app.ir:
+    if not (app.ir and app.diag):
         return "ambassador waiting for config\n", 503
 
     status = envoy_status(app.estats)

--- a/ambassador/tests/t_circuitbreaker.py
+++ b/ambassador/tests/t_circuitbreaker.py
@@ -47,7 +47,7 @@ spec:
 class CircuitBreakingTest(AmbassadorTest):
     target: ServiceType
 
-    TARGET_CLUSTER='cluster_circuitbreakingtest_http'
+    TARGET_CLUSTER='cluster_circuitbreakingtest_http_cbdc1p1'
 
     def init(self):
         self.target = HTTP()
@@ -148,9 +148,7 @@ apiVersion: ambassador/v1
 kind:  Mapping
 name:  {self.target.path.k8s}-pr
 prefix: /{self.name}-pr/
-service: http://httpstat.us
-host_rewrite: httpstat.us
-#service: {self.target.path.fqdn}
+service: {self.target.path.fqdn}
 circuit_breakers:
 - priority: default
   max_pending_requests: 1024
@@ -160,9 +158,7 @@ apiVersion: ambassador/v1
 kind:  Mapping
 name:  {self.target.path.k8s}-normal
 prefix: /{self.name}-normal/
-service: http://httpstat.us
-host_rewrite: httpstat.us
-#service: {self.target.path.fqdn}
+service: {self.target.path.fqdn}
 ---
 apiVersion: ambassador/v1
 kind:  Module
@@ -176,13 +172,11 @@ config:
 
     def queries(self):
         for i in range(500):
-            yield Query(self.url(self.name) + '-pr/200?sleep=1000', ignore_result=True, phase=2)
-            # yield Query(self.url(self.name) + '-pr/', headers={ "Requested-Backend-Delay": "1000" },
-            #             ignore_result=True, phase=1)
+            yield Query(self.url(self.name) + '-pr/', headers={ "Requested-Backend-Delay": "1000" },
+                        ignore_result=True, phase=1)
         for i in range(500):
-            yield Query(self.url(self.name) + '-normal/200?sleep=1000', ignore_result=True, phase=2)
-            # yield Query(self.url(self.name) + '-normal/', headers={ "Requested-Backend-Delay": "1000" },
-            #             ignore_result=True, phase=1)
+            yield Query(self.url(self.name) + '-normal/', headers={ "Requested-Backend-Delay": "1000" },
+                        ignore_result=True, phase=1)
 
     def check(self):
 

--- a/ambassador/tests/t_circuitbreaker.py
+++ b/ambassador/tests/t_circuitbreaker.py
@@ -4,30 +4,33 @@ from abstract_tests import AmbassadorTest, HTTP, ServiceType
 from kat.harness import Query
 from kat.manifests import AMBASSADOR, RBAC_CLUSTER_SCOPE
 
-GRAPHITE_CONFIG = """
+STATSD_MANIFEST = """
 ---
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: {0}
+  name: {name}
 spec:
   replicas: 1
   template:
     metadata:
       labels:
-        service: {0}
+        service: {name}
     spec:
       containers:
-      - name: {0}
-        image: hopsoft/graphite-statsd:v0.9.15-phusion0.9.18
+      - name: {name}
+        image: dwflynn/stats-test:0.1.0
+        env:
+        - name: STATSD_TEST_CLUSTER
+          value: {target}
       restartPolicy: Always
 ---
 apiVersion: v1
 kind: Service
 metadata:
   labels:
-    service: {0}
-  name: {0}
+    service: {name}
+  name: {name}
 spec:
   ports:
   - protocol: UDP
@@ -35,13 +38,16 @@ spec:
     name: statsd-metrics
   - protocol: TCP
     port: 80
-    name: graphite-www
+    targetPort: 3000
+    name: statsd-http
   selector:
-    service: {0}
+    service: {name}
 """
 
-class CircuitBreakingTestCANFLAKE(AmbassadorTest):
+class CircuitBreakingTest(AmbassadorTest):
     target: ServiceType
+
+    TARGET_CLUSTER='cluster_circuitbreakingtest_http'
 
     def init(self):
         self.target = HTTP()
@@ -55,7 +61,8 @@ class CircuitBreakingTestCANFLAKE(AmbassadorTest):
 """
 
         return self.format(RBAC_CLUSTER_SCOPE + AMBASSADOR, image=os.environ["AMBASSADOR_DOCKER_IMAGE"],
-                           envs=envs, extra_ports="") + GRAPHITE_CONFIG.format('cbstatsd-sink')
+                           envs=envs, extra_ports="") + STATSD_MANIFEST.format(name='cbstatsd-sink',
+                                                                               target=self.__class__.TARGET_CLUSTER)
 
     def config(self):
         yield self, self.format("""
@@ -64,43 +71,68 @@ apiVersion: ambassador/v1
 kind:  Mapping
 name:  {self.target.path.k8s}-pr
 prefix: /{self.name}-pr/
-service: httpstat.us
-host_rewrite: httpstat.us
+service: {self.target.path.fqdn}
 circuit_breakers:
 - priority: default
   max_pending_requests: 1
   max_connections: 1
+---
+apiVersion: ambassador/v1
+kind: Mapping
+name: {self.name}-reset
+case_sensitive: false
+prefix: /reset/
+rewrite: /RESET/
+service: cbstatsd-sink
+---
+apiVersion: ambassador/v1
+kind: Mapping
+name: {self.name}-dump
+case_sensitive: false
+prefix: /dump/
+rewrite: /DUMP/
+service: cbstatsd-sink
 """)
+
+    def requirements(self):
+        yield ("url", Query(self.url("RESET/")))
 
     def queries(self):
         for i in range(500):
-            yield Query(self.url(self.name) + '-pr/200?sleep=1000', ignore_result=True, phase=1)
+            yield Query(self.url(self.name) + '-pr/', headers={ "Requested-Backend-Delay": "1000" },
+                        ignore_result=True, phase=1)
 
-        for i in range(20):
-            yield Query("http://cbstatsd-sink/render?format=json&target=summarize(stats.envoy.cluster.cluster_httpstat_us.upstream_rq_pending_overflow,'1hour','sum',true)&from=-1hour", phase=2, ignore_result=True)
+        yield Query(self.url("DUMP/"), phase=2)
 
     def check(self):
+        result_count = len(self.results)
+        assert result_count == 501, f'wanted 501 results, got {result_count}'
 
-        assert len(self.results) == 520
         pending_results = self.results[0:500]
-        pending_stats = self.results[500:520]
+        stats = self.results[500].json or {}
 
         # pending requests tests
         pending_overloaded = 0
+
+        # printed = False
+
         for result in pending_results:
+            # if not printed:
+            #     import json
+            #     print(json.dumps(result.as_dict(), sort_keys=True, indent=2))
+            #     printed = True
+
             if 'X-Envoy-Overloaded' in result.headers:
                 pending_overloaded += 1
-        assert 450 < pending_overloaded < 500, f'[CF] expected 450-500 pending_overloaded, got {pending_overloaded}'
 
-        pending_datapoints = 0
-        for stat in pending_stats:
-            if stat.status == 200:
-                pending_datapoints = stat.json[0]['datapoints'][0][0]
-                break
-        assert pending_datapoints > 0
-        assert 450 < pending_datapoints*10 <= 500, f'[CF] expected 45-50 pending_datapoints, got {pending_datapoints}'
+        assert 450 < pending_overloaded < 500, f'Expected between 450 and 500 overloaded, got {pending_overloaded}'
 
-        assert abs(pending_overloaded-(pending_datapoints*10)) < 10
+        cluster_stats = stats.get(self.__class__.TARGET_CLUSTER, {})
+        rq_completed = cluster_stats.get('upstream_rq_completed', -1)
+        rq_pending_overflow = cluster_stats.get('upstream_rq_pending_overflow', -1)
+
+        assert rq_completed == 500, f'Expected 500 completed requests to {self.__class__.TARGET_CLUSTER}, got {rq_completed}'
+        assert abs(pending_overloaded - rq_pending_overflow) < 2, f'Expected {pending_overloaded} rq_pending_overflow, got {rq_pending_overflow}'
 
 
 class GlobalCircuitBreakingTest(AmbassadorTest):
@@ -116,15 +148,13 @@ apiVersion: ambassador/v1
 kind:  Mapping
 name:  {self.target.path.k8s}-pr
 prefix: /{self.name}-pr/
-service: httpstat.us
+service: http://httpstat.us
 host_rewrite: httpstat.us
+#service: {self.target.path.fqdn}
 circuit_breakers:
 - priority: default
   max_pending_requests: 1024
   max_connections: 1024
-""")
-
-        yield self, self.format("""
 ---
 apiVersion: ambassador/v1
 kind:  Mapping
@@ -132,9 +162,8 @@ name:  {self.target.path.k8s}-normal
 prefix: /{self.name}-normal/
 service: http://httpstat.us
 host_rewrite: httpstat.us
-""")
-
-        yield self, self.format("""
+#service: {self.target.path.fqdn}
+---
 apiVersion: ambassador/v1
 kind:  Module
 name:  ambassador
@@ -148,8 +177,12 @@ config:
     def queries(self):
         for i in range(500):
             yield Query(self.url(self.name) + '-pr/200?sleep=1000', ignore_result=True, phase=2)
+            # yield Query(self.url(self.name) + '-pr/', headers={ "Requested-Backend-Delay": "1000" },
+            #             ignore_result=True, phase=1)
         for i in range(500):
             yield Query(self.url(self.name) + '-normal/200?sleep=1000', ignore_result=True, phase=2)
+            # yield Query(self.url(self.name) + '-normal/', headers={ "Requested-Backend-Delay": "1000" },
+            #             ignore_result=True, phase=1)
 
     def check(self):
 
@@ -157,16 +190,26 @@ config:
         cb_mapping_results = self.results[0:500]
         normal_mapping_results = self.results[500:1000]
 
-        # circuit breaker mapping tests
-        cb_mapping_overloaded = 0
+        # '-pr' mapping tests: this is a priority class of connection
+        pr_mapping_overloaded = 0
+
         for result in cb_mapping_results:
             if 'X-Envoy-Overloaded' in result.headers:
-                cb_mapping_overloaded += 1
-        assert cb_mapping_overloaded == 0
+                pr_mapping_overloaded += 1
 
-        # normal mapping tests, global configuration should be in effect
+        assert pr_mapping_overloaded == 0, f'[GCR] expected no -pr overloaded, got {pr_mapping_overloaded}'
+
+        # '-normal' mapping tests: global configuration should be in effect
         normal_overloaded = 0
+        printed = False
+
         for result in normal_mapping_results:
+            if not printed:
+                import json
+                print(json.dumps(result.as_dict(), sort_keys=True, indent=2))
+                printed = True
+
             if 'X-Envoy-Overloaded' in result.headers:
                 normal_overloaded += 1
-        assert 450 < normal_overloaded < 500
+
+        assert 450 < normal_overloaded < 500, f'[GCF] expected 450-500 normal_overloaded, got {normal_overloaded}'

--- a/ambassador/tests/t_consul.py
+++ b/ambassador/tests/t_consul.py
@@ -98,6 +98,9 @@ name:  {self.path.k8s}-client-context
 secret: {self.path.k8s}-client-cert-secret
 """)
 
+    def requirements(self):
+        yield("url", Query(self.format("http://{self.path.k8s}-consul:8500/ui/")))
+
     def queries(self):
         # The K8s service should be OK. The Consul service should 503 because it has no upstreams
         # in phase 1.

--- a/ambassador/tests/t_grpc_web.py
+++ b/ambassador/tests/t_grpc_web.py
@@ -50,19 +50,19 @@ service: {self.target.path.k8s}
                     grpc_type="web")
 
     def check(self):
-        print('AcceptanceGrpcWebTest results:')
-
-        i = 0
-
-        for result in self.results:
-            print(f'{i}: {json.dumps(result.as_dict(), sort_keys=True, indent=4)}')
-            print(f'    headers {json.dumps(result.headers, sort_keys=True)}')
-            print(f'    grpc-status {json.dumps(result.headers.get("Grpc-Status", "-none-"), sort_keys=True)}')
-            i += 1
+        # print('AcceptanceGrpcWebTest results:')
+        #
+        # i = 0
+        #
+        # for result in self.results:
+        #     print(f'{i}: {json.dumps(result.as_dict(), sort_keys=True, indent=4)}')
+        #     print(f'    headers {json.dumps(result.headers, sort_keys=True)}')
+        #     print(f'    grpc-status {json.dumps(result.headers.get("Grpc-Status", "-none-"), sort_keys=True)}')
+        #     i += 1
 
         # [0]
         gstat = self.results[0].headers.get("Grpc-Status", "-none-")
-        print(f'    grpc-status {gstat}')
+        # print(f'    grpc-status {gstat}')
 
         if gstat == [ '0' ]:
             assert True

--- a/ambassador/tests/t_mappingtests.py
+++ b/ambassador/tests/t_mappingtests.py
@@ -436,7 +436,7 @@ add_response_headers:
     def check(self):
         for r in self.results:
             if r.headers:
-                print(r.headers)
+                # print(r.headers)
                 assert r.headers['Koo'] == ['KooK']
                 assert r.headers['Zoo'] == ['Zoo', 'ZooZ']
                 assert r.headers['Test'] == ['Test', 'boo']
@@ -474,7 +474,7 @@ remove_request_headers:
 
     def check(self):
         for r in self.results:
-            print(r.json)
+            # print(r.json)
             if 'headers' in r.json:
                 assert r.json['headers']['Foo'] == 'FooF'
                 assert 'Zoo' not in r.json['headers']

--- a/kat/kat/harness.py
+++ b/kat/kat/harness.py
@@ -339,6 +339,33 @@ class Node(ABC):
     def requirements(self):
         yield from ()
 
+    # log_kube_artifacts writes various logs about our underlying Kubernetes objects to
+    # a place where the artifact publisher can find them. See run-tests.sh.
+    def log_kube_artifacts(self):
+        if not getattr(self, 'already_logged', False):
+            self.already_logged = True
+
+            print(f'logging kube artifacts for {self.path.k8s}')
+            sys.stdout.flush()
+
+            DEV = os.environ.get("AMBASSADOR_DEV", "0").lower() in ("1", "yes", "true")
+
+            log_path = f'/tmp/kat-logs-{self.path.k8s}'
+
+            if DEV:
+                os.system(f'docker logs {self.path.k8s} >{log_path} 2>&1')
+            else:
+                os.system(f'kubectl logs -n {self.namespace} {self.path.k8s} >{log_path} 2>&1')
+
+                event_path = f'/tmp/kat-events-{self.path.k8s}'
+
+                fs1 = f'involvedObject.name={self.path.k8s}'
+                fs2 = f'involvedObject.namespace={self.namespace}'
+
+                cmd = f'kubectl get events -o json --field-selector "{fs1}" --field-selector "{fs2}"'
+                os.system(f'echo ==== "{cmd}" >{event_path}')
+                os.system(f'{cmd} >>{event_path} 2>&1')
+
 
 class Test(Node):
 
@@ -501,6 +528,9 @@ class Result:
                     ("'%s'" % self.error) if self.error else "no error"
                 )
             else:
+                if self.query.expected != self.status:
+                    self.parent.log_kube_artifacts()
+
                 assert self.query.expected == self.status, \
                        "%s: expected status code %s, got %s instead with error %s" % (
                            self.query.url, self.query.expected, self.status, self.error)
@@ -1118,19 +1148,11 @@ class Runner:
             _holdouts = holdouts.get(kind, [])
 
             if _holdouts:
-                DEV = os.environ.get("AMBASSADOR_DEV", "0").lower() in ("1", "yes", "true")
-
                 print(f'  {kind}:')
 
                 for node, text in _holdouts:
-                    print(f'\n================================ LOGS FOR {node.path.k8s} ({text})')
-
-                    if DEV:
-                        os.system(f'docker logs {node.path.k8s}')
-                    else:
-                        os.system(f'kubectl logs -n {node.namespace} {node.path.k8s}')
-
-                    print(f'================================ END LOGS FOR {node.path.k8s} ({text})\n')
+                    print(f'    {node.path.k8s} ({text})')
+                    node.log_kube_artifacts()
 
         assert False, "requirements not satisfied in %s seconds" % limit
 

--- a/kat/kat/harness.py
+++ b/kat/kat/harness.py
@@ -715,7 +715,7 @@ def label(yaml, scope):
 
 CLIENT_GO = "kat_client"
 
-def run_queries(queries: Sequence[Query]) -> Sequence[Result]:
+def run_queries(name: str, queries: Sequence[Query]) -> Sequence[Result]:
     jsonified = []
     byid = {}
 
@@ -723,12 +723,16 @@ def run_queries(queries: Sequence[Query]) -> Sequence[Result]:
         jsonified.append(q.as_json())
         byid[id(q)] = q
 
-    with open("/tmp/urls.json", "w") as f:
+    path_urls = f'/tmp/kat-client-{name}-urls.json'
+    path_results = f'/tmp/kat-client-{name}-results.json'
+    path_log = f'/tmp/kat-client-{name}.log'
+
+    with open(path_urls, 'w') as f:
         json.dump(jsonified, f)
 
-    run("%s -input /tmp/urls.json -output /tmp/results.json 2> /tmp/client.log" % CLIENT_GO)
+    run(f"{CLIENT_GO} -input {path_urls} -output {path_results} 2> {path_log}")
 
-    with open("/tmp/results.json") as f:
+    with open(path_results, 'r') as f:
         json_results = json.load(f)
 
     results = []
@@ -1187,7 +1191,7 @@ class Runner:
         # print("URL Reqs:")
         # print("\n".join([ f'{q.parent.name}: {q.url}' for q in queries ]))
 
-        result = run_queries(queries)
+        result = run_queries("reqcheck", queries)
 
         not_ready = [r for r in result if r.status != r.query.expected]
 
@@ -1250,7 +1254,7 @@ class Runner:
             print("Querying %s urls in phase %s..." % (len(phase_queries), phase), end="")
             sys.stdout.flush()
 
-            results = run_queries(phase_queries)
+            results = run_queries(f'phase{phase}', phase_queries)
 
             print(" done.")
 

--- a/releng/run-tests.sh
+++ b/releng/run-tests.sh
@@ -30,14 +30,11 @@ fi
 
 TEST_ARGS="--tb=short -s"
 
-seq=(
-    'Plain'
-    'not Plain and (A or C)'
-    'not Plain and not (A or C)'
-)
+seq=("")
 
 if [[ -n "${TEST_NAME}" ]]; then
     case "${TEST_NAME}" in
+    group0) seq=('Plain' 'not Plain and (A or C)' 'not Plain and not (A or C)') ;;
     group1) seq=('Plain') ;;
     group2) seq=('not Plain and (A or C)') ;;
     group3) seq=('not Plain and not (A or C)') ;;
@@ -57,7 +54,13 @@ for el in "${seq[@]}"; do
 #    kubectl delete namespaces -l scope=AmbassadorTest
 #    kubectl delete all -l scope=AmbassadorTest
 
-    if ! pytest ${TEST_ARGS} -k "$el"; then
+    k_args=""
+
+    if [ -n "$el" ]; then
+        k_args="-k $el"
+    fi
+
+    if ! pytest ${TEST_ARGS} $k_args; then
         failed+=("$el")
 
         kubectl get pods --all-namespaces

--- a/releng/run-tests.sh
+++ b/releng/run-tests.sh
@@ -81,6 +81,15 @@ for el in "${seq[@]}"; do
     if [ -f /tmp/k8s-AmbassadorTest ]; then
         mv /tmp/k8s-AmbassadorTest.yaml /tmp/k8s-$el-AmbassadorTest.yaml
     fi
+
+    for file in /tmp/kat-logs-*; do
+        if [ "$file" = '/tmp/kat-logs-*' ]; then
+            break
+        else
+            echo "==== $file"
+            cat $file && rm $file
+        fi
+    done
 done
 
 if (( ${#failed[@]} == 0 )); then


### PR DESCRIPTION
If you do this commit-by-commit it will likely work out best. The first five commits:

| ID     | What |
|------|:------|
| `0b86579` | Kill some needless debugging. |
| `76b65b1` | Undo the three-phase test run; label selectors manage this correctly. |
| `9e8e37d` | I can't take the spewage from `kubectl port-forward` any more. |
| `b3a7ba0` | Pull Kubernetes logs for tests where a check fails. |
| `33e9f75` | Save logs for all kat phases. Push a tarball of artifacts to S3 on test failure, rather than trying to dump them all to stdout. |

are about the test infrastructure. They address #1702 among other improvements.

The remaining commits:

| ID     | What |
|------|:------|
| `f2230c2` | Add a requirement to wait for Consul to actually be running. |
| `265b9ac` | Make certain that app.diag is ready before we allow check_ready to succeed. |
| `d5e3d10` | Clean up non-global CircuitBreakingTest, start diving into GlobalCircuitBreakingTest. |
| `d399ace` | Take circuit breakers into account when reconciling cluster names. Update t_clustertest to match, and to avoid httpstat.us. |
| `00cc3b9` | Ditch dead code. |

are about improving specific tests:

- they address #1767, so that multiple `Mapping`s to the same upstream with different circuit breaker settings do the right thing;
- they fix a race where an Ambassador pod could report ready before `diagd` could answer on the diag service;
- they fix a flake in the Consul test (Consul can take quite awhile to start); and
- they scrap a couple of lines we don't need any more.

We are still in a situation where Travis has nasty issues with Ambassador's CI; that's for the future. But this makes some things better.
