### PR TITLE
Make 128-bits traceids the default

### DIFF
--- a/ambassador/ambassador/envoy/v2/v2tracing.py
+++ b/ambassador/ambassador/envoy/v2/v2tracing.py
@@ -41,6 +41,9 @@ class V2Tracing(dict):
             # The collector_endpoint is mandatory now.
             if not driver_config.get('collector_endpoint'):
                 driver_config['collector_endpoint'] = '/api/v1/spans'
+            # Make 128-bit traceid the default
+            if not 'trace_id_128bit' in driver_config:
+                driver_config['trace_id_128bit'] = True
 
         self['http'] = {
             "name": name,

--- a/docs/reference/services/tracing-service.md
+++ b/docs/reference/services/tracing-service.md
@@ -35,7 +35,7 @@ Please note that you must use the HTTP/2 preudo-header names. For example:
 
 ### `zipkin` driver configurations:
 - `collector_endpoint` gives the API endpoint of the Zipkin service where the spans will be sent. The default value is `/api/v1/spans`
-- `trace_id_128bit` whether a 128bit trace id will be used when creating a new trace instance. The default value is `false`, which will result in a 64 bit trace id being used.
+- `trace_id_128bit` whether a 128bit trace id will be used when creating a new trace instance. Defaults to `true`. Setting to `false` will result in a 64 bit trace id being used.
 - `shared_span_context` whether client and server spans will shared the same span id. The default value is `true`.
 
 You may only use a single `TracingService` manifest.


### PR DESCRIPTION
## Description

Make traceids 128bit option the default

Several reasons for this change:

- The [b3 propagation spec][1] from OpenZipkin defines the traceid as _either_ 64 or 128 bits, so both values should be interchangeable
- 128-bit traceid are the [default in Istio 1.1+][2]
- The draft [W3C TraceContext spec][3] standardises on 128-bit; 64 bits is not supported

The OpenCensus libraries (e.g. [for nodejs][4]) use the TraceContext spec, so this change makes Ambassador compatible with them as well.

[1]: https://github.com/openzipkin/b3-propagation
[2]: https://github.com/istio/istio/issues/10732
[3]: https://w3c.github.io/trace-context/
[4]: https://github.com/census-instrumentation/opencensus-node/blob/v0.0.17/packages/opencensus-propagation-tracecontext/src/validators.ts#L67-L75

## Related Issues

n/a

## Testing

The default tracing test now checks that the generated traceids are 128 bits, and if the 128 option is set to false, that they are 64 bits.

## Todos
- [x] Tests
- [x] Documentation

## Other
* If this is a documentation change, please open the pull request at https://github.com/datawire/ambassador-docs instead.
* Code changes should occur against `master`.
