### PR TITLE
Rhs/mac

### DIFF
--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -47,6 +47,8 @@ RUN apk --no-cache add bash curl jq rsync python3 python3-dev build-base libffi-
     chmod a+x /usr/bin/kubectl && \
     ln -s /usr/bin/python3 /usr/bin/python
 
+RUN chmod u+s $(which docker)
+
 COPY --from=envoy /usr/local/bin/envoy /usr/local/bin/envoy
 RUN setcap 'cap_net_bind_service=+ep' /usr/local/bin/envoy
 

--- a/builder/builder.mk
+++ b/builder/builder.mk
@@ -125,7 +125,7 @@ define NL
 
 endef
 
-define HELP=
+define HELP
 
 This Makefile builds ambassador source code in a standard build environment
 inside a docker container. It then creates the ambassdaor, kat-server, and

--- a/builder/builder.mk
+++ b/builder/builder.mk
@@ -25,11 +25,11 @@ export DOCKER_ERR=$(RED)ERROR: cannot find docker, please make sure docker is in
 
 preflight:
 ifeq ($(strip $(shell $(BUILDER))),)
-	@echo -e "$(WHT)==$(GRN)Preflight checks$(WHT)==$(END)"
+	@printf "$(WHT)==$(GRN)Preflight checks$(WHT)==$(END)"
 	# Checking for rsync --info
-	test -n "$$(rsync --help | fgrep -- --info)" || (echo -e "$${RSYNC_ERR}"; exit 1)
+	test -n "$$(rsync --help | fgrep -- --info)" || (printf "$${RSYNC_ERR}"; exit 1)
 	# Checking for docker
-	which docker > /dev/null || (echo -e "$${DOCKER_ERR}"; exit 1)
+	which docker > /dev/null || (printf "$${DOCKER_ERR}"; exit 1)
 endif
 .PHONY: preflight
 
@@ -46,11 +46,11 @@ commit:
 images:
 	@$(MAKE) --no-print-directory compile
 	@$(MAKE) --no-print-directory commit
-	@echo -e "$(WHT)==$(GRN)Building $(BLU)ambassador$(GRN) image$(WHT)==$(END)"
+	@printf "$(WHT)==$(GRN)Building $(BLU)ambassador$(GRN) image$(WHT)==$(END)"
 	@$(DBUILD) $(BUILDER_HOME) --build-arg artifacts=snapshot --target ambassador -t ambassador
-	@echo -e "$(WHT)==$(GRN)Building $(BLU)kat-client$(GRN) image$(WHT)==$(END)"
+	@printf "$(WHT)==$(GRN)Building $(BLU)kat-client$(GRN) image$(WHT)==$(END)"
 	@$(DBUILD) $(BUILDER_HOME) --build-arg artifacts=snapshot --target kat-client -t kat-client
-	@echo -e "$(WHT)==$(GRN)Building $(BLU)kat-server$(GRN) image$(WHT)==$(END)"
+	@printf "$(WHT)==$(GRN)Building $(BLU)kat-server$(GRN) image$(WHT)==$(END)"
 	@$(DBUILD) $(BUILDER_HOME) --build-arg artifacts=snapshot --target kat-server -t kat-server
 
 AMB_IMAGE=$(DEV_REGISTRY)/ambassador:$(shell docker images -q ambassador:latest)
