### PR TITLE
Go 1.13

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -264,7 +264,7 @@ export-vars:
 	@echo "export VERSION='$(VERSION)'"
 
 # All of this will likely fail horribly outside of CI, for the record.
-docker-registry:
+docker-registry: $(KUBECONFIG)
 ifneq ($(DOCKER_EPHEMERAL_REGISTRY),)
 	@if [ "$(TRAVIS)" != "true" ]; then \
 		echo "make docker-registry is only for CI" >&2 ;\
@@ -506,7 +506,7 @@ $(KAT_CLIENT): $(wildcard go/kat-client/*) go/apis/kat/echo.pb.go
 
 setup-develop: venv $(KAT_CLIENT) $(TELEPROXY) $(KUBERNAUT) $(WATT) $(KUBESTATUS) version
 
-cluster.yaml: $(CLAIM_FILE)
+cluster.yaml: $(CLAIM_FILE) $(KUBERNAUT)
 ifeq ($(USE_KUBERNAUT), true)
 	$(KUBERNAUT_DISCARD)
 	$(KUBERNAUT_CLAIM)
@@ -519,6 +519,9 @@ ifneq ($(USE_KUBERNAUT),false)
 endif
 endif
 endif
+# Make is too dumb to understand equivalence between absolute and
+# relative paths.
+$(CURDIR)/cluster.yaml: cluster.yaml
 
 setup-test: cluster-and-teleproxy
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/datawire/ambassador
 
-go 1.12
+go 1.13
 
 require (
 	github.com/envoyproxy/protoc-gen-validate v0.0.15-0.20190405222122-d6164de49109

--- a/go/kat-client/client.go
+++ b/go/kat-client/client.go
@@ -30,7 +30,7 @@ import (
 )
 
 // Should we output GRPCWeb debugging?
-var debug_grpc_web bool 	// We set this value in main()   XXX This is a hack
+var debug_grpc_web bool // We set this value in main()   XXX This is a hack
 
 // Limit concurrency
 
@@ -357,8 +357,8 @@ func (q Query) CheckErr(err error) bool {
 // returns the decoded proto and trailers.
 func DecodeGrpcWebTextBody(body []byte) ([]byte, http.Header, error) {
 	// First, decode all the base64 stuff coming in. An annoyance here
-	// is that while the data coming over the wire are encoded in 
-	// multiple chunks, we can't rely on seeing that framing when 
+	// is that while the data coming over the wire are encoded in
+	// multiple chunks, we can't rely on seeing that framing when
 	// decoding: a chunk that's the right length to not need any base-64
 	// padding will just run into the next chunk.
 	//
@@ -403,8 +403,8 @@ func DecodeGrpcWebTextBody(body []byte) ([]byte, http.Header, error) {
 	// For our use case here, a type of 0 is the protobuf frame, and a type
 	// of 0x80 is the trailers.
 
-	trailers := make(http.Header)	// the trailers will get saved here
-	var proto []byte 				// this is what we hand off to protobuf decode
+	trailers := make(http.Header) // the trailers will get saved here
+	var proto []byte              // this is what we hand off to protobuf decode
 
 	var frame_start, frame_len uint32
 	var frame_type byte
@@ -418,9 +418,9 @@ func DecodeGrpcWebTextBody(body []byte) ([]byte, http.Header, error) {
 
 	for (frame_start + 5) < uint32(len(raw)) {
 		frame_type = raw[frame_start]
-		frame_len = binary.BigEndian.Uint32(raw[frame_start + 1:frame_start + 5])
+		frame_len = binary.BigEndian.Uint32(raw[frame_start+1 : frame_start+5])
 
-		frame = raw[frame_start + 5:frame_start + 5 + frame_len]
+		frame = raw[frame_start+5 : frame_start+5+frame_len]
 
 		if (frame_type & 128) > 0 {
 			// Trailers frame
@@ -456,7 +456,7 @@ func DecodeGrpcWebTextBody(body []byte) ([]byte, http.Header, error) {
 // AddResponse populates a query's result with data from the query's HTTP
 // response object.
 //
-// This is not called for websockets or real GRPC. It _is_ called for 
+// This is not called for websockets or real GRPC. It _is_ called for
 // GRPC-bridge, GRPC-web, and (of course) HTTP(s).
 func (q Query) AddResponse(resp *http.Response) {
 	result := q.Result()
@@ -470,7 +470,7 @@ func (q Query) AddResponse(resp *http.Response) {
 		cstart := q["client-start-date"]
 
 		// We'll only have a client-start-date if we're doing plain old HTTP, at
-		// present -- so not for WebSockets or gRPC or the like. Don't try to 
+		// present -- so not for WebSockets or gRPC or the like. Don't try to
 		// save the start and end dates if we have no start date.
 		if cstart != nil {
 			headers.Add("Client-Start-Date", q["client-start-date"].(string))
@@ -491,7 +491,7 @@ func (q Query) AddResponse(resp *http.Response) {
 		result["body"] = body
 		if q.GrpcType() != "" && len(body) > 5 {
 			if q.GrpcType() == "web" {
-				// This is the GRPC-web case. Go forth and decode the base64'd 
+				// This is the GRPC-web case. Go forth and decode the base64'd
 				// GRPC-web body madness.
 				decodedBody, trailers, err := DecodeGrpcWebTextBody(body)
 				if q.CheckErr(err) {
@@ -843,7 +843,7 @@ func ExecuteQuery(query Query, secureTransport *http.Transport) {
 
 func main() {
 	debug_grpc_web = false
-	
+
 	rlimit()
 
 	var input, output string

--- a/go/kat-client/client.go
+++ b/go/kat-client/client.go
@@ -147,7 +147,7 @@ func (q Query) MinTLSVersion() uint16 {
 	case "v1.2":
 		return tls.VersionTLS12
 	case "v1.3":
-		return 0x0304
+		return tls.VersionTLS13
 	default:
 		return 0
 	}
@@ -163,7 +163,7 @@ func (q Query) MaxTLSVersion() uint16 {
 	case "v1.2":
 		return tls.VersionTLS12
 	case "v1.3":
-		return 0x0304
+		return tls.VersionTLS13
 	default:
 		return 0
 	}

--- a/go/kat-server/server.go
+++ b/go/kat-server/server.go
@@ -19,10 +19,6 @@ const (
 	SSLPort int16 = 8443
 )
 
-func init() {
-	os.Setenv("GODEBUG", os.Getenv("GODEBUG")+",tls13=1")
-}
-
 func main() {
 	listeners := make([]srv.Service, 0)
 	var s srv.Service

--- a/go/kat-server/services/grpc-auth.go
+++ b/go/kat-server/services/grpc-auth.go
@@ -14,8 +14,8 @@ import (
 	"strings"
 
 	core "github.com/datawire/ambassador/go/apis/envoy/api/v2/core"
-	pb_legacy "github.com/datawire/ambassador/go/apis/envoy/service/auth/v2alpha"
 	pb "github.com/datawire/ambassador/go/apis/envoy/service/auth/v2"
+	pb_legacy "github.com/datawire/ambassador/go/apis/envoy/service/auth/v2alpha"
 	envoy_type "github.com/datawire/ambassador/go/apis/envoy/type"
 
 	"github.com/gogo/googleapis/google/rpc"

--- a/releng/travis-install.sh
+++ b/releng/travis-install.sh
@@ -16,7 +16,7 @@
 
 KUBECTL_VERSION=1.10.2
 HELM_VERSION=2.9.1
-GO_VERSION=1.12.9
+GO_VERSION=1.13
 
 set -o errexit
 set -o nounset


### PR DESCRIPTION
## Description

This updates KAT to work with Go 1.13, and updates CI to use Go 1.13 (from Go 1.12.9).

As discussed in #1825 and more in person:  With Go 1.13, the `ClientCertificateAuthentication` test failed because the error message it gets when trying to authenticate without a cert changed from "handshake failure" to "alert(116)".  The TLS 1.3 spec says that alert=116 is "certificate_required", which does describe the error condition we're testing for.  All good; just add "alert(116)" to the list of allowed errors, right?

Wrong.  alert=116 was introduced in TLS 1.3, and isn't valid in TLS 1.2.  So I duplicated the check; once with `maxTLSv="v1.2"` (expecting alert=40 `"handshake faulure"`) and once with `minTLSv="v1.3"` (expecting alert=116 `"alert(116)"`).  ... and that failed, it was giving me the TLS 1.3 error code even when I told it to negotiate TLS 1.2.

Well, it turned out that kat-client was totally ignoring `minTLSv`/`maxTLSv` unless `sni=True`, so it was just negotiating TLS 1.3 in both cases.  I adjusted kat-client to obey all of the TLS settings separately, instead of making them dependent on eachother, and now everything seems to work.

## Testing

See above.

## Other

Unrelated to anything with Go 1.13, I polished Kubernaut support in Makefile a bit, as I stubbed my toes on it.