### PR TITLE
TLSContext.schema bug fix

### DIFF
--- a/ambassador/schemas/v1/TLSContext.schema
+++ b/ambassador/schemas/v1/TLSContext.schema
@@ -25,8 +25,8 @@
         "cert_required": { "type": "boolean" },
         "min_tls_version": { "enum": [ "v1.0", "v1.1", "v1.2", "v1.3" ] },
         "max_tls_version": { "enum": [ "v1.0", "v1.1", "v1.2", "v1.3" ] },
-        "cipher_suites": { "array", "items": { "type": "string" }  },
-        "ecdh_curves": { "array", "items": { "type": "string" }  },
+        "cipher_suites": { "type": "array", "items": { "type": "string" }  },
+        "ecdh_curves": { "type": "array", "items": { "type": "string" }  },
         "secret_namespacing": { "type": "boolean" }
     },
     "required": [ "apiVersion", "kind", "name" ],


### PR DESCRIPTION
Fixes WARNING: corrupt schema at /ambassador/.cache/ambassador-0.0.0.dev0-py3.6.egg-tmp/schemas/v1/TLSContext.schema, skipping (Expecting ':' delimiter: line 28 column 35 (char 1093))

## Description
TLSContext.schema bug fix

## Related Issues
WARNING: corrupt schema at /ambassador/.cache/ambassador-0.0.0.dev0-py3.6.egg-tmp/schemas/v1/TLSContext.schema, skipping (Expecting ':' delimiter: line 28 column 35 (char 1093))

## Testing
None, but it's an obvious fix
