### PR TITLE
Perform status updates of Ingress resources across namespaces

### DIFF
--- a/python/ambassador/config/resourcefetcher.py
+++ b/python/ambassador/config/resourcefetcher.py
@@ -518,7 +518,7 @@ class ResourceFetcher:
             self.logger.error(f"Unable to update Ingress {ingress_name}'s status, could not find Ambassador service")
         else:
             ingress_status = self.ambassador_service_raw.get('status', {})
-            ingress_status_update = (k8s_object.get('kind'), ingress_status)
+            ingress_status_update = (k8s_object.get('kind'), ingress_namespace, ingress_status)
             self.logger.info(f"Updating Ingress {ingress_name} status to {ingress_status_update}")
             self.aconf.k8s_status_updates[ingress_name] = ingress_status_update
 

--- a/python/ambassador/ir/ir.py
+++ b/python/ambassador/ir/ir.py
@@ -532,7 +532,7 @@ class IR:
 
                             # Remember that we need to update status on this resource.
                             utcnow = datetime.datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
-                            status_update = (kind, {
+                            status_update = (kind, ci_namespace, {
                                 "observedGeneration": current_generation,
                                 "conditions": [
                                     {

--- a/python/ambassador_diag/diagd.py
+++ b/python/ambassador_diag/diagd.py
@@ -967,16 +967,16 @@ class AmbassadorEventWatcher(threading.Thread):
 
         if app.ir.k8s_status_updates:
             for name in app.ir.k8s_status_updates.keys():
-                kind, update = app.ir.k8s_status_updates[name]
+                kind, namespace, update = app.ir.k8s_status_updates[name]
 
-                self.logger.info(f"doing K8s status update for {kind} {name}...")
+                self.logger.info(f"doing K8s status update for {kind} {namespace} {name}...")
 
                 text = json.dumps(update)
 
                 with open(f'/tmp/kstat-{kind}-{name}', 'w') as out:
                     out.write(text)
 
-                cmd = [ '/ambassador/kubestatus', kind, '-f', f'metadata.name={name}', '-u', '/dev/fd/0' ]
+                cmd = [ '/ambassador/kubestatus', kind, '-f', f'metadata.name={name}', '-n', namespace, '-u', '/dev/fd/0' ]
                 self.logger.info(f"Running command: {cmd}")
 
                 try:

--- a/python/tests/t_ingress.py
+++ b/python/tests/t_ingress.py
@@ -113,3 +113,63 @@ spec:
         ingress_out, _ = ingress_run.communicate()
         ingress_json = json.loads(ingress_out)
         assert ingress_json['status'] == self.status_update, f"Expected Ingress status to be {self.status_update}, got {ingress_json['status']} instead"
+
+class IngressStatusTestAcrossNamespaces(AmbassadorTest):
+    status_update = {
+        "loadBalancer": {
+            "ingress": [{
+                "ip": "168.168.168.168"
+            }]
+        }
+    }
+
+    def init(self):
+        self.target = HTTP()
+
+    def manifests(self) -> str:
+        return super().manifests() + """
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: alt-namespace
+---
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: ambassador
+    getambassador.io/ambassador-id: {self.ambassador_id}
+  name: {self.name.k8s}
+  namespace: alt-namespace
+spec:
+  rules:
+  - http:
+      paths:
+      - backend:
+          serviceName: {self.target.path.k8s}
+          servicePort: 80
+        path: /{self.name}/
+"""
+
+    def queries(self):
+        text = json.dumps(self.status_update)
+
+        update_cmd = ['../kubestatus', 'Service', '-f', f'metadata.name={self.name.k8s}', '-u', '/dev/fd/0']
+        subprocess.run(update_cmd, input=text.encode('utf-8'), timeout=5)
+
+        yield Query(self.url(self.name + "/"))
+        yield Query(self.url(f'need-normalization/../{self.name}/'))
+
+    def check(self):
+        for r in self.results:
+            if r.backend:
+                assert r.backend.name == self.target.path.k8s, (r.backend.name, self.target.path.k8s)
+                assert r.backend.request.headers['x-envoy-original-path'][0] == f'/{self.name}/'
+
+        # check for Ingress IP here
+        ingress_cmd = ["kubectl", "get", "-o", "json", "ingress", self.path.k8s, "-n", "alt-namespace"]
+        ingress_run = subprocess.Popen(ingress_cmd, stdout=subprocess.PIPE)
+        ingress_out, _ = ingress_run.communicate()
+        ingress_json = json.loads(ingress_out)
+        assert ingress_json['status'] == self.status_update, f"Expected Ingress status to be {self.status_update}, got {ingress_json['status']} instead"

--- a/python/tests/t_ingress.py
+++ b/python/tests/t_ingress.py
@@ -124,7 +124,7 @@ class IngressStatusTestAcrossNamespaces(AmbassadorTest):
     }
 
     def init(self):
-        self.target = HTTP()
+        self.target = HTTP(namespace="alt-namespace")
 
     def manifests(self) -> str:
         return super().manifests() + """


### PR DESCRIPTION
## Description
Whenever an Ingress resource status was updated, it assumed it was declared in the same namespace as Ambassador. If Ambassador is operating across namespaces, it needs to target the proper Ingress object.

## Related Issues
No related github issue.

## Testing
Manual tests were performed in the conformance suite along with already in place automated regression tests.

## Todos
- [ ] Tests
- [ ] Documentation

## Other
* If this is a documentation change, please open the pull request at https://github.com/datawire/ambassador-docs instead.
* Code changes should occur against `master`.
