### PR TITLE
Allow ambassador service log level to be specified

### DIFF
--- a/ambassador/tests/t_diagd_logs.py
+++ b/ambassador/tests/t_diagd_logs.py
@@ -4,8 +4,39 @@ from kat.utils import ShellCommand
 from abstract_tests import AmbassadorTest
 
 
+class DiagdLogLevelTest(AmbassadorTest):
+    """Test that no DEBUG logs show up when we set the value to INFO."""
+    log_level: str
+
+    def init(self):
+        self.debug_diagd = False
+        self.log_level = 'INFO'
+
+    def manifests(self) -> str:
+        self.manifest_envs = f"""
+    - name: AMBASSADOR_LOG_LEVEL
+      value: "{self.log_level}"
+"""
+
+        return super().manifests()
+
+    def check(self):
+        cmd = ShellCommand("kubectl", "log", self.path.k8s)
+        if not cmd.check("retrieve ambassador pod logs"):
+            pytest.exit("Unable to retrieve logs from ambassador pod")
+
+        # Filter out kubewatch logs since kubewatch is always launched with --debug
+        allowed_debug_regex = re.compile('.*kubewatch.*DEBUG:')
+
+        for line in cmd.stdout.splitlines():
+            if allowed_debug_regex.match(line):
+                continue
+
+            assert 'DEBUG:' not in line
+
+
 class InvalidLogLevel(AmbassadorTest):
-    """Test when an invalid log level is provided for AMBASSADOR_LOG_LEVEL"""
+    """Test when an invalid log level is provided for AMBASSADOR_LOG_LEVEL."""
 
     def manifests(self) -> str:
         self.manifest_envs = """

--- a/ambassador/tests/t_diagd_logs.py
+++ b/ambassador/tests/t_diagd_logs.py
@@ -1,0 +1,22 @@
+import pytest, re
+
+from kat.utils import ShellCommand
+from abstract_tests import AmbassadorTest
+
+
+class InvalidLogLevel(AmbassadorTest):
+    """Test when an invalid log level is provided for AMBASSADOR_LOG_LEVEL"""
+
+    def manifests(self) -> str:
+        self.manifest_envs = """
+    - name: AMBASSADOR_LOG_LEVEL
+      value: "invalid"
+"""
+        return super().manifests()
+
+    def check(self):
+        cmd = ShellCommand("kubectl", "log", self.path.k8s)
+        if not cmd.check("retrieve ambassador pod logs"):
+            pytest.exit("Unable to retrieve logs from ambassador pod")
+
+        assert 'Ignoring invalid log level value "INVALID"' in cmd.stdout

--- a/python/ambassador_diag/diagd.py
+++ b/python/ambassador_diag/diagd.py
@@ -54,11 +54,10 @@ __version__ = Version
 
 boot_time = datetime.datetime.now()
 
-log_level_name = os.environ.get('AMBASSADOR_LOG_LEVEL', 'INFO').upper()
+log_level_name = os.environ.get('AMBASSADOR_LOG_LEVEL', 'INFO')
+log_level = logging.getLevelName(log_level_name)
 
-try:
-    log_level = getattr(logging, log_level_name)
-except AttributeError:
+if not isinstance(log_level, int):
     print(f'Ignoring invalid log level value "{log_level_name}"')
     log_level = logging.INFO
 

--- a/python/ambassador_diag/diagd.py
+++ b/python/ambassador_diag/diagd.py
@@ -68,7 +68,7 @@ logging.basicConfig(
 )
 
 # Shut up Werkzeug's standard request logs -- they're just too noisy.
-logging.getLogger("werkzeug").setLevel(max(log_level, logging.CRITICAL))
+logging.getLogger("werkzeug").setLevel(logging.CRITICAL)
 
 # Likewise make requests a bit quieter.
 logging.getLogger("urllib3").setLevel(max(log_level, logging.WARNING))

--- a/python/ambassador_diag/diagd.py
+++ b/python/ambassador_diag/diagd.py
@@ -54,7 +54,13 @@ __version__ = Version
 
 boot_time = datetime.datetime.now()
 
-log_level = getattr(logging, os.environ.get('AMBASSADOR_LOG_LEVEL', 'INFO').upper())
+log_level_name = os.environ.get('AMBASSADOR_LOG_LEVEL', 'INFO').upper()
+
+try:
+    log_level = getattr(logging, log_level_name)
+except AttributeError:
+    print(f'Ignoring invalid log level value "{log_level_name}"')
+    log_level = logging.INFO
 
 logging.basicConfig(
     level=log_level,

--- a/python/ambassador_diag/diagd.py
+++ b/python/ambassador_diag/diagd.py
@@ -54,18 +54,20 @@ __version__ = Version
 
 boot_time = datetime.datetime.now()
 
+log_level = getattr(logging, os.environ.get('AMBASSADOR_LOG_LEVEL', 'INFO').upper())
+
 logging.basicConfig(
-    level=logging.INFO,
+    level=log_level,
     format="%%(asctime)s diagd %s [P%%(process)dT%%(threadName)s] %%(levelname)s: %%(message)s" % __version__,
     datefmt="%Y-%m-%d %H:%M:%S"
 )
 
 # Shut up Werkzeug's standard request logs -- they're just too noisy.
-logging.getLogger("werkzeug").setLevel(logging.CRITICAL)
+logging.getLogger("werkzeug").setLevel(max(log_level, logging.CRITICAL))
 
 # Likewise make requests a bit quieter.
-logging.getLogger("urllib3").setLevel(logging.WARNING)
-logging.getLogger("requests").setLevel(logging.WARNING)
+logging.getLogger("urllib3").setLevel(max(log_level, logging.WARNING))
+logging.getLogger("requests").setLevel(max(log_level, logging.WARNING))
 
 ambassador_targets = {
     'mapping': 'https://www.getambassador.io/reference/configuration#mappings',
@@ -136,7 +138,7 @@ class DiagApp (Flask):
 
         # This feels like overkill.
         self.logger = logging.getLogger("ambassador.diagd")
-        self.logger.setLevel(logging.INFO)
+        self.logger.setLevel(log_level)
 
         if debug:
             self.logger.setLevel(logging.DEBUG)

--- a/python/tests/test_ambassador.py
+++ b/python/tests/test_ambassador.py
@@ -31,6 +31,7 @@ import t_knative
 import t_capabilities
 import t_envoy_logs
 import t_ingress
+import t_diagd_logs
 
 # pytest will find this because Runner is a toplevel callable object in a file
 # that pytest is willing to look inside.


### PR DESCRIPTION
## Description
By default `diagd` uses INFO level logging which means that it prints to STDOUT on every request which includes healthchecks and metrics requests causing the logs to be a little cluttered. This PR adds an environment variable to the ambassador Deployment that allows a log level to be specified. If no option is provided, the existing behavior is un-changed.

Happy to add documentation, just wasn't sure what section of the documentation was best for environment variables.

## Related Issues
https://github.com/datawire/ambassador/issues/1819

## Testing
We have been using this in production and have not seen any issues but open to any additional testing that we should do.

## Todos
- [x] Tests
- [ ] Documentation
