### PR TITLE
Update Ingress status when annotations are present

### DIFF
--- a/python/ambassador/config/resourcefetcher.py
+++ b/python/ambassador/config/resourcefetcher.py
@@ -510,9 +510,6 @@ class ResourceFetcher:
                 self.logger.info(f"Generated mapping from Ingress {ingress_name}: {path_mapping}")
                 self.handle_k8s_crd(path_mapping)
 
-        if parsed_ambassador_annotations is not None:
-            return resource_identifier, parsed_ambassador_annotations
-
         # let's make arrangements to update Ingress' status now
         if not self.ambassador_service_raw:
             self.logger.error(f"Unable to update Ingress {ingress_name}'s status, could not find Ambassador service")
@@ -521,6 +518,9 @@ class ResourceFetcher:
             ingress_status_update = (k8s_object.get('kind'), ingress_namespace, ingress_status)
             self.logger.info(f"Updating Ingress {ingress_name} status to {ingress_status_update}")
             self.aconf.k8s_status_updates[ingress_name] = ingress_status_update
+
+        if parsed_ambassador_annotations is not None:
+            return resource_identifier, parsed_ambassador_annotations
 
         return None
 

--- a/python/tests/t_ingress.py
+++ b/python/tests/t_ingress.py
@@ -125,6 +125,7 @@ spec:
         ingress_json = json.loads(ingress_out)
         assert ingress_json['status'] == self.status_update, f"Expected Ingress status to be {self.status_update}, got {ingress_json['status']} instead"
 
+
 class IngressStatusTestAcrossNamespaces(AmbassadorTest):
     status_update = {
         "loadBalancer": {
@@ -184,6 +185,65 @@ spec:
 
         # check for Ingress IP here
         ingress_cmd = ["kubectl", "get", "-o", "json", "ingress", self.path.k8s, "-n", "alt-namespace"]
+        ingress_run = subprocess.Popen(ingress_cmd, stdout=subprocess.PIPE)
+        ingress_out, _ = ingress_run.communicate()
+        ingress_json = json.loads(ingress_out)
+        assert ingress_json['status'] == self.status_update, f"Expected Ingress status to be {self.status_update}, got {ingress_json['status']} instead"
+
+
+class IngressStatusTestWithAnnotations(AmbassadorTest):
+    status_update = {
+        "loadBalancer": {
+            "ingress": [{
+                "ip": "200.200.200.200"
+            }]
+        }
+    }
+
+    def init(self):
+        self.target = HTTP()
+
+    def manifests(self) -> str:
+        return super().manifests() + """
+---
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+    getambassador.io/config: |
+      ---
+      apiVersion: ambassador/v1
+      kind:  Mapping
+      name:  {self.name}-nested
+      prefix: /{self.name}-nested/
+      service: http://{self.target.path.fqdn}
+      ambassador_id: {self.ambassador_id}
+    kubernetes.io/ingress.class: ambassador
+    getambassador.io/ambassador-id: {self.ambassador_id}
+  name: {self.name.k8s}
+spec:
+  rules:
+  - http:
+      paths:
+      - backend:
+          serviceName: {self.target.path.k8s}
+          servicePort: 80
+        path: /{self.name}/
+"""
+
+    def queries(self):
+        text = json.dumps(self.status_update)
+
+        update_cmd = ['../kubestatus', 'Service', '-f', f'metadata.name={self.name.k8s}', '-u', '/dev/fd/0']
+        subprocess.run(update_cmd, input=text.encode('utf-8'), timeout=5)
+
+        yield Query(self.url(self.name + "/"))
+        yield Query(self.url(self.name + "-nested/"))
+        yield Query(self.url(f'need-normalization/../{self.name}/'))
+
+    def check(self):
+        # check for Ingress IP here
+        ingress_cmd = ["kubectl", "get", "-o", "json", "ingress", self.path.k8s]
         ingress_run = subprocess.Popen(ingress_cmd, stdout=subprocess.PIPE)
         ingress_out, _ = ingress_run.communicate()
         ingress_json = json.loads(ingress_out)

--- a/python/tests/t_ingress.py
+++ b/python/tests/t_ingress.py
@@ -234,7 +234,7 @@ spec:
     def queries(self):
         text = json.dumps(self.status_update)
 
-        update_cmd = ['../kubestatus', 'Service', '-f', f'metadata.name={self.name.k8s}', '-u', '/dev/fd/0']
+        update_cmd = ['./kubestatus', 'Service', '-f', f'metadata.name={self.name.k8s}', '-u', '/dev/fd/0']
         subprocess.run(update_cmd, input=text.encode('utf-8'), timeout=5)
 
         yield Query(self.url(self.name + "/"))

--- a/python/tests/t_ingress.py
+++ b/python/tests/t_ingress.py
@@ -234,7 +234,7 @@ spec:
     def queries(self):
         text = json.dumps(self.status_update)
 
-        update_cmd = ['./kubestatus', 'Service', '-f', f'metadata.name={self.name.k8s}', '-u', '/dev/fd/0']
+        update_cmd = ['kubestatus', 'Service', '-f', f'metadata.name={self.name.k8s}', '-u', '/dev/fd/0']
         subprocess.run(update_cmd, input=text.encode('utf-8'), timeout=5)
 
         yield Query(self.url(self.name + "/"))


### PR DESCRIPTION
There was a preliminary return statement which did not allow
Ambassador to update an Ingress' status which had Ambassador
annotations present. This commit fixes that.