### PR TITLE
fixup envoy build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,3 +6,4 @@
 !watt
 !kubestatus
 !envoy-bin/
+envoy-bin/*-static

--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,7 @@ unused-e2e
 /envoy-src/
 /envoy-bin/
 /envoy-build-image.txt
+/envoy-build-container.txt
 
 .forge
 forge.yaml

--- a/Dockerfile.base-envoy
+++ b/Dockerfile.base-envoy
@@ -19,4 +19,6 @@
 
 FROM frolvlad/alpine-glibc:alpine-3.9
 
+RUN apk --no-cache add rsync
+
 ADD envoy-bin/envoy-static /usr/local/bin/envoy

--- a/Dockerfile.base-envoy
+++ b/Dockerfile.base-envoy
@@ -21,4 +21,4 @@ FROM frolvlad/alpine-glibc:alpine-3.9
 
 RUN apk --no-cache add rsync
 
-ADD envoy-bin/envoy-static /usr/local/bin/envoy
+ADD ./envoy-static /usr/local/bin/envoy

--- a/Makefile
+++ b/Makefile
@@ -110,7 +110,7 @@ ENVOY_FILE ?= envoy-bin/envoy-static-stripped
 
 
   # Increment BASE_ENVOY_RELVER on changes to `Dockerfile.base-envoy`, or Envoy recipes
-  BASE_ENVOY_RELVER ?= 2
+  BASE_ENVOY_RELVER ?= 3
   # Increment BASE_GO_RELVER on changes to `Dockerfile.base-go`
   BASE_GO_RELVER    ?= 15
   # Increment BASE_PY_RELVER on changes to `Dockerfile.base-py`, `releng/*`, `multi/requirements.txt`, `ambassador/requirements.txt`
@@ -342,7 +342,7 @@ envoy-bin:
 envoy-bin/envoy-static: $(ENVOY_BASH.deps) FORCE | envoy-bin
 	@PS4=; set -ex; { \
 	    if docker run --rm --entrypoint=true $(BASE_ENVOY_IMAGE); then \
-	        docker run --rm --volume=$(CURDIR)/$(@D):/xfer:rw --user=$$(id -u):$$(id -g) $(BASE_ENVOY_IMAGE) cp -a /usr/local/bin/envoy /xfer/$(@F); \
+	        rsync -Pav --blocking-io -e 'docker run --rm -i' $$(docker image inspect $(BASE_ENVOY_IMAGE) --format='{{.Id}}' | sed 's/^sha256://'):/usr/local/bin/envoy $@; \
 	    else \
 	        if [ -n '$(CI)' ]; then \
 	            echo 'error: This should not happen in CI: should not try to compile Envoy'; \

--- a/Makefile
+++ b/Makefile
@@ -397,7 +397,7 @@ envoy-shell: $(ENVOY_BASH.deps)
 
 base-envoy.docker: Dockerfile.base-envoy envoy-bin/envoy-static $(var.)BASE_ENVOY_IMAGE $(WRITE_IFCHANGED)
 	@if [ -n "$(AMBASSADOR_DEV)" ]; then echo "Do not run this from a dev shell" >&2; exit 1; fi
-	docker build $(DOCKER_OPTS) -t $(BASE_ENVOY_IMAGE) -f $< .
+	docker build $(DOCKER_OPTS) -t $(BASE_ENVOY_IMAGE) -f $< envoy-bin
 	@docker image inspect $(BASE_ENVOY_IMAGE) --format='{{.Id}}' | $(WRITE_IFCHANGED) $@
 
 base-py.docker: Dockerfile.base-py $(var.)BASE_PY_IMAGE $(WRITE_IFCHANGED)


### PR DESCRIPTION
## Description

This should fix the "slow" issues that macOS users (@kflynn) see and the "doesn't work" issues that minikube-dockerd users (@containscafeine) see.

Please provide feedback.

As a frame of reference, a no-op everything-is-already-up-to-date `make -j1 envoy-bin/envoy-static-stripped` takes 6 seconds for me if `make docker-base-images` hasn't been done, and about 4 seconds if it has.