### PR TITLE
Propagate KAT_ variables to tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -577,6 +577,8 @@ test: setup-develop
 	BASE_PY_IMAGE="$(BASE_PY_IMAGE)" \
 	BASE_GO_IMAGE="$(BASE_GO_IMAGE)" \
 	KUBECONFIG="$(KUBECONFIG)" \
+	KAT_CLIENT_DOCKER_IMAGE="$(KAT_CLIENT_DOCKER_IMAGE)" \
+	KAT_SERVER_DOCKER_IMAGE="$(KAT_SERVER_DOCKER_IMAGE)" \
 	PATH="$(shell pwd)/venv/bin:$(PATH)" \
 	bash ../releng/run-tests.sh
 


### PR DESCRIPTION
Recently introduced KAT_CLIENT_DOCKER_IMAGE and
KAT_SERVER_DOCKER_IMAGE environment variables are not propagated
correctly leading to failures when running tests locally.

This commit fixes that so `make test` does not fail.