### PR TITLE
Add basic ambassador cli test

### DIFF
--- a/ambassador/tests/t_basics.py
+++ b/ambassador/tests/t_basics.py
@@ -1,6 +1,7 @@
 from typing import Tuple, Union
 
 from kat.harness import Query
+from kat.utils import ShellCommand
 
 from abstract_tests import AmbassadorTest, assert_default_errors, HTTP, Node, ServiceType
 
@@ -100,3 +101,9 @@ service: {self.target.path.fqdn}
 
     def check(self):
         assert self.results[0].headers["Server"] == [ "test-server" ]
+
+
+class CliTest(AmbassadorTest):
+    def check(self):
+        cmd = ShellCommand('kubectl', 'exec', self.path.k8s, '--', 'ambassador', '--help')
+        assert cmd.check("ambassador cli")


### PR DESCRIPTION
## Description
Test that the ambassador cli does not crash when called with `--help`

## Related Issues
#1795 

## Testing
Automated test

## Todos
- [x] Tests
- [x] Documentation
