### PR TITLE
Simple tweaks to clean up some annoyances that Abhay noticed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,9 @@ VERSION.py
 .mypy_cache
 cluster.yaml
 watt
+kubestatus
+kat_client
+teleproxy
 kat/kat/client
 
 *.docker

--- a/ambassador/tests/t_tcpmapping.py
+++ b/ambassador/tests/t_tcpmapping.py
@@ -25,13 +25,13 @@ class TCPMappingTest(AmbassadorTest):
 
     def init(self):
         self.target1 = HTTP(name="target1")
-        print("TCP target1 %s" % self.target1.namespace)
+        # print("TCP target1 %s" % self.target1.namespace)
 
         self.target2 = HTTP(name="target2", namespace="other-namespace")
-        print("TCP target2 %s" % self.target2.namespace)
+        # print("TCP target2 %s" % self.target2.namespace)
 
         self.target3 = HTTP(name="target3")
-        print("TCP target3 %s" % self.target3.namespace)
+        # print("TCP target3 %s" % self.target3.namespace)
 
     # manifests returns a string of Kubernetes YAML that will be applied to the
     # Kubernetes cluster before running any tests.

--- a/ambassador/tests/test_docker.py
+++ b/ambassador/tests/test_docker.py
@@ -1,10 +1,12 @@
-import sys
 import os
+
+import pytest
 
 import pexpect
 import requests
 
-DockerImage = os.environ["AMBASSADOR_DOCKER_IMAGE"]
+DockerImage = os.environ.get("AMBASSADOR_DOCKER_IMAGE", None)
+
 child = None    # see docker_start()
 
 def docker_start(logfile) -> bool:
@@ -51,6 +53,9 @@ def check_http(logfile) -> bool:
         return False
 
 def test_docker():
+    if not DockerImage:
+        pytest.fail('no DockerImage')
+
     test_status = False
 
     with open('/tmp/test_docker_output', 'w') as logfile:

--- a/ambassador/tests/test_docker.py
+++ b/ambassador/tests/test_docker.py
@@ -53,9 +53,6 @@ def check_http(logfile) -> bool:
         return False
 
 def test_docker():
-    if not DockerImage:
-        pytest.fail('no DockerImage')
-
     test_status = False
 
     with open('/tmp/test_docker_output', 'w') as logfile:

--- a/ambassador/tests/test_docker.py
+++ b/ambassador/tests/test_docker.py
@@ -1,7 +1,5 @@
 import os
 
-import pytest
-
 import pexpect
 import requests
 

--- a/ambassador/tests/test_scout.py
+++ b/ambassador/tests/test_scout.py
@@ -198,9 +198,6 @@ def check_chimes(logfile) -> bool:
     return result
 
 def test_scout():
-    if not DockerImage:
-        pytest.fail('no DockerImage')
-
     test_status = False
 
     with open('/tmp/test_scout_output', 'w') as logfile:

--- a/ambassador/tests/test_scout.py
+++ b/ambassador/tests/test_scout.py
@@ -1,13 +1,14 @@
 from typing import Any, Dict, List, Optional
 
-import sys
 import os
 import time
+
+import pytest
 
 import pexpect
 import requests
 
-DockerImage = os.environ["AMBASSADOR_DOCKER_IMAGE"]
+DockerImage = os.environ.get("AMBASSADOR_DOCKER_IMAGE", None)
 child = None    # see docker_start()
 
 SEQUENCES = [
@@ -197,6 +198,9 @@ def check_chimes(logfile) -> bool:
     return result
 
 def test_scout():
+    if not DockerImage:
+        pytest.fail('no DockerImage')
+
     test_status = False
 
     with open('/tmp/test_scout_output', 'w') as logfile:

--- a/ambassador/tests/test_scout.py
+++ b/ambassador/tests/test_scout.py
@@ -3,8 +3,6 @@ from typing import Any, Dict, List, Optional
 import os
 import time
 
-import pytest
-
 import pexpect
 import requests
 

--- a/kat/kat/harness.py
+++ b/kat/kat/harness.py
@@ -38,33 +38,60 @@ def kube_version_json():
     return json.loads(stdout)
 
 
-def kube_server_version():
-    version_json = kube_version_json()
-    server_json = version_json['serverVersion']
-    return f"{server_json['major']}.{server_json['minor']}"
+def kube_server_version(version_json=None):
+    if not version_json:
+        version_json = kube_version_json()
+
+    server_json = version_json.get('serverVersion', {})
+
+    if server_json:
+        server_major = server_json.get('major', None)
+        server_minor = server_json.get('minor', None)
+
+        return f"{server_major}.{server_minor}"
+    else:
+        return None
 
 
-def kube_client_version():
-    version_json = kube_version_json()
-    client_json = version_json['clientVersion']
-    return f"{client_json['major']}.{client_json['minor']}"
+def kube_client_version(version_json=None):
+    if not version_json:
+        version_json = kube_version_json()
+
+    client_json = version_json.get('clientVersion', {})
+
+    if client_json:
+        client_major = client_json.get('major', None)
+        client_minor = client_json.get('minor', None)
+
+        return f"{client_major}.{client_minor}"
+    else:
+        return None
 
 
 def is_knative():
     is_cluster_compatible = True
-    server_version = kube_server_version()
-    client_version = kube_client_version()
-    if version.parse(server_version) < version.parse('1.11'):
-        print(f"server version {server_version} is incompatible with Knative")
-        is_cluster_compatible = False
-    else:
-        print(f"server version {server_version} is compatible with Knative")
+    kube_json = kube_version_json()
 
-    if version.parse(client_version) < version.parse('1.10'):
-        print(f"client version {client_version} is incompatible with Knative")
-        is_cluster_compatible = False
+    server_version = kube_server_version(kube_json)
+    client_version = kube_client_version(kube_json)
+
+    if server_version:
+        if version.parse(server_version) < version.parse('1.11'):
+            print(f"server version {server_version} is incompatible with Knative")
+            is_cluster_compatible = False
+        else:
+            print(f"server version {server_version} is compatible with Knative")
     else:
-        print(f"client version {client_version} is compatible with Knative")
+        print("could not determine Kubernetes server version?")
+
+    if client_version:
+        if version.parse(client_version) < version.parse('1.10'):
+            print(f"client version {client_version} is incompatible with Knative")
+            is_cluster_compatible = False
+        else:
+            print(f"client version {client_version} is compatible with Knative")
+    else:
+        print("could not determine Kubernetes client version?")
 
     return is_cluster_compatible
 

--- a/releng/run-tests.sh
+++ b/releng/run-tests.sh
@@ -127,8 +127,8 @@ else
     copy_if_present '/tmp/kat-events-*' "$tmpdir"
     copy_if_present '/tmp/kat-client*' "$tmpdir"
 
-    cp /tmp/teleproxy.log "$tmpdir"
-    cp /etc/resolv.conf "$tmpdir"
+    copy_if_present '/tmp/teleproxy.log' "$tmpdir"
+    copy_if_present '/etc/resolv.conf' "$tmpdir"
 
     mv "$tmpdir" "$outdir"
 


### PR DESCRIPTION
Nothing earth-shattering here, just make it a little smoother to work on things:

- you can run `venv/bin/pytest --collect-only` after a `make` but without `make shell`;
- `kubestatus` won't clutter `git status`
- the log collector will work on test failures even though `teleproxy` isn't running.
