### PR TITLE
Make `make push-docs` also push to the local repo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -836,12 +836,21 @@ pull-docs:
 		git subtree merge --prefix=docs "$${docs_head}" && \
 		git subtree split --prefix=docs --rejoin --onto="$${docs_head}"; \
 	}
+
+# There are two `git push`es in `make push-docs` because:
+# - the first one pushes to the `ambassador-docs` repo, and
+# - the second one pushes to the `ambassador` repo.
+#
+# (The `git subtree` usually lands a couple of commits onto the local
+#  working copy, so the second `git push` is important to keep the 
+#  trees fully in sync.)
 push-docs:
 	{ \
 		git fetch https://github.com/datawire/ambassador-docs master && \
 		docs_old=$$(git rev-parse FETCH_HEAD) && \
 		docs_new=$$(git subtree split --prefix=docs --rejoin --onto="$${docs_old}") && \
 		git push $(if $(GH_TOKEN),https://d6e-automaton:${GH_TOKEN}@github.com/,git@github.com:)datawire/ambassador-docs.git "$${docs_new}:refs/heads/$(or $(PUSH_BRANCH),master)"; \
+		git push; \
 	}
 .PHONY: pull-docs push-docs
 


### PR DESCRIPTION
It currently only pushes to the docs repo, and leaves a couple of commits lying unpushed locally.

I really don't know a good way to test this, sadly, until our next release...