### PR TITLE
Bump to Envoy commit 18b1f5acc8d75e992f81d540bbb0d05f8abfe244

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -285,9 +285,32 @@ That's it! Now simply run `make clean docker-push test` for the first time. In t
 Updating Ambassador's Envoy
 ---------------------------
 
-Ambassador currently relies on a custom Envoy build. This build lives in `https://github.com/datawire/envoy`, which is a fork of `https://github.com/envoyproxy/envoy`, and it'll need to be updated at least as often as Envoy releases happen. To do that:
+Ambassador currently relies on a custom Envoy build. This build lives in
+`https://github.com/datawire/envoy`, which is a fork of
+`https://github.com/envoyproxy/envoy`, and it'll need to be updated at
+least as often as Envoy releases happen. 
 
- 1. Run `make envoy-src` to instruct Make to clone `$ENVOY_REPO` to `./envoy/`.  It will check out `$ENVOY_COMMMIT` (instead of `master`).
+Ambassador's current release engineering works by using `git clone`ing the
+`datawire/envoy` tree into the `envoy-src` subdirectory of Ambassador's
+source tree. **Pay attention** to your working directory as you work through
+the update procedure! There are two separate repos involved, even though one
+appears as a subdirectory of the other.
+
+ 0. In Ambassador's `Makefile`:
+
+    - `$ENVOY_REPO` is the URL of the Envoy source repo. Typically this is
+      the `datawire/envoy` repo, shown above; and
+
+    - `$ENVOY_COMMIT` is the commit within `$ENVOY_REPO` from which
+      Ambassador will build Envoy. Typically this is the tip of the
+      `rebase/master` branch in the `datawire/envoy` repo.
+
+    You **must** edit `$ENVOY_COMMIT` as part of the updating procedure. 
+    Think hard before changing `$ENVOY_REPO`!
+
+ 1. Within your `datawire/ambassador` clone, use `make envoy-src` to clone
+    `$ENVOY_REPO` to `./envoy-src`.  It will check out `$ENVOY_COMMMIT`
+    (instead of `master`):
 
     ```
     $ make envoy-src
@@ -296,23 +319,75 @@ Ambassador currently relies on a custom Envoy build. This build lives in `https:
     HEAD is now at a484da25f updated legacy RLS name
     ```
 
- 2. Rebase that commit on to the latest upstream commit that you would like to incorporate.  Usually, `$ENVOY_COMMIT` points to the tip of `rebase/master`, so that's a good branch to work on.
+ 2. You'll need to manipulate branches in `$ENVOY_REPO`, so
+
+    ```
+    $ cd envoy-src
+    ```
+
+    to be in the correct place.
+
+ 2. You'll need to have the latest commits from the `envoyproxy/envoy` repo
+    available so that you can pull the latest changes:
+
+    ```
+    $ git remote add upstream git://github.com/envoyproxy/envoy.git
+    $ git fetch upstream master
+    ```
+
+ 3. Since `$ENVOY_COMMIT` typically points at the tip of the `rebase/master`
+    branch, that's usually a good branch to work on:
 
     ```
     $ git checkout rebase/master
     Branch 'rebase/master' set up to track remote branch 'rebase/master' from 'origin'.
     Switched to a new branch 'rebase/master'
-    $ git rebase v1.10.0
+    ```
+
+ 4. Once on the correct branch, `git rebase` the commit you want for the new
+    `$ENVOY_COMMIT`:
+
+    ```
+    $ git rebase $NEW_ENVOY_COMMIT
     …
     ```
 
- 3. Run `ENVOY_COMMIT=- make envoy-bin/envoy-static` to make sure that your new Envoy commit compiles correctly.  If there are problems with the build, you can run `ENVOY_COMMIT=- make envoy-shell` to get a shell in to the Docker image where Envoy is compiled.  Any changes you make in the Docker image WILL be copied back to the host, potentially OVERWRITING changes you made  in the host's `./envoy-src/` directory.
+ 5. Deal with any merge conflicts. Sigh.
 
- 4. Run `ENVOY_COMMIT=- make check-envoy` to make sure that your new Envoy commit passes Envoy's own test-suite.
-
- 5. Push the Envoy commit:
+ 6. Switch back to your enclosing Ambassador repo:
 
     ```
+    $ cd ..
+    ```
+
+ 7. Try compiling your new Envoy from the sources you've rebased locally:
+
+    ```
+    $ ENVOY_COMMIT=- make envoy-bin/envoy-static
+    ```
+
+    If there are problems with the build, you can run 
+
+    ```
+    $ ENVOY_COMMIT=- make envoy-shell
+    ```
+
+    to get a shell in to the Docker image where Envoy is compiled.  Any changes
+    you make in the Docker image WILL be copied back to the host, potentially
+    OVERWRITING changes you made  in the host's `./envoy-src/` directory.
+
+ 8. Once you have a clean compile, run
+
+    ```
+    $ ENVOY_COMMIT=- make check-envoy
+    ```
+
+    to make sure that your new Envoy commit passes Envoy's own test-suite.
+
+ 9. Finally, push your new Envoy commit _from the `envoy-src` directory_:
+
+    ```
+    $ cd envoy-src
     $ git tag "datawire-$(git describe --tags)"
     $ git push --tags
     …
@@ -320,7 +395,7 @@ Ambassador currently relies on a custom Envoy build. This build lives in `https:
     …
     ```
 
- 6. Edit `ENVOY_COMMIT ?=` in the Makefile to point to your new Envoy commit.  Follow the instructions in the Makefile when doing so:
+ 10. Edit `ENVOY_COMMIT ?=` in the Makefile to point to your new Envoy commit.  Follow the instructions in the Makefile when doing so:
 
     a. Then run `make docker-update-base` to compile Envoy, and build+push new docker base images incorporating that Envoy binary.  This will also update the `go/apis/envoy/` directory if any of Envoy's protobuf definitions have changed; make sure to commit those changes when you commit the change to `ENVOY_COMMIT`.
 

--- a/Makefile
+++ b/Makefile
@@ -105,7 +105,7 @@ ENVOY_FILE ?= envoy-bin/envoy-static-stripped
 
 # IF YOU MESS WITH ANY OF THESE VALUES, YOU MUST RUN `make docker-update-base`.
   ENVOY_REPO ?= $(if $(IS_PRIVATE),git@github.com:datawire/envoy-private.git,git://github.com/datawire/envoy.git)
-  ENVOY_COMMIT ?= 4616a0939972438ea47f0ac6657296fb836d1187
+  ENVOY_COMMIT ?= 18b1f5acc8d75e992f81d540bbb0d05f8abfe244
   ENVOY_COMPILATION_MODE ?= dbg
 
 

--- a/Makefile
+++ b/Makefile
@@ -320,7 +320,7 @@ envoy-src: FORCE
 envoy-build-image.txt: FORCE envoy-src
 	@echo "Making $@..."
 	set -e; \
-	cd envoy-src; . ci/envoy_build_sha.sh; cd ..; \
+	cd envoy-src/ci; . envoy_build_sha.sh; cd ../..; \
 	echo docker.io/envoyproxy/envoy-build-ubuntu:$$ENVOY_BUILD_SHA > .tmp.$@.tmp; \
 	if cmp -s .tmp.$@.tmp $@; then \
 		rm -f .tmp.$@.tmp; \

--- a/ambassador/ambassador/envoy/v2/v2listener.py
+++ b/ambassador/ambassador/envoy/v2/v2listener.py
@@ -318,9 +318,6 @@ def v2filter_authv1(auth: IRAuth, v2config: 'V2Config'):
         if body_info:
             auth_info['config']['with_request_body'] = body_info
 
-        if 'retry_policy' in auth:
-            auth_info['config']["retry_policy"] = auth.retry_policy.as_dict()
-
         if 'failure_mode_allow' in auth:
             auth_info['config']["failure_mode_allow"] = auth.failure_mode_allow
         

--- a/ambassador/ambassador/ir/irauth.py
+++ b/ambassador/ambassador/ir/irauth.py
@@ -141,10 +141,6 @@ class IRAuth (IRFilter):
         failure_mode_allow = module.get('failure_mode_allow', None)
         if failure_mode_allow:
             self['failure_mode_allow'] = failure_mode_allow
-        
-        retry_policy = module.get('retry_policy', None)
-        if retry_policy:
-            self["retry_policy"] = IRRetryPolicy(ir=self.ir, aconf=self.ir.aconf, **retry_policy)
 
         # Required fields check.
         if self["api_version"] == None:

--- a/ambassador/schemas/v1/AuthService.schema
+++ b/ambassador/schemas/v1/AuthService.schema
@@ -49,18 +49,6 @@
             }
         },
         "failure_mode_allow": { "type": "boolean" },
-        "retry_policy": {
-            "type": "object",
-            "properties": {
-                "retry_on":  {
-                    "type": "string",
-                    "enum": ["5xx", "gateway-error", "connect-failure", "retriable-4xx", "refused-stream", "retriable-status-codes"]
-                },
-                "num_retries": { "type": "integer" },
-                "per_try_timeout": { "type": "string" }
-            },
-            "additionalProperties": false
-        }
     },
     "required": [ "apiVersion", "kind", "name", "auth_service" ],
     "additionalProperties": false

--- a/ambassador/tests/t_extauth.py
+++ b/ambassador/tests/t_extauth.py
@@ -423,10 +423,6 @@ allowed_authorization_headers:
 status_on_error:
   code: 503
 
-retry_policy:
-  retry_on: "5xx"
-  num_retries: 2
-
 ---
 apiVersion: ambassador/v1
 kind: AuthService
@@ -450,10 +446,6 @@ allowed_authorization_headers:
 
 status_on_error:
   code: 503
-
-retry_policy:
-  retry_on: "5xx"
-  num_retries: 2
 
 """)
         yield self, self.format("""

--- a/docs/reference/services/auth-service.md
+++ b/docs/reference/services/auth-service.md
@@ -28,9 +28,6 @@ include_body:
 status_on_error: 
   code: 503
 failure_mode_allow: false
-retry_policy:
-  retry_on: "5xx"
-  num_retries: 2
 add_linkerd_headers: true
 cluster_idle_timeout_ms: 30000
 ```


### PR DESCRIPTION
That's after Envoy v1.11.1 on the v1.12 path, after the fix for [Envoy issue 8025](https://github.com/envoyproxy/envoy/issues/8025).

Note that this _disables_ `retry_policy` in an `AuthService`. This was added in [Ambassador PR 1632]( https://github.com/datawire/ambassador/pull/1632/files), but as it happens, Envoy didn't actually support `retry_policy` -- it just wasn't generating an error, because Envoy's default behavior was to ignore unknown fields.

That default was flipped in Envoy commit 0418a855d9f9e37ec70b4c6d1942688fc8bb5751, so now, absent the `--allow-unknown-static-fields` command-line argument, Envoy will reject `retry_policy` and other unknown fields. 

`status_on_failure` and `failure_mode_allow` in an `AuthService` are still supported, and in many use cases they're all that's needed. If `retry_policy` is needed, it'll need to be set on a `Mapping`.