### PR TITLE
Add kat docker images targets to test target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -531,14 +531,22 @@ else
 endif
 
 docker-push-kat-client: kat-client-docker-image
+ifeq ($(DOCKER_REGISTRY),-)
+	@echo "No DOCKER_REGISTRY set"
+else
 	@echo 'PUSH $(KAT_CLIENT_DOCKER_IMAGE)'
 	@set -o pipefail; \
 		docker push $(KAT_CLIENT_DOCKER_IMAGE) | python releng/linify.py push.log
+endif
 
 docker-push-kat-server: kat-server-docker-image
+ifeq ($(DOCKER_REGISTRY),-)
+	@echo "No DOCKER_REGISTRY set"
+else
 	@echo 'PUSH $(KAT_SERVER_DOCKER_IMAGE)'
 	@set -o pipefail; \
 		docker push $(KAT_SERVER_DOCKER_IMAGE) | python releng/linify.py push.log
+endif
 
 # TODO: validate version is conformant to some set of rules might be a good idea to add here
 ambassador/ambassador/VERSION.py: FORCE $(WRITE_IFCHANGED)
@@ -666,7 +674,7 @@ clean-test:
 	rm -f $(CLAIM_FILE)
 	$(call kill_teleproxy)
 
-test: setup-develop
+test: setup-develop docker-push-kat-client docker-push-kat-server
 	cd ambassador && \
 	AMBASSADOR_DOCKER_IMAGE="$(AMBASSADOR_DOCKER_IMAGE)" \
 	BASE_PY_IMAGE="$(BASE_PY_IMAGE)" \

--- a/Makefile
+++ b/Makefile
@@ -180,6 +180,8 @@ KAT_SERVER_DOCKER_REPO ?= $(if $(filter-out -,$(DOCKER_REGISTRY)),$(DOCKER_REGIS
 KAT_CLIENT_DOCKER_IMAGE ?= $(KAT_CLIENT_DOCKER_REPO):$(AMBASSADOR_DOCKER_TAG)
 KAT_SERVER_DOCKER_IMAGE ?= $(KAT_SERVER_DOCKER_REPO):$(AMBASSADOR_DOCKER_TAG)
 
+KAT_IMAGE_PULL_POLICY ?= Always
+
 KAT_CLIENT ?= venv/bin/kat_client
 
 # Allow overriding which watt we use.
@@ -548,6 +550,8 @@ else
 		docker push $(KAT_SERVER_DOCKER_IMAGE) | python releng/linify.py push.log
 endif
 
+docker-push-kat: docker-push-kat-client docker-push-kat-server
+
 # TODO: validate version is conformant to some set of rules might be a good idea to add here
 ambassador/ambassador/VERSION.py: FORCE $(WRITE_IFCHANGED)
 	$(call check_defined, VERSION, VERSION is not set)
@@ -674,7 +678,7 @@ clean-test:
 	rm -f $(CLAIM_FILE)
 	$(call kill_teleproxy)
 
-test: setup-develop docker-push-kat-client docker-push-kat-server
+test: setup-develop
 	cd ambassador && \
 	AMBASSADOR_DOCKER_IMAGE="$(AMBASSADOR_DOCKER_IMAGE)" \
 	BASE_PY_IMAGE="$(BASE_PY_IMAGE)" \
@@ -682,6 +686,7 @@ test: setup-develop docker-push-kat-client docker-push-kat-server
 	KUBECONFIG="$(KUBECONFIG)" \
 	KAT_CLIENT_DOCKER_IMAGE="$(KAT_CLIENT_DOCKER_IMAGE)" \
 	KAT_SERVER_DOCKER_IMAGE="$(KAT_SERVER_DOCKER_IMAGE)" \
+	KAT_IMAGE_PULL_POLICY="$(KAT_IMAGE_PULL_POLICY)" \
 	PATH="$(shell pwd)/venv/bin:$(PATH)" \
 	bash ../releng/run-tests.sh
 

--- a/kat/kat/manifests.py
+++ b/kat/kat/manifests.py
@@ -10,7 +10,7 @@ spec:
   containers:
   - name: backend
     image: {environ[KAT_CLIENT_DOCKER_IMAGE]}
-    imagePullPolicy: Always
+    imagePullPolicy: IfNotPresent
 """
 
 BACKEND_SERVICE = """
@@ -45,7 +45,7 @@ spec:
   containers:
   - name: backend
     image: {environ[KAT_SERVER_DOCKER_IMAGE]}
-    imagePullPolicy: Always
+    imagePullPolicy: IfNotPresent
     ports:
     - containerPort: 8080
     env:
@@ -72,7 +72,7 @@ spec:
       containers:
       - name: backend
         image: {environ[KAT_SERVER_DOCKER_IMAGE]}
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         # ports:
         # (ports)
         env:
@@ -110,7 +110,7 @@ spec:
   containers:
   - name: backend
     image: {environ[KAT_SERVER_DOCKER_IMAGE]}
-    imagePullPolicy: Always
+    imagePullPolicy: IfNotPresent
     ports:
     - containerPort: 8080
     env:
@@ -149,7 +149,7 @@ spec:
   containers:
   - name: backend
     image: {environ[KAT_SERVER_DOCKER_IMAGE]}
-    imagePullPolicy: Always
+    imagePullPolicy: IfNotPresent
     ports:
     - containerPort: 8080
     env:
@@ -188,7 +188,7 @@ spec:
   containers:
   - name: backend
     image: {environ[KAT_SERVER_DOCKER_IMAGE]}
-    imagePullPolicy: Always
+    imagePullPolicy: IfNotPresent
     ports:
     - containerPort: 8080
     env:

--- a/kat/kat/manifests.py
+++ b/kat/kat/manifests.py
@@ -10,7 +10,7 @@ spec:
   containers:
   - name: backend
     image: {environ[KAT_CLIENT_DOCKER_IMAGE]}
-    imagePullPolicy: IfNotPresent
+    imagePullPolicy: {environ[KAT_IMAGE_PULL_POLICY]}
 """
 
 BACKEND_SERVICE = """
@@ -45,7 +45,7 @@ spec:
   containers:
   - name: backend
     image: {environ[KAT_SERVER_DOCKER_IMAGE]}
-    imagePullPolicy: IfNotPresent
+    imagePullPolicy: {environ[KAT_IMAGE_PULL_POLICY]}
     ports:
     - containerPort: 8080
     env:
@@ -72,7 +72,7 @@ spec:
       containers:
       - name: backend
         image: {environ[KAT_SERVER_DOCKER_IMAGE]}
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: {environ[KAT_IMAGE_PULL_POLICY]}
         # ports:
         # (ports)
         env:
@@ -110,7 +110,7 @@ spec:
   containers:
   - name: backend
     image: {environ[KAT_SERVER_DOCKER_IMAGE]}
-    imagePullPolicy: IfNotPresent
+    imagePullPolicy: {environ[KAT_IMAGE_PULL_POLICY]}
     ports:
     - containerPort: 8080
     env:
@@ -149,7 +149,7 @@ spec:
   containers:
   - name: backend
     image: {environ[KAT_SERVER_DOCKER_IMAGE]}
-    imagePullPolicy: IfNotPresent
+    imagePullPolicy: {environ[KAT_IMAGE_PULL_POLICY]}
     ports:
     - containerPort: 8080
     env:
@@ -188,7 +188,7 @@ spec:
   containers:
   - name: backend
     image: {environ[KAT_SERVER_DOCKER_IMAGE]}
-    imagePullPolicy: IfNotPresent
+    imagePullPolicy: {environ[KAT_IMAGE_PULL_POLICY]}
     ports:
     - containerPort: 8080
     env:


### PR DESCRIPTION
Some recent changes require kat client and server images to be
tagged and pushed before tests are run. Since these images are
required to run tests, this causes tests failures if they're not
pushed - which they are not during `make test`. This commit adds
both the kat targets to `make test` to fix this.