### PR TITLE
Switch to version tags with a leading 'v'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,9 +69,9 @@ IS_PRIVATE ?= $(findstring private,$(_git_remote_urls))
 # Note that for everything except RC builds, VERSION will be set to the version
 # we'd use for a GA build. This is by design.
 ifneq ($(GIT_TAG_SANITIZED),)
-VERSION = $(shell printf "$(GIT_TAG_SANITIZED)" | sed -e 's/-.*//g')
+VERSION = $(shell printf "$(GIT_TAG_SANITIZED)" | sed -e 's/-.*//g' | sed -e 's/^[vV]//')
 else
-VERSION = $(GIT_VERSION)
+VERSION = $(shell printf "$(GIT_VERSION)" | sed -e 's/^[vV]//') 
 endif
 
 # We need this for tagging in some situations.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -11,11 +11,11 @@ If you're still reading, you must be at Datawire. Congrats, you picked a fine pl
 
 1. PRs will pile up on `master`. **Don't accept PRs for which CI doesn't show passing tests.**
 
-2. Once `master` has all the release drivers, tag `master` with an RC tag, e.g. `0.33.0-rc1`.
+2. Once `master` has all the release drivers, tag `master` with an RC tag, e.g. `v0.77.0-rc1`. **This version tag must start with a 'v'.**
 
 3. The RC tag will trigger CI to run a new build and new tests. It had better pass: if not, figure out why.
 
-4. The RC build will be available as e.g. `quay.io/datawire/ambassador:0.33.0-rc1` and also as e.g. `quay.io/datawire/ambassador:0.33.0-rc-latest`. Any other testing you want to do against this image, rock on.
+4. The RC build will be available as e.g. `quay.io/datawire/ambassador:v0.77.0-rc1` and also as e.g. `quay.io/datawire/ambassador:v0.77.0-rc-latest`. Any other testing you want to do against this image, rock on.
 
 5. When you're happy with everything, sync up the docs!
    - `make pull-docs` to pull updates from the docs repo
@@ -28,7 +28,7 @@ If you're still reading, you must be at Datawire. Congrats, you picked a fine pl
    - It is *critical* to update `docs/versions.yml` so that everyone gets the new version.
 
 7. Now for the time-critical bit.
-   - Tag `master` with a GA tag like `0.33.0` and let CI do its thing.
+   - Tag `master` with a GA tag like `v0.77.0` and let CI do its thing. **This version tag must start with a 'v'.**
    - CI will retag the latest RC image as the GA image.
 
 8. _After the CI run finishes_:
@@ -37,6 +37,8 @@ If you're still reading, you must be at Datawire. Congrats, you picked a fine pl
       - `make release-prep` should've output the text to paste into the release description.
 
    **Note** that there must be at least one RC build before a GA, since the GA tag **does not** rebuild the docker images -- it retags the ones built by the RC build. This is intentional, to allow for testing to happen on the actual artifacts that will be released.
+
+   **Note also** that even though the version _tag_ starts with a 'v', the version _number_ displayed by the diag UI will _not_ start with a 'v'.**
 
 9. Submit a PR into the `helm/charts` repo to update things in `stable/ambassador`. You may be able to ask Support to do this, but if not:
    - in `Chart.yaml`, update `appVersion` with the new Ambassador version, and bump `version`.

--- a/releng/travis-script.sh
+++ b/releng/travis-script.sh
@@ -19,7 +19,7 @@ set -o nounset
 
 printf "== Begin: travis-script.sh ==\n"
 
-if [[ "$GIT_BRANCH" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+if [[ "$GIT_BRANCH" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
     COMMIT_TYPE=GA
 elif [[ "$GIT_BRANCH" =~ -rc[0-9]+$ ]]; then
     COMMIT_TYPE=RC
@@ -29,6 +29,15 @@ elif [[ "$TRAVIS_PULL_REQUEST" != false ]]; then
     COMMIT_TYPE=PR
 else
     COMMIT_TYPE=random
+fi
+
+if [[ "$COMMIT_TYPE" != "random" ]]; then
+    # GIT_BRANCH should start with a 'v' for consistency here. The Makefile yanks off
+    # the 'v' in the version number.
+    if ! [[ "$GIT_BRANCH" =~ ^[vV] ]]; then
+        echo "GIT_BRANCH '$GIT_BRANCH' does not start with a 'v'" >&2
+        exit 1
+    fi
 fi
 
 # If downstream, don't re-run release machinery for tags that are an

--- a/releng/travis-script.sh
+++ b/releng/travis-script.sh
@@ -19,20 +19,25 @@ set -o nounset
 
 printf "== Begin: travis-script.sh ==\n"
 
+NEEDS_V=
+
 if [[ "$GIT_BRANCH" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
     COMMIT_TYPE=GA
+    NEEDS_V=yes
 elif [[ "$GIT_BRANCH" =~ -rc[0-9]+$ ]]; then
     COMMIT_TYPE=RC
+    NEEDS_V=yes
 elif [[ "$GIT_BRANCH" =~ -ea[0-9]+$ ]]; then
     COMMIT_TYPE=EA
+    NEEDS_V=yes
 elif [[ "$TRAVIS_PULL_REQUEST" != false ]]; then
     COMMIT_TYPE=PR
 else
     COMMIT_TYPE=random
 fi
 
-if [[ "$COMMIT_TYPE" != "random" ]]; then
-    # GIT_BRANCH should start with a 'v' for consistency here. The Makefile yanks off
+if [ -n "$NEEDS_V" ]; then
+    # GIT_BRANCH must start with a 'v' for consistency here. The Makefile yanks off
     # the 'v' in the version number.
     if ! [[ "$GIT_BRANCH" =~ ^[vV] ]]; then
         echo "GIT_BRANCH '$GIT_BRANCH' does not start with a 'v'" >&2


### PR DESCRIPTION
This way, Go code using the protobuf code we generate can reference `v0.77.0` or the like, instead of being forced to use a commit hash.

(Yes, Go is silly.)

Note that the version numbers in the diag UI will stay the same (e.g. `0.77.0` instead of `v0.77.0`).