### PR TITLE
Support setting cipher_suites and ecdh_curves in TLSContext

### DIFF
--- a/ambassador/ambassador/envoy/v2/v2tls.py
+++ b/ambassador/ambassador/envoy/v2/v2tls.py
@@ -76,6 +76,11 @@ class V2TLSContext(Dict):
         if value == "v1.3":
             common['tls_params'][key] = "TLSv1_3"
 
+    def update_tls_cipher(self, key: str, value: list) -> None:
+        common = self.get_common()
+        common.setdefault('tls_params', {})
+        common['tls_params'][key] = value
+
     def update_validation(self, key: str, value: str) -> None:
         empty_context: EnvoyValidationContext = {}
         validation = typecast(EnvoyValidationContext, self.get_common().setdefault('validation_context', empty_context))
@@ -99,6 +104,8 @@ class V2TLSContext(Dict):
             ( 'cert_required', self.__setitem__, 'require_client_certificate' ),
             ( 'min_tls_version', self.update_tls_version, 'tls_minimum_protocol_version' ),
             ( 'max_tls_version', self.update_tls_version, 'tls_maximum_protocol_version' ),
+            ( 'cipher_suites', self.update_tls_cipher, 'cipher_suites' ),
+            ( 'ecdh_curves', self.update_tls_cipher, 'ecdh_curves' ),
         ]:
             value = ctx.get(ctxkey, None)
 

--- a/ambassador/ambassador/ir/irtlscontext.py
+++ b/ambassador/ambassador/ir/irtlscontext.py
@@ -28,6 +28,8 @@ class IRTLSContext(IRResource):
     cert_required: Optional[bool]
     min_tls_version: Optional[str]
     max_tls_version: Optional[str]
+    cipher_suites: Optional[str]
+    ecdh_curves: Optional[str]
     redirect_cleartext_from: Optional[int]
     secret_namespacing: Optional[bool]
     secret_info: dict
@@ -60,6 +62,8 @@ class IRTLSContext(IRResource):
         self.cert_required = config.get('cert_required')
         self.min_tls_version = config.get('min_tls_version')
         self.max_tls_version = config.get('max_tls_version')
+        self.cipher_suites = config.get('cipher_suites')
+        self.ecdh_curves = config.get('ecdh_curves')
         self.secret_namespacing = config.get('secret_namespacing', None)
 
         rcf = config.get('redirect_cleartext_from')

--- a/ambassador/schemas/v1/TLSContext.schema
+++ b/ambassador/schemas/v1/TLSContext.schema
@@ -25,6 +25,8 @@
         "cert_required": { "type": "boolean" },
         "min_tls_version": { "enum": [ "v1.0", "v1.1", "v1.2", "v1.3" ] },
         "max_tls_version": { "enum": [ "v1.0", "v1.1", "v1.2", "v1.3" ] },
+        "cipher_suites": { "array", "items": { "type": "string" }  },
+        "ecdh_curves": { "array", "items": { "type": "string" }  },
         "secret_namespacing": { "type": "boolean" }
     },
     "required": [ "apiVersion", "kind", "name" ],

--- a/ambassador/tests/t_tls.py
+++ b/ambassador/tests/t_tls.py
@@ -828,3 +828,96 @@ max_tls_version: v1.2
         # We're replacing super()'s requirements deliberately here. Without a Host header they can't work.
         yield ("url", Query(self.url("ambassador/v0/check_ready"), headers={"Host": "tls-context-host-1"}, insecure=True, sni=True))
         yield ("url", Query(self.url("ambassador/v0/check_alive"), headers={"Host": "tls-context-host-1"}, insecure=True, sni=True))
+
+class TLSContextCipherSuites(AmbassadorTest):
+    # debug = True
+
+    def init(self):
+        self.target = HTTP()
+
+    def manifests(self) -> str:
+        return super().manifests() + """
+---
+apiVersion: v1
+data:
+  tls.crt: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURnRENDQW1pZ0F3SUJBZ0lKQUpycUl0ekY2MTBpTUEwR0NTcUdTSWIzRFFFQkN3VUFNRlV4Q3pBSkJnTlYKQkFZVEFsVlRNUXN3Q1FZRFZRUUlEQUpOUVRFUE1BMEdBMVVFQnd3R1FtOXpkRzl1TVFzd0NRWURWUVFLREFKRQpWekViTUJrR0ExVUVBd3dTZEd4ekxXTnZiblJsZUhRdGFHOXpkQzB4TUI0WERURTRNVEV3TVRFek5UTXhPRm9YCkRUSTRNVEF5T1RFek5UTXhPRm93VlRFTE1Ba0dBMVVFQmhNQ1ZWTXhDekFKQmdOVkJBZ01BazFCTVE4d0RRWUQKVlFRSERBWkNiM04wYjI0eEN6QUpCZ05WQkFvTUFrUlhNUnN3R1FZRFZRUUREQkowYkhNdFkyOXVkR1Y0ZEMxbwpiM04wTFRFd2dnRWlNQTBHQ1NxR1NJYjNEUUVCQVFVQUE0SUJEd0F3Z2dFS0FvSUJBUUM5T2dDOHd4eUlyUHpvCkdYc0xwUEt0NzJERXgyd2p3VzhuWFcyd1dieWEzYzk2bjJuU0NLUEJuODVoYnFzaHpqNWloU1RBTURJb2c5RnYKRzZSS1dVUFhUNEtJa1R2M0NESHFYc0FwSmxKNGxTeW5ReW8yWnYwbytBZjhDTG5nWVpCK3JmenRad3llRGhWcAp3WXpCVjIzNXp6NisycWJWbUNabHZCdVhiVXFUbEVZWXZ1R2xNR3o3cFBmT1dLVXBlWW9kYkcyZmIraEZGcGVvCkN4a1VYclFzT29SNUpkSEc1aldyWnVCTzQ1NVNzcnpCTDhSbGU1VUhvMDVXY0s3YkJiaVF6MTA2cEhDSllaK3AKdmxQSWNOU1g1S2gzNEZnOTZVUHg5bFFpQTN6RFRLQmZ5V2NMUStxMWNabExjV2RnUkZjTkJpckdCLzdyYTFWVApnRUplR2tQekFnTUJBQUdqVXpCUk1CMEdBMVVkRGdRV0JCUkRWVUtYWWJsRFdNTzE3MUJuWWZhYlkzM0NFVEFmCkJnTlZIU01FR0RBV2dCUkRWVUtYWWJsRFdNTzE3MUJuWWZhYlkzM0NFVEFQQmdOVkhSTUJBZjhFQlRBREFRSC8KTUEwR0NTcUdTSWIzRFFFQkN3VUFBNElCQVFBUE8vRDRUdDUyWHJsQ0NmUzZnVUVkRU5DcnBBV05YRHJvR2M2dApTVGx3aC8rUUxRYk5hZEtlaEtiZjg5clhLaituVXF0cS9OUlpQSXNBSytXVWtHOVpQb1FPOFBRaVY0V1g1clE3CjI5dUtjSmZhQlhrZHpVVzdxTlFoRTRjOEJhc0JySWVzcmtqcFQ5OVF4SktuWFFhTitTdzdvRlBVSUFOMzhHcWEKV2wvS1BNVHRicWt3eWFjS01CbXExVkx6dldKb0g1Q2l6Skp3aG5rWHh0V0tzLzY3clROblBWTXorbWVHdHZTaQpkcVg2V1NTbUdMRkVFcjJoZ1VjQVpqazNWdVFoLzc1aFh1K1UySXRzQys1cXBsaEc3Q1hzb1huS0t5MVhsT0FFCmI4a3IyZFdXRWs2STVZNm5USnpXSWxTVGtXODl4d1hyY3RtTjlzYjlxNFNuaVZsegotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==
+  tls.key: LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0tCk1JSUV2UUlCQURBTkJna3Foa2lHOXcwQkFRRUZBQVNDQktjd2dnU2pBZ0VBQW9JQkFRQzlPZ0M4d3h5SXJQem8KR1hzTHBQS3Q3MkRFeDJ3andXOG5YVzJ3V2J5YTNjOTZuMm5TQ0tQQm44NWhicXNoemo1aWhTVEFNRElvZzlGdgpHNlJLV1VQWFQ0S0lrVHYzQ0RIcVhzQXBKbEo0bFN5blF5bzJadjBvK0FmOENMbmdZWkIrcmZ6dFp3eWVEaFZwCndZekJWMjM1eno2KzJxYlZtQ1psdkJ1WGJVcVRsRVlZdnVHbE1HejdwUGZPV0tVcGVZb2RiRzJmYitoRkZwZW8KQ3hrVVhyUXNPb1I1SmRIRzVqV3JadUJPNDU1U3NyekJMOFJsZTVVSG8wNVdjSzdiQmJpUXoxMDZwSENKWVorcAp2bFBJY05TWDVLaDM0Rmc5NlVQeDlsUWlBM3pEVEtCZnlXY0xRK3ExY1psTGNXZGdSRmNOQmlyR0IvN3JhMVZUCmdFSmVHa1B6QWdNQkFBRUNnZ0VBQmFsN3BpcE1hMGFKMXNRVWEzZkhEeTlQZlBQZXAzODlQVGROZGU1cGQxVFYKeFh5SnBSQS9IaWNTL05WYjU0b05VZE5jRXlnZUNCcFJwUHAxd3dmQ3dPbVBKVmo3SzF3aWFqbmxsQldpZUJzMgpsOWFwcDdFVE9DdWJ5WTNWU2dLQldWa0piVzBjOG9uSFdEL0RYM0duUjhkTXdGYzRrTUdadkllUlo4bU1acmdHCjZPdDNKOHI2eVZsZWI2OGF1WmtneXMwR2VGc3pNdVRubHJCOEw5djI1UUtjVGtESjIvRWx1Y1p5aER0eGF0OEIKTzZOUnNubmNyOHhwUVdPci9sV3M5VVFuZEdCdHFzbXMrdGNUN1ZUNU9UanQ4WHY5NVhNSHB5Z29pTHk3czhvYwpJMGprNDJabzRKZW5JT3c2Rm0weUFEZ0E3eWlXcks0bEkzWGhqaTVSb1FLQmdRRGRqaWNkTUpYVUZWc28rNTJkCkUwT2EwcEpVMFNSaC9JQmdvRzdNakhrVWxiaXlpR1pNanA5MEo5VHFaL1ErM1pWZVdqMmxPSWF0OG5nUzB6MDAKVzA3T1ZxYXprMVNYaFZlY2tGNWFEcm5PRDNhU2VWMSthV3JUdDFXRWdqOVFxYnJZYVA5emd4UkpkRzV3WENCUApGNDNFeXE5ZEhXOWF6SSt3UHlJQ0JqNnZBd0tCZ1FEYXBTelhPR2ViMi9SMWhlWXdWV240czNGZEtYVjgzemtTCnFSWDd6d1pLdkk5OGMybDU1Y1ZNUzBoTGM0bTVPMXZCaUd5SG80eTB2SVAvR0k0Rzl4T1FhMXdpVnNmUVBiSU4KLzJPSDFnNXJLSFdCWVJUaHZGcERqdHJRU2xyRHVjWUNSRExCd1hUcDFrbVBkL09mY2FybG42MjZEamthZllieAp3dWUydlhCTVVRS0JnQm4vTmlPOHNiZ0RFWUZMbFFEN1k3RmxCL3FmMTg4UG05aTZ1b1dSN2hzMlBrZmtyV3hLClIvZVBQUEtNWkNLRVNhU2FuaVVtN3RhMlh0U0dxT1hkMk85cFI0Skd4V1JLSnkrZDJSUmtLZlU5NTBIa3I4M0gKZk50KzVhLzR3SWtzZ1ZvblorSWIvV05wSUJSYkd3ZHMwaHZIVkxCdVpjU1h3RHlFQysrRTRCSVZBb0dCQUoxUQp6eXlqWnRqYnI4NkhZeEpQd29teEF0WVhLSE9LWVJRdUdLVXZWY1djV2xrZTZUdE51V0dsb1FTNHd0VkdBa1VECmxhTWFaL2o2MHJaT3dwSDhZRlUvQ2ZHakl1MlFGbmEvMUtzOXR1NGZGRHpjenh1RVhDWFR1Vmk0eHdtZ3R2bVcKZkRhd3JTQTZrSDdydlp4eE9wY3hCdHloc3pCK05RUHFTckpQSjJlaEFvR0FkdFJKam9vU0lpYURVU25lZUcyZgpUTml1T01uazJkeFV3RVF2S1E4eWNuUnpyN0QwaEtZVWIycThHKzE2bThQUjNCcFMzZDFLbkpMVnI3TUhaWHpSCitzZHNaWGtTMWVEcEZhV0RFREFEWWI0ckRCb2RBdk8xYm03ZXdTMzhSbk1UaTlhdFZzNVNTODNpZG5HbFZiSmsKYkZKWG0rWWxJNHFkaXowTFdjWGJyREE9Ci0tLS0tRU5EIFBSSVZBVEUgS0VZLS0tLS0K
+kind: Secret
+metadata:
+  name: secret.cipher-suites
+  labels:
+    kat-ambassador-id: tlscontextciphersuites
+type: kubernetes.io/tls
+"""
+
+    def config(self):
+        yield self, self.format("""
+---
+apiVersion: ambassador/v0
+kind:  Mapping
+name:  {self.name}-same-prefix-1
+prefix: /tls-context-same/
+service: https://{self.target.path.fqdn}
+host: tls-context-host-1
+""")
+        yield self, self.format("""
+---
+apiVersion: ambassador/v1
+kind: TLSContext
+name: {self.name}-same-context-1
+hosts:
+- tls-context-host-1
+secret: secret.cipher-suites
+secret_namespacing: False
+max_tls_version: v1.2
+cipher_suites:
+- ECDHE-RSA-AES128-GCM-SHA256
+ecdh_curves:
+- P-256
+""")
+
+    def scheme(self) -> str:
+        return "https"
+
+    @staticmethod
+    def _go_close_connection_error(url):
+        """
+        :param url: url passed to the query
+        :return: error message string that Go's net/http package throws when server closes connection
+        """
+        return "Get {}: EOF".format(url)
+
+    def queries(self):
+        yield Query(self.url("tls-context-same/"),
+                    headers={"Host": "tls-context-host-1"},
+                    expected=200,
+                    insecure=True,
+                    sni=True,
+                    cipherSuites=["TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"],
+                    maxTLSv="v1.2")
+
+        yield Query(self.url("tls-context-same/"),
+                    headers={"Host": "tls-context-host-1"},
+                    expected=200,
+                    insecure=True,
+                    sni=True,
+                    cipherSuites=["TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256"],
+                    maxTLSv="v1.2",
+                    error="tls: handshake failure",)
+
+        yield Query(self.url("tls-context-same/"),
+                    headers={"Host": "tls-context-host-1"},
+                    expected=200,
+                    insecure=True,
+                    sni=True,
+                    cipherSuites=["TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"],
+                    ecdhCurves=["X25519"],
+                    maxTLSv="v1.2",
+                    error="tls: handshake failure",)
+
+    def check(self):
+      self.results[0].backend.request.tls.negotiated_protocol_version == "v1.2"
+
+    def requirements(self):
+        yield ("url", Query(self.url("ambassador/v0/check_ready"), headers={"Host": "tls-context-host-1"}, insecure=True, sni=True))
+        yield ("url", Query(self.url("ambassador/v0/check_alive"), headers={"Host": "tls-context-host-1"}, insecure=True, sni=True))

--- a/docs/reference/core/tls.md
+++ b/docs/reference/core/tls.md
@@ -97,11 +97,15 @@ Without setting setting alpn_protocols as shown above, HTTP2 will not be availab
 
 If you leave off http/1.1, only HTTP2 connections will be supported.
 
-### `min_tls_version` and `max_tls_version`
+### TLS Parameters
 
 The `min_tls_version` setting configures the minimum TLS protocol version that Ambassador will use to establish a secure connection. When a client using a lower version attempts to connect to the server, the handshake will result in the following error: `tls: protocol version not supported`.
 
 The `max_tls_version` setting configures the maximum TLS protocol version that Ambassador will use to establish a secure connection. When a client using a higher version attempts to connect to the server, the handshake will result in the following error: `tls: server selected unsupported protocol version`.
+
+The `cipher_suites` setting configures the supported [cipher list](https://commondatastorage.googleapis.com/chromium-boringssl-docs/ssl.h.html#Cipher-suite-configuration) when negotiating a TLS 1.0-1.2 connection. This setting has no effect when negotiating a TLS 1.3 connection.  When a client does not support a matching cipher a handshake error will result.
+
+The `ecdh_curves` setting configures the supported ECDH curves when negotiating a TLS connection.  When a client does not support a matching ECDH a handshake error will result.
 
 ```yaml
 ---
@@ -112,6 +116,12 @@ hosts: ["*"]
 secret: ambassador-certs
 min_tls_version: v1.0
 max_tls_version: v1.3
+cipher_suites:
+- "[ECDHE-ECDSA-AES128-GCM-SHA256|ECDHE-ECDSA-CHACHA20-POLY1305]"
+- "[ECDHE-RSA-AES128-GCM-SHA256|ECDHE-RSA-CHACHA20-POLY1305]"
+ecdh_curves:
+- X25519
+- P-256
 ```
 
 ## TLS `Module`

--- a/kat/kat/harness.py
+++ b/kat/kat/harness.py
@@ -414,7 +414,7 @@ class Query:
     def __init__(self, url, expected=None, method="GET", headers=None, messages=None, insecure=False, skip=None,
                  xfail=None, phase=1, debug=False, sni=False, error=None, client_crt=None, client_key=None,
                  client_cert_required=False, ca_cert=None, grpc_type=None, cookies=None, ignore_result=False, body=None,
-                 minTLSv="", maxTLSv=""):
+                 minTLSv="", maxTLSv="", cipherSuites=[], ecdhCurves=[]):
         self.method = method
         self.url = url
         self.headers = headers
@@ -424,6 +424,8 @@ class Query:
         self.insecure = insecure
         self.minTLSv = minTLSv
         self.maxTLSv = maxTLSv
+        self.cipherSuites = cipherSuites
+        self.ecdhCurves = ecdhCurves
         if expected is None:
             if url.lower().startswith("ws:"):
                 self.expected = 101
@@ -461,6 +463,10 @@ class Query:
             result["maxTLSv"] = self.maxTLSv
         if self.method:
             result["minTLSv"] = self.minTLSv
+        if self.cipherSuites:
+            result["cipherSuites"] = self.cipherSuites
+        if self.ecdhCurves:
+            result["ecdhCurves"] = self.ecdhCurves
         if self.headers:
             result["headers"] = self.headers
         if self.body is not None:


### PR DESCRIPTION
## Description
Adds the ability to tune the cipher suites and ecdh curves.

## Related Issues
None.

## Testing
Implemented some tests to check that the ciphers / curves work and do not work as expected.
This required a small change in the kat_client to support specifying these.

https://github.com/datawire/kat-backend/pull/15

## Todos
- [x] Tests
- [x] Documentation

## Other
* If this is a documentation change, please open the pull request at https://github.com/datawire/ambassador-docs instead.
* Code changes should occur against `master`.
