### PR TITLE
Bump watt to the latest commit

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	git.lukeshu.com/go/libsystemd v0.5.3
 	github.com/Masterminds/sprig v2.17.1+incompatible
 	github.com/datawire/libk8s v0.0.0-20190923150809-3b461b0ee981
-	github.com/datawire/teleproxy v0.7.3-0.20190923151525-f9c9898fc956
+	github.com/datawire/teleproxy v0.7.3-0.20191008172333-62878af1fb91
 	github.com/envoyproxy/go-control-plane v0.6.9
 	github.com/envoyproxy/protoc-gen-validate v0.0.15-0.20190405222122-d6164de49109
 	github.com/fsnotify/fsnotify v1.4.7

--- a/go.sum
+++ b/go.sum
@@ -26,8 +26,11 @@ github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDk
 github.com/datawire/libk8s v0.0.0-20190923150809-3b461b0ee981 h1:2NKTcGOUo1OMwHrEMcehGmlLlUUxalfsCCkMnpGIvp0=
 github.com/datawire/libk8s v0.0.0-20190923150809-3b461b0ee981/go.mod h1:GBLaVOglMDiCZZaxcsMaYJvcZuxtAVsUkmtn+zxTSUA=
 github.com/datawire/pf v0.0.0-20180510150411-31a823f9495a/go.mod h1:H8uUmE8qqo7z9u30MYB9riLyRckPHOPBk9ZdCuH+dQQ=
+github.com/datawire/teleproxy v0.7.2 h1:wXJVJMQXU7rhG8gaFQJD0CV9gXZyXyFLttqbhcRXehc=
 github.com/datawire/teleproxy v0.7.3-0.20190923151525-f9c9898fc956 h1:cfZn+l8Yf+G2I8iR22IHfOfXMQ2u1boa7TEvXYF/vhY=
 github.com/datawire/teleproxy v0.7.3-0.20190923151525-f9c9898fc956/go.mod h1:zJcszWNe8hm+YamkdU2mfS+DUcCFMJBkG3ec4oDFNN0=
+github.com/datawire/teleproxy v0.7.3-0.20191008172333-62878af1fb91 h1:HYiYYgfRvvAkN2YJL+1d+NDoojei4n+tgfcXqeN6Ha0=
+github.com/datawire/teleproxy v0.7.3-0.20191008172333-62878af1fb91/go.mod h1:zJcszWNe8hm+YamkdU2mfS+DUcCFMJBkG3ec4oDFNN0=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=


### PR DESCRIPTION
This commit updates teleproxy to the latest commit because we
need the fix for rapid apply-delete bug - see
https://github.com/datawire/teleproxy/pull/197

go get github.com/datawire/teleproxy@62878af1fb91eebb080593a2185147e3bb543d9f
was run and the resulting diff has been committed.