### PR TITLE
.gitignore: Ignore files created by newer build-aux docker.mk

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,10 @@ VERSION.py
 cluster.yaml
 watt
 kat/kat/client
+
 *.docker
+*.docker.tag.*
+*.docker.push.*
 
 *.egg-info
 build


### PR DESCRIPTION
## Description

A newer `build-aux/docker.mk` also generates `NAME.docker.tag.*` and `NAME.docker.push.*` files.  Ambassador OSS isn't (yet) using `docker.mk`, but in the build integration with Pro, the parent build is using it, and is dumping those files in the OSS checkout, so ignore them, so that `VERSION.py` doesn't think the build is dirty.