### PR TITLE
Minor CI tweaks

### DIFF
--- a/python/tests/abstract_tests.py
+++ b/python/tests/abstract_tests.py
@@ -77,7 +77,7 @@ class AmbassadorTest(Test):
     name: Name
     path: Name
     extra_ports: Optional[List[int]] = None
-    debug_diagd: bool = True
+    debug_diagd: bool = False
     manifest_envs = ""
 
     env = []

--- a/python/tests/t_ingress.py
+++ b/python/tests/t_ingress.py
@@ -1,4 +1,7 @@
+import sys
+
 import json
+import pytest
 import subprocess
 
 from kat.harness import Query
@@ -38,15 +41,19 @@ spec:
 """
 
     def queries(self):
-        text = json.dumps(self.status_update)
+        if sys.platform != 'darwin':
+            text = json.dumps(self.status_update)
 
-        update_cmd = ['kubestatus', 'Service', '-f', f'metadata.name={self.name.k8s}', '-u', '/dev/fd/0']
-        subprocess.run(update_cmd, input=text.encode('utf-8'), timeout=5)
+            update_cmd = ['../kubestatus', 'Service', '-f', f'metadata.name={self.name.k8s}', '-u', '/dev/fd/0']
+            subprocess.run(update_cmd, input=text.encode('utf-8'), timeout=5)
 
-        yield Query(self.url(self.name + "/"))
-        yield Query(self.url(f'need-normalization/../{self.name}/'))
+            yield Query(self.url(self.name + "/"))
+            yield Query(self.url(f'need-normalization/../{self.name}/'))
 
     def check(self):
+        if sys.platform == 'darwin':
+            pytest.xfail('not supported on Darwin')
+
         for r in self.results:
             if r.backend:
                 assert r.backend.name == self.target.path.k8s, (r.backend.name, self.target.path.k8s)
@@ -93,15 +100,19 @@ spec:
 """
 
     def queries(self):
-        text = json.dumps(self.status_update)
+        if sys.platform != 'darwin':
+            text = json.dumps(self.status_update)
 
-        update_cmd = ['kubestatus', 'Service', '-f', f'metadata.name={self.name.k8s}', '-u', '/dev/fd/0']
-        subprocess.run(update_cmd, input=text.encode('utf-8'), timeout=5)
+            update_cmd = ['../kubestatus', 'Service', '-f', f'metadata.name={self.name.k8s}', '-u', '/dev/fd/0']
+            subprocess.run(update_cmd, input=text.encode('utf-8'), timeout=5)
 
-        yield Query(self.url(self.name + "/"))
-        yield Query(self.url(f'need-normalization/../{self.name}/'))
+            yield Query(self.url(self.name + "/"))
+            yield Query(self.url(f'need-normalization/../{self.name}/'))
 
     def check(self):
+        if sys.platform == 'darwin':
+            pytest.xfail('not supported on Darwin')
+
         for r in self.results:
             if r.backend:
                 assert r.backend.name == self.target.path.k8s, (r.backend.name, self.target.path.k8s)
@@ -153,15 +164,19 @@ spec:
 """
 
     def queries(self):
-        text = json.dumps(self.status_update)
+        if sys.platform != 'darwin':
+            text = json.dumps(self.status_update)
 
-        update_cmd = ['kubestatus', 'Service', '-f', f'metadata.name={self.name.k8s}', '-u', '/dev/fd/0']
-        subprocess.run(update_cmd, input=text.encode('utf-8'), timeout=5)
+            update_cmd = ['../kubestatus', 'Service', '-f', f'metadata.name={self.name.k8s}', '-u', '/dev/fd/0']
+            subprocess.run(update_cmd, input=text.encode('utf-8'), timeout=5)
 
-        yield Query(self.url(self.name + "/"))
-        yield Query(self.url(f'need-normalization/../{self.name}/'))
+            yield Query(self.url(self.name + "/"))
+            yield Query(self.url(f'need-normalization/../{self.name}/'))
 
     def check(self):
+        if sys.platform == 'darwin':
+            pytest.xfail('not supported on Darwin')
+
         for r in self.results:
             if r.backend:
                 assert r.backend.name == self.target.path.k8s, (r.backend.name, self.target.path.k8s)

--- a/python/tests/t_ingress.py
+++ b/python/tests/t_ingress.py
@@ -44,7 +44,7 @@ spec:
         if sys.platform != 'darwin':
             text = json.dumps(self.status_update)
 
-            update_cmd = ['../kubestatus', 'Service', '-f', f'metadata.name={self.name.k8s}', '-u', '/dev/fd/0']
+            update_cmd = ['kubestatus', 'Service', '-f', f'metadata.name={self.name.k8s}', '-u', '/dev/fd/0']
             subprocess.run(update_cmd, input=text.encode('utf-8'), timeout=5)
 
             yield Query(self.url(self.name + "/"))
@@ -103,7 +103,7 @@ spec:
         if sys.platform != 'darwin':
             text = json.dumps(self.status_update)
 
-            update_cmd = ['../kubestatus', 'Service', '-f', f'metadata.name={self.name.k8s}', '-u', '/dev/fd/0']
+            update_cmd = ['kubestatus', 'Service', '-f', f'metadata.name={self.name.k8s}', '-u', '/dev/fd/0']
             subprocess.run(update_cmd, input=text.encode('utf-8'), timeout=5)
 
             yield Query(self.url(self.name + "/"))
@@ -167,7 +167,7 @@ spec:
         if sys.platform != 'darwin':
             text = json.dumps(self.status_update)
 
-            update_cmd = ['../kubestatus', 'Service', '-f', f'metadata.name={self.name.k8s}', '-u', '/dev/fd/0']
+            update_cmd = ['kubestatus', 'Service', '-f', f'metadata.name={self.name.k8s}', '-u', '/dev/fd/0']
             subprocess.run(update_cmd, input=text.encode('utf-8'), timeout=5)
 
             yield Query(self.url(self.name + "/"))

--- a/python/tests/t_knative.py
+++ b/python/tests/t_knative.py
@@ -1,3 +1,5 @@
+import pytest
+
 from kat.harness import Query, is_knative
 from kat.manifests import KNATIVE_SERVING_071, KNATIVE_SERVING_080
 
@@ -27,43 +29,60 @@ class Knative071Test(AmbassadorTest):
     target: ServiceType
 
     def init(self) -> None:
-        if not is_knative():
-            self.skip_node = True
-
         self.target = HTTP()
 
     def manifests(self) -> str:
-        self.manifest_envs = """
+        if is_knative():
+            self.manifest_envs = """
     - name: AMBASSADOR_KNATIVE_SUPPORT
       value: "true"
 """
 
-        return super().manifests() + KNATIVE_SERVING_071 + KNATIVE_EXAMPLE
+            return super().manifests() + KNATIVE_SERVING_071 + KNATIVE_EXAMPLE
+        else:
+            return super().manifests()
 
     def queries(self):
-        yield Query(self.url(""), expected=404)
-        yield Query(self.url(""), headers={'Host': 'random.host.whatever'}, expected=404)
-        yield Query(self.url(""), headers={'Host': 'helloworld-go.default.example.com'}, expected=200)
+        if is_knative():
+            yield Query(self.url(""), expected=404)
+            yield Query(self.url(""), headers={'Host': 'random.host.whatever'}, expected=404)
+            yield Query(self.url(""), headers={'Host': 'helloworld-go.default.example.com'}, expected=200)
+        else:
+            yield from ()
 
+    def check(self):
+        if not is_knative():
+            pytest.xfail("Knative is not supported")
+
+        return super().check()
 
 class Knative080Test(AmbassadorTest):
     target: ServiceType
 
     def init(self) -> None:
-        if not is_knative():
-            self.skip_node = True
-
         self.target = HTTP()
 
     def manifests(self) -> str:
-        self.manifest_envs = """
+        if is_knative():
+            self.manifest_envs = """
     - name: AMBASSADOR_KNATIVE_SUPPORT
       value: "true"
 """
 
-        return super().manifests() + KNATIVE_SERVING_080 + KNATIVE_EXAMPLE
+            return super().manifests() + KNATIVE_SERVING_080 + KNATIVE_EXAMPLE
+        else:
+            return super().manifests()
 
     def queries(self):
-        yield Query(self.url(""), expected=404)
-        yield Query(self.url(""), headers={'Host': 'random.host.whatever'}, expected=404)
-        yield Query(self.url(""), headers={'Host': 'helloworld-go.default.example.com'}, expected=200)
+        if is_knative():
+            yield Query(self.url(""), expected=404)
+            yield Query(self.url(""), headers={'Host': 'random.host.whatever'}, expected=404)
+            yield Query(self.url(""), headers={'Host': 'helloworld-go.default.example.com'}, expected=200)
+        else:
+            yield from ()
+
+    def check(self):
+        if not is_knative():
+            pytest.xfail("Knative is not supported")
+
+        return super().check()


### PR DESCRIPTION
- Change the `debug_diagd` default for the tests to False. There's just too much output to make sense of when it's default True.
- Drop the circuitbreaker tests to 400 requests rather than 500 or 1000. I'm of two minds about this one; more digging is indicated.
- Make the Knative tests XFail, rather than being skipped, when they're not supported. (They're not supported in Kubernaut CI, and skipping all the tests was making the Knative part fail, which makes CI fail.)
- Make the Ingress tests XFail on MacOS, where we can't run the (built-for-Linux) `kubestatus` command.