### PR TITLE
mypy 0.730 causes trouble for us. Pin to 0.720 until we figure that out.

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -5,5 +5,5 @@ awscli
 pytest
 pytest-cov
 dpath
-mypy
+mypy==0.720
 pexpect


### PR DESCRIPTION
(0.730 includes https://github.com/python/mypy/pull/7232)

