### PR TITLE
Add auth_context_extensions to v2/v2route.py

### DIFF
--- a/ambassador/ambassador/envoy/v2/v2route.py
+++ b/ambassador/ambassador/envoy/v2/v2route.py
@@ -62,6 +62,10 @@ class V2Route(dict):
         # `per_filter_config` is used for customization of an Envoy filter
         per_filter_config = {}
 
+        auth_context_extensions = mapping.get('auth_context_extensions', False)
+        if auth_context_extensions:
+            per_filter_config['envoy.ext_authz'] = {'check_settings': {'context_extensions': auth_context_extensions}}
+
         if mapping.get('bypass_auth', False):
             per_filter_config['envoy.ext_authz'] = {'disabled': True}
 

--- a/ambassador/ambassador/ir/irhttpmapping.py
+++ b/ambassador/ambassador/ir/irhttpmapping.py
@@ -99,6 +99,7 @@ class IRHTTPMapping (IRBaseMapping):
         "use_websocket": True,
         "weight": True,
         "bypass_auth": True,
+        "auth_context_extensions": True,
 
         # Include the serialization, too.
         "serialization": True,

--- a/ambassador/schemas/v1/Mapping.schema
+++ b/ambassador/schemas/v1/Mapping.schema
@@ -118,6 +118,7 @@
         "use_websocket": { "type": "boolean" },
         "weight": { "type": "integer" },
         "bypass_auth": { "type": "boolean" },
+        "auth_context_extensions": { "$ref": "#/definitions/mapStrStr" },
 
         "modules": {
             "type": "array",


### PR DESCRIPTION
## Description
This allows a user to add auth context extensions per mapping. The auth service sees these extensions on the gRPC ext_authz message.

## Related Issues
List related issues.

## Testing
Only manual tests, needs real tests.

## Todos
- [ ] Tests
- [ ] Documentation
