### PR TITLE
Additional requirements for the GlobalCircuitBreakingTest

### DIFF
--- a/ambassador/tests/t_circuitbreaker.py
+++ b/ambassador/tests/t_circuitbreaker.py
@@ -97,6 +97,7 @@ service: cbstatsd-sink
 
     def requirements(self):
         yield from super().requirements()
+        yield ("url", Query(self.url(self.name) + '-pr/'))
         yield ("url", Query(self.url("RESET/")))
 
     def queries(self):

--- a/ambassador/tests/t_circuitbreaker.py
+++ b/ambassador/tests/t_circuitbreaker.py
@@ -172,6 +172,11 @@ config:
     max_connections: 1
 """)
 
+    def requirements(self):
+        yield from super().requirements()
+        yield ("url", Query(self.url(self.name) + '-pr/'))
+        yield ("url", Query(self.url(self.name) + '-normal/'))
+
     def queries(self):
         for i in range(500):
             yield Query(self.url(self.name) + '-pr/', headers={ "Requested-Backend-Delay": "1000" },

--- a/ambassador/tests/t_circuitbreaker.py
+++ b/ambassador/tests/t_circuitbreaker.py
@@ -134,7 +134,7 @@ service: cbstatsd-sink
         rq_completed = cluster_stats.get('upstream_rq_completed', -1)
         rq_pending_overflow = cluster_stats.get('upstream_rq_pending_overflow', -1)
 
-        assert rq_completed == 500, f'Expected 500 completed requests to {self.__class__.TARGET_CLUSTER}, got {rq_completed}'
+        assert rq_completed == 501, f'Expected 501 completed requests to {self.__class__.TARGET_CLUSTER}, got {rq_completed}'
         assert abs(pending_overloaded - rq_pending_overflow) < 2, f'Expected {pending_overloaded} rq_pending_overflow, got {rq_pending_overflow}'
 
 


### PR DESCRIPTION
I've been seeing some flakes here, so I'm adding some additional `requirements` to try to make sure that routing is _completely_ working before the test starts.
