### PR TITLE
Upgrade all deployments to apps/v1

### DIFF
--- a/docs/reference/debugging.md
+++ b/docs/reference/debugging.md
@@ -114,7 +114,7 @@ Namespace:              default
 CreationTimestamp:      Mon, 15 Oct 2018 13:26:40 +0100
 Labels:                 service=ambassador
 Annotations:            deployment.kubernetes.io/revision=1
-                       kubectl.kubernetes.io/last-applied-configuration={"apiVersion":"extensions/v1beta1","kind":"Deployment","metadata":{"annotations":{},"name":"ambassador","namespace":"default"},"spec":{"replicas":3,"te...
+                       kubectl.kubernetes.io/last-applied-configuration={"apiVersion":"apps/v1","kind":"Deployment","metadata":{"annotations":{},"name":"ambassador","namespace":"default"},"spec":{"replicas":3,"te...
 Selector:               service=ambassador
 Replicas:               3 desired | 3 updated | 3 total | 3 available | 0 unavailable
 StrategyType:           RollingUpdate
@@ -306,7 +306,7 @@ If the generated Envoy configuration is not looking as expected, you can manuall
 
 ```shell
 $ kubectl scale deployment ambassador --replicas=1
-deployment.extensions "ambassador" scaled
+deployment.apps "ambassador" scaled
  tmp $ kubectl get pods
 NAME                         READY     STATUS        RESTARTS   AGE
 ambassador-85c4cf67b-4pfj2   1/1       Running       0          30m

--- a/docs/reference/debugging.md
+++ b/docs/reference/debugging.md
@@ -306,7 +306,7 @@ If the generated Envoy configuration is not looking as expected, you can manuall
 
 ```shell
 $ kubectl scale deployment ambassador --replicas=1
-deployment.apps "ambassador" scaled
+deployment.apps/ambassador scaled
  tmp $ kubectl get pods
 NAME                         READY     STATUS        RESTARTS   AGE
 ambassador-85c4cf67b-4pfj2   1/1       Running       0          30m

--- a/docs/reference/running.md
+++ b/docs/reference/running.md
@@ -18,12 +18,15 @@ Starting with Ambassador 0.35, we support running Ambassador as non-root. This i
 
 ```yaml
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: ambassador
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      service: ambassador
   template:
     metadata:
       labels:

--- a/docs/reference/tls/mtls.md
+++ b/docs/reference/tls/mtls.md
@@ -16,7 +16,7 @@ Istio creates stores it's tls certificates in a form that Ambassador is currentl
 
    ```yaml
     ---
-    apiVersion: extensions/v1beta1
+    apiVersion: apps/v1
     kind: Deployment
     metadata:
       name: ambassador

--- a/docs/user-guide/auth-tutorial.md
+++ b/docs/user-guide/auth-tutorial.md
@@ -39,7 +39,7 @@ spec:
     name: http-example-auth
     targetPort: http-api
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: example-auth
@@ -47,6 +47,9 @@ spec:
   replicas: 1
   strategy:
     type: RollingUpdate
+  selector:
+    matchLabels:
+      app: example-auth
   template:
     metadata:
       labels:

--- a/docs/user-guide/bare-metal.md
+++ b/docs/user-guide/bare-metal.md
@@ -32,12 +32,15 @@ This can be configured by setting `hostNetwork: true` in the Ambassador deployme
 
 ```diff
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: ambassador
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      service: ambassador
   template:
     metadata:
       annotations:

--- a/docs/user-guide/consul-connect-ambassador.md
+++ b/docs/user-guide/consul-connect-ambassador.md
@@ -84,7 +84,7 @@ To test that the Ambassador Consul Connector is working, you will need to have a
 
 ```yaml
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: qotm
@@ -92,6 +92,9 @@ spec:
   replicas: 1
   strategy:
     type: RollingUpdate
+  selector:
+    matchLabels:
+      app: qotm
   template:
     metadata:
       labels:

--- a/docs/user-guide/consul.md
+++ b/docs/user-guide/consul.md
@@ -61,7 +61,7 @@ You'll now register a demo application with Consul, and show how Ambassador can 
 
     ```yaml
     ---
-    apiVersion: extensions/v1beta1
+    apiVersion: apps/v1
     kind: Deployment
     metadata:
       name: qotm
@@ -69,6 +69,9 @@ You'll now register a demo application with Consul, and show how Ambassador can 
       replicas: 1
       strategy:
         type: RollingUpdate
+      selector:
+        matchLabels:
+          app: qotm
       template:
         metadata:
           labels:
@@ -170,7 +173,7 @@ This will install into your cluster:
 
     ```yaml
     ---
-    apiVersion: extensions/v1beta1
+    apiVersion: apps/v1
     kind: Deployment
     metadata:
       name: qotm-mtls
@@ -178,6 +181,9 @@ This will install into your cluster:
       replicas: 1
       strategy:
         type: RollingUpdate
+      selector:
+        matchLabels:
+          app: qotm
       template:
         metadata:
           labels:

--- a/docs/user-guide/grpc.md
+++ b/docs/user-guide/grpc.md
@@ -116,12 +116,15 @@ spec:
   selector:
     service: grpc-example
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: grpc-example
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      service: grpc-example
   template:
     metadata:
       labels:

--- a/docs/user-guide/knative.md
+++ b/docs/user-guide/knative.md
@@ -35,7 +35,7 @@ Ambassador can watch for changes in Knative configuration in your Kubernetes clu
 
     ```yaml
     ---
-    apiVersion: extensions/v1beta1
+    apiVersion: apps/v1
     kind: Deployment
     metadata:
       name: ambassador

--- a/docs/user-guide/monitoring.md
+++ b/docs/user-guide/monitoring.md
@@ -148,13 +148,17 @@ To deploy Grafana behind Ambassador: replace `{{AMBASSADOR_IP}}` with the IP add
 
 ```yaml
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: grafana
   namespace: default
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: grafana
+      componenet: core
   template:
     metadata:
       labels:

--- a/docs/user-guide/rate-limiting-tutorial.md
+++ b/docs/user-guide/rate-limiting-tutorial.md
@@ -41,7 +41,7 @@ spec:
     name: http-example-rate-limit
     targetPort: http-api
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: example-rate-limit
@@ -49,6 +49,9 @@ spec:
   replicas: 1
   strategy:
     type: RollingUpdate
+  selector:
+    matchLabels:
+      app: example-rate-limit
   template:
     metadata:
       labels:

--- a/docs/user-guide/tracing-tutorial.md
+++ b/docs/user-guide/tracing-tutorial.md
@@ -43,7 +43,7 @@ spec:
     targetPort: http
   type: NodePort
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: zipkin
@@ -51,6 +51,9 @@ spec:
   replicas: 1
   strategy:
     type: RollingUpdate
+  selector:
+    matchLabels:
+      app: zipkin
   template:
     metadata:
       labels:

--- a/docs/user-guide/with-istio.md
+++ b/docs/user-guide/with-istio.md
@@ -175,12 +175,15 @@ In case of RBAC:
 
 ``` yaml
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: ambassador
 spec:
   replicas: 3
+  selector:
+    matchLabels:
+      service: ambassador
   template:
     metadata:
       annotations:

--- a/docs/yaml/ambassador/ambassador-knative.yaml
+++ b/docs/yaml/ambassador/ambassador-knative.yaml
@@ -234,12 +234,15 @@ spec:
     categories:
     - ambassador-crds
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: ambassador
 spec:
   replicas: 3
+  selector:
+    matchLabels:
+      service: ambassador
   template:
     metadata:
       annotations:

--- a/docs/yaml/ambassador/ambassador-no-rbac.yaml
+++ b/docs/yaml/ambassador/ambassador-no-rbac.yaml
@@ -33,7 +33,7 @@ spec:
     spec:
       containers:
       - name: ambassador
-        image: quay.io/datawire/ambassador:0.78.0
+        image: quay.io/datawire/ambassador:%version%
         resources:
           limits:
             cpu: 1

--- a/docs/yaml/ambassador/ambassador-no-rbac.yaml
+++ b/docs/yaml/ambassador/ambassador-no-rbac.yaml
@@ -14,12 +14,15 @@ spec:
   selector:
     service: ambassador
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: ambassador
 spec:
   replicas: 3
+  selector:
+    matchLabels:
+      service: ambassador
   template:
     metadata:
       annotations:
@@ -30,7 +33,7 @@ spec:
     spec:
       containers:
       - name: ambassador
-        image: quay.io/datawire/ambassador:%version%
+        image: quay.io/datawire/ambassador:0.78.0
         resources:
           limits:
             cpu: 1

--- a/docs/yaml/ambassador/ambassador-rbac-prometheus.yaml
+++ b/docs/yaml/ambassador/ambassador-rbac-prometheus.yaml
@@ -238,12 +238,15 @@ metadata:
 data:
   exporterConfiguration: ''
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: ambassador
 spec:
   replicas: 3
+  selector:
+    matchLabels:
+      service: ambassador
   template:
     metadata:
       annotations:

--- a/docs/yaml/ambassador/ambassador-rbac.yaml
+++ b/docs/yaml/ambassador/ambassador-rbac.yaml
@@ -240,12 +240,15 @@ spec:
     categories:
     - ambassador-crds
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: ambassador
 spec:
   replicas: 3
+  selector:
+    matchLabels:
+      service: ambassador
   template:
     metadata:
       annotations:

--- a/docs/yaml/demo/demo-auth.yaml
+++ b/docs/yaml/demo/demo-auth.yaml
@@ -12,12 +12,15 @@ spec:
     name: http-example-auth
     targetPort: http-api
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: example-auth
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: example-auth
   strategy:
     type: RollingUpdate
   template:

--- a/docs/yaml/demo/demo-grpc.yaml
+++ b/docs/yaml/demo/demo-grpc.yaml
@@ -24,12 +24,15 @@ spec:
   selector:
     service: grpc-greet
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: grpc-greet
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      service: grpc-greet
   template:
     metadata:
       labels:

--- a/docs/yaml/demo/demo-gruesvc.yaml
+++ b/docs/yaml/demo/demo-gruesvc.yaml
@@ -14,13 +14,16 @@ spec:
   selector:
     service: gruesvc
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   creationTimestamp: null
   name: gruesvc
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      service: gruesvc
   strategy: {}
   template:
     metadata:

--- a/docs/yaml/demo/demo-qotm.yaml
+++ b/docs/yaml/demo/demo-qotm.yaml
@@ -12,12 +12,15 @@ spec:
     name: http-qotm
     targetPort: http-api
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: qotm
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: qotm
   strategy:
     type: RollingUpdate
   template:

--- a/docs/yaml/demo/demo-usersvc.yaml
+++ b/docs/yaml/demo/demo-usersvc.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   creationTimestamp: null
@@ -7,6 +7,9 @@ metadata:
 spec:
   replicas: 1
   strategy: {}
+  selector:
+    matchLabels:
+      service: 
   template:
     metadata:
       creationTimestamp: null
@@ -35,7 +38,7 @@ spec:
   selector:
     service: postgres
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   creationTimestamp: null
@@ -43,6 +46,9 @@ metadata:
 spec:
   replicas: 1
   strategy: {}
+  selector:
+    matchLabels:
+      service: usersvc
   template:
     metadata:
       creationTimestamp: null

--- a/docs/yaml/monitoring/statsd-sink.yaml
+++ b/docs/yaml/monitoring/statsd-sink.yaml
@@ -1,11 +1,14 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   creationTimestamp: null
   name: statsd-sink
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      service: statsd-sink
   strategy: {}
   template:
     metadata:


### PR DESCRIPTION
extensions/v1beta1 has been removed in kube 1.16

Signed-off-by: Noah Krause <krausenoah@gmail.com>

## Description
A few sentences describing the overall goals of the pull request's commits.

## Related Issues
List related issues.

## Testing
A few sentences describing what testing you've done, e.g., manual tests, automated tests, deployed in production, etc.

## Todos
- [ ] Tests
- [ ] Documentation

## Other
* If this is a documentation change, please open the pull request at https://github.com/datawire/ambassador-docs instead.
* Code changes should occur against `master`.
