### PR TITLE
version number cleanup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,13 +27,6 @@ services:
 env:
   global:
     - DOCKER_REGISTRY=quay.io/datawire
-    
-    # Set the branch in a predictable way. Travis behavior is that when you are
-    # executing due to a PR then the value of $TRAVIS_BRANCH is actually the
-    # name of the base branch (e.g. "master" rather than "dev/new-feature").
-    #
-    # See also: https://graysonkoonce.com/getting-the-current-branch-name-during-a-pull-request-in-travis-ci/
-    - GIT_BRANCH=$(if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then printf "$TRAVIS_BRANCH"; else printf "$TRAVIS_PULL_REQUEST_BRANCH"; fi)
 
     # Set from the repository settings:
     #- DOCKER_BUILD_USERNAME=[secure] (optional)

--- a/Makefile
+++ b/Makefile
@@ -57,11 +57,7 @@ GIT_TAG_SANITIZED := $(shell \
 
 # Trees get dirty sometimes by choice and sometimes accidently. If we are in a dirty tree then append "-dirty" to the
 # GIT_COMMIT.
-ifeq ($(GIT_DIRTY),dirty)
-GIT_VERSION := $(GIT_BRANCH_SANITIZED)-$(GIT_COMMIT)-dirty
-else
-GIT_VERSION := $(GIT_BRANCH_SANITIZED)-$(GIT_COMMIT)
-endif
+GIT_VERSION := $(GIT_BRANCH_SANITIZED)-$(GIT_COMMIT)$(if $(GIT_DIRTY),-dirty)
 
 # This gives the _previous_ tag, plus a git delta, like
 # 0.36.0-436-g8b8c5d3
@@ -76,11 +72,7 @@ IS_PRIVATE ?= $(findstring private,$(_git_remote_urls))
 # we'd use for a GA build. This is by design.
 #
 # Also note that we strip off the leading 'v' here -- that's just for the git tag.
-ifneq ($(GIT_TAG_SANITIZED),)
-VERSION = $(patsubst v%,%,$(firstword $(subst -, ,$(GIT_TAG_SANITIZED))))
-else
-VERSION = $(patsubst v%,%,$(firstword $(subst -, ,$(GIT_VERSION))))
-endif
+VERSION = $(patsubst v%,%,$(firstword $(subst -, ,$(or $(GIT_TAG_SANITIZED),$(GIT_VERSION)))))
 
 # We need this for tagging in some situations.
 LATEST_RC=$(VERSION)-rc-latest

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ SHELL = bash
 # use what is defined.
 #
 # read: https://graysonkoonce.com/getting-the-current-branch-name-during-a-pull-request-in-travis-ci/
-GIT_DIRTY ?= $(shell test -z "$(shell git status --porcelain)" || printf "dirty")
+GIT_DIRTY ?= $(if $(shell git status --porcelain),dirty)
 
 GIT_BRANCH ?= $(shell git rev-parse --abbrev-ref HEAD)
 

--- a/Makefile
+++ b/Makefile
@@ -26,13 +26,19 @@ SHELL = bash
     teleproxy-restart teleproxy-stop
 .SECONDARY:
 
-# GIT_BRANCH on TravisCI needs to be set through some external custom logic. Default to a Git native mechanism or
-# use what is defined.
-#
-# read: https://graysonkoonce.com/getting-the-current-branch-name-during-a-pull-request-in-travis-ci/
 GIT_DIRTY ?= $(if $(shell git status --porcelain),dirty)
 
-GIT_BRANCH ?= $(shell git rev-parse --abbrev-ref HEAD)
+# This is only "kinda" the git branch name:
+#
+#  - if checked out is the synthetic merge-commit for a PR, then use
+#    the PR's branch name (even though the merge commit we have
+#    checked out isn't part of the branch")
+#  - if this is a CI run for a tag (not a branch or PR), then use the
+#    tag name
+#  - if none of the above, then use the actual git branch name
+#
+# read: https://graysonkoonce.com/getting-the-current-branch-name-during-a-pull-request-in-travis-ci/
+GIT_BRANCH ?= $(or $(TRAVIS_PULL_REQUEST_BRANCH),$(TRAVIS_BRANCH),$(shell git rev-parse --abbrev-ref HEAD))
 
 GIT_COMMIT ?= $(shell git rev-parse --short HEAD)
 

--- a/Makefile
+++ b/Makefile
@@ -136,8 +136,10 @@ TEST_SERVICE_ROOTS = $(notdir $(wildcard test-services/*))
 TEST_SERVICE_IMAGES = $(patsubst %,test-%.docker,$(TEST_SERVICE_ROOTS) auth-tls)
 
 # Set default tag values...
-docker.tag.release = $(AMBASSADOR_DOCKER_TAG)
-docker.tag.local = $(AMBASSADOR_DOCKER_TAG)
+docker.tag.release    = $(AMBASSADOR_DOCKER_TAG)
+docker.tag.release-rc = $(AMBASSADOR_EXTERNAL_DOCKER_REPO):$(VERSION) $(AMBASSADOR_EXTERNAL_DOCKER_REPO):$(LATEST_RC)
+docker.tag.release-ea = $(AMBASSADOR_EXTERNAL_DOCKER_REPO):$(VERSION)
+docker.tag.local      = $(AMBASSADOR_DOCKER_TAG)
 
 TEST_SERVICE_VERSION ?= 0.0.3
 
@@ -770,6 +772,16 @@ release:
 	docker tag $(AMBASSADOR_DOCKER_REPO):$(LATEST_RC) $(AMBASSADOR_DOCKER_REPO):$(VERSION)
 	docker push $(AMBASSADOR_DOCKER_REPO):$(VERSION)
 	$(MAKE) SCOUT_APP_KEY=app.json STABLE_TXT_KEY=stable.txt update-aws
+
+release-rc: ambassador.docker.push.release-rc
+release-rc: SCOUT_APP_KEY = testapp.json
+release-rc: STABLE_TXT_KEY = teststable.txt
+release-rc: update-aws
+
+release-ea: ambassador.docker.push.release-ea
+release-ea: SCOUT_APP_KEY = earlyapp.json
+release-ea: STABLE_TXT_KEY = earlystable.txt
+release-ea: update-aws
 
 # ------------------------------------------------------------------------------
 # Go gRPC bindings (Envoy)

--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ endif
 
 # This gives the _previous_ tag, plus a git delta, like
 # 0.36.0-436-g8b8c5d3
-GIT_DESCRIPTION := $(shell git describe $(GIT_COMMIT))
+GIT_DESCRIPTION := $(shell git describe --tags $(GIT_COMMIT))
 
 # IS_PRIVATE: empty=false, nonempty=true
 # Default is true if any of the git remotes have the string "private" in any of their URLs.

--- a/Makefile
+++ b/Makefile
@@ -42,18 +42,10 @@ GIT_BRANCH ?= $(or $(TRAVIS_PULL_REQUEST_BRANCH),$(TRAVIS_BRANCH),$(shell git re
 
 GIT_COMMIT ?= $(shell git rev-parse --short HEAD)
 
-# This commands prints the tag of this commit or "undefined". Later we use GIT_TAG_SANITIZED and set it to "" if this
-# string is "undefined" or blank.
+# This commands prints the tag of this commit or "undefined".
 GIT_TAG ?= $(shell git name-rev --tags --name-only $(GIT_COMMIT))
 
 GIT_BRANCH_SANITIZED := $(shell printf $(GIT_BRANCH) | tr '[:upper:]' '[:lower:]' | sed -e 's/[^a-zA-Z0-9]/-/g' -e 's/-\{2,\}/-/g')
-GIT_TAG_SANITIZED := $(shell \
-	if [ "$(GIT_TAG)" = "undefined" -o -z "$(GIT_TAG)" ]; then \
-		printf ""; \
-	else \
-		printf "$(GIT_TAG)" | sed -e 's/\^.*//g'; \
-	fi \
-)
 
 # This gives the _previous_ tag, plus a git delta, like
 # 0.36.0-436-g8b8c5d3
@@ -275,7 +267,6 @@ print-vars:
 	@echo "GIT_DESCRIPTION                  = $(GIT_DESCRIPTION)"
 	@echo "GIT_DIRTY                        = $(GIT_DIRTY)"
 	@echo "GIT_TAG                          = $(GIT_TAG)"
-	@echo "GIT_TAG_SANITIZED                = $(GIT_TAG_SANITIZED)"
 	@echo "KAT_CLIENT_DOCKER_IMAGE          = $(KAT_CLIENT_DOCKER_IMAGE)"
 	@echo "KAT_SERVER_DOCKER_IMAGE          = $(KAT_SERVER_DOCKER_IMAGE)"
 	@echo "KUBECONFIG                       = $(KUBECONFIG)"
@@ -301,7 +292,6 @@ export-vars:
 	@echo "export GIT_DESCRIPTION='$(GIT_DESCRIPTION)'"
 	@echo "export GIT_DIRTY='$(GIT_DIRTY)'"
 	@echo "export GIT_TAG='$(GIT_TAG)'"
-	@echo "export GIT_TAG_SANITIZED='$(GIT_TAG_SANITIZED)'"
 	@echo "export KAT_CLIENT_DOCKER_IMAGE='$(KAT_CLIENT_DOCKER_IMAGE)'"
 	@echo "export KAT_SERVER_DOCKER_IMAGE='$(KAT_SERVER_DOCKER_IMAGE)'"
 	@echo "export KUBECONFIG='$(KUBECONFIG)'"

--- a/releng/travis-script.sh
+++ b/releng/travis-script.sh
@@ -19,30 +19,25 @@ set -o nounset
 
 printf "== Begin: travis-script.sh ==\n"
 
-NEEDS_V=
-
-if [[ "$GIT_BRANCH" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-    COMMIT_TYPE=GA
-    NEEDS_V=yes
-elif [[ "$GIT_BRANCH" =~ -rc[0-9]+$ ]]; then
-    COMMIT_TYPE=RC
-    NEEDS_V=yes
-elif [[ "$GIT_BRANCH" =~ -ea[0-9]+$ ]]; then
-    COMMIT_TYPE=EA
-    NEEDS_V=yes
+if [[ -n "$TRAVIS_TAG" ]]; then
+    if [[ "$TRAVIS_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+        COMMIT_TYPE=GA
+    elif [[ "$TRAVIS_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+-rc[0-9]+$ ]]; then
+        COMMIT_TYPE=RC
+    elif [[ "$TRAVIS_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+-ea[0-9]+$ ]]; then
+        COMMIT_TYPE=EA
+    else
+        echo "TRAVIS_TAG '$TRAVIS_TAG' is not in one of the recognized tag formats:" >&2
+        echo " - 'vSEMVER'" >&2
+        echo " - 'vSEMVER-rcN'" >&2
+        echo " - 'vSEMVER-eaN'" >&2
+        echo "Note that the tag name must start with a lowercase 'v'" >&2
+        exit 1
+    fi
 elif [[ "$TRAVIS_PULL_REQUEST" != false ]]; then
     COMMIT_TYPE=PR
 else
     COMMIT_TYPE=random
-fi
-
-if [ -n "$NEEDS_V" ]; then
-    # GIT_BRANCH must start with a 'v' for consistency here. The Makefile yanks off
-    # the 'v' in the version number.
-    if ! [[ "$GIT_BRANCH" =~ ^[vV] ]]; then
-        echo "GIT_BRANCH '$GIT_BRANCH' does not start with a 'v'" >&2
-        exit 1
-    fi
 fi
 
 # If downstream, don't re-run release machinery for tags that are an

--- a/releng/travis-script.sh
+++ b/releng/travis-script.sh
@@ -104,28 +104,13 @@ case "$COMMIT_TYPE" in
         if [[ -n "${DOCKER_RELEASE_USERNAME:-}" ]]; then
             docker login -u="$DOCKER_RELEASE_USERNAME" --password-stdin "${AMBASSADOR_EXTERNAL_DOCKER_REPO%%/*}" <<<"$DOCKER_RELEASE_PASSWORD"
         fi
-        tags=(
-            "${AMBASSADOR_EXTERNAL_DOCKER_REPO}:${VERSION}" # public X.Y.Z-rcA
-            "${AMBASSADOR_EXTERNAL_DOCKER_REPO}:${LATEST_RC}"         # public X.Y.Z-rc-latest
-        )
-        for tag in "${tags[@]}"; do
-            docker tag "$AMBASSADOR_DOCKER_IMAGE" "$tag"
-            docker push "$tag"
-        done
-        make VERSION="$VERSION" SCOUT_APP_KEY=testapp.json STABLE_TXT_KEY=teststable.txt update-aws
+        make release-rc
         ;;
     EA)
         if [[ -n "${DOCKER_RELEASE_USERNAME:-}" ]]; then
             docker login -u="$DOCKER_RELEASE_USERNAME" --password-stdin "${AMBASSADOR_EXTERNAL_DOCKER_REPO%%/*}" <<<"$DOCKER_RELEASE_PASSWORD"
         fi
-        tags=(
-            "${AMBASSADOR_EXTERNAL_DOCKER_REPO}:${VERSION}" # public X.Y.Z-eaA
-        )
-        for tag in "${tags[@]}"; do
-            docker tag "$AMBASSADOR_DOCKER_IMAGE" "$tag"
-            docker push "$tag"
-        done
-        make VERSION="$VERSION" SCOUT_APP_KEY=earlyapp.json STABLE_TXT_KEY=earlystable.txt update-aws
+        make release-ea
         ;;
     *)
         : # Nothing to do


### PR DESCRIPTION
## Description

Ever since 5d5f6e3d8de2d4c950615ed5f96ba11811f932c4, `-rcN` tags don't actually get pushed to quay.io.

I could just revert that commit, and then say `${GIT_TAG_SANITIZED#v}`, but IMO the root problem is that there are a whole buncha version-related variables, and no one really knows what they're each for, at least not for more than 10 minutes at a time.

So, instead of doing the bare minimum to fix the docker-tag issue, go ahead and try to clean up the version-variable situation.

Oh, while we're at it, use `docker.mk` to do the RC and EA docker pushes, since that makes things easier (it's almost like I had ambassador.git's use-case in mind when I wrote the current version of `docker.mk`).