### PR TITLE
Serialize Knative tests

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -4,6 +4,7 @@ docopt
 awscli
 pytest
 pytest-cov
+pytest-custom_exit_code
 dpath
 mypy
 pexpect

--- a/releng/run-tests.sh
+++ b/releng/run-tests.sh
@@ -30,7 +30,7 @@ if [[ "$USE_KUBERNAUT" != "true" ]]; then
     ( cd "$ROOT"; bash "$HERE/test-warn.sh" )
 fi
 
-TEST_ARGS_GENERIC=(--tb=short -s)
+TEST_ARGS_GENERIC=(--tb=short -s --suppress-no-test-exit-code)
 TEST_ARGS_WITHOUT_KNATIVE=("${TEST_ARGS_GENERIC[@]}" -k 'not Knative')
 TEST_ARGS_WITH_KNATIVE=("${TEST_ARGS_GENERIC[@]}" -k 'Knative')
 


### PR DESCRIPTION
Knative tests are resource intensive, so we don't always want them
to run along with other tests to interfere with them. This commit
serializes Knative tests to run after the rest of test suite is
done. Some of run-tests.sh has been refactored in the process as
well.