### PR TITLE
Allow TLS context in RateLimitService

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -422,10 +422,10 @@ which will build the test services, then push them to `$(DOCKER_REGISTRY)`.
 **Using locally-built tests:**
 
 To use a single test service that you've built locally, set the environment variable
-`TEST_SVC_$svc` to point to the image you've just built and pushed, e.g.
+`TEST_SERVICE_$svc` to point to the image you've just built and pushed, e.g.
 
 ```
-export TEST_SVC_AUTH=dwflynn/test_services:test-auth-v0.80.0-28-g3ed96316
+export TEST_SERVICE_AUTH=dwflynn/test_services:test-auth-v0.80.0-28-g3ed96316
 ```
 
 before running `make test`. The different `$svc` possibilities are `auth`, `auth-tls`,
@@ -434,15 +434,15 @@ before running `make test`. The different `$svc` possibilities are `auth`, `auth
 To use your copy of _all_ the test services:
 
 ```
-export TEST_SVC_REGISTRY=$registry
-export TEST_SVC_VERSION=$version
+export TEST_SERVICE_REGISTRY=$registry
+export TEST_SERVICE_VERSION=$version
 ```
 
 before running `make test`, e.g.
 
 ```
-export TEST_SVC_REGISTRY=dwflynn/test_services
-export TEST_SVC_VERSION=v0.80.0-28-g3ed96316
+export TEST_SERVICE_REGISTRY=dwflynn/test_services
+export TEST_SERVICE_VERSION=v0.80.0-28-g3ed96316
 ```
 
 to match the example above.

--- a/ambassador/ambassador/ir/irratelimit.py
+++ b/ambassador/ambassador/ir/irratelimit.py
@@ -50,6 +50,7 @@ class IRRateLimit (IRFilter):
         # OK, we have a valid config.
 
         self.service = service
+        self.ctx_name = config.get('tls', None)
         self.name = "rate_limit"    # Force this, just in case.
         self.domain = config.get('domain', ir.ambassador_module.default_label_domain)
 
@@ -80,7 +81,8 @@ class IRRateLimit (IRFilter):
                 location=self.location,
                 service=self.service,
                 grpc=True,
-                host_rewrite=self.get('host_rewrite', None)
+                host_rewrite=self.get('host_rewrite', None),
+                ctx_name=self.get('ctx_name', None)
             )
         )
 

--- a/ambassador/schemas/v1/RateLimitService.schema
+++ b/ambassador/schemas/v1/RateLimitService.schema
@@ -14,10 +14,11 @@
                 { "type": "array", "items": { "type": "string" } }
             ]
         },
-        
+
         "service": { "type": "string" },
         "timeout_ms": { "type": "integer" },
-        "domain": { "type": "string" }
+        "domain": { "type": "string" },
+        "tls": { "type": [ "string", "boolean" ] }
     },
     "required": [ "apiVersion", "kind", "name", "service" ],
     "additionalProperties": false

--- a/ambassador/tests/t_ratelimit.py
+++ b/ambassador/tests/t_ratelimit.py
@@ -154,7 +154,7 @@ spec:
     spec:
       containers:
       - name: rate-limit
-        image: dwflynn/ratelimit-service:0.0.1
+        image: {self.test_image[ratelimit]}
         imagePullPolicy: Always
         ports:
         - name: grpc
@@ -190,6 +190,115 @@ kind: RateLimitService
 name: ratelimit
 service: rate-limit:5000
 timeout_ms: 500
+""")
+
+    def queries(self):
+        # No matching headers, won't even go through ratelimit-service filter
+        yield Query(self.url("target/"))
+
+        # Header instructing dummy ratelimit-service to allow request
+        yield Query(self.url("target/"), expected=200, headers={
+            'x-ambassador-test-allow': 'true'
+        })
+
+        # Header instructing dummy ratelimit-service to reject request
+        yield Query(self.url("target/"), expected=429, headers={
+            'x-ambassador-test-allow': 'over my dead body'
+        })
+
+class RateLimitV1WithTLSTest(AmbassadorTest):
+    # debug = True
+    target: ServiceType
+
+    def init(self):
+        self.target = HTTP()
+
+    def manifests(self) -> str:
+        return super().manifests() + """
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: rate-limit
+spec:
+  selector:
+    app: rate-limit
+  ports:
+  - port: 5000
+    name: grpc
+    targetPort: grpc
+  type: ClusterIP
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: rate-limit
+spec:
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: rate-limit
+    spec:
+      containers:
+      - name: rate-limit
+        image: {self.test_image[ratelimit]}
+        imagePullPolicy: Always
+        env:
+        - name: "USE_TLS"
+          value: "true"
+        ports:
+        - name: grpc
+          containerPort: 5000
+        resources:
+          limits:
+            cpu: "0.1"
+            memory: 100Mi
+---
+apiVersion: v1
+data:
+  tls.crt: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURDakNDQWZJQ0NRRGdYUjZ3V1Z6Wk9EQU5CZ2txaGtpRzl3MEJBUVVGQURCSE1SNHdIQVlEVlFRRERCVnkKWVhSbGJHbHRhWFF1WkdGMFlYZHBjbVV1YVc4eEpUQWpCZ2txaGtpRzl3MEJDUUVXRm1odmMzUnRZWE4wWlhKQQpaR0YwWVhkcGNtVXVhVzh3SGhjTk1Ua3dPVEU1TVRnek16QXlXaGNOTWpFd09ERTVNVGd6TXpBeVdqQkhNUjR3CkhBWURWUVFEREJWeVlYUmxiR2x0YVhRdVpHRjBZWGRwY21VdWFXOHhKVEFqQmdrcWhraUc5dzBCQ1FFV0ZtaHYKYzNSdFlYTjBaWEpBWkdGMFlYZHBjbVV1YVc4d2dnRWlNQTBHQ1NxR1NJYjNEUUVCQVFVQUE0SUJEd0F3Z2dFSwpBb0lCQVFDeWw5VkJtVjVCcFYxOHZzclNqUktyZGlEVnZZS0dxNlZVaGFTRTlZSWNRODhiSTFaeHlhUE9zUVlRCmMycmY4Q0RKdUp4M1hoUjUzMENwN3pQNmVSMjNwMkZBOSsxSWs5SHZhWUx0WDRtQTJOdjh4V1kxaEhua1BURnMKVFRwazBMREdYYjVZWnh2QkczNTNKL3NFKzFrSUUxenpKZldpQUpUMzZzMk5PRzRVQWhoVmFPS2p1K3grYXJwbQoyZnNhTldKTTFEMS9CUXVVN1Vid0p0QmIyZFo2WUtUNHE4M2doQWgybDhad1hQcFdJQmtpWGpNNXJ0WkQ3QmN4CkRxdFNtVE1ZejVjZWNwbmhiNEw4Z3hFVUJyWlRxQ3g4RVkvcDArY05mN2hScmFWbTd6Q3BaRDhvSUtLS0IvUDQKM1dHZHRHNlpHS0VFSmtXNjB5QWtxRmI3czNWdEFnTUJBQUV3RFFZSktvWklodmNOQVFFRkJRQURnZ0VCQUFJUwp2Znh1K3dQcUxicVRZV1NLTUt6S3JmNUxxWlpBZFpZZXNIR0oxNmFyVmt6eGhzcElGRGZpblZ1UmI1eERxWVVSCnFta0U1K0dCNDh5UGoxaUQvdXdPOEI0ckFnNW1Pekw1MEpUMDVQT1dyc0hjK1loLzAvUXpGNmlqNHlVNWZ6dloKRHpJdFBiNE5qWTMxUE44WkJMYTFGSHk5d2JGSzdyS2lWK2MxTzd0UHVjQTVUWnoxS0h5VUVYaWxHdmNoczB4OApzazRJR2xrVTNoSDFVWHBzTmw0NTI4VjR0L3dXOTdiYmhFeHYvYnBwR3RLbjRKei9hYkNScjA3Q3kzUytjUzc5CnlQNTZiQVZxa1R2TTVkUkhiNG9zOGYzNUJuQTdPci9YRTQ2K2VRMXNVY21IVG5OUWdFVkpWZGVwR3V4Sk5pNFMKejJ0WHhHSStTdTFlUnlQcVNGWT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=
+  tls.key: LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0tCk1JSUV2UUlCQURBTkJna3Foa2lHOXcwQkFRRUZBQVNDQktjd2dnU2pBZ0VBQW9JQkFRQ3lsOVZCbVY1QnBWMTgKdnNyU2pSS3JkaURWdllLR3E2VlVoYVNFOVlJY1E4OGJJMVp4eWFQT3NRWVFjMnJmOENESnVKeDNYaFI1MzBDcAo3elA2ZVIyM3AyRkE5KzFJazlIdmFZTHRYNG1BMk52OHhXWTFoSG5rUFRGc1RUcGswTERHWGI1WVp4dkJHMzUzCkovc0UrMWtJRTF6ekpmV2lBSlQzNnMyTk9HNFVBaGhWYU9LanUreCthcnBtMmZzYU5XSk0xRDEvQlF1VTdVYncKSnRCYjJkWjZZS1Q0cTgzZ2hBaDJsOFp3WFBwV0lCa2lYak01cnRaRDdCY3hEcXRTbVRNWXo1Y2VjcG5oYjRMOApneEVVQnJaVHFDeDhFWS9wMCtjTmY3aFJyYVZtN3pDcFpEOG9JS0tLQi9QNDNXR2R0RzZaR0tFRUprVzYweUFrCnFGYjdzM1Z0QWdNQkFBRUNnZ0VBS3hvNzdOWWdDb1hubHpqUTZKb0ZuSDRwRkl6bFdLMUtmS2k0ZVNKcm9YaTQKSGx1Yi9HQm0rWFo5K1RCeDVkUWxoYW5aa1hHU1RZdVZKcTVGaERrQTlCY2dnTGFWZlFPNEVpa0w0VkJDZG1kZwpTSlEzdzhqU1JrU0NqaG5oY3YxdS9LRVpWR3FtSnlnRWtLdUVpTUpFelk4bXlzUXBrVXpFcDBUekVSZENjZTljClNKT2Q2V2dGYUdzN3ZmTEpMajBmTk1SYytwcjFORnBmcTk0R2lyZFVyQUIvOHhlL2lpT3hnZXJoM1JPR0I4Z1MKZWpMeTZmZEhZK0Y1d2cyREtFMjVjeHcrdWFUeEo4MElucktWYTdhVjlqeGl1L0YvWW42a0FGT201cUFaTEdJUQo3bDVDY0dMWCtKdS96UGNpSEJRRWx2R2dSTGdZTCtxWHNPYStyZ3VvZ1FLQmdRRFpVU25xQUdvd2Zma3h1QTB2CnVxc042M3NaMHFVVUMraDB1aGZCanV1ZGxEZU8rM2U5WC9ncW1vTHFnYmpLbUNxcHZ0eFRKT2RZbWlkTG42QysKU3ZIMkw5V3RBNzVFMDB1bDdWb0VEOWs5S1c5aEU4M1ZoM0hJcnowQ3RtLzAvMEtJaVlXb2VkaWw2YktlTndUSApXci9MdlI5M2F2dHo2NUkwVWFBVjVyMjhqUUtCZ1FEU1loS2R1YzB1YUQ2VW45NW0yTmZJelRaNWxaNmZZdFFyCkZHbzByWWlTelZCRlZrNnR3akI5dmhtdmtjZjBNU21wQ1NPUUZGcjJ3Zk9UZGtBTnlxTWxwNXdHK3ZpRi9LeGMKcXNMQ1RROGhwNmFnazMzRE9MVEl2OXpKdkhnU2NsWW9pOTZqNk9Zc28rWUtITkxmTU1jVWw3dThqYmZ3YWx2dwp4Tno3WkdRVVlRS0JnSFdsZWRKamJSbFphVWxnUVV0QWZBL3FGbGR4Y01xOGM1aVZrZnpJT1lleVVLMklOMWQvCkYrTkFpSFVaeXdkcWYxWXJyQzBhd2w5MS9LWDFBZGxpeTBDaXZzT09UamdHUjJMSmJyemFNNW5uejVNM1hHd24KaWhMQnczNnZjMGFuMWNZQzVTZkM1dVZTOGM2ekxGUWNMYzdIVUx5ZVh3aHZWRlFjaUZTeStLNlZBb0dBUkFObQpwMDBBOHliS1RId2VoenRGRDJxZ1dOQXc5ckFaalUvTlFmaHo5Wm1nZ0xuMU42RlcwZC9hSi9OR0pFQ2Npa1FsCkZoZ3VqQ1dKbkR1WFc1NE4va2RnWHJWV0VPTHR5Z3QrYVJoR2N3ZmpDM2lES05DMVNVMFZrTFo0VHVaZHlqL2wKbXpIWTc4ZVF2K1l2bWU0SC9qVkxnUnFEdzVwdTNMaVlCRUdoUlNFQ2dZRUExdmNGWmsxOXVLS0JSWDhFRlgzbQphTlk2QWVhWTVJV2xVbDFJbEpHUHBFNnBnejh1aVRYNU9paG5KbGh4NDIzdjBIRU1QV0ZxNXQzcCtJdGRKZ24zCnlTQ0RNcXhyZUo4cytCS3BqeUcwVHFjN0pkbkpUcm1NN1FUMCtVUXExYmlBOENiU0FvMWVybHJpcEZ1blVMblEKSXp3SURyM1VzN0ROQkxNZmlOaDZuVWs9Ci0tLS0tRU5EIFBSSVZBVEUgS0VZLS0tLS0K
+kind: Secret
+metadata:
+  name: ratelimit-tls-secret
+type: kubernetes.io/tls
+"""
+
+    def config(self):
+        # Use self.target here, because we want this mapping to be annotated
+        # on the service, not the Ambassador.
+        yield self.target, self.format("""
+---
+apiVersion: ambassador/v1
+kind: TLSContext
+name: ratelimit-tls-context
+secret: ratelimit-tls-secret
+alpn_protocols: h2
+---
+apiVersion: ambassador/v1
+kind:  Mapping
+name:  ratelimit_target_mapping
+prefix: /target/
+service: {self.target.path.fqdn}
+labels:
+  ambassador:
+    - request_label_group:
+      - x-ambassador-test-allow:
+          header: "x-ambassador-test-allow"
+          omit_if_not_present: true
+""")
+
+        yield self, self.format("""
+---
+apiVersion: ambassador/v1
+kind: RateLimitService
+name: ratelimit
+service: rate-limit:5000
+timeout_ms: 500
+tls: ratelimit-tls-context
 """)
 
     def queries(self):

--- a/ambassador/tests/t_ratelimit.py
+++ b/ambassador/tests/t_ratelimit.py
@@ -219,10 +219,10 @@ class RateLimitV1WithTLSTest(AmbassadorTest):
 apiVersion: v1
 kind: Service
 metadata:
-  name: rate-limit
+  name: rate-limit-tls
 spec:
   selector:
-    app: rate-limit
+    app: rate-limit-tls
   ports:
   - port: 5000
     name: grpc
@@ -232,7 +232,7 @@ spec:
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: rate-limit
+  name: rate-limit-tls
 spec:
   replicas: 1
   strategy:
@@ -240,7 +240,7 @@ spec:
   template:
     metadata:
       labels:
-        app: rate-limit
+        app: rate-limit-tls
     spec:
       containers:
       - name: rate-limit
@@ -295,8 +295,8 @@ labels:
 ---
 apiVersion: ambassador/v1
 kind: RateLimitService
-name: ratelimit
-service: rate-limit:5000
+name: ratelimit-tls
+service: rate-limit-tls:5000
 timeout_ms: 500
 tls: ratelimit-tls-context
 """)
@@ -312,5 +312,5 @@ tls: ratelimit-tls-context
 
         # Header instructing dummy ratelimit-service to reject request
         yield Query(self.url("target/"), expected=429, headers={
-            'x-ambassador-test-allow': 'over my dead body'
+            'x-ambassador-test-allow': 'nope'
         })

--- a/ambassador/tests/t_ratelimit.py
+++ b/ambassador/tests/t_ratelimit.py
@@ -15,10 +15,10 @@ class RateLimitV0Test(AmbassadorTest):
 apiVersion: v1
 kind: Service
 metadata:
-  name: rate-limit
+  name: rate-limit-v0
 spec:
   selector:
-    app: rate-limit
+    app: rate-limit-v0
   ports:
   - port: 5000
     name: grpc
@@ -28,7 +28,7 @@ spec:
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: rate-limit
+  name: rate-limit-v0
 spec:
   replicas: 1
   strategy:
@@ -36,7 +36,7 @@ spec:
   template:
     metadata:
       labels:
-        app: rate-limit
+        app: rate-limit-v0
     spec:
       containers:
       - name: rate-limit
@@ -93,8 +93,8 @@ labels:
 ---
 apiVersion: ambassador/v0
 kind: RateLimitService
-name: ratelimit
-service: rate-limit:5000
+name: ratelimit-v0
+service: rate-limit-v0:5000
 timeout_ms: 500
 """)
 
@@ -129,10 +129,10 @@ class RateLimitV1Test(AmbassadorTest):
 apiVersion: v1
 kind: Service
 metadata:
-  name: rate-limit
+  name: rate-limit-v1
 spec:
   selector:
-    app: rate-limit
+    app: rate-limit-v1
   ports:
   - port: 5000
     name: grpc
@@ -142,7 +142,7 @@ spec:
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: rate-limit
+  name: rate-limit-v1
 spec:
   replicas: 1
   strategy:
@@ -150,7 +150,7 @@ spec:
   template:
     metadata:
       labels:
-        app: rate-limit
+        app: rate-limit-v1
     spec:
       containers:
       - name: rate-limit
@@ -187,8 +187,8 @@ labels:
 ---
 apiVersion: ambassador/v1
 kind: RateLimitService
-name: ratelimit
-service: rate-limit:5000
+name: ratelimit-v1
+service: rate-limit-v1:5000
 timeout_ms: 500
 """)
 

--- a/docs/reference/services/rate-limit-service.md
+++ b/docs/reference/services/rate-limit-service.md
@@ -79,6 +79,12 @@ service: "example-rate-limit:5000"
 
 You may only use a single `RateLimitService` manifest.
 
+## Rate Limit Service and TLS
+
+You can tell Ambassador to use TLS to talk to your service by using a `RateLimitService` with an `https://` prefix. However, you may also provide a `tls` attribute: if `tls` is present and `true`, Ambassador will originate TLS even if the `service` does not have the `https://` prefix.
+
+If `tls` is present with a value that is not `true`, the value is assumed to be the name of a defined TLS context, which will determine the certificate presented to the upstream service.
+
 ## Example
 
 The [Ambassador Rate Limiting Tutorial](/user-guide/rate-limiting-tutorial) has a simple rate limiting example. For a more advanced example, read the [advanced rate limiting tutorial](/user-guide/advanced-rate-limiting) with Ambassador Pro tutorial.
