### PR TITLE
Stop using deprecated Envoy APIs

### DIFF
--- a/ambassador/ambassador/envoy/v2/v2bootstrap.py
+++ b/ambassador/ambassador/envoy/v2/v2bootstrap.py
@@ -37,13 +37,29 @@ class V2Bootstrap(dict):
         clusters = [{
             "name": "xds_cluster",
             "connect_timeout": "1s",
-            "hosts": [ {
-                "socket_address": {
-                    "address": "127.0.0.1",
-                    "port_value": 8003
-                }
-            } ],
+            "dns_lookup_family": "V4_ONLY",
             "http2_protocol_options": {},
+            "lb_policy": "ROUND_ROBIN",
+            "load_assignment": {
+                "cluster_name": "cluster_127_0_0_1_8003",
+                "endpoints": [
+                    {
+                        "lb_endpoints": [
+                            {
+                                "endpoint": {
+                                    "address": {
+                                        "socket_address": {
+                                            "address": "127.0.0.1",
+                                            "port_value": 8003,
+                                            "protocol": "TCP"
+                                        }
+                                    }
+                                }
+                            }
+                        ]
+                    }
+                ]
+            }
         }]
 
         if config.tracing:

--- a/ambassador/ambassador/envoy/v2/v2route.py
+++ b/ambassador/ambassador/envoy/v2/v2route.py
@@ -125,12 +125,16 @@ class V2Route(dict):
         cors = None
 
         if "cors" in group:
-            cors = group.cors.as_dict()
+            cors = group.cors
         elif "cors" in config.ir.ambassador_module:
-            cors = config.ir.ambassador_module.cors.as_dict()
+            cors = config.ir.ambassador_module.cors
 
         if cors:
-            route['cors'] = cors
+            # Duplicate this IRCORS, then set its group ID correctly.
+            cors = cors.dup()
+            cors.set_id(group.group_id)
+
+            route['cors'] = cors.as_dict()
 
         retry_policy = None
 

--- a/ambassador/ambassador/ir/ircors.py
+++ b/ambassador/ambassador/ir/ircors.py
@@ -1,5 +1,7 @@
 from typing import Any, TYPE_CHECKING
 
+import copy
+
 from ..config import Config
 from ..utils import RichStatus
 
@@ -49,8 +51,22 @@ class IRCORS (IRResource):
             if value:
                 self[to_key] = self._cors_normalize(value)
 
-        self.enabled = True
+        # This IRCORS has not been finalized with an ID, so leave with an 'unset' ID so far.
+        self.set_id('unset')
+
         return True
+
+    def set_id(self, group_id: str):
+        self['filter_enabled'] = {
+            "default_value": {
+                "denominator": "HUNDRED",
+                "numerator": 100
+            },
+            "runtime_key": f"routing.cors_enabled.{group_id}"
+        }
+
+    def dup(self) -> 'IRCORS':
+        return copy.copy(self)
 
     @staticmethod
     def _cors_normalize(value: Any) -> Any:

--- a/ambassador/ambassador/resource.py
+++ b/ambassador/ambassador/resource.py
@@ -91,7 +91,10 @@ class Resource (dict):
         return self._referenced_by.get(other_location, None)
 
     def __getattr__(self, key: str) -> Any:
-        return self[key]
+        try:
+            return self[key]
+        except KeyError:
+            raise AttributeError(key)
 
     def __setattr__(self, key: str, value: Any) -> None:
         self[key] = value

--- a/ambassador/tests/t_cors.py
+++ b/ambassador/tests/t_cors.py
@@ -39,10 +39,23 @@ cors:
 """)
 
     def queries(self):
+        # 0. No Access-Control-Allow-Origin because no Origin was provided.
         yield Query(self.url("foo/"))
+
+        # 1. Access-Control-Allow-Origin because a matching Origin was provided.
         yield Query(self.url("foo/"), headers={ "Origin": "http://foo.example.com" })
+
+        # 2. No Access-Control-Allow-Origin because the provided Origin does not match.
+        yield Query(self.url("foo/"), headers={ "Origin": "http://wrong.example.com" })
+
+        # 3. No Access-Control-Allow-Origin because no Origin was provided.
         yield Query(self.url("bar/"))
+
+        # 4. Access-Control-Allow-Origin because a matching Origin was provided.
         yield Query(self.url("bar/"), headers={ "Origin": "http://bar.example.com" })
+
+        # 5. No Access-Control-Allow-Origin because no Origin was provided.
+        yield Query(self.url("bar/"), headers={ "Origin": "http://wrong.example.com" })
 
     def check(self):
         assert self.results[0].backend.name == self.target.path.k8s
@@ -55,4 +68,10 @@ cors:
         assert "Access-Control-Allow-Origin" not in self.results[2].headers
 
         assert self.results[3].backend.name == self.target.path.k8s
-        assert self.results[3].headers["Access-Control-Allow-Origin"] == [ "http://bar.example.com" ]
+        assert "Access-Control-Allow-Origin" not in self.results[3].headers
+
+        assert self.results[4].backend.name == self.target.path.k8s
+        assert self.results[4].headers["Access-Control-Allow-Origin"] == [ "http://bar.example.com" ]
+
+        assert self.results[5].backend.name == self.target.path.k8s
+        assert "Access-Control-Allow-Origin" not in self.results[5].headers

--- a/ambassador/tests/t_cors.py
+++ b/ambassador/tests/t_cors.py
@@ -1,0 +1,58 @@
+# Note that there's also a CORS OptionTest in t_optiontests.py.
+
+from kat.harness import Query
+
+from abstract_tests import AmbassadorTest, HTTP, Node, ServiceType
+
+
+class GlobalCORSTest(AmbassadorTest):
+    target: ServiceType
+
+    def init(self):
+        self.target = HTTP()
+
+    def config(self):
+        yield self, self.format("""
+---
+apiVersion: ambassador/v1
+kind:  Module
+name:  ambassador
+config:
+  cors:
+    origins: http://foo.example.com
+    methods: POST, GET, OPTIONS
+---
+apiVersion: ambassador/v1
+kind:  Mapping
+name:  {self.target.path.k8s}-foo
+prefix: /foo/
+service: {self.target.path.fqdn}
+---
+apiVersion: ambassador/v1
+kind:  Mapping
+name:  {self.target.path.k8s}-bar
+prefix: /bar/
+service: {self.target.path.fqdn}
+cors:
+  origins: http://bar.example.com
+  methods: POST, GET, OPTIONS
+""")
+
+    def queries(self):
+        yield Query(self.url("foo/"))
+        yield Query(self.url("foo/"), headers={ "Origin": "http://foo.example.com" })
+        yield Query(self.url("bar/"))
+        yield Query(self.url("bar/"), headers={ "Origin": "http://bar.example.com" })
+
+    def check(self):
+        assert self.results[0].backend.name == self.target.path.k8s
+        assert "Access-Control-Allow-Origin" not in self.results[0].headers
+
+        assert self.results[1].backend.name == self.target.path.k8s
+        assert self.results[1].headers["Access-Control-Allow-Origin"] == [ "http://foo.example.com" ]
+
+        assert self.results[2].backend.name == self.target.path.k8s
+        assert "Access-Control-Allow-Origin" not in self.results[2].headers
+
+        assert self.results[3].backend.name == self.target.path.k8s
+        assert self.results[3].headers["Access-Control-Allow-Origin"] == [ "http://bar.example.com" ]

--- a/ambassador/tests/t_optiontests.py
+++ b/ambassador/tests/t_optiontests.py
@@ -90,6 +90,8 @@ class CORS(OptionTest):
     # isolated = True
     # debug = True
 
+    # Note that there's also a GlobalCORSTest in t_cors.py.
+
     parent: MappingTest
 
     def config(self):

--- a/ambassador/tests/test_ambassador.py
+++ b/ambassador/tests/test_ambassador.py
@@ -5,6 +5,7 @@ from abstract_tests import AmbassadorTest
 # Import all the real tests from other files, to make it easier to pick and choose during development.
 
 import t_basics
+import t_cors
 import t_extauth
 import t_grpc
 import t_grpc_bridge


### PR DESCRIPTION
Fixes #1568 by switching to the _correct_ ways to configure these features.