### PR TITLE
Resurrect the ephemeral Docker registry for CI, so it can start running again.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,8 @@ env:
   global:
     - DOCKER_REGISTRY=quay.io/datawire
     - CLAIM_NAME=kat-${USER}
-    - DEV_REGISTRY=rschloming
+    # We create, and use, an ephemeral Docker registry in CI
+    - DEV_REGISTRY=localhost:31000 
     - DEV_KUBECONFIG=~/.kube/${CLAIM_NAME}.yaml
 
     # Set from the repository settings:

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,10 +27,6 @@ services:
 env:
   global:
     - DOCKER_REGISTRY=quay.io/datawire
-    - CLAIM_NAME=kat-${USER}
-    # We create, and use, an ephemeral Docker registry in CI
-    - DEV_REGISTRY=localhost:31000 
-    - DEV_KUBECONFIG=~/.kube/${CLAIM_NAME}.yaml
 
     # Set from the repository settings:
     #- DOCKER_BUILD_USERNAME=[secure] (optional)
@@ -47,7 +43,11 @@ env:
 
 install:
   - ./releng/travis-install.sh
+  # Adjust the environment per travis-install.sh
   - PATH=~/bin:$PATH
+  - CLAIM_NAME=$(cat ~/kubernaut-claim.txt)
+  - export DEV_KUBECONFIG=~/.kube/${CLAIM_NAME}.yaml
+  - export DEV_REGISTRY=localhost:31000
   - source ~/.gimme/envs/latest.env
 
 script:

--- a/releng/travis-install.sh
+++ b/releng/travis-install.sh
@@ -41,6 +41,14 @@ KUBERNAUT=~/bin/kubernaut
 curl -o ${KUBERNAUT} http://releases.datawire.io/kubernaut/${KUBERNAUT_VERSION}/linux/amd64/kubernaut
 chmod +x ${KUBERNAUT}
 
+# Configure kubernaut
+base64 -d < kconf.b64 | ( cd ~ ; tar xzf - )
+
+# Grab a kubernaut cluster
+CLAIM_NAME=kat-${USER}-$(uuidgen)
+DEV_KUBECONFIG=~/.kube/${CLAIM_NAME}.yaml
+echo $CLAIM_NAME > ~/kubernaut-claim.txt
+
 kubernaut claims delete ${CLAIM_NAME}
 kubernaut claims create --name ${CLAIM_NAME} --cluster-group main
 kubectl --kubeconfig ${DEV_KUBECONFIG} -n default get service kubernetes
@@ -74,7 +82,5 @@ while true; do
 		break
 	fi
 done
-
-
 
 printf "== End:   travis-install.sh ==\n"

--- a/releng/travis-script.sh
+++ b/releng/travis-script.sh
@@ -81,10 +81,9 @@ case "$COMMIT_TYPE" in
     *)
         # CI might have set DOCKER_BUILD_USERNAME and DOCKER_BUILD_PASSWORD
         # (in case BASE_DOCKER_REPO is private)
-#        if [[ -n "${DOCKER_BUILD_USERNAME:-}" ]]; then
-#            docker login -u="$DOCKER_BUILD_USERNAME" --password-stdin "${BASE_DOCKER_REPO%%/*}" <<<"$DOCKER_BUILD_PASSWORD"
-#        fi
-        docker login -u rschloming -p b1ackb3rd
+       if [[ -n "${DOCKER_BUILD_USERNAME:-}" ]]; then
+           docker login -u="$DOCKER_BUILD_USERNAME" --password-stdin "${BASE_DOCKER_REPO%%/*}" <<<"$DOCKER_BUILD_PASSWORD"
+       fi
 
 #        make setup-develop cluster.yaml docker-registry
 #        make docker-push docker-push-kat-client docker-push-kat-server # to the in-cluster registry (DOCKER_REGISTRY)


### PR DESCRIPTION
Awhile ago, we switched CI to use an ephemeral Docker registry in its test cluster, to speed things up and to cut down on credential madness. That got ripped out yesterday, by mistake. Now it's back.

Also, put a UUID back into CI's Kubernaut claim, since that way we won't have CI runs stomping on each other's clusters. (Props to @LukeShu for realizing that it was gone!)