@@ -89,5 +95,3 @@ The [Ambassador Rate Limiting Tutorial](/user-guide/rate-limiting-tutorial) has 
 * [Rate limiting for API Gateways](https://blog.getambassador.io/rate-limiting-for-api-gateways-892310a2da02)
 * [Implementing a Java Rate Limiting Service for Ambassador](https://blog.getambassador.io/implementing-a-java-rate-limiting-service-for-the-ambassador-api-gateway-e09d542455da)
 * [Designing a Rate Limit Service for Ambassador](https://blog.getambassador.io/designing-a-rate-limiting-service-for-ambassador-f460e9fabedb)
-
-

--- a/kat/kat/harness.py
+++ b/kat/kat/harness.py
@@ -30,13 +30,13 @@ class TestImage:
     def __init__(self, *args, **kwargs) -> None:
         self.images: Dict[str, str] = {}
 
-        default_registry = os.environ.get('TEST_SVC_REGISTRY', 'quay.io/datawire/test_services')
-        default_version = os.environ.get('TEST_SVC_VERSION', '0.0.2')
+        default_registry = os.environ.get('TEST_SERVICE_REGISTRY', 'quay.io/datawire/test_services')
+        default_version = os.environ.get('TEST_SERVICE_VERSION', '0.0.3')
 
         for svc in ['auth', 'auth-tls', 'ratelimit', 'shadow', 'stats']:
             key = svc.replace('-', '_').upper()
 
-            image = os.environ.get(f'TEST_SVC_{key}', f'{default_registry}:test-{svc}-{default_version}')
+            image = os.environ.get(f'TEST_SERVICE_{key}', f'{default_registry}:test-{svc}-{default_version}')
 
             self.images[svc] = image
 


### PR DESCRIPTION
## Description

Adds ability to set TLS context when defining `RateLimitService`. This is already available with `AuthService` and operates in the same way.

## Testing

Deployed and tested manually local setup with `istio` using strict `mTLS` configuration.

Added automated testing for v1 format and for TLS.