### PR TITLE
Make mismatch error more descriptive

### DIFF
--- a/ambassador/ambassador/ir/irhttpmappinggroup.py
+++ b/ambassador/ambassador/ir/irhttpmappinggroup.py
@@ -126,7 +126,9 @@ class IRHTTPMappingGroup (IRBaseMappingGroup):
                 mismatches.append((k, mapping[k], self.get(k, '-unset-')))
 
         if mismatches:
-            self.post_error("cannot accept new mapping %s with mismatched %s" % (
+            self.post_error("cannot accept new mapping %s with mismatched %s."
+                            "Please verify field is set with the same value in all related mappings."
+                            "Example: When canary is configured, related mappings should have same fields and values" % (
                                 mapping.name,
                                 ", ".join([ "%s: %s != %s" % (x, y, z) for x, y, z in mismatches ])
                             ))


### PR DESCRIPTION
This commit makes the mismatch attribute error more apparent and
informative to the end user. Generally, in case of canary
deployments if mappings with weight have different attributes
and values, this error is posted to the user.