### PR TITLE
Only add diagd to AMBASSADOR_DEBUG when enabled for a test

### DIFF
--- a/ambassador/tests/abstract_tests.py
+++ b/ambassador/tests/abstract_tests.py
@@ -79,13 +79,14 @@ class AmbassadorTest(Test):
     extra_ports: Optional[List[int]] = None
     debug_diagd: bool = False
     manifest_envs = ""
-    
+
     env = []
 
     def manifests(self) -> str:
         rbac = manifests.RBAC_CLUSTER_SCOPE
 
-        self.manifest_envs += """
+        if self.debug_diagd:
+            self.manifest_envs += """
     - name: AMBASSADOR_DEBUG
       value: "diagd"
 """

--- a/ambassador/tests/abstract_tests.py
+++ b/ambassador/tests/abstract_tests.py
@@ -77,7 +77,7 @@ class AmbassadorTest(Test):
     name: Name
     path: Name
     extra_ports: Optional[List[int]] = None
-    debug_diagd: bool = False
+    debug_diagd: bool = True
     manifest_envs = ""
 
     env = []


### PR DESCRIPTION
## Description
Previously in the tests, it was not possible for a test to suppress the `diagd` debug logs since they were always set regardless of the value of `AmbassadorTest.debug_diagd`. This PR respects the `AmbassadorTest.debug_diagd` value when modifying the `manifest_envs` such that a subclass of `AmbassadorTest` (such as the ones we need to write for [this PR](https://github.com/datawire/ambassador/pull/1817)) can disable `AMBASSADOR_DEBUG` completely.

In order to maintain the existing behavior, the default value is changed to `True`

## Testing
The expected behavior is that all current tests pass. 