### PR TITLE
Minor changes

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -181,7 +181,10 @@ you don't `make clean` or `make clobber` in between.
 
 #### `ambassador dump`
 
-The `ambassador dump` function (run from a `make shell`) will export the full Envoy v2 configuration. It works from an input which can be either a single file or a directory full of files in the following formats:
+After running `make setup-develop` or `make shell`, you'll be able to use the
+`ambassador` CLI. The most useful thing it can do is `ambassador dump`, which
+can export the most import data structures that Ambassador works with as JSON.
+It works from an input which can be either a single file or a directory full of files in the following formats:
 
 - raw Ambassador resources like you'll find in the `demo/config` directory; or
 - an annotated Kubernetes resources like you'll find in `/tmp/k8s-AmbassadorTest.yaml` after running `make test`; or
@@ -195,7 +198,8 @@ Given an input source, running
 venv/bin/ambassador dump --ir --v2 [$input_flags] $input > test.json
 ```
 
-will dump the Ambassador IR and v2 Envoy configuration into `test.json`. Here `$input_flags` will be
+will dump the Ambassador IR and v2 Envoy configuration into `test.json`. Here
+`$input_flags` will be
 
 - nothing for raw Ambassador resources;
 - `--k8s` for Kubernetes resources; or
@@ -207,7 +211,8 @@ You can get more information with
 venv/bin/ambassador dump --help
 ```
 
-(Note that if you're in a dev shell, you can just run `ambassador` instead of `venv/bin/ambassador`.)
+(Note that if you're in a dev shell, you can just run `ambassador` instead of
+`venv/bin/ambassador`.)
 
 #### The Test Suite and Your Cluster
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -97,9 +97,8 @@ COPY ambassador/grab-snapshots.py .
 COPY ambassador/kick_ads.sh .
 COPY ambassador/kubewatch.py .
 COPY ambassador/post_update.py .
-COPY ambassador/post_watt.sh .
 COPY ambassador/watch_hook.py .
-RUN chmod 755 entrypoint.sh grab-snapshots.py kick_ads.sh kubewatch.py post_update.py post_watt.sh watch_hook.py
+RUN chmod 755 entrypoint.sh grab-snapshots.py kick_ads.sh kubewatch.py post_update.py watch_hook.py
 
 # XXX Move to base image
 COPY watt .

--- a/ambassador/entrypoint.sh
+++ b/ambassador/entrypoint.sh
@@ -388,7 +388,7 @@ if [[ -z "${AMBASSADOR_NO_KUBEWATCH}" ]]; then
     launch "watt" /ambassador/watt \
            --port 8002 \
            ${AMBASSADOR_SINGLE_NAMESPACE:+ --namespace "${AMBASSADOR_NAMESPACE}" } \
-           --notify 'sh /ambassador/post_watt.sh' \
+           --notify 'python /ambassador/post_update.py --watt ' \
            ${KUBEWATCH_SYNC_KINDS} \
            ${AMBASSADOR_FIELD_SELECTOR_ARG} \
            ${AMBASSADOR_LABEL_SELECTOR_ARG} \

--- a/ambassador/post_watt.sh
+++ b/ambassador/post_watt.sh
@@ -1,5 +1,0 @@
-#!/bin/sh
-
-ROOT=$(cd $(dirname $0); pwd)
-
-AMBASSADOR_EVENT_URL=http://localhost:8877/_internal/v0/watt python3 $ROOT/post_update.py "$@"


### PR DESCRIPTION
- I rescued some more `BUILDING.md` changes from an orphaned stash.

- `post_update.py` can now take `--watt`, `--k8s`, and `--fs` flags to specify what kind of update 
it should send, and `entrypoint.sh` now tells `watt` to send `watt`-format updates.

- `post_watt.sh` is no more.
