### PR TITLE
Manifest environment variable expansion

### DIFF
--- a/ambassador/ambassador/config/resourcefetcher.py
+++ b/ambassador/ambassador/config/resourcefetcher.py
@@ -117,6 +117,9 @@ class ResourceFetcher:
         #                   (self.location, len(serialization), "" if (len(serialization) == 1) else "s",
         #                    serialization))
 
+        # Expand environment variables allowing interpolation in manifests.
+        serialization = os.path.expandvars(serialization)
+
         try:
             objects = parse_yaml(serialization)
             self.parse_object(objects=objects, k8s=k8s, rkey=rkey, filename=filename)
@@ -131,6 +134,9 @@ class ResourceFetcher:
         # self.logger.debug("%s: parsing %d byte%s of YAML:\n%s" %
         #                   (self.location, len(serialization), "" if (len(serialization) == 1) else "s",
         #                    serialization))
+
+        # Expand environment variables allowing interpolation in manifests.
+        serialization = os.path.expandvars(serialization)
 
         try:
             objects = json.loads(serialization)
@@ -152,6 +158,9 @@ class ResourceFetcher:
 
         if os.path.isfile(os.path.join(basedir, '.ambassador_ignore_ingress')):
             self.aconf.post_error("Ambassador is not permitted to read Ingress resources. Please visit https://www.getambassador.io/user-guide/ingress-controller/ for more information. You can continue using Ambassador, but Ingress resources will be ignored...")
+        
+        # Expand environment variables allowing interpolation in manifests.
+        serialization = os.path.expandvars(serialization)
 
         try:
             watt_dict = json.loads(serialization)

--- a/ambassador/tests/t_lua_scripts.py
+++ b/ambassador/tests/t_lua_scripts.py
@@ -7,7 +7,11 @@ class LuaTest(AmbassadorTest):
 
     def init(self):
         self.target = HTTP()
-        self.env = ["LUA_SCRIPTS_ENABLED=Processed"]
+
+        self.manifest_envs = """
+    - name: LUA_SCRIPTS_ENABLED
+      value: Processed
+"""
 
     def manifests(self) -> str:
         return super().manifests() + self.format('''

--- a/ambassador/tests/t_lua_scripts.py
+++ b/ambassador/tests/t_lua_scripts.py
@@ -7,6 +7,7 @@ class LuaTest(AmbassadorTest):
 
     def init(self):
         self.target = HTTP()
+        self.env = ["LUA_SCRIPTS_ENABLED=Processed"]
 
     def manifests(self) -> str:
         return super().manifests() + self.format('''
@@ -20,7 +21,7 @@ spec:
   config:
     lua_scripts: |
       function envoy_on_response(response_handle)
-        response_handle: headers():add("Lua-Scripts-Enabled", "Processed")
+        response_handle: headers():add("Lua-Scripts-Enabled", "${LUA_SCRIPTS_ENABLED}")
       end
 ---
 apiVersion: getambassador.io/v1

--- a/ambassador/tests/t_lua_scripts.py
+++ b/ambassador/tests/t_lua_scripts.py
@@ -25,7 +25,7 @@ spec:
   config:
     lua_scripts: |
       function envoy_on_response(response_handle)
-        response_handle: headers():add("Lua-Scripts-Enabled", "${LUA_SCRIPTS_ENABLED}")
+        response_handle: headers():add("Lua-Scripts-Enabled", "$LUA_SCRIPTS_ENABLED")
       end
 ---
 apiVersion: getambassador.io/v1

--- a/ambassador/tests/test_envvar_expansion.py
+++ b/ambassador/tests/test_envvar_expansion.py
@@ -1,0 +1,47 @@
+from typing import Optional
+
+import logging
+import os
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s test %(levelname)s: %(message)s",
+    datefmt='%Y-%m-%d %H:%M:%S'
+)
+
+logger = logging.getLogger("ambassador")
+
+from ambassador import Config, IR
+from ambassador.config import ResourceFetcher
+from ambassador.utils import NullSecretHandler
+from ambassador.ir import IRResource
+from ambassador.ir.irbuffer import IRBuffer
+
+yaml = '''
+---
+apiVersion: getambassador.io/v1
+kind: Mapping
+name: test_mapping
+prefix: /test/
+service: $TEST_SERVICE:9999
+'''
+
+
+def test_envvar_expansion():
+    os.environ["TEST_SERVICE"] = "foo"
+
+    aconf = Config()
+
+    fetcher = ResourceFetcher(logger, aconf)
+    fetcher.parse_yaml(yaml)
+
+    aconf.load_all(fetcher.sorted())
+
+    mappings = aconf.config["mappings"]
+    test_mapping = mappings["test_mapping"]
+
+    assert test_mapping.service == "foo:9999"
+
+
+if __name__ == '__main__':
+    test_envvar_expansion()

--- a/ambassador/tests/test_envvar_expansion.py
+++ b/ambassador/tests/test_envvar_expansion.py
@@ -23,7 +23,7 @@ apiVersion: getambassador.io/v1
 kind: Mapping
 name: test_mapping
 prefix: /test/
-service: $TEST_SERVICE:9999
+service: ${TEST_SERVICE}:9999
 '''
 
 


### PR DESCRIPTION
## Description
Adding environment variable expansion support for manifests (CRD/Anootations), it will allow you to for example expand $HOST_IP into manifests which is currently used to solve the issue for #1828 in a more generic way.

## Related Issues
#1828

## Testing
Have written an initial test, I plan to add one more to cover another scenario but as I cannot for the life of me get tests running locally opening a PR to have CI do it for me.

## Todos
- [X] Tests
- [ ] Documentation