@@ -60,14 +60,14 @@ KAT_SRV_IMAGE=$(DEV_REGISTRY)/kat-server:$(shell docker images -q kat-server:lat
 export REGISTRY_ERR=$(RED)ERROR: please set the DEV_REGISTRY make/env variable to the docker registry\n       you would like to use for development$(END)
 
 push: images
-	@test -n "$(DEV_REGISTRY)" || (echo -e "$${REGISTRY_ERR}"; exit 1)
-	@echo -e "$(WHT)==$(GRN)Pushing $(BLU)ambassador$(GRN) image$(WHT)==$(END)"
+	@test -n "$(DEV_REGISTRY)" || (printf "$${REGISTRY_ERR}"; exit 1)
+	@printf "$(WHT)==$(GRN)Pushing $(BLU)ambassador$(GRN) image$(WHT)==$(END)"
 	docker tag ambassador $(AMB_IMAGE)
 	docker push $(AMB_IMAGE)
-	@echo -e "$(WHT)==$(GRN)Pushing $(BLU)kat-client$(GRN) image$(WHT)==$(END)"
+	@printf "$(WHT)==$(GRN)Pushing $(BLU)kat-client$(GRN) image$(WHT)==$(END)"
 	docker tag kat-client $(KAT_CLI_IMAGE)
 	docker push $(KAT_CLI_IMAGE)
-	@echo -e "$(WHT)==$(GRN)Pushing $(BLU)kat-server$(GRN) image$(WHT)==$(END)"
+	@printf "$(WHT)==$(GRN)Pushing $(BLU)kat-server$(GRN) image$(WHT)==$(END)"
 	docker tag kat-server $(KAT_SRV_IMAGE)
 	docker push $(KAT_SRV_IMAGE)
 
@@ -75,8 +75,8 @@ export KUBECONFIG_ERR=$(RED)ERROR: please set the $(YEL)DEV_KUBECONFIG$(RED) mak
 export KUBECTL_ERR=$(RED)ERROR: preflight kubectl check failed$(END)
 
 test-ready: push
-	@test -n "$(DEV_KUBECONFIG)" || (echo -e "$${KUBECONFIG_ERR}"; exit 1)
-	@kubectl --kubeconfig $(DEV_KUBECONFIG) -n default get service kubernetes > /dev/null || (echo -e "$${KUBECTL_ERR}"; exit 1)
+	@test -n "$(DEV_KUBECONFIG)" || (printf "$${KUBECONFIG_ERR}"; exit 1)
+	@kubectl --kubeconfig $(DEV_KUBECONFIG) -n default get service kubernetes > /dev/null || (printf "$${KUBECTL_ERR}"; exit 1)
 	@docker cp $(DEV_KUBECONFIG) $(shell $(BUILDER)):/buildroot/kubeconfig.yaml
 	@if [ -e ~/.docker/config.json ]; then \
 		cat ~/.docker/config.json | docker exec -i $(shell $(BUILDER)) sh -c "mkdir -p /home/dw/.docker && cat > /home/dw/.docker/config.json" ; \
@@ -89,7 +89,7 @@ test-ready: push
 PYTEST_ARGS ?=
 
 pytest: test-ready
-	@echo -e "$(WHT)==$(GRN)Running $(BLU)py$(GRN) tests$(WHT)==$(END)"
+	@printf "$(WHT)==$(GRN)Running $(BLU)py$(GRN) tests$(WHT)==$(END)"
 	docker exec \
 		-e AMBASSADOR_DOCKER_IMAGE=$(AMB_IMAGE) \
 		-e KAT_CLIENT_DOCKER_IMAGE=$(KAT_CLI_IMAGE) \
@@ -103,7 +103,7 @@ GOTEST_PKGS ?= ./...
 GOTEST_ARGS ?=
 
 gotest: test-ready
-	@echo -e "$(WHT)==$(GRN)Running $(BLU)go$(GRN) tests$(WHT)==$(END)"
+	@printf "$(WHT)==$(GRN)Running $(BLU)go$(GRN) tests$(WHT)==$(END)"
 	docker exec -w /buildroot/$(MODULE) -e DTEST_REGISTRY=$(DEV_REGISTRY) -e DTEST_KUBECONFIG=/buildroot/kubeconfig.yaml -e GOTEST_PKGS=$(GOTEST_PKGS) -e GOTEST_ARGS=$(GOTEST_ARGS) $(shell $(BUILDER)) /buildroot/builder.sh test-internal
 
 test: gotest pytest
@@ -118,7 +118,7 @@ clobber:
 	@$(BUILDER) clobber
 
 help:
-	@echo -e "$(subst $(NL),\n,$(HELP))"
+	@printf "$(subst $(NL),\n,$(HELP))"
 
 define NL
 

--- a/builder/builder.mk
+++ b/builder/builder.mk
@@ -20,6 +20,8 @@ DBUILD = $(abspath $(BUILDER_HOME)/dbuild.sh)
 
 all: help
 
+.NOTPARALLEL:
+
 export RSYNC_ERR=$(RED)ERROR: please update to a version of rsync with the --info option$(END)
 export DOCKER_ERR=$(RED)ERROR: cannot find docker, please make sure docker is installed$(END)
 

--- a/builder/builder.mk
+++ b/builder/builder.mk
@@ -27,11 +27,11 @@ export DOCKER_ERR=$(RED)ERROR: cannot find docker, please make sure docker is in
 
 preflight:
 ifeq ($(strip $(shell $(BUILDER))),)
-	@printf "$(WHT)==$(GRN)Preflight checks$(WHT)==$(END)"
+	@printf "$(WHT)==$(GRN)Preflight checks$(WHT)==$(END)\n"
 	# Checking for rsync --info
-	test -n "$$(rsync --help | fgrep -- --info)" || (printf "$${RSYNC_ERR}"; exit 1)
+	test -n "$$(rsync --help | fgrep -- --info)" || (printf "$${RSYNC_ERR}\n"; exit 1)
 	# Checking for docker
-	which docker > /dev/null || (printf "$${DOCKER_ERR}"; exit 1)
+	which docker > /dev/null || (printf "$${DOCKER_ERR}\n"; exit 1)
 endif
 .PHONY: preflight
 
@@ -48,11 +48,11 @@ commit:
 images:
 	@$(MAKE) --no-print-directory compile
 	@$(MAKE) --no-print-directory commit
-	@printf "$(WHT)==$(GRN)Building $(BLU)ambassador$(GRN) image$(WHT)==$(END)"
+	@printf "$(WHT)==$(GRN)Building $(BLU)ambassador$(GRN) image$(WHT)==$(END)\n"
 	@$(DBUILD) $(BUILDER_HOME) --build-arg artifacts=snapshot --target ambassador -t ambassador
-	@printf "$(WHT)==$(GRN)Building $(BLU)kat-client$(GRN) image$(WHT)==$(END)"
+	@printf "$(WHT)==$(GRN)Building $(BLU)kat-client$(GRN) image$(WHT)==$(END)\n"
 	@$(DBUILD) $(BUILDER_HOME) --build-arg artifacts=snapshot --target kat-client -t kat-client
-	@printf "$(WHT)==$(GRN)Building $(BLU)kat-server$(GRN) image$(WHT)==$(END)"
+	@printf "$(WHT)==$(GRN)Building $(BLU)kat-server$(GRN) image$(WHT)==$(END)\n"
 	@$(DBUILD) $(BUILDER_HOME) --build-arg artifacts=snapshot --target kat-server -t kat-server
 
 AMB_IMAGE=$(DEV_REGISTRY)/ambassador:$(shell docker images -q ambassador:latest)
@@ -62,14 +62,14 @@ KAT_SRV_IMAGE=$(DEV_REGISTRY)/kat-server:$(shell docker images -q kat-server:lat
 export REGISTRY_ERR=$(RED)ERROR: please set the DEV_REGISTRY make/env variable to the docker registry\n       you would like to use for development$(END)
 
 push: images
-	@test -n "$(DEV_REGISTRY)" || (printf "$${REGISTRY_ERR}"; exit 1)
-	@printf "$(WHT)==$(GRN)Pushing $(BLU)ambassador$(GRN) image$(WHT)==$(END)"
+	@test -n "$(DEV_REGISTRY)" || (printf "$${REGISTRY_ERR}\n"; exit 1)
+	@printf "$(WHT)==$(GRN)Pushing $(BLU)ambassador$(GRN) image$(WHT)==$(END)\n"
 	docker tag ambassador $(AMB_IMAGE)
 	docker push $(AMB_IMAGE)
-	@printf "$(WHT)==$(GRN)Pushing $(BLU)kat-client$(GRN) image$(WHT)==$(END)"
+	@printf "$(WHT)==$(GRN)Pushing $(BLU)kat-client$(GRN) image$(WHT)==$(END)\n"
 	docker tag kat-client $(KAT_CLI_IMAGE)
 	docker push $(KAT_CLI_IMAGE)
-	@printf "$(WHT)==$(GRN)Pushing $(BLU)kat-server$(GRN) image$(WHT)==$(END)"
+	@printf "$(WHT)==$(GRN)Pushing $(BLU)kat-server$(GRN) image$(WHT)==$(END)\n"
 	docker tag kat-server $(KAT_SRV_IMAGE)
 	docker push $(KAT_SRV_IMAGE)
 
@@ -77,8 +77,8 @@ export KUBECONFIG_ERR=$(RED)ERROR: please set the $(YEL)DEV_KUBECONFIG$(RED) mak
 export KUBECTL_ERR=$(RED)ERROR: preflight kubectl check failed$(END)
 
 test-ready: push
-	@test -n "$(DEV_KUBECONFIG)" || (printf "$${KUBECONFIG_ERR}"; exit 1)
-	@kubectl --kubeconfig $(DEV_KUBECONFIG) -n default get service kubernetes > /dev/null || (printf "$${KUBECTL_ERR}"; exit 1)
+	@test -n "$(DEV_KUBECONFIG)" || (printf "$${KUBECONFIG_ERR}\n"; exit 1)
+	@kubectl --kubeconfig $(DEV_KUBECONFIG) -n default get service kubernetes > /dev/null || (printf "$${KUBECTL_ERR}\n"; exit 1)
 	@docker cp $(DEV_KUBECONFIG) $(shell $(BUILDER)):/buildroot/kubeconfig.yaml
 	@if [ -e ~/.docker/config.json ]; then \
 		cat ~/.docker/config.json | docker exec -i $(shell $(BUILDER)) sh -c "mkdir -p /home/dw/.docker && cat > /home/dw/.docker/config.json" ; \
@@ -91,7 +91,7 @@ test-ready: push
 PYTEST_ARGS ?=
 
 pytest: test-ready
-	@printf "$(WHT)==$(GRN)Running $(BLU)py$(GRN) tests$(WHT)==$(END)"
+	@printf "$(WHT)==$(GRN)Running $(BLU)py$(GRN) tests$(WHT)==$(END)\n"
 	docker exec \
 		-e AMBASSADOR_DOCKER_IMAGE=$(AMB_IMAGE) \
 		-e KAT_CLIENT_DOCKER_IMAGE=$(KAT_CLI_IMAGE) \
@@ -105,7 +105,7 @@ GOTEST_PKGS ?= ./...
 GOTEST_ARGS ?=
 
 gotest: test-ready
-	@printf "$(WHT)==$(GRN)Running $(BLU)go$(GRN) tests$(WHT)==$(END)"
+	@printf "$(WHT)==$(GRN)Running $(BLU)go$(GRN) tests$(WHT)==$(END)\n"
 	docker exec -w /buildroot/$(MODULE) -e DTEST_REGISTRY=$(DEV_REGISTRY) -e DTEST_KUBECONFIG=/buildroot/kubeconfig.yaml -e GOTEST_PKGS=$(GOTEST_PKGS) -e GOTEST_ARGS=$(GOTEST_ARGS) $(shell $(BUILDER)) /buildroot/builder.sh test-internal
 
 test: gotest pytest
@@ -120,7 +120,7 @@ clobber:
 	@$(BUILDER) clobber
 
 help:
-	@printf "$(subst $(NL),\n,$(HELP))"
+	@printf "$(subst $(NL),\n,$(HELP))\n"
 
 define NL
 

--- a/builder/builder.sh
+++ b/builder/builder.sh
@@ -31,11 +31,11 @@ builder_volume() { docker volume ls -q -f label=builder; }
 bootstrap() {
     if [ -z "$(builder_volume)" ] ; then
         docker volume create --label builder
-        printf "${GRN}Created docker volume ${BLU}$(builder_volume)${GRN} for caching${END}"
+        printf "${GRN}Created docker volume ${BLU}$(builder_volume)${GRN} for caching${END}\n"
     fi
 
     if [ -z "$(builder)" ] ; then
-        printf "${WHT}==${GRN}Bootstrapping build image${WHT}==${END}"
+        printf "${WHT}==${GRN}Bootstrapping build image${WHT}==${END}\n"
         ${DBUILD} --target builder ${DIR} -t builder
         if [ "$(uname -s)" == Darwin ]; then
             DOCKER_GID=$(stat -f "%g" /var/run/docker.sock)
@@ -47,7 +47,7 @@ bootstrap() {
             exit 1
         fi
         docker run --group-add ${DOCKER_GID} -d --rm -v /var/run/docker.sock:/var/run/docker.sock -v $(builder_volume):/home/dw --net=host --cap-add NET_ADMIN -lbuilder --entrypoint tail builder -f /dev/null > /dev/null
-        printf "${GRN}Started build container ${BLU}$(builder)${END}"
+        printf "${GRN}Started build container ${BLU}$(builder)${END}\n"
     fi
 
     rsync -q -a -e 'docker exec -i' ${DIR}/builder.sh $(builder):/buildroot
@@ -82,11 +82,11 @@ summarize-sync() {
     if [ "$#" != 0 ]; then
         docker exec -i ${container} touch /buildroot/${name}.dirty
     fi
-    printf "${GRN}Synced $# ${BLU}${name}${GRN} source files${END}"
+    printf "${GRN}Synced $# ${BLU}${name}${GRN} source files${END}\n"
     prevdel=""
     for var in "$@"; do
         if [ -n "$prevdel" ]; then
-            printf "  ${YEL}deleted${END} $var"
+            printf "  ${YEL}deleted${END} $var\n"
         fi
         if [ "${var}" == "deleting" ]; then
             prevdel="x"
@@ -99,7 +99,7 @@ summarize-sync() {
 clean() {
     cid=$(builder)
     if [ -n "${cid}" ] ; then
-        printf "${GRN}Killing build container ${BLU}${cid}${END}"
+        printf "${GRN}Killing build container ${BLU}${cid}${END}\n"
         docker kill ${cid} > /dev/null 2>&1
         docker wait ${cid} > /dev/null 2>&1 || true
     fi
@@ -115,7 +115,7 @@ case "${cmd}" in
         clean
         vid=$(builder_volume)
         if [ -n "${vid}" ] ; then
-            printf "${GRN}Killing cache volume ${BLU}${vid}${END}"
+            printf "${GRN}Killing cache volume ${BLU}${vid}${END}\n"
             docker volume rm ${vid} > /dev/null 2>&1
         fi
         ;;
@@ -143,7 +143,7 @@ case "${cmd}" in
             if [ -e ${module}.dirty ]; then
                 case ${SRCDIR} in
                     */go.mod)
-                        printf "${WHT}==${GRN}Building ${BLU}${module}${GRN} go code${WHT}==${END}"
+                        printf "${WHT}==${GRN}Building ${BLU}${module}${GRN} go code${WHT}==${END}\n"
                         wd=$(dirname ${SRCDIR})
                         echo_on
                         (cd ${wd} && GOBIN=/buildroot/bin go install ./cmd/...) || exit 1
@@ -151,7 +151,7 @@ case "${cmd}" in
                         ;;
                     */python)
                         if ! [ -e ${SRCDIR}/*.egg-info ]; then
-                            printf "${WHT}==${GRN}Setting up ${BLU}${module}${GRN} python code${WHT}==${END}"
+                            printf "${WHT}==${GRN}Setting up ${BLU}${module}${GRN} python code${WHT}==${END}\n"
                             echo_on
                             sudo pip install --no-deps -e ${SRCDIR} || exit 1
                             echo_off
@@ -188,7 +188,7 @@ case "${cmd}" in
         fi
         cid=$(builder)
         if dirty ${cid}; then
-	    printf "${WHT}==${GRN}Snapshotting ${BLU}builder${GRN} image${WHT}==${END}"
+	    printf "${WHT}==${GRN}Snapshotting ${BLU}builder${GRN} image${WHT}==${END}\n"
 	    docker rmi -f "${name}" > /dev/null
             docker commit -c 'ENTRYPOINT [ "/bin/bash" ]' ${cid} "${name}"
         fi

--- a/pkg/teleproxy/teleproxy.go
+++ b/pkg/teleproxy/teleproxy.go
@@ -48,7 +48,10 @@ func dnsListeners(p *supervisor.Process, port string) (listeners []string) {
 			p.Log("not listening on docker bridge")
 			return
 		}
-		listeners = append(listeners, fmt.Sprintf("%s:%s", strings.TrimSpace(output), port))
+		extraIP := strings.TrimSpace(output)
+		if extraIP != "127.0.0.1" {
+			listeners = append(listeners, fmt.Sprintf("%s:%s", extraIP, port))
+		}
 	}
 
 	return

--- a/pkg/teleproxy/teleproxy.go
+++ b/pkg/teleproxy/teleproxy.go
@@ -49,7 +49,7 @@ func dnsListeners(p *supervisor.Process, port string) (listeners []string) {
 			return
 		}
 		extraIP := strings.TrimSpace(output)
-		if extraIP != "127.0.0.1" {
+		if extraIP != "127.0.0.1" && extraIP != "0.0.0.0" && extraIP != "" {
 			listeners = append(listeners, fmt.Sprintf("%s:%s", extraIP, port))
 		}
 	}


### PR DESCRIPTION
## Description
This fixes a number of compatibility issues:
 - replaces `echo -e` with printf
 - fixes `make help` for mac (the entire makefile should now work with the make 3.8 that appears to be standard on macs)
 - makes docker suid inside the build container in order to avoid permissions for the docker socket
 - fixes a bug in teleproxy that occurs when running inside a container on a mac that mounts the docker socket
 - add .NOTPARALLEL to the makefile
