### PR TITLE
Clean up v-versions a touch more

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,10 +68,12 @@ IS_PRIVATE ?= $(findstring private,$(_git_remote_urls))
 
 # Note that for everything except RC builds, VERSION will be set to the version
 # we'd use for a GA build. This is by design.
+#
+# Also note that we strip off the leading 'v' here -- that's just for the git tag.
 ifneq ($(GIT_TAG_SANITIZED),)
-VERSION = $(shell printf "$(GIT_TAG_SANITIZED)" | sed -e 's/-.*//g' | sed -e 's/^[vV]//')
+VERSION = $(patsubst v%,%,$(firstword $(subst -, ,$(GIT_TAG_SANITIZED))))
 else
-VERSION = $(shell printf "$(GIT_VERSION)" | sed -e 's/^[vV]//') 
+VERSION = $(patsubst v%,%,$(firstword $(subst -, ,$(GIT_VERSION))))
 endif
 
 # We need this for tagging in some situations.

--- a/releng/travis-script.sh
+++ b/releng/travis-script.sh
@@ -110,7 +110,7 @@ case "$COMMIT_TYPE" in
             docker login -u="$DOCKER_RELEASE_USERNAME" --password-stdin "${AMBASSADOR_EXTERNAL_DOCKER_REPO%%/*}" <<<"$DOCKER_RELEASE_PASSWORD"
         fi
         tags=(
-            "${AMBASSADOR_EXTERNAL_DOCKER_REPO}:${GIT_TAG_SANITIZED}" # public X.Y.Z-rcA
+            "${AMBASSADOR_EXTERNAL_DOCKER_REPO}:${VERSION}" # public X.Y.Z-rcA
             "${AMBASSADOR_EXTERNAL_DOCKER_REPO}:${LATEST_RC}"         # public X.Y.Z-rc-latest
         )
         for tag in "${tags[@]}"; do
@@ -124,7 +124,7 @@ case "$COMMIT_TYPE" in
             docker login -u="$DOCKER_RELEASE_USERNAME" --password-stdin "${AMBASSADOR_EXTERNAL_DOCKER_REPO%%/*}" <<<"$DOCKER_RELEASE_PASSWORD"
         fi
         tags=(
-            "${AMBASSADOR_EXTERNAL_DOCKER_REPO}:${GIT_TAG_SANITIZED}" # public X.Y.Z-eaA
+            "${AMBASSADOR_EXTERNAL_DOCKER_REPO}:${VERSION}" # public X.Y.Z-eaA
         )
         for tag in "${tags[@]}"; do
             docker tag "$AMBASSADOR_DOCKER_IMAGE" "$tag"


### PR DESCRIPTION
- Use `VERSION` rather than `GIT_TAG_SANITIZED` to derive the RC tag
- Use `patsubst` rather than `sed` to generate `VERSION`