### PR TITLE
[legacy-build] Move Envoy stuff to ./cxx/

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,7 +7,6 @@
 !ambex
 !watt
 !kubestatus
-!envoy-bin/
-envoy-bin/*-static
 !bin_linux_amd64/
 bin_linux_amd64/.go-build/
+bin_linux_amd64/*-static

--- a/.gitignore
+++ b/.gitignore
@@ -52,10 +52,6 @@ package-lock.json
 node_modules
 unused-e2e
 
-/envoy-src/
-/envoy-bin/
-/envoy-build-image.txt
-/envoy-build-container.txt
 /vendor/
 
 /ambex
@@ -87,6 +83,11 @@ kubernaut-claim.txt
 # Remove the tail of this list when the commit making the change gets
 # far enough in to the past.
 
+# 2019-10-11
+/envoy-src/
+/envoy-bin/
+/envoy-build-image.txt
+/envoy-build-container.txt
 # 2019-10-08
 /kat-sandbox/grpc_auth/docker-compose.yml
 /kat-sandbox/grpc_web/*_pb.js

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -324,12 +324,12 @@ Ambassador currently relies on a custom Envoy build. This build lives in
 least as often as Envoy releases happen. 
 
 Ambassador's current release engineering works by using `git clone`ing the
-`datawire/envoy` tree into the `envoy-src` subdirectory of Ambassador's
+`datawire/envoy` tree into the `cxx/envoy/` subdirectory of Ambassador's
 source tree. **Pay attention** to your working directory as you work through
 the update procedure! There are two separate repos involved, even though one
 appears as a subdirectory of the other.
 
- 0. In Ambassador's `Makefile`:
+ 0. In Ambassador's `cxx/envoy.mk`:
 
     - `$ENVOY_REPO` is the URL of the Envoy source repo. Typically this is
       the `datawire/envoy` repo, shown above; and
@@ -341,21 +341,21 @@ appears as a subdirectory of the other.
     You **must** edit `$ENVOY_COMMIT` as part of the updating procedure. 
     Think hard before changing `$ENVOY_REPO`!
 
- 1. Within your `datawire/ambassador` clone, use `make envoy-src` to clone
-    `$ENVOY_REPO` to `./envoy-src`.  It will check out `$ENVOY_COMMMIT`
+ 1. Within your `datawire/ambassador` clone, use `make cxx/envoy` to clone
+    `$ENVOY_REPO` to `./cxx/envoy`.  It will check out `$ENVOY_COMMMIT`
     (instead of `master`):
 
-    ```
-    $ make envoy-src
-    git init envoy
+    ```console
+    ambassador$ make cxx/envoy
+    git init cxx/envoy
     …
     HEAD is now at a484da25f updated legacy RLS name
     ```
 
  2. You'll need to manipulate branches in `$ENVOY_REPO`, so
 
-    ```
-    $ cd envoy-src
+    ```console
+    ambassador$ cd cxx/envoy
     ```
 
     to be in the correct place.
@@ -363,16 +363,16 @@ appears as a subdirectory of the other.
  2. You'll need to have the latest commits from the `envoyproxy/envoy` repo
     available so that you can pull the latest changes:
 
-    ```
-    $ git remote add upstream git://github.com/envoyproxy/envoy.git
-    $ git fetch upstream master
+    ```console
+    ambassador/cxx/envoy$ git remote add upstream git://github.com/envoyproxy/envoy.git
+    ambassador/cxx/envoy$ git fetch upstream master
     ```
 
  3. Since `$ENVOY_COMMIT` typically points at the tip of the `rebase/master`
     branch, that's usually a good branch to work on:
 
-    ```
-    $ git checkout rebase/master
+    ```console
+    ambassador/cxx/envoy$ git checkout rebase/master
     Branch 'rebase/master' set up to track remote branch 'rebase/master' from 'origin'.
     Switched to a new branch 'rebase/master'
     ```
@@ -380,8 +380,8 @@ appears as a subdirectory of the other.
  4. Once on the correct branch, `git rebase` the commit you want for the new
     `$ENVOY_COMMIT`:
 
-    ```
-    $ git rebase $NEW_ENVOY_COMMIT
+    ```console
+    ambassador/cxx/envoy$ git rebase $NEW_ENVOY_COMMIT
     …
     ```
 
@@ -389,48 +389,48 @@ appears as a subdirectory of the other.
 
  6. Switch back to your enclosing Ambassador repo:
 
-    ```
-    $ cd ..
+    ```console
+    ambassador/cxx/envoy$ cd ../..
     ```
 
  7. Try compiling your new Envoy from the sources you've rebased locally:
 
-    ```
-    $ ENVOY_COMMIT=- make envoy-bin/envoy-static
+    ```console
+    ambassador$ ENVOY_COMMIT=- make bin_linux_amd64/envoy-static
     ```
 
     If there are problems with the build, you can run 
 
-    ```
-    $ ENVOY_COMMIT=- make envoy-shell
+    ```console
+    ambassador$ ENVOY_COMMIT=- make envoy-shell
     ```
 
     to get a shell in to the Docker image where Envoy is compiled.  Any changes
     you make in the Docker image WILL be copied back to the host, potentially
-    OVERWRITING changes you made  in the host's `./envoy-src/` directory.
+    OVERWRITING changes you made  in the host's `./cxx/envoy/` directory.
 
  8. Once you have a clean compile, run
 
-    ```
-    $ ENVOY_COMMIT=- make check-envoy
+    ```console
+    ambassador$ ENVOY_COMMIT=- make check-envoy
     ```
 
     to make sure that your new Envoy commit passes Envoy's own test-suite.
 
- 9. Finally, push your new Envoy commit _from the `envoy-src` directory_:
+ 9. Finally, push your new Envoy commit _from the `cxx/envoy` directory_:
 
-    ```
-    $ cd envoy-src
-    $ git tag "datawire-$(git describe --tags)"
-    $ git push --tags
+    ```console
+    ambassador$ cd cxx/envoy
+    ambassador/cxx/envoy$ git tag "datawire-$(git describe --tags)"
+    ambassador/cxx/envoy$$git push --tags
     …
-    $ git push -f origin rebase/master
+    ambassador/cxx/envoy$ git push -f origin rebase/master
     …
     ```
 
  10. Edit `ENVOY_COMMIT ?=` in the Makefile to point to your new Envoy commit.  Follow the instructions in the Makefile when doing so:
 
-    a. Then run `make docker-update-base` to compile Envoy, and build+push new docker base images incorporating that Envoy binary.  This will also update the `go/apis/envoy/` directory if any of Envoy's protobuf definitions have changed; make sure to commit those changes when you commit the change to `ENVOY_COMMIT`.
+    a. Then run `make docker-update-base` to compile Envoy, and build+push new docker base images incorporating that Envoy binary.  This will also update the `pkg/api/envoy/` directory if any of Envoy's protobuf definitions have changed; make sure to commit those changes when you commit the change to `ENVOY_COMMIT`.
 
 Updating the Test Services
 --------------------------

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -422,7 +422,7 @@ appears as a subdirectory of the other.
     ```console
     ambassador$ cd cxx/envoy
     ambassador/cxx/envoy$ git tag "datawire-$(git describe --tags)"
-    ambassador/cxx/envoy$$git push --tags
+    ambassador/cxx/envoy$ git push --tags
     …
     ambassador/cxx/envoy$ git push -f origin rebase/master
     …

--- a/Makefile
+++ b/Makefile
@@ -91,25 +91,14 @@ AMBASSADOR_DOCKER_IMAGE ?= $(AMBASSADOR_DOCKER_REPO):$(AMBASSADOR_DOCKER_TAG)
 AMBASSADOR_EXTERNAL_DOCKER_IMAGE ?= $(AMBASSADOR_EXTERNAL_DOCKER_REPO):$(AMBASSADOR_DOCKER_TAG)
 
 YES_I_AM_UPDATING_THE_BASE_IMAGES ?=
-YES_I_AM_OK_WITH_COMPILING_ENVOY ?=
-
-ENVOY_FILE ?= envoy-bin/envoy-static-stripped
 
 # IF YOU MESS WITH ANY OF THESE VALUES, YOU MUST RUN `make docker-update-base`.
-  ENVOY_REPO ?= $(if $(IS_PRIVATE),git@github.com:datawire/envoy-private.git,git://github.com/datawire/envoy.git)
-  ENVOY_COMMIT ?= 6e6ae35f214b040f76666d86b30a6ad3ceb67046
-  ENVOY_COMPILATION_MODE ?= dbg
-
-
-  # Increment BASE_ENVOY_RELVER on changes to `Dockerfile.base-envoy`, or Envoy recipes
-  BASE_ENVOY_RELVER   ?= 5
   # Increment BASE_RUNTIME_RELVER on changes to `Dockerfile.base-runtime`
   BASE_RUNTIME_RELVER ?= 1
   # Increment BASE_PY_RELVER on changes to `Dockerfile.base-py` or `python/requirements.txt`
   BASE_PY_RELVER      ?= 1
 
   BASE_DOCKER_REPO   ?= quay.io/datawire/ambassador-base$(if $(IS_PRIVATE),-private)
-  BASE_IMAGE.envoy   ?= $(BASE_DOCKER_REPO):envoy-$(BASE_ENVOY_RELVER).$(ENVOY_COMMIT).$(ENVOY_COMPILATION_MODE)
   BASE_IMAGE.runtime ?= $(BASE_DOCKER_REPO):runtime-$(BASE_RUNTIME_RELVER)
   BASE_IMAGE.py      ?= $(BASE_DOCKER_REPO):py-$(BASE_RUNTIME_RELVER).$(BASE_PY_RELVER)
 # END LIST OF VARIABLES REQUIRING `make docker-update-base`.
@@ -204,6 +193,8 @@ all:
 include build-aux/prelude.mk
 include build-aux/var.mk
 include build-aux/docker.mk
+include build-aux/common.mk
+include cxx/envoy.mk
 
 # clean_docker_images could just be a fixed list of the images that we
 # generate, but writing that fixed list would require a human to
@@ -211,7 +202,7 @@ include build-aux/docker.mk
 clean_docker_images  = $(wildcard *.docker)
 clean_docker_images += $(patsubst %.tag.release,%,$(wildcard *.docker.tag.release))
 clean_docker_images += $(patsubst %.tag.local,%,$(wildcard *.docker.tag.local))
-clean: clean-test envoy-build-container.txt.clean $(addsuffix .clean,$(clean_docker_images))
+clean: clean-test $(addsuffix .clean,$(clean_docker_images))
 	rm -rf docs/_book docs/_site docs/package-lock.json
 	rm -rf helm/*.tgz
 	rm -rf app.json
@@ -230,9 +221,6 @@ clean: clean-test envoy-build-container.txt.clean $(addsuffix .clean,$(clean_doc
 	rm -f tools/sandbox/http_auth/docker-compose.yml
 	rm -f tools/sandbox/grpc_auth/docker-compose.yml
 	rm -f tools/sandbox/grpc_web/docker-compose.yaml tools/sandbox/grpc_web/*_pb.js
-	rm -rf pkg/api.envoy.tmp/
-	rm -rf envoy-bin
-	rm -f envoy-build-image.txt
 	rm -f cmd/ambex/ambex
 # Files made by older versions.  Remove the tail of this list when the
 # commit making the change gets far enough in to the past.
@@ -246,15 +234,12 @@ clean: clean-test envoy-build-container.txt.clean $(addsuffix .clean,$(clean_doc
 
 clobber: clean kill-docker-registry
 	-rm -f build/kat/client/teleproxy
-	-$(if $(filter-out -,$(ENVOY_COMMIT)),rm -rf envoy envoy-src)
 	-rm -rf docs/node_modules
 	-rm -rf venv && echo && echo "Deleted venv, run 'deactivate' command if your virtualenv is activated" || true
 
 generate: pkg/api/kat/echo.pb.go
-generate: pkg/api/envoy
-generate: api/envoy
 generate-clean: clobber
-	rm -rf api/envoy pkg/api
+	rm -rf pkg/api
 .PHONY: generate generate-clean
 
 print-%:
@@ -342,114 +327,6 @@ kill-docker-registry:
 		echo "Docker registry should not be running" ;\
 	fi
 
-envoy-src: FORCE
-	@echo "Getting Envoy sources..."
-	@if test -d envoy && ! test -d envoy-src; then PS4=; set -x; mv envoy envoy-src; fi
-# Ensure that GIT_DIR and GIT_WORK_TREE are unset so that `git bisect`
-# and friends work properly.
-	@PS4=; set -ex; { \
-	    unset GIT_DIR GIT_WORK_TREE; \
-	    git init $@; \
-	    cd $@; \
-	    if git remote get-url origin &>/dev/null; then \
-	        git remote set-url origin $(ENVOY_REPO); \
-	    else \
-	        git remote add origin $(ENVOY_REPO); \
-	    fi; \
-	    if [[ $(ENVOY_REPO) == http://github.com/* || $(ENVOY_REPO) == https://github.com/* || $(ENVOY_REPO) == git://github.com/* ]]; then \
-	        git remote set-url --push origin git@github.com:$(word 3,$(subst /, ,$(ENVOY_REPO)))/$(patsubst %.git,%,$(word 4,$(subst /, ,$(ENVOY_REPO)))).git; \
-	    fi; \
-	    git fetch --tags origin; \
-	    if [ $(ENVOY_COMMIT) != '-' ]; then \
-	        git checkout $(ENVOY_COMMIT); \
-	    elif ! git rev-parse HEAD >/dev/null 2>&1; then \
-	        git checkout origin/master; \
-	    fi; \
-	}
-
-envoy-build-image.txt: FORCE envoy-src $(WRITE_IFCHANGED)
-	@PS4=; set -ex -o pipefail; { \
-	    pushd envoy-src/ci; \
-	    . envoy_build_sha.sh; \
-	    popd; \
-	    echo docker.io/envoyproxy/envoy-build-ubuntu:$$ENVOY_BUILD_SHA | $(WRITE_IFCHANGED) $@; \
-	}
-
-envoy-build-container.txt: envoy-build-image.txt FORCE
-	@PS4=; set -ex; { \
-	    if [ $@ -nt $< ] && docker exec $$(cat $@) true; then \
-	        exit 0; \
-	    fi; \
-	    if [ -e $@ ]; then \
-	        docker kill $$(cat $@) || true; \
-	    fi; \
-	    docker run --detach --name=envoy-build --rm --privileged --volume=envoy-build:/root:rw $$(cat $<) tail -f /dev/null > $@; \
-	}
-
-envoy-build-container.txt.clean: %.clean:
-	@PS4=; set -ex; { \
-	    if [ -e $* ]; then \
-	        docker kill $$(cat $*) || true; \
-	    fi; \
-	}
-.PHONY: envoy-build-container.txt.clean
-
-# We do everything with rsync and a persistent build-container
-# (instead of using a volume), because
-#  1. Docker for Mac's osxfs is very slow, so volumes are bad for
-#     macOS users.
-#  2. Volumes mounts just straight-up don't work for people who use
-#     Minikube's dockerd.
-ENVOY_SYNC_HOST_TO_DOCKER = rsync -Pav --delete --blocking-io -e "docker exec -i" envoy-src/ $$(cat envoy-build-container.txt):/root/envoy
-ENVOY_SYNC_DOCKER_TO_HOST = rsync -Pav --delete --blocking-io -e "docker exec -i" $$(cat envoy-build-container.txt):/root/envoy/ envoy-src/
-
-ENVOY_BASH.cmd = bash -c 'PS4=; set -ex; $(ENVOY_SYNC_HOST_TO_DOCKER); trap '\''$(ENVOY_SYNC_DOCKER_TO_HOST)'\'' EXIT; '$(call quote.shell,$1)
-ENVOY_BASH.deps = envoy-build-container.txt
-
-envoy-bin:
-	mkdir -p $@
-envoy-bin/envoy-static: $(ENVOY_BASH.deps) FORCE | envoy-bin
-	@PS4=; set -ex; { \
-	    if docker run --rm --entrypoint=true $(BASE_IMAGE.envoy); then \
-	        rsync -Pav --blocking-io -e 'docker run --rm -i' $$(docker image inspect $(BASE_IMAGE.envoy) --format='{{.Id}}' | sed 's/^sha256://'):/usr/local/bin/envoy $@; \
-	    else \
-	        if [ -z '$(YES_I_AM_UPDATING_THE_BASE_IMAGES)' ]; then \
-	            { set +x; } &>/dev/null; \
-	            echo 'error: failed to pull $(BASE_IMAGE.envoy), but $$YES_I_AM_UPDATING_THE_BASE_IMAGES is not set'; \
-	            echo '       If you are trying to update the base images, then set that variable to a non-empty value.'; \
-	            echo '       If you are not trying to update the base images, then check your network connection and Docker credentials.'; \
-	            exit 1; \
-	        fi; \
-	        if [ -z '$(YES_I_AM_OK_WITH_COMPILING_ENVOY)' ]; then \
-	            { set +x; } &>/dev/null; \
-	            echo 'error: Envoy compilation triggered, but $$YES_I_AM_OK_WITH_COMPILING_ENVOY is not set'; \
-	            exit 1; \
-	        fi; \
-	        $(call ENVOY_BASH.cmd, \
-	            docker exec --workdir=/root/envoy $$(cat envoy-build-container.txt) bazel build --verbose_failures -c $(ENVOY_COMPILATION_MODE) //source/exe:envoy-static; \
-	            rsync -Pav --blocking-io -e 'docker exec -i' $$(cat envoy-build-container.txt):/root/envoy/bazel-bin/source/exe/envoy-static $@; \
-	        ); \
-	    fi; \
-	}
-%-stripped: % envoy-build-container.txt
-	@PS4=; set -ex; { \
-	    rsync -Pav --blocking-io -e 'docker exec -i' $< $$(cat envoy-build-container.txt):/tmp/$(<F); \
-	    docker exec $$(cat envoy-build-container.txt) strip /tmp/$(<F) -o /tmp/$(@F); \
-	    rsync -Pav --blocking-io -e 'docker exec -i' $$(cat envoy-build-container.txt):/tmp/$(@F) $@; \
-	}
-
-check-envoy: $(ENVOY_BASH.deps)
-	$(call ENVOY_BASH.cmd, \
-	    docker exec --workdir=/root/envoy $$(cat envoy-build-container.txt) bazel test --verbose_failures -c dbg --test_env=ENVOY_IP_TEST_VERSIONS=v4only //test/...; \
-	)
-.PHONY: check-envoy
-
-envoy-shell: $(ENVOY_BASH.deps)
-	$(call ENVOY_BASH.cmd, \
-	    docker exec -it $$(cat envoy-build-container.txt) || true; \
-	)
-.PHONY: envoy-shell
-
 base-%.docker: Dockerfile.base-% $(var.)BASE_IMAGE.% $(WRITE_IFCHANGED)
 	@if [ -n "$(AMBASSADOR_DEV)" ]; then echo "Do not run this from a dev shell" >&2; exit 1; fi
 	@PS4=; set -ex; { \
@@ -465,10 +342,6 @@ base-%.docker: Dockerfile.base-% $(var.)BASE_IMAGE.% $(WRITE_IFCHANGED)
 	    fi; \
 	}
 	docker image inspect $(BASE_IMAGE.$*) --format='{{.Id}}' | $(WRITE_IFCHANGED) $@
-
-base-envoy.docker: envoy-build-image.txt envoy-bin/envoy-static
-base-envoy.docker.DOCKER_OPTS = --build-arg=ENVOY_BUILD_IMAGE=$$(cat envoy-build-image.txt)
-base-envoy.docker.DOCKER_DIR = envoy-bin
 
 base-runtime.docker.DOCKER_OPTS =
 
@@ -500,7 +373,7 @@ docker-base-images: $(addsuffix .docker.tag.base,base-envoy base-runtime base-py
 docker-push-base-images: $(addsuffix .docker.push.base,base-envoy base-runtime base-py)
 
 docker-update-base:
-	$(MAKE) docker-base-images pkg/api/envoy
+	$(MAKE) docker-base-images generate
 	$(MAKE) docker-push-base-images
 
 ambassador-docker-image: ambassador.docker
@@ -718,110 +591,6 @@ release-ea: ambassador.docker.push.release-ea
 release-ea: SCOUT_APP_KEY = earlyapp.json
 release-ea: STABLE_TXT_KEY = earlystable.txt
 release-ea: update-aws
-
-# ------------------------------------------------------------------------------
-# Go gRPC bindings (Envoy)
-# ------------------------------------------------------------------------------
-
-# The version numbers of `protoc` (in this Makefile),
-# `protoc-gen-gogofast` (in go.mod), and `protoc-gen-validate` (in
-# go.mod) are based on
-# https://github.com/envoyproxy/go-control-plane/blob/0e75602d5e36e96eafbe053999c0569edec9fe07/Dockerfile.ci
-# (since that commit most closely corresponds to our ENVOY_COMMIT).
-# Additionally, the package names of those programs are mentioned in
-# ./go/pin.go, so that `go mod tidy` won't make the go.mod file forget
-# about them.
-
-PROTOC_VERSION = 3.5.1
-PROTOC_PLATFORM = $(patsubst darwin,osx,$(GOOS))-$(patsubst amd64,x86_64,$(patsubst 386,x86_32,$(GOARCH)))
-
-venv/protoc-$(PROTOC_VERSION)-$(PROTOC_PLATFORM).zip: $(var.)PROTOC_VERSION | venv/bin/activate
-	curl -o $@ --fail -L https://github.com/protocolbuffers/protobuf/releases/download/v$(PROTOC_VERSION)/$(@F)
-venv/bin/protoc: venv/protoc-$(PROTOC_VERSION)-$(PROTOC_PLATFORM).zip
-	bsdtar -xf $< -C venv bin/protoc
-
-venv/bin/protoc-gen-gogofast: go.mod $(FLOCK) | venv/bin/activate
-	$(FLOCK) go.mod go build -o $@ github.com/gogo/protobuf/protoc-gen-gogofast
-
-venv/bin/protoc-gen-validate: go.mod $(FLOCK) | venv/bin/activate
-	$(FLOCK) go.mod go build -o $@ github.com/envoyproxy/protoc-gen-validate
-
-api/envoy: envoy-src
-	rsync --recursive --delete --delete-excluded --prune-empty-dirs --include='*/' --include='*.proto' --exclude='*' $</api/envoy/ $@
-
-# Search path for .proto files
-gomoddir = $(shell $(FLOCK) go.mod go list $1/... >/dev/null 2>/dev/null; $(FLOCK) go.mod go list -m -f='{{.Dir}}' $1)
-# This list is based on 'imports=()' in https://github.com/envoyproxy/go-control-plane/blob/0e75602d5e36e96eafbe053999c0569edec9fe07/build/generate_protos.sh
-# (since that commit most closely corresponds to our ENVOY_COMMIT).
-#
-# However, we make the following edits:
-#  - "github.com/gogo/protobuf/protobuf" instead of "github.com/gogo/protobuf" (we add an
-#    extra "/protobuf" at the end).  I have no idea why.  I have no idea how the
-#    go-control-plane version works without the extra "/protobuf" at the end; it looks to
-#    me like they would need it too.  It makes no sense.
-#  - Mess with the paths under "istio.io/gogo-genproto", since in 929161c and ee07f27 they
-#    moved the .proto files all around.  The reason this affects us and not
-#    go-control-plane is that our newer Envoy needs googleapis'
-#    "google/api/expr/v1alpha1/", which was added in 32e3935 (.pb.go files) and ee07f27
-#    (.proto files).
-imports += $(CURDIR)/api
-imports += $(call gomoddir,github.com/envoyproxy/protoc-gen-validate)
-imports += $(call gomoddir,github.com/gogo/protobuf)/protobuf
-imports += $(call gomoddir,istio.io/gogo-genproto)/common-protos
-imports += $(call gomoddir,istio.io/gogo-genproto)/common-protos/github.com/prometheus/client_model
-imports += $(call gomoddir,istio.io/gogo-genproto)/common-protos/github.com/census-instrumentation/opencensus-proto/src
-
-# Map from .proto files to Go package names
-# This list is based on 'mappings=()' in https://github.com/envoyproxy/go-control-plane/blob/0e75602d5e36e96eafbe053999c0569edec9fe07/build/generate_protos.sh
-# (since that commit most closely corresponds to our ENVOY_COMMIT).
-#
-# However, we make the following edits:
-#  - Add an entry for "google/api/expr/v1alpha1/syntax.proto", which didn't exist yet in
-#    the version that go-control-plane uses (see the comment around "imports" above).
-mappings += gogoproto/gogo.proto=github.com/gogo/protobuf/gogoproto
-mappings += google/api/annotations.proto=istio.io/gogo-genproto/googleapis/google/api
-mappings += google/api/expr/v1alpha1/syntax.proto=istio.io/gogo-genproto/googleapis/google/api/expr/v1alpha1
-mappings += google/api/http.proto=istio.io/gogo-genproto/googleapis/google/api
-mappings += google/protobuf/any.proto=github.com/gogo/protobuf/types
-mappings += google/protobuf/duration.proto=github.com/gogo/protobuf/types
-mappings += google/protobuf/empty.proto=github.com/gogo/protobuf/types
-mappings += google/protobuf/struct.proto=github.com/gogo/protobuf/types
-mappings += google/protobuf/timestamp.proto=github.com/gogo/protobuf/types
-mappings += google/protobuf/wrappers.proto=github.com/gogo/protobuf/types
-mappings += google/rpc/code.proto=istio.io/gogo-genproto/googleapis/google/rpc
-mappings += google/rpc/error_details.proto=istio.io/gogo-genproto/googleapis/google/rpc
-mappings += google/rpc/status.proto=istio.io/gogo-genproto/googleapis/google/rpc
-mappings += metrics.proto=istio.io/gogo-genproto/prometheus
-mappings += opencensus/proto/trace/v1/trace.proto=istio.io/gogo-genproto/opencensus/proto/trace/v1
-mappings += opencensus/proto/trace/v1/trace_config.proto=istio.io/gogo-genproto/opencensus/proto/trace/v1
-mappings += validate/validate.proto=github.com/envoyproxy/protoc-gen-validate/validate
-mappings += $(shell find $(CURDIR)/api/envoy -type f -name '*.proto' | sed -E 's,^$(CURDIR)/api/((.*)/[^/]*),\1=github.com/datawire/ambassador/pkg/api/\2,')
-
-joinlist=$(if $(word 2,$2),$(firstword $2)$1$(call joinlist,$1,$(wordlist 2,$(words $2),$2)),$2)
-comma = ,
-
-_imports = $(call lazyonce,_imports,$(imports))
-_mappings = $(call lazyonce,_mappings,$(mappings))
-pkg/api/envoy: api/envoy $(FLOCK) venv/bin/protoc venv/bin/protoc-gen-gogofast venv/bin/protoc-gen-validate $(var.)_imports $(var.)_mappings
-	rm -rf $@ $(@D).envoy.tmp
-	mkdir -p $(@D).envoy.tmp
-# go-control-plane `make generate`
-	@set -e; find $(CURDIR)/api/envoy -type f -name '*.proto' | sed 's,/[^/]*$$,,' | uniq | while read -r dir; do \
-		echo "Generating $$dir"; \
-		./venv/bin/protoc \
-			$(addprefix --proto_path=,$(_imports))  \
-			--plugin=$(CURDIR)/venv/bin/protoc-gen-gogofast --gogofast_out='$(call joinlist,$(comma),plugins=grpc $(addprefix M,$(_mappings))):$(@D).envoy.tmp' \
-			--plugin=$(CURDIR)/venv/bin/protoc-gen-validate --validate_out='lang=gogo:$(@D).envoy.tmp' \
-			"$$dir"/*.proto; \
-	done
-# go-control-plane `make generate-patch`
-# https://github.com/envoyproxy/go-control-plane/issues/173
-	find $(@D).envoy.tmp -name '*.validate.go' -exec sed -E -i.bak 's,"(envoy/.*)"$$,"github.com/datawire/ambassador/pkg/api/\1",' {} +
-	find $(@D).envoy.tmp -name '*.bak' -delete
-# move things in to place
-	mkdir -p $(@D)
-	mv $(@D).envoy.tmp/envoy $@
-	rmdir $(@D).envoy.tmp
 
 # ------------------------------------------------------------------------------
 # gRPC bindings for KAT

--- a/api/envoy/api/v2/cds.proto
+++ b/api/envoy/api/v2/cds.proto
@@ -238,8 +238,8 @@ message Cluster {
 
   reserved 12;
 
-  // Additional options when handling HTTP requests. These options will be applicable to both
-  // HTTP1 and HTTP2 requests.
+  // Additional options when handling HTTP requests upstream. These options will be applicable to
+  // both HTTP1 and HTTP2 requests.
   core.HttpProtocolOptions common_http_protocol_options = 29;
 
   // Additional options when handling HTTP1 requests.

--- a/api/envoy/api/v2/core/protocol.proto
+++ b/api/envoy/api/v2/core/protocol.proto
@@ -20,11 +20,19 @@ message TcpProtocolOptions {
 }
 
 message HttpProtocolOptions {
-  // The idle timeout for upstream connection pool connections. The idle timeout is defined as the
+  // The idle timeout for connections. The idle timeout is defined as the
   // period in which there are no active requests. If not set, there is no idle timeout. When the
-  // idle timeout is reached the connection will be closed. Note that request based timeouts mean
-  // that HTTP/2 PINGs will not keep the connection alive.
+  // idle timeout is reached the connection will be closed. If the connection is an HTTP/2
+  // downstream connection a drain sequence will occur prior to closing the connection, see
+  // :ref:`drain_timeout
+  // <envoy_api_field_config.filter.network.http_connection_manager.v2.HttpConnectionManager.drain_timeout>`.
+  // Note that request based timeouts mean that HTTP/2 PINGs will not keep the connection alive.
   google.protobuf.Duration idle_timeout = 1;
+
+  // The maximum number of headers. If unconfigured, the default
+  // maximum number of request headers allowed is 100. Requests that exceed this limit will receive
+  // a 431 response for HTTP/1.x and cause a stream reset for HTTP/2.
+  google.protobuf.UInt32Value max_headers_count = 2 [(validate.rules).uint32 = {gte: 1}];
 }
 
 message Http1ProtocolOptions {

--- a/api/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto
+++ b/api/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto
@@ -23,7 +23,7 @@ import "validate/validate.proto";
 // [#protodoc-title: HTTP connection manager]
 // HTTP connection manager :ref:`configuration overview <config_http_conn_man>`.
 
-// [#comment:next free field: 35]
+// [#comment:next free field: 36]
 message HttpConnectionManager {
   enum CodecType {
 
@@ -139,6 +139,10 @@ message HttpConnectionManager {
   // <envoy_api_msg_config.trace.v2.Tracing>`.
   Tracing tracing = 7;
 
+  // Additional settings for HTTP requests handled by the connection manager. These will be
+  // applicable to both HTTP1 and HTTP2 requests.
+  envoy.api.v2.core.HttpProtocolOptions common_http_protocol_options = 35;
+
   // Additional HTTP/1 settings that are passed to the HTTP/1 codec.
   envoy.api.v2.core.Http1ProtocolOptions http_protocol_options = 8;
 
@@ -178,10 +182,11 @@ message HttpConnectionManager {
   // idle timeout is defined as the period in which there are no active
   // requests. If not set, there is no idle timeout. When the idle timeout is
   // reached the connection will be closed. If the connection is an HTTP/2
-  // connection a drain sequence will occur prior to closing the connection. See
-  // :ref:`drain_timeout
-  // <envoy_api_field_config.filter.network.http_connection_manager.v2.HttpConnectionManager.drain_timeout>`.
-  google.protobuf.Duration idle_timeout = 11;
+  // connection a drain sequence will occur prior to closing the connection.
+  // This field is deprecated. Use :ref:`idle_timeout
+  // <envoy_api_field_config.filter.network.http_connection_manager.v2.HttpConnectionManager.common_http_protocol_options>`
+  // instead.
+  google.protobuf.Duration idle_timeout = 11 [deprecated = true];
 
   // The stream idle timeout for connections managed by the connection manager.
   // If not specified, this defaults to 5 minutes. The default value was selected

--- a/build-aux/prelude.mk
+++ b/build-aux/prelude.mk
@@ -16,6 +16,7 @@
 #  String support:
 #  - Variable: export NL
 #  - Variable:        SPACE
+#  - Variable:        COMMA
 #  - Function: str.eq
 #
 #  Unsigned integer support:

--- a/build-aux/prelude_str.mk
+++ b/build-aux/prelude_str.mk
@@ -16,6 +16,8 @@ define SPACE
  
 endef
 
+COMMA = ,
+
 # Usage: $(call str.eq,STR1,STR2)
 # Evaluates to either $(TRUE) or $(FALSE)
 str.eq = $(if $(subst x$1,,x$2)$(subst x$2,,x$1),$(FALSE),$(TRUE))

--- a/cxx/.gitignore
+++ b/cxx/.gitignore
@@ -1,0 +1,3 @@
+/envoy/
+/envoy-build-image.txt
+/envoy-build-container.txt

--- a/cxx/envoy.mk
+++ b/cxx/envoy.mk
@@ -1,0 +1,276 @@
+srcdir := $(patsubst %/,%,$(dir $(lastword $(MAKEFILE_LIST))))
+topsrcdir := $(patsubst %/,%,$(dir $(firstword $(MAKEFILE_LIST))))
+
+YES_I_AM_OK_WITH_COMPILING_ENVOY ?=
+ENVOY_FILE ?= $(topsrcdir)/bin_linux_amd64/envoy-static-stripped
+
+# IF YOU MESS WITH ANY OF THESE VALUES, YOU MUST RUN `make docker-update-base`.
+  ENVOY_REPO ?= $(if $(IS_PRIVATE),git@github.com:datawire/envoy-private.git,git://github.com/datawire/envoy.git)
+  ENVOY_COMMIT ?= 6e6ae35f214b040f76666d86b30a6ad3ceb67046
+  ENVOY_COMPILATION_MODE ?= dbg
+
+  # Increment BASE_ENVOY_RELVER on changes to `Dockerfile.base-envoy`, or Envoy recipes
+  BASE_ENVOY_RELVER ?= 6
+
+  BASE_IMAGE.envoy ?= $(BASE_DOCKER_REPO):envoy-$(BASE_ENVOY_RELVER).$(ENVOY_COMMIT).$(ENVOY_COMPILATION_MODE)
+# END LIST OF VARIABLES REQUIRING `make docker-update-base`.
+
+#
+# Envoy build
+
+$(srcdir)/envoy: FORCE
+	@echo "Getting Envoy sources..."
+# Migrate from old layouts
+	@set -e; { \
+	    if ! test -d $@; then \
+	        if test -d $(topsrcdir)/envoy; then \
+	            set -x; \
+	            mv $(topsrcdir)/envoy $@; \
+	        elif test -d $(topsrcdir)/envoy-src; then \
+	            set -x; \
+	            mv $(topsrcdir)/envoy-src $@; \
+	        fi; \
+	    fi; \
+	}
+# Ensure that GIT_DIR and GIT_WORK_TREE are unset so that `git bisect`
+# and friends work properly.
+	@PS4=; set -ex; { \
+	    unset GIT_DIR GIT_WORK_TREE; \
+	    git init $@; \
+	    cd $@; \
+	    if git remote get-url origin &>/dev/null; then \
+	        git remote set-url origin $(ENVOY_REPO); \
+	    else \
+	        git remote add origin $(ENVOY_REPO); \
+	    fi; \
+	    if [[ $(ENVOY_REPO) == http://github.com/* || $(ENVOY_REPO) == https://github.com/* || $(ENVOY_REPO) == git://github.com/* ]]; then \
+	        git remote set-url --push origin git@github.com:$(word 3,$(subst /, ,$(ENVOY_REPO)))/$(patsubst %.git,%,$(word 4,$(subst /, ,$(ENVOY_REPO)))).git; \
+	    fi; \
+	    git fetch --tags origin; \
+	    if [ $(ENVOY_COMMIT) != '-' ]; then \
+	        git checkout $(ENVOY_COMMIT); \
+	    elif ! git rev-parse HEAD >/dev/null 2>&1; then \
+	        git checkout origin/master; \
+	    fi; \
+	}
+
+$(srcdir)/envoy-build-image.txt: $(srcdir)/envoy $(WRITE_IFCHANGED) FORCE
+	@PS4=; set -ex -o pipefail; { \
+	    pushd $</ci; \
+	    . envoy_build_sha.sh; \
+	    popd; \
+	    echo docker.io/envoyproxy/envoy-build-ubuntu:$$ENVOY_BUILD_SHA | $(WRITE_IFCHANGED) $@; \
+	}
+
+$(srcdir)/envoy-build-container.txt: $(srcdir)/envoy-build-image.txt FORCE
+	@PS4=; set -ex; { \
+	    if [ $@ -nt $< ] && docker exec $$(cat $@) true; then \
+	        exit 0; \
+	    fi; \
+	    if [ -e $@ ]; then \
+	        docker kill $$(cat $@) || true; \
+	    fi; \
+	    docker run --detach --rm --privileged --volume=envoy-build:/root:rw $$(cat $<) tail -f /dev/null > $@; \
+	}
+
+%-container.txt.clean:
+	@PS4=; set -ex; { \
+	    if [ -e $*-container.txt ]; then \
+	        docker kill $$(cat $*-container.txt) || true; \
+	    fi; \
+	}
+	rm -f $*-container.txt
+.PHONY: %-container.txt.clean
+
+# We do everything with rsync and a persistent build-container
+# (instead of using a volume), because
+#  1. Docker for Mac's osxfs is very slow, so volumes are bad for
+#     macOS users.
+#  2. Volumes mounts just straight-up don't work for people who use
+#     Minikube's dockerd.
+ENVOY_SYNC_HOST_TO_DOCKER = rsync -Pav --delete --blocking-io -e "docker exec -i" $(srcdir)/envoy/ $$(cat $(srcdir)/envoy-build-container.txt):/root/envoy
+ENVOY_SYNC_DOCKER_TO_HOST = rsync -Pav --delete --blocking-io -e "docker exec -i" $$(cat $(srcdir)/envoy-build-container.txt):/root/envoy/ $(srcdir)/envoy/
+
+ENVOY_BASH.cmd = bash -c 'PS4=; set -ex; $(ENVOY_SYNC_HOST_TO_DOCKER); trap '\''$(ENVOY_SYNC_DOCKER_TO_HOST)'\'' EXIT; '$(call quote.shell,$1)
+ENVOY_BASH.deps = $(srcdir)/envoy-build-container.txt
+
+$(topsrcdir)/bin_linux_amd64/envoy-static: $(ENVOY_BASH.deps) FORCE
+	mkdir -p $(@D)
+	@PS4=; set -ex; { \
+	    if docker run --rm --entrypoint=true $(BASE_IMAGE.envoy); then \
+	        rsync -Pav --blocking-io -e 'docker run --rm -i' $$(docker image inspect $(BASE_IMAGE.envoy) --format='{{.Id}}' | sed 's/^sha256://'):/usr/local/bin/envoy $@; \
+	    else \
+	        if [ -z '$(YES_I_AM_UPDATING_THE_BASE_IMAGES)' ]; then \
+	            { set +x; } &>/dev/null; \
+	            echo 'error: failed to pull $(BASE_IMAGE.envoy), but $$YES_I_AM_UPDATING_THE_BASE_IMAGES is not set'; \
+	            echo '       If you are trying to update the base images, then set that variable to a non-empty value.'; \
+	            echo '       If you are not trying to update the base images, then check your network connection and Docker credentials.'; \
+	            exit 1; \
+	        fi; \
+	        if [ -z '$(YES_I_AM_OK_WITH_COMPILING_ENVOY)' ]; then \
+	            { set +x; } &>/dev/null; \
+	            echo 'error: Envoy compilation triggered, but $$YES_I_AM_OK_WITH_COMPILING_ENVOY is not set'; \
+	            exit 1; \
+	        fi; \
+	        $(call ENVOY_BASH.cmd, \
+	            docker exec --workdir=/root/envoy $$(cat $(srcdir)/envoy-build-container.txt) bazel build --verbose_failures -c $(ENVOY_COMPILATION_MODE) //source/exe:envoy-static; \
+	            rsync -Pav --blocking-io -e 'docker exec -i' $$(cat $(srcdir)/envoy-build-container.txt):/root/envoy/bazel-bin/source/exe/envoy-static $@; \
+	        ); \
+	    fi; \
+	}
+%-stripped: % $(srcdir)/envoy-build-container.txt
+	@PS4=; set -ex; { \
+	    rsync -Pav --blocking-io -e 'docker exec -i' $< $$(cat $(srcdir)/envoy-build-container.txt):/tmp/$(<F); \
+	    docker exec $$(cat $(srcdir)/envoy-build-container.txt) strip /tmp/$(<F) -o /tmp/$(@F); \
+	    rsync -Pav --blocking-io -e 'docker exec -i' $$(cat $(srcdir)/envoy-build-container.txt):/tmp/$(@F) $@; \
+	}
+
+check-envoy: ## Run the Envoy test suite
+check-envoy: $(ENVOY_BASH.deps)
+	$(call ENVOY_BASH.cmd, \
+	    docker exec --workdir=/root/envoy $$(cat $(srcdir)/envoy-build-container.txt) bazel test --verbose_failures -c dbg --test_env=ENVOY_IP_TEST_VERSIONS=v4only //test/...; \
+	)
+.PHONY: check-envoy
+
+envoy-shell: ## Run a shell in the Envoy build container
+envoy-shell: $(ENVOY_BASH.deps)
+	$(call ENVOY_BASH.cmd, \
+	    docker exec -it $$(cat $(srcdir)/envoy-build-container.txt) || true; \
+	)
+.PHONY: envoy-shell
+
+base-envoy.docker: $(srcdir)/envoy-build-image.txt $(topsrcdir)/bin_linux_amd64/envoy-static
+base-envoy.docker.DOCKER_OPTS = --build-arg=ENVOY_BUILD_IMAGE=$$(cat $(srcdir)/envoy-build-image.txt)
+base-envoy.docker.DOCKER_DIR = $(topsrcdir)/bin_linux_amd64
+
+#
+# Envoy generate
+
+generate: pkg/api/envoy
+generate: api/envoy
+
+# The version numbers of `protoc` (in this Makefile),
+# `protoc-gen-gogofast` (in go.mod), and `protoc-gen-validate` (in
+# go.mod) are based on
+# https://github.com/envoyproxy/go-control-plane/blob/0e75602d5e36e96eafbe053999c0569edec9fe07/Dockerfile.ci
+# (since that commit most closely corresponds to our ENVOY_COMMIT).
+# Additionally, the package names of those programs are mentioned in
+# ./go/pin.go, so that `go mod tidy` won't make the go.mod file forget
+# about them.
+
+PROTOC_VERSION = 3.5.1
+PROTOC_PLATFORM = $(patsubst darwin,osx,$(GOOS))-$(patsubst amd64,x86_64,$(patsubst 386,x86_32,$(GOARCH)))
+
+venv/protoc-$(PROTOC_VERSION)-$(PROTOC_PLATFORM).zip: $(var.)PROTOC_VERSION | venv/bin/activate
+	curl -o $@ --fail -L https://github.com/protocolbuffers/protobuf/releases/download/v$(PROTOC_VERSION)/$(@F)
+venv/bin/protoc: venv/protoc-$(PROTOC_VERSION)-$(PROTOC_PLATFORM).zip
+	bsdtar -xf $< -C venv bin/protoc
+
+venv/bin/protoc-gen-gogofast: go.mod $(FLOCK) | venv/bin/activate
+	$(FLOCK) go.mod go build -o $@ github.com/gogo/protobuf/protoc-gen-gogofast
+
+venv/bin/protoc-gen-validate: go.mod $(FLOCK) | venv/bin/activate
+	$(FLOCK) go.mod go build -o $@ github.com/envoyproxy/protoc-gen-validate
+
+api/envoy: $(srcdir)/envoy
+	rsync --recursive --delete --delete-excluded --prune-empty-dirs --include='*/' --include='*.proto' --exclude='*' $</api/envoy/ $@
+
+# Search path for .proto files
+gomoddir = $(shell $(FLOCK) go.mod go list $1/... >/dev/null 2>/dev/null; $(FLOCK) go.mod go list -m -f='{{.Dir}}' $1)
+# This list is based on 'imports=()' in https://github.com/envoyproxy/go-control-plane/blob/0e75602d5e36e96eafbe053999c0569edec9fe07/build/generate_protos.sh
+# (since that commit most closely corresponds to our ENVOY_COMMIT).
+#
+# However, we make the following edits:
+#  - "github.com/gogo/protobuf/protobuf" instead of "github.com/gogo/protobuf" (we add an
+#    extra "/protobuf" at the end).  I have no idea why.  I have no idea how the
+#    go-control-plane version works without the extra "/protobuf" at the end; it looks to
+#    me like they would need it too.  It makes no sense.
+#  - Mess with the paths under "istio.io/gogo-genproto", since in 929161c and ee07f27 they
+#    moved the .proto files all around.  The reason this affects us and not
+#    go-control-plane is that our newer Envoy needs googleapis'
+#    "google/api/expr/v1alpha1/", which was added in 32e3935 (.pb.go files) and ee07f27
+#    (.proto files).
+imports += $(CURDIR)/api
+imports += $(call gomoddir,github.com/envoyproxy/protoc-gen-validate)
+imports += $(call gomoddir,github.com/gogo/protobuf)/protobuf
+imports += $(call gomoddir,istio.io/gogo-genproto)/common-protos
+imports += $(call gomoddir,istio.io/gogo-genproto)/common-protos/github.com/prometheus/client_model
+imports += $(call gomoddir,istio.io/gogo-genproto)/common-protos/github.com/census-instrumentation/opencensus-proto/src
+
+# Map from .proto files to Go package names
+# This list is based on 'mappings=()' in https://github.com/envoyproxy/go-control-plane/blob/0e75602d5e36e96eafbe053999c0569edec9fe07/build/generate_protos.sh
+# (since that commit most closely corresponds to our ENVOY_COMMIT).
+#
+# However, we make the following edits:
+#  - Add an entry for "google/api/expr/v1alpha1/syntax.proto", which didn't exist yet in
+#    the version that go-control-plane uses (see the comment around "imports" above).
+mappings += gogoproto/gogo.proto=github.com/gogo/protobuf/gogoproto
+mappings += google/api/annotations.proto=istio.io/gogo-genproto/googleapis/google/api
+mappings += google/api/expr/v1alpha1/syntax.proto=istio.io/gogo-genproto/googleapis/google/api/expr/v1alpha1
+mappings += google/api/http.proto=istio.io/gogo-genproto/googleapis/google/api
+mappings += google/protobuf/any.proto=github.com/gogo/protobuf/types
+mappings += google/protobuf/duration.proto=github.com/gogo/protobuf/types
+mappings += google/protobuf/empty.proto=github.com/gogo/protobuf/types
+mappings += google/protobuf/struct.proto=github.com/gogo/protobuf/types
+mappings += google/protobuf/timestamp.proto=github.com/gogo/protobuf/types
+mappings += google/protobuf/wrappers.proto=github.com/gogo/protobuf/types
+mappings += google/rpc/code.proto=istio.io/gogo-genproto/googleapis/google/rpc
+mappings += google/rpc/error_details.proto=istio.io/gogo-genproto/googleapis/google/rpc
+mappings += google/rpc/status.proto=istio.io/gogo-genproto/googleapis/google/rpc
+mappings += metrics.proto=istio.io/gogo-genproto/prometheus
+mappings += opencensus/proto/trace/v1/trace.proto=istio.io/gogo-genproto/opencensus/proto/trace/v1
+mappings += opencensus/proto/trace/v1/trace_config.proto=istio.io/gogo-genproto/opencensus/proto/trace/v1
+mappings += validate/validate.proto=github.com/envoyproxy/protoc-gen-validate/validate
+mappings += $(shell find $(CURDIR)/api/envoy -type f -name '*.proto' | sed -E 's,^$(CURDIR)/api/((.*)/[^/]*),\1=github.com/datawire/ambassador/pkg/api/\2,')
+
+_imports = $(call lazyonce,_imports,$(imports))
+_mappings = $(call lazyonce,_mappings,$(mappings))
+pkg/api/envoy: api/envoy $(FLOCK) venv/bin/protoc venv/bin/protoc-gen-gogofast venv/bin/protoc-gen-validate $(var.)_imports $(var.)_mappings
+	rm -rf $@ $(@D).envoy.tmp
+	mkdir -p $(@D).envoy.tmp
+# go-control-plane `make generate`
+	@set -e; find $(CURDIR)/api/envoy -type f -name '*.proto' | sed 's,/[^/]*$$,,' | uniq | while read -r dir; do \
+		echo "Generating $$dir"; \
+		./venv/bin/protoc \
+			$(addprefix --proto_path=,$(_imports))  \
+			--plugin=$(CURDIR)/venv/bin/protoc-gen-gogofast --gogofast_out='$(call joinlist,$(COMMA),plugins=grpc $(addprefix M,$(_mappings))):$(@D).envoy.tmp' \
+			--plugin=$(CURDIR)/venv/bin/protoc-gen-validate --validate_out='lang=gogo:$(@D).envoy.tmp' \
+			"$$dir"/*.proto; \
+	done
+# go-control-plane `make generate-patch`
+# https://github.com/envoyproxy/go-control-plane/issues/173
+	find $(@D).envoy.tmp -name '*.validate.go' -exec sed -E -i.bak 's,"(envoy/.*)"$$,"github.com/datawire/ambassador/pkg/api/\1",' {} +
+	find $(@D).envoy.tmp -name '*.bak' -delete
+# move things in to place
+	mkdir -p $(@D)
+	mv $(@D).envoy.tmp/envoy $@
+	rmdir $(@D).envoy.tmp
+
+#
+# Envoy clean
+
+clean: _clean-envoy
+clobber: _clobber-envoy
+
+_clean-envoy: _clean-envoy-old
+_clean-envoy: $(srcdir)/envoy-build-container.txt.clean
+	rm -f $(srcdir)/envoy-build-image.txt
+	rm -rf $(topsrcdir)/pkg/api.envoy.tmp/
+_clobber-envoy: _clean-envoy
+	$(if $(filter-out -,$(ENVOY_COMMIT)),rm -rf $(srcdir)/envoy)
+_generate-clean-envoy: _clobber-envoy
+	rm -rf $(topsrcdir)/api/envoy
+.PHONY: _clean-envoy _clobber-envoy _generate-clean-envoy
+
+# Files made by older versions.  Remove the tail of this list when the
+# commit making the change gets far enough in to the past.
+_clean-envoy-old:
+# 2019-10-11
+_clean-envoy-old: $(topsrcdir)/envoy-build-container.txt.clean
+# 2019-10-11
+	rm -rf $(topsrcdir)/envoy-bin
+	$(if $(filter-out -,$(ENVOY_COMMIT)),rm -rf $(topsrcdir)/envoy-src)
+	rm -f $(topsrcdir)/envoy-build-image.txt
+# older than that
+	$(if $(filter-out -,$(ENVOY_COMMIT)),rm -rf $(topsrcdir)/envoy)
+.PHONY: _clean-envoy-old

--- a/cxx/go.mod
+++ b/cxx/go.mod
@@ -1,0 +1,1 @@
+module ignore

--- a/go.sum
+++ b/go.sum
@@ -49,6 +49,7 @@ github.com/envoyproxy/go-control-plane v0.6.9 h1:deEH9W8ZAUGNbCdX+9iNzBOGrAOrnpJ
 github.com/envoyproxy/go-control-plane v0.6.9/go.mod h1:SBwIajubJHhxtWwsL9s8ss4safvEdbitLhGGK48rN6g=
 github.com/envoyproxy/protoc-gen-validate v0.0.15-0.20190405222122-d6164de49109 h1:U1RyeEwqO++6RvIA7bY98AcYIFPQMwrOeWNmw+dvq9w=
 github.com/envoyproxy/protoc-gen-validate v0.0.15-0.20190405222122-d6164de49109/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
+github.com/envoyproxy/protoc-gen-validate v0.1.0 h1:EQciDnbrYxy13PgWoY8AqoxGiPrpgBZ1R8UNe3ddc+A=
 github.com/evanphx/json-patch v4.2.0+incompatible h1:fUDGZCv/7iAN7u0puUVhvKCcsR6vRfwrJatElLBEf0I=
 github.com/evanphx/json-patch v4.2.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=

--- a/pkg/api/envoy/admin/v2alpha/certs.pb.go
+++ b/pkg/api/envoy/admin/v2alpha/certs.pb.go
@@ -21,7 +21,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // Proto representation of certificate details. Admin endpoint uses this wrapper for `/certs` to
 // display certificate information. See :ref:`/certs <operations_admin_interface_certs>` for more
@@ -306,70 +306,12 @@ func (m *SubjectAlternateName) GetUri() string {
 	return ""
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*SubjectAlternateName) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _SubjectAlternateName_OneofMarshaler, _SubjectAlternateName_OneofUnmarshaler, _SubjectAlternateName_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*SubjectAlternateName) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*SubjectAlternateName_Dns)(nil),
 		(*SubjectAlternateName_Uri)(nil),
 	}
-}
-
-func _SubjectAlternateName_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*SubjectAlternateName)
-	// name
-	switch x := m.Name.(type) {
-	case *SubjectAlternateName_Dns:
-		_ = b.EncodeVarint(1<<3 | proto.WireBytes)
-		_ = b.EncodeStringBytes(x.Dns)
-	case *SubjectAlternateName_Uri:
-		_ = b.EncodeVarint(2<<3 | proto.WireBytes)
-		_ = b.EncodeStringBytes(x.Uri)
-	case nil:
-	default:
-		return fmt.Errorf("SubjectAlternateName.Name has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _SubjectAlternateName_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*SubjectAlternateName)
-	switch tag {
-	case 1: // name.dns
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeStringBytes()
-		m.Name = &SubjectAlternateName_Dns{x}
-		return true, err
-	case 2: // name.uri
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeStringBytes()
-		m.Name = &SubjectAlternateName_Uri{x}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _SubjectAlternateName_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*SubjectAlternateName)
-	// name
-	switch x := m.Name.(type) {
-	case *SubjectAlternateName_Dns:
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(len(x.Dns)))
-		n += len(x.Dns)
-	case *SubjectAlternateName_Uri:
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(len(x.Uri)))
-		n += len(x.Uri)
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 func init() {

--- a/pkg/api/envoy/admin/v2alpha/clusters.pb.go
+++ b/pkg/api/envoy/admin/v2alpha/clusters.pb.go
@@ -22,7 +22,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // Admin endpoint uses this wrapper for `/clusters` to display cluster status information.
 // See :ref:`/clusters <operations_admin_interface_clusters>` for more information.

--- a/pkg/api/envoy/admin/v2alpha/config_dump.pb.go
+++ b/pkg/api/envoy/admin/v2alpha/config_dump.pb.go
@@ -24,7 +24,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // The :ref:`/config_dump <operations_admin_interface_config_dump>` admin endpoint uses this wrapper
 // message to maintain and serve arbitrary configuration information from any component in Envoy.

--- a/pkg/api/envoy/admin/v2alpha/listeners.pb.go
+++ b/pkg/api/envoy/admin/v2alpha/listeners.pb.go
@@ -21,7 +21,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // Admin endpoint uses this wrapper for `/listeners` to display listener status information.
 // See :ref:`/listeners <operations_admin_interface_listeners>` for more information.

--- a/pkg/api/envoy/admin/v2alpha/memory.pb.go
+++ b/pkg/api/envoy/admin/v2alpha/memory.pb.go
@@ -20,7 +20,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // Proto representation of the internal memory consumption of an Envoy instance. These represent
 // values extracted from an internal TCMalloc instance. For more information, see the section of the

--- a/pkg/api/envoy/admin/v2alpha/metrics.pb.go
+++ b/pkg/api/envoy/admin/v2alpha/metrics.pb.go
@@ -20,7 +20,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 type SimpleMetric_Type int32
 

--- a/pkg/api/envoy/admin/v2alpha/mutex_stats.pb.go
+++ b/pkg/api/envoy/admin/v2alpha/mutex_stats.pb.go
@@ -20,7 +20,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // Proto representation of the statistics collected upon absl::Mutex contention, if Envoy is run
 // under :option:`--enable-mutex-tracing`. For more information, see the `absl::Mutex`

--- a/pkg/api/envoy/admin/v2alpha/server_info.pb.go
+++ b/pkg/api/envoy/admin/v2alpha/server_info.pb.go
@@ -21,7 +21,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 type ServerInfo_State int32
 

--- a/pkg/api/envoy/admin/v2alpha/tap.pb.go
+++ b/pkg/api/envoy/admin/v2alpha/tap.pb.go
@@ -22,7 +22,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // The /tap admin request body that is used to configure an active tap session.
 type TapRequest struct {

--- a/pkg/api/envoy/admin/v3alpha/certs.pb.go
+++ b/pkg/api/envoy/admin/v3alpha/certs.pb.go
@@ -21,7 +21,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // Proto representation of certificate details. Admin endpoint uses this wrapper for `/certs` to
 // display certificate information. See :ref:`/certs <operations_admin_interface_certs>` for more
@@ -306,70 +306,12 @@ func (m *SubjectAlternateName) GetUri() string {
 	return ""
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*SubjectAlternateName) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _SubjectAlternateName_OneofMarshaler, _SubjectAlternateName_OneofUnmarshaler, _SubjectAlternateName_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*SubjectAlternateName) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*SubjectAlternateName_Dns)(nil),
 		(*SubjectAlternateName_Uri)(nil),
 	}
-}
-
-func _SubjectAlternateName_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*SubjectAlternateName)
-	// name
-	switch x := m.Name.(type) {
-	case *SubjectAlternateName_Dns:
-		_ = b.EncodeVarint(1<<3 | proto.WireBytes)
-		_ = b.EncodeStringBytes(x.Dns)
-	case *SubjectAlternateName_Uri:
-		_ = b.EncodeVarint(2<<3 | proto.WireBytes)
-		_ = b.EncodeStringBytes(x.Uri)
-	case nil:
-	default:
-		return fmt.Errorf("SubjectAlternateName.Name has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _SubjectAlternateName_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*SubjectAlternateName)
-	switch tag {
-	case 1: // name.dns
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeStringBytes()
-		m.Name = &SubjectAlternateName_Dns{x}
-		return true, err
-	case 2: // name.uri
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeStringBytes()
-		m.Name = &SubjectAlternateName_Uri{x}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _SubjectAlternateName_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*SubjectAlternateName)
-	// name
-	switch x := m.Name.(type) {
-	case *SubjectAlternateName_Dns:
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(len(x.Dns)))
-		n += len(x.Dns)
-	case *SubjectAlternateName_Uri:
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(len(x.Uri)))
-		n += len(x.Uri)
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 func init() {

--- a/pkg/api/envoy/admin/v3alpha/clusters.pb.go
+++ b/pkg/api/envoy/admin/v3alpha/clusters.pb.go
@@ -22,7 +22,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // Admin endpoint uses this wrapper for `/clusters` to display cluster status information.
 // See :ref:`/clusters <operations_admin_interface_clusters>` for more information.

--- a/pkg/api/envoy/admin/v3alpha/config_dump.pb.go
+++ b/pkg/api/envoy/admin/v3alpha/config_dump.pb.go
@@ -24,7 +24,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // The :ref:`/config_dump <operations_admin_interface_config_dump>` admin endpoint uses this wrapper
 // message to maintain and serve arbitrary configuration information from any component in Envoy.

--- a/pkg/api/envoy/admin/v3alpha/listeners.pb.go
+++ b/pkg/api/envoy/admin/v3alpha/listeners.pb.go
@@ -21,7 +21,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // Admin endpoint uses this wrapper for `/listeners` to display listener status information.
 // See :ref:`/listeners <operations_admin_interface_listeners>` for more information.

--- a/pkg/api/envoy/admin/v3alpha/memory.pb.go
+++ b/pkg/api/envoy/admin/v3alpha/memory.pb.go
@@ -20,7 +20,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // Proto representation of the internal memory consumption of an Envoy instance. These represent
 // values extracted from an internal TCMalloc instance. For more information, see the section of the

--- a/pkg/api/envoy/admin/v3alpha/metrics.pb.go
+++ b/pkg/api/envoy/admin/v3alpha/metrics.pb.go
@@ -20,7 +20,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 type SimpleMetric_Type int32
 

--- a/pkg/api/envoy/admin/v3alpha/mutex_stats.pb.go
+++ b/pkg/api/envoy/admin/v3alpha/mutex_stats.pb.go
@@ -20,7 +20,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // Proto representation of the statistics collected upon absl::Mutex contention, if Envoy is run
 // under :option:`--enable-mutex-tracing`. For more information, see the `absl::Mutex`

--- a/pkg/api/envoy/admin/v3alpha/server_info.pb.go
+++ b/pkg/api/envoy/admin/v3alpha/server_info.pb.go
@@ -21,7 +21,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 type ServerInfo_State int32
 

--- a/pkg/api/envoy/admin/v3alpha/tap.pb.go
+++ b/pkg/api/envoy/admin/v3alpha/tap.pb.go
@@ -22,7 +22,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // The /tap admin request body that is used to configure an active tap session.
 type TapRequest struct {

--- a/pkg/api/envoy/api/v2/auth/cert.pb.go
+++ b/pkg/api/envoy/api/v2/auth/cert.pb.go
@@ -23,7 +23,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 type TlsParameters_TlsProtocol int32
 
@@ -286,78 +286,12 @@ func (m *PrivateKeyProvider) GetTypedConfig() *types.Any {
 	return nil
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*PrivateKeyProvider) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _PrivateKeyProvider_OneofMarshaler, _PrivateKeyProvider_OneofUnmarshaler, _PrivateKeyProvider_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*PrivateKeyProvider) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*PrivateKeyProvider_Config)(nil),
 		(*PrivateKeyProvider_TypedConfig)(nil),
 	}
-}
-
-func _PrivateKeyProvider_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*PrivateKeyProvider)
-	// config_type
-	switch x := m.ConfigType.(type) {
-	case *PrivateKeyProvider_Config:
-		_ = b.EncodeVarint(2<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.Config); err != nil {
-			return err
-		}
-	case *PrivateKeyProvider_TypedConfig:
-		_ = b.EncodeVarint(3<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.TypedConfig); err != nil {
-			return err
-		}
-	case nil:
-	default:
-		return fmt.Errorf("PrivateKeyProvider.ConfigType has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _PrivateKeyProvider_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*PrivateKeyProvider)
-	switch tag {
-	case 2: // config_type.config
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(types.Struct)
-		err := b.DecodeMessage(msg)
-		m.ConfigType = &PrivateKeyProvider_Config{msg}
-		return true, err
-	case 3: // config_type.typed_config
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(types.Any)
-		err := b.DecodeMessage(msg)
-		m.ConfigType = &PrivateKeyProvider_TypedConfig{msg}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _PrivateKeyProvider_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*PrivateKeyProvider)
-	// config_type
-	switch x := m.ConfigType.(type) {
-	case *PrivateKeyProvider_Config:
-		s := proto.Size(x.Config)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *PrivateKeyProvider_TypedConfig:
-		s := proto.Size(x.TypedConfig)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 type TlsCertificate struct {
@@ -867,97 +801,13 @@ func (m *CommonTlsContext) GetAlpnProtocols() []string {
 	return nil
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*CommonTlsContext) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _CommonTlsContext_OneofMarshaler, _CommonTlsContext_OneofUnmarshaler, _CommonTlsContext_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*CommonTlsContext) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*CommonTlsContext_ValidationContext)(nil),
 		(*CommonTlsContext_ValidationContextSdsSecretConfig)(nil),
 		(*CommonTlsContext_CombinedValidationContext)(nil),
 	}
-}
-
-func _CommonTlsContext_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*CommonTlsContext)
-	// validation_context_type
-	switch x := m.ValidationContextType.(type) {
-	case *CommonTlsContext_ValidationContext:
-		_ = b.EncodeVarint(3<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.ValidationContext); err != nil {
-			return err
-		}
-	case *CommonTlsContext_ValidationContextSdsSecretConfig:
-		_ = b.EncodeVarint(7<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.ValidationContextSdsSecretConfig); err != nil {
-			return err
-		}
-	case *CommonTlsContext_CombinedValidationContext:
-		_ = b.EncodeVarint(8<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.CombinedValidationContext); err != nil {
-			return err
-		}
-	case nil:
-	default:
-		return fmt.Errorf("CommonTlsContext.ValidationContextType has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _CommonTlsContext_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*CommonTlsContext)
-	switch tag {
-	case 3: // validation_context_type.validation_context
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(CertificateValidationContext)
-		err := b.DecodeMessage(msg)
-		m.ValidationContextType = &CommonTlsContext_ValidationContext{msg}
-		return true, err
-	case 7: // validation_context_type.validation_context_sds_secret_config
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(SdsSecretConfig)
-		err := b.DecodeMessage(msg)
-		m.ValidationContextType = &CommonTlsContext_ValidationContextSdsSecretConfig{msg}
-		return true, err
-	case 8: // validation_context_type.combined_validation_context
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(CommonTlsContext_CombinedCertificateValidationContext)
-		err := b.DecodeMessage(msg)
-		m.ValidationContextType = &CommonTlsContext_CombinedValidationContext{msg}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _CommonTlsContext_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*CommonTlsContext)
-	// validation_context_type
-	switch x := m.ValidationContextType.(type) {
-	case *CommonTlsContext_ValidationContext:
-		s := proto.Size(x.ValidationContext)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *CommonTlsContext_ValidationContextSdsSecretConfig:
-		s := proto.Size(x.ValidationContextSdsSecretConfig)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *CommonTlsContext_CombinedValidationContext:
-		s := proto.Size(x.CombinedValidationContext)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 type CommonTlsContext_CombinedCertificateValidationContext struct {
@@ -1213,78 +1063,12 @@ func (m *DownstreamTlsContext) GetSessionTicketKeysSdsSecretConfig() *SdsSecretC
 	return nil
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*DownstreamTlsContext) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _DownstreamTlsContext_OneofMarshaler, _DownstreamTlsContext_OneofUnmarshaler, _DownstreamTlsContext_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*DownstreamTlsContext) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*DownstreamTlsContext_SessionTicketKeys)(nil),
 		(*DownstreamTlsContext_SessionTicketKeysSdsSecretConfig)(nil),
 	}
-}
-
-func _DownstreamTlsContext_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*DownstreamTlsContext)
-	// session_ticket_keys_type
-	switch x := m.SessionTicketKeysType.(type) {
-	case *DownstreamTlsContext_SessionTicketKeys:
-		_ = b.EncodeVarint(4<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.SessionTicketKeys); err != nil {
-			return err
-		}
-	case *DownstreamTlsContext_SessionTicketKeysSdsSecretConfig:
-		_ = b.EncodeVarint(5<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.SessionTicketKeysSdsSecretConfig); err != nil {
-			return err
-		}
-	case nil:
-	default:
-		return fmt.Errorf("DownstreamTlsContext.SessionTicketKeysType has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _DownstreamTlsContext_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*DownstreamTlsContext)
-	switch tag {
-	case 4: // session_ticket_keys_type.session_ticket_keys
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(TlsSessionTicketKeys)
-		err := b.DecodeMessage(msg)
-		m.SessionTicketKeysType = &DownstreamTlsContext_SessionTicketKeys{msg}
-		return true, err
-	case 5: // session_ticket_keys_type.session_ticket_keys_sds_secret_config
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(SdsSecretConfig)
-		err := b.DecodeMessage(msg)
-		m.SessionTicketKeysType = &DownstreamTlsContext_SessionTicketKeysSdsSecretConfig{msg}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _DownstreamTlsContext_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*DownstreamTlsContext)
-	// session_ticket_keys_type
-	switch x := m.SessionTicketKeysType.(type) {
-	case *DownstreamTlsContext_SessionTicketKeys:
-		s := proto.Size(x.SessionTicketKeys)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *DownstreamTlsContext_SessionTicketKeysSdsSecretConfig:
-		s := proto.Size(x.SessionTicketKeysSdsSecretConfig)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 // [#proto-status: experimental]
@@ -1448,97 +1232,13 @@ func (m *Secret) GetValidationContext() *CertificateValidationContext {
 	return nil
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*Secret) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _Secret_OneofMarshaler, _Secret_OneofUnmarshaler, _Secret_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*Secret) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*Secret_TlsCertificate)(nil),
 		(*Secret_SessionTicketKeys)(nil),
 		(*Secret_ValidationContext)(nil),
 	}
-}
-
-func _Secret_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*Secret)
-	// type
-	switch x := m.Type.(type) {
-	case *Secret_TlsCertificate:
-		_ = b.EncodeVarint(2<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.TlsCertificate); err != nil {
-			return err
-		}
-	case *Secret_SessionTicketKeys:
-		_ = b.EncodeVarint(3<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.SessionTicketKeys); err != nil {
-			return err
-		}
-	case *Secret_ValidationContext:
-		_ = b.EncodeVarint(4<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.ValidationContext); err != nil {
-			return err
-		}
-	case nil:
-	default:
-		return fmt.Errorf("Secret.Type has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _Secret_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*Secret)
-	switch tag {
-	case 2: // type.tls_certificate
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(TlsCertificate)
-		err := b.DecodeMessage(msg)
-		m.Type = &Secret_TlsCertificate{msg}
-		return true, err
-	case 3: // type.session_ticket_keys
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(TlsSessionTicketKeys)
-		err := b.DecodeMessage(msg)
-		m.Type = &Secret_SessionTicketKeys{msg}
-		return true, err
-	case 4: // type.validation_context
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(CertificateValidationContext)
-		err := b.DecodeMessage(msg)
-		m.Type = &Secret_ValidationContext{msg}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _Secret_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*Secret)
-	// type
-	switch x := m.Type.(type) {
-	case *Secret_TlsCertificate:
-		s := proto.Size(x.TlsCertificate)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *Secret_SessionTicketKeys:
-		s := proto.Size(x.SessionTicketKeys)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *Secret_ValidationContext:
-		s := proto.Size(x.ValidationContext)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 func init() {

--- a/pkg/api/envoy/api/v2/cds.pb.go
+++ b/pkg/api/envoy/api/v2/cds.pb.go
@@ -31,7 +31,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // Refer to :ref:`service discovery type <arch_overview_service_discovery_types>`
 // for an explanation on each type.
@@ -889,142 +889,15 @@ func (m *Cluster) GetLoadBalancingPolicy() *LoadBalancingPolicy {
 	return nil
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*Cluster) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _Cluster_OneofMarshaler, _Cluster_OneofUnmarshaler, _Cluster_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*Cluster) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*Cluster_Type)(nil),
 		(*Cluster_ClusterType)(nil),
 		(*Cluster_RingHashLbConfig_)(nil),
 		(*Cluster_OriginalDstLbConfig_)(nil),
 		(*Cluster_LeastRequestLbConfig_)(nil),
 	}
-}
-
-func _Cluster_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*Cluster)
-	// cluster_discovery_type
-	switch x := m.ClusterDiscoveryType.(type) {
-	case *Cluster_Type:
-		_ = b.EncodeVarint(2<<3 | proto.WireVarint)
-		_ = b.EncodeVarint(uint64(x.Type))
-	case *Cluster_ClusterType:
-		_ = b.EncodeVarint(38<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.ClusterType); err != nil {
-			return err
-		}
-	case nil:
-	default:
-		return fmt.Errorf("Cluster.ClusterDiscoveryType has unexpected type %T", x)
-	}
-	// lb_config
-	switch x := m.LbConfig.(type) {
-	case *Cluster_RingHashLbConfig_:
-		_ = b.EncodeVarint(23<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.RingHashLbConfig); err != nil {
-			return err
-		}
-	case *Cluster_OriginalDstLbConfig_:
-		_ = b.EncodeVarint(34<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.OriginalDstLbConfig); err != nil {
-			return err
-		}
-	case *Cluster_LeastRequestLbConfig_:
-		_ = b.EncodeVarint(37<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.LeastRequestLbConfig); err != nil {
-			return err
-		}
-	case nil:
-	default:
-		return fmt.Errorf("Cluster.LbConfig has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _Cluster_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*Cluster)
-	switch tag {
-	case 2: // cluster_discovery_type.type
-		if wire != proto.WireVarint {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeVarint()
-		m.ClusterDiscoveryType = &Cluster_Type{Cluster_DiscoveryType(x)}
-		return true, err
-	case 38: // cluster_discovery_type.cluster_type
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(Cluster_CustomClusterType)
-		err := b.DecodeMessage(msg)
-		m.ClusterDiscoveryType = &Cluster_ClusterType{msg}
-		return true, err
-	case 23: // lb_config.ring_hash_lb_config
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(Cluster_RingHashLbConfig)
-		err := b.DecodeMessage(msg)
-		m.LbConfig = &Cluster_RingHashLbConfig_{msg}
-		return true, err
-	case 34: // lb_config.original_dst_lb_config
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(Cluster_OriginalDstLbConfig)
-		err := b.DecodeMessage(msg)
-		m.LbConfig = &Cluster_OriginalDstLbConfig_{msg}
-		return true, err
-	case 37: // lb_config.least_request_lb_config
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(Cluster_LeastRequestLbConfig)
-		err := b.DecodeMessage(msg)
-		m.LbConfig = &Cluster_LeastRequestLbConfig_{msg}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _Cluster_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*Cluster)
-	// cluster_discovery_type
-	switch x := m.ClusterDiscoveryType.(type) {
-	case *Cluster_Type:
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(x.Type))
-	case *Cluster_ClusterType:
-		s := proto.Size(x.ClusterType)
-		n += 2 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	// lb_config
-	switch x := m.LbConfig.(type) {
-	case *Cluster_RingHashLbConfig_:
-		s := proto.Size(x.RingHashLbConfig)
-		n += 2 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *Cluster_OriginalDstLbConfig_:
-		s := proto.Size(x.OriginalDstLbConfig)
-		n += 2 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *Cluster_LeastRequestLbConfig_:
-		s := proto.Size(x.LeastRequestLbConfig)
-		n += 2 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 // Extended cluster type.
@@ -1690,78 +1563,12 @@ func (m *Cluster_CommonLbConfig) GetCloseConnectionsOnHostSetChange() bool {
 	return false
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*Cluster_CommonLbConfig) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _Cluster_CommonLbConfig_OneofMarshaler, _Cluster_CommonLbConfig_OneofUnmarshaler, _Cluster_CommonLbConfig_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*Cluster_CommonLbConfig) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*Cluster_CommonLbConfig_ZoneAwareLbConfig_)(nil),
 		(*Cluster_CommonLbConfig_LocalityWeightedLbConfig_)(nil),
 	}
-}
-
-func _Cluster_CommonLbConfig_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*Cluster_CommonLbConfig)
-	// locality_config_specifier
-	switch x := m.LocalityConfigSpecifier.(type) {
-	case *Cluster_CommonLbConfig_ZoneAwareLbConfig_:
-		_ = b.EncodeVarint(2<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.ZoneAwareLbConfig); err != nil {
-			return err
-		}
-	case *Cluster_CommonLbConfig_LocalityWeightedLbConfig_:
-		_ = b.EncodeVarint(3<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.LocalityWeightedLbConfig); err != nil {
-			return err
-		}
-	case nil:
-	default:
-		return fmt.Errorf("Cluster_CommonLbConfig.LocalityConfigSpecifier has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _Cluster_CommonLbConfig_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*Cluster_CommonLbConfig)
-	switch tag {
-	case 2: // locality_config_specifier.zone_aware_lb_config
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(Cluster_CommonLbConfig_ZoneAwareLbConfig)
-		err := b.DecodeMessage(msg)
-		m.LocalityConfigSpecifier = &Cluster_CommonLbConfig_ZoneAwareLbConfig_{msg}
-		return true, err
-	case 3: // locality_config_specifier.locality_weighted_lb_config
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(Cluster_CommonLbConfig_LocalityWeightedLbConfig)
-		err := b.DecodeMessage(msg)
-		m.LocalityConfigSpecifier = &Cluster_CommonLbConfig_LocalityWeightedLbConfig_{msg}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _Cluster_CommonLbConfig_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*Cluster_CommonLbConfig)
-	// locality_config_specifier
-	switch x := m.LocalityConfigSpecifier.(type) {
-	case *Cluster_CommonLbConfig_ZoneAwareLbConfig_:
-		s := proto.Size(x.ZoneAwareLbConfig)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *Cluster_CommonLbConfig_LocalityWeightedLbConfig_:
-		s := proto.Size(x.LocalityWeightedLbConfig)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 // Configuration for :ref:`zone aware routing

--- a/pkg/api/envoy/api/v2/cluster/circuit_breaker.pb.go
+++ b/pkg/api/envoy/api/v2/cluster/circuit_breaker.pb.go
@@ -22,7 +22,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // :ref:`Circuit breaking<arch_overview_circuit_break>` settings can be
 // specified individually for each defined priority.

--- a/pkg/api/envoy/api/v2/cluster/filter.pb.go
+++ b/pkg/api/envoy/api/v2/cluster/filter.pb.go
@@ -22,7 +22,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // [#protodoc-title: Upstream filters]
 //

--- a/pkg/api/envoy/api/v2/cluster/outlier_detection.pb.go
+++ b/pkg/api/envoy/api/v2/cluster/outlier_detection.pb.go
@@ -22,7 +22,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // See the :ref:`architecture overview <arch_overview_outlier_detection>` for
 // more information on outlier detection.

--- a/pkg/api/envoy/api/v2/core/address.pb.go
+++ b/pkg/api/envoy/api/v2/core/address.pb.go
@@ -22,7 +22,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 type SocketAddress_Protocol int32
 
@@ -233,69 +233,12 @@ func (m *SocketAddress) GetIpv4Compat() bool {
 	return false
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*SocketAddress) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _SocketAddress_OneofMarshaler, _SocketAddress_OneofUnmarshaler, _SocketAddress_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*SocketAddress) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*SocketAddress_PortValue)(nil),
 		(*SocketAddress_NamedPort)(nil),
 	}
-}
-
-func _SocketAddress_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*SocketAddress)
-	// port_specifier
-	switch x := m.PortSpecifier.(type) {
-	case *SocketAddress_PortValue:
-		_ = b.EncodeVarint(3<<3 | proto.WireVarint)
-		_ = b.EncodeVarint(uint64(x.PortValue))
-	case *SocketAddress_NamedPort:
-		_ = b.EncodeVarint(4<<3 | proto.WireBytes)
-		_ = b.EncodeStringBytes(x.NamedPort)
-	case nil:
-	default:
-		return fmt.Errorf("SocketAddress.PortSpecifier has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _SocketAddress_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*SocketAddress)
-	switch tag {
-	case 3: // port_specifier.port_value
-		if wire != proto.WireVarint {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeVarint()
-		m.PortSpecifier = &SocketAddress_PortValue{uint32(x)}
-		return true, err
-	case 4: // port_specifier.named_port
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeStringBytes()
-		m.PortSpecifier = &SocketAddress_NamedPort{x}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _SocketAddress_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*SocketAddress)
-	// port_specifier
-	switch x := m.PortSpecifier.(type) {
-	case *SocketAddress_PortValue:
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(x.PortValue))
-	case *SocketAddress_NamedPort:
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(len(x.NamedPort)))
-		n += len(x.NamedPort)
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 type TcpKeepalive struct {
@@ -525,78 +468,12 @@ func (m *Address) GetPipe() *Pipe {
 	return nil
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*Address) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _Address_OneofMarshaler, _Address_OneofUnmarshaler, _Address_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*Address) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*Address_SocketAddress)(nil),
 		(*Address_Pipe)(nil),
 	}
-}
-
-func _Address_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*Address)
-	// address
-	switch x := m.Address.(type) {
-	case *Address_SocketAddress:
-		_ = b.EncodeVarint(1<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.SocketAddress); err != nil {
-			return err
-		}
-	case *Address_Pipe:
-		_ = b.EncodeVarint(2<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.Pipe); err != nil {
-			return err
-		}
-	case nil:
-	default:
-		return fmt.Errorf("Address.Address has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _Address_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*Address)
-	switch tag {
-	case 1: // address.socket_address
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(SocketAddress)
-		err := b.DecodeMessage(msg)
-		m.Address = &Address_SocketAddress{msg}
-		return true, err
-	case 2: // address.pipe
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(Pipe)
-		err := b.DecodeMessage(msg)
-		m.Address = &Address_Pipe{msg}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _Address_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*Address)
-	// address
-	switch x := m.Address.(type) {
-	case *Address_SocketAddress:
-		s := proto.Size(x.SocketAddress)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *Address_Pipe:
-		s := proto.Size(x.Pipe)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 // CidrRange specifies an IP Address and a prefix length to construct

--- a/pkg/api/envoy/api/v2/core/base.pb.go
+++ b/pkg/api/envoy/api/v2/core/base.pb.go
@@ -23,7 +23,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // Envoy supports :ref:`upstream priority routing
 // <arch_overview_http_routing_priority>` both at the route and the virtual
@@ -741,85 +741,13 @@ func (m *DataSource) GetInlineString() string {
 	return ""
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*DataSource) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _DataSource_OneofMarshaler, _DataSource_OneofUnmarshaler, _DataSource_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*DataSource) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*DataSource_Filename)(nil),
 		(*DataSource_InlineBytes)(nil),
 		(*DataSource_InlineString)(nil),
 	}
-}
-
-func _DataSource_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*DataSource)
-	// specifier
-	switch x := m.Specifier.(type) {
-	case *DataSource_Filename:
-		_ = b.EncodeVarint(1<<3 | proto.WireBytes)
-		_ = b.EncodeStringBytes(x.Filename)
-	case *DataSource_InlineBytes:
-		_ = b.EncodeVarint(2<<3 | proto.WireBytes)
-		_ = b.EncodeRawBytes(x.InlineBytes)
-	case *DataSource_InlineString:
-		_ = b.EncodeVarint(3<<3 | proto.WireBytes)
-		_ = b.EncodeStringBytes(x.InlineString)
-	case nil:
-	default:
-		return fmt.Errorf("DataSource.Specifier has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _DataSource_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*DataSource)
-	switch tag {
-	case 1: // specifier.filename
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeStringBytes()
-		m.Specifier = &DataSource_Filename{x}
-		return true, err
-	case 2: // specifier.inline_bytes
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeRawBytes(true)
-		m.Specifier = &DataSource_InlineBytes{x}
-		return true, err
-	case 3: // specifier.inline_string
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeStringBytes()
-		m.Specifier = &DataSource_InlineString{x}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _DataSource_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*DataSource)
-	// specifier
-	switch x := m.Specifier.(type) {
-	case *DataSource_Filename:
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(len(x.Filename)))
-		n += len(x.Filename)
-	case *DataSource_InlineBytes:
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(len(x.InlineBytes)))
-		n += len(x.InlineBytes)
-	case *DataSource_InlineString:
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(len(x.InlineString)))
-		n += len(x.InlineString)
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 // The message specifies how to fetch data from remote and how to verify it.
@@ -961,78 +889,12 @@ func (m *AsyncDataSource) GetRemote() *RemoteDataSource {
 	return nil
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*AsyncDataSource) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _AsyncDataSource_OneofMarshaler, _AsyncDataSource_OneofUnmarshaler, _AsyncDataSource_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*AsyncDataSource) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*AsyncDataSource_Local)(nil),
 		(*AsyncDataSource_Remote)(nil),
 	}
-}
-
-func _AsyncDataSource_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*AsyncDataSource)
-	// specifier
-	switch x := m.Specifier.(type) {
-	case *AsyncDataSource_Local:
-		_ = b.EncodeVarint(1<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.Local); err != nil {
-			return err
-		}
-	case *AsyncDataSource_Remote:
-		_ = b.EncodeVarint(2<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.Remote); err != nil {
-			return err
-		}
-	case nil:
-	default:
-		return fmt.Errorf("AsyncDataSource.Specifier has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _AsyncDataSource_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*AsyncDataSource)
-	switch tag {
-	case 1: // specifier.local
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(DataSource)
-		err := b.DecodeMessage(msg)
-		m.Specifier = &AsyncDataSource_Local{msg}
-		return true, err
-	case 2: // specifier.remote
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(RemoteDataSource)
-		err := b.DecodeMessage(msg)
-		m.Specifier = &AsyncDataSource_Remote{msg}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _AsyncDataSource_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*AsyncDataSource)
-	// specifier
-	switch x := m.Specifier.(type) {
-	case *AsyncDataSource_Local:
-		s := proto.Size(x.Local)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *AsyncDataSource_Remote:
-		s := proto.Size(x.Remote)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 // Configuration for transport socket in :ref:`listeners <config_listeners>` and
@@ -1132,78 +994,12 @@ func (m *TransportSocket) GetTypedConfig() *types.Any {
 	return nil
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*TransportSocket) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _TransportSocket_OneofMarshaler, _TransportSocket_OneofUnmarshaler, _TransportSocket_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*TransportSocket) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*TransportSocket_Config)(nil),
 		(*TransportSocket_TypedConfig)(nil),
 	}
-}
-
-func _TransportSocket_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*TransportSocket)
-	// config_type
-	switch x := m.ConfigType.(type) {
-	case *TransportSocket_Config:
-		_ = b.EncodeVarint(2<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.Config); err != nil {
-			return err
-		}
-	case *TransportSocket_TypedConfig:
-		_ = b.EncodeVarint(3<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.TypedConfig); err != nil {
-			return err
-		}
-	case nil:
-	default:
-		return fmt.Errorf("TransportSocket.ConfigType has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _TransportSocket_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*TransportSocket)
-	switch tag {
-	case 2: // config_type.config
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(types.Struct)
-		err := b.DecodeMessage(msg)
-		m.ConfigType = &TransportSocket_Config{msg}
-		return true, err
-	case 3: // config_type.typed_config
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(types.Any)
-		err := b.DecodeMessage(msg)
-		m.ConfigType = &TransportSocket_TypedConfig{msg}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _TransportSocket_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*TransportSocket)
-	// config_type
-	switch x := m.ConfigType.(type) {
-	case *TransportSocket_Config:
-		s := proto.Size(x.Config)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *TransportSocket_TypedConfig:
-		s := proto.Size(x.TypedConfig)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 // Generic socket option message. This would be used to set socket options that
@@ -1326,69 +1122,12 @@ func (m *SocketOption) GetState() SocketOption_SocketState {
 	return SocketOption_STATE_PREBIND
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*SocketOption) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _SocketOption_OneofMarshaler, _SocketOption_OneofUnmarshaler, _SocketOption_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*SocketOption) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*SocketOption_IntValue)(nil),
 		(*SocketOption_BufValue)(nil),
 	}
-}
-
-func _SocketOption_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*SocketOption)
-	// value
-	switch x := m.Value.(type) {
-	case *SocketOption_IntValue:
-		_ = b.EncodeVarint(4<<3 | proto.WireVarint)
-		_ = b.EncodeVarint(uint64(x.IntValue))
-	case *SocketOption_BufValue:
-		_ = b.EncodeVarint(5<<3 | proto.WireBytes)
-		_ = b.EncodeRawBytes(x.BufValue)
-	case nil:
-	default:
-		return fmt.Errorf("SocketOption.Value has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _SocketOption_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*SocketOption)
-	switch tag {
-	case 4: // value.int_value
-		if wire != proto.WireVarint {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeVarint()
-		m.Value = &SocketOption_IntValue{int64(x)}
-		return true, err
-	case 5: // value.buf_value
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeRawBytes(true)
-		m.Value = &SocketOption_BufValue{x}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _SocketOption_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*SocketOption)
-	// value
-	switch x := m.Value.(type) {
-	case *SocketOption_IntValue:
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(x.IntValue))
-	case *SocketOption_BufValue:
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(len(x.BufValue)))
-		n += len(x.BufValue)
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 // Runtime derived FractionalPercent with defaults for when the numerator or denominator is not

--- a/pkg/api/envoy/api/v2/core/config_source.pb.go
+++ b/pkg/api/envoy/api/v2/core/config_source.pb.go
@@ -22,7 +22,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // APIs may be fetched via either REST or gRPC.
 type ApiConfigSource_ApiType int32
@@ -395,93 +395,13 @@ func (m *ConfigSource) GetInitialFetchTimeout() *types.Duration {
 	return nil
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*ConfigSource) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _ConfigSource_OneofMarshaler, _ConfigSource_OneofUnmarshaler, _ConfigSource_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*ConfigSource) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*ConfigSource_Path)(nil),
 		(*ConfigSource_ApiConfigSource)(nil),
 		(*ConfigSource_Ads)(nil),
 	}
-}
-
-func _ConfigSource_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*ConfigSource)
-	// config_source_specifier
-	switch x := m.ConfigSourceSpecifier.(type) {
-	case *ConfigSource_Path:
-		_ = b.EncodeVarint(1<<3 | proto.WireBytes)
-		_ = b.EncodeStringBytes(x.Path)
-	case *ConfigSource_ApiConfigSource:
-		_ = b.EncodeVarint(2<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.ApiConfigSource); err != nil {
-			return err
-		}
-	case *ConfigSource_Ads:
-		_ = b.EncodeVarint(3<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.Ads); err != nil {
-			return err
-		}
-	case nil:
-	default:
-		return fmt.Errorf("ConfigSource.ConfigSourceSpecifier has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _ConfigSource_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*ConfigSource)
-	switch tag {
-	case 1: // config_source_specifier.path
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeStringBytes()
-		m.ConfigSourceSpecifier = &ConfigSource_Path{x}
-		return true, err
-	case 2: // config_source_specifier.api_config_source
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(ApiConfigSource)
-		err := b.DecodeMessage(msg)
-		m.ConfigSourceSpecifier = &ConfigSource_ApiConfigSource{msg}
-		return true, err
-	case 3: // config_source_specifier.ads
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(AggregatedConfigSource)
-		err := b.DecodeMessage(msg)
-		m.ConfigSourceSpecifier = &ConfigSource_Ads{msg}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _ConfigSource_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*ConfigSource)
-	// config_source_specifier
-	switch x := m.ConfigSourceSpecifier.(type) {
-	case *ConfigSource_Path:
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(len(x.Path)))
-		n += len(x.Path)
-	case *ConfigSource_ApiConfigSource:
-		s := proto.Size(x.ApiConfigSource)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *ConfigSource_Ads:
-		s := proto.Size(x.Ads)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 func init() {

--- a/pkg/api/envoy/api/v2/core/grpc_service.pb.go
+++ b/pkg/api/envoy/api/v2/core/grpc_service.pb.go
@@ -22,7 +22,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // gRPC service configuration. This is used by :ref:`ApiConfigSource
 // <envoy_api_msg_core.ApiConfigSource>` and filter configurations.
@@ -127,78 +127,12 @@ func (m *GrpcService) GetInitialMetadata() []*HeaderValue {
 	return nil
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*GrpcService) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _GrpcService_OneofMarshaler, _GrpcService_OneofUnmarshaler, _GrpcService_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*GrpcService) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*GrpcService_EnvoyGrpc_)(nil),
 		(*GrpcService_GoogleGrpc_)(nil),
 	}
-}
-
-func _GrpcService_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*GrpcService)
-	// target_specifier
-	switch x := m.TargetSpecifier.(type) {
-	case *GrpcService_EnvoyGrpc_:
-		_ = b.EncodeVarint(1<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.EnvoyGrpc); err != nil {
-			return err
-		}
-	case *GrpcService_GoogleGrpc_:
-		_ = b.EncodeVarint(2<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.GoogleGrpc); err != nil {
-			return err
-		}
-	case nil:
-	default:
-		return fmt.Errorf("GrpcService.TargetSpecifier has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _GrpcService_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*GrpcService)
-	switch tag {
-	case 1: // target_specifier.envoy_grpc
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(GrpcService_EnvoyGrpc)
-		err := b.DecodeMessage(msg)
-		m.TargetSpecifier = &GrpcService_EnvoyGrpc_{msg}
-		return true, err
-	case 2: // target_specifier.google_grpc
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(GrpcService_GoogleGrpc)
-		err := b.DecodeMessage(msg)
-		m.TargetSpecifier = &GrpcService_GoogleGrpc_{msg}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _GrpcService_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*GrpcService)
-	// target_specifier
-	switch x := m.TargetSpecifier.(type) {
-	case *GrpcService_EnvoyGrpc_:
-		s := proto.Size(x.EnvoyGrpc)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *GrpcService_GoogleGrpc_:
-		s := proto.Size(x.GoogleGrpc)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 type GrpcService_EnvoyGrpc struct {
@@ -569,97 +503,13 @@ func (m *GrpcService_GoogleGrpc_ChannelCredentials) GetLocalCredentials() *GrpcS
 	return nil
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*GrpcService_GoogleGrpc_ChannelCredentials) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _GrpcService_GoogleGrpc_ChannelCredentials_OneofMarshaler, _GrpcService_GoogleGrpc_ChannelCredentials_OneofUnmarshaler, _GrpcService_GoogleGrpc_ChannelCredentials_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*GrpcService_GoogleGrpc_ChannelCredentials) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*GrpcService_GoogleGrpc_ChannelCredentials_SslCredentials)(nil),
 		(*GrpcService_GoogleGrpc_ChannelCredentials_GoogleDefault)(nil),
 		(*GrpcService_GoogleGrpc_ChannelCredentials_LocalCredentials)(nil),
 	}
-}
-
-func _GrpcService_GoogleGrpc_ChannelCredentials_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*GrpcService_GoogleGrpc_ChannelCredentials)
-	// credential_specifier
-	switch x := m.CredentialSpecifier.(type) {
-	case *GrpcService_GoogleGrpc_ChannelCredentials_SslCredentials:
-		_ = b.EncodeVarint(1<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.SslCredentials); err != nil {
-			return err
-		}
-	case *GrpcService_GoogleGrpc_ChannelCredentials_GoogleDefault:
-		_ = b.EncodeVarint(2<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.GoogleDefault); err != nil {
-			return err
-		}
-	case *GrpcService_GoogleGrpc_ChannelCredentials_LocalCredentials:
-		_ = b.EncodeVarint(3<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.LocalCredentials); err != nil {
-			return err
-		}
-	case nil:
-	default:
-		return fmt.Errorf("GrpcService_GoogleGrpc_ChannelCredentials.CredentialSpecifier has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _GrpcService_GoogleGrpc_ChannelCredentials_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*GrpcService_GoogleGrpc_ChannelCredentials)
-	switch tag {
-	case 1: // credential_specifier.ssl_credentials
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(GrpcService_GoogleGrpc_SslCredentials)
-		err := b.DecodeMessage(msg)
-		m.CredentialSpecifier = &GrpcService_GoogleGrpc_ChannelCredentials_SslCredentials{msg}
-		return true, err
-	case 2: // credential_specifier.google_default
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(types.Empty)
-		err := b.DecodeMessage(msg)
-		m.CredentialSpecifier = &GrpcService_GoogleGrpc_ChannelCredentials_GoogleDefault{msg}
-		return true, err
-	case 3: // credential_specifier.local_credentials
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(GrpcService_GoogleGrpc_GoogleLocalCredentials)
-		err := b.DecodeMessage(msg)
-		m.CredentialSpecifier = &GrpcService_GoogleGrpc_ChannelCredentials_LocalCredentials{msg}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _GrpcService_GoogleGrpc_ChannelCredentials_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*GrpcService_GoogleGrpc_ChannelCredentials)
-	// credential_specifier
-	switch x := m.CredentialSpecifier.(type) {
-	case *GrpcService_GoogleGrpc_ChannelCredentials_SslCredentials:
-		s := proto.Size(x.SslCredentials)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *GrpcService_GoogleGrpc_ChannelCredentials_GoogleDefault:
-		s := proto.Size(x.GoogleDefault)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *GrpcService_GoogleGrpc_ChannelCredentials_LocalCredentials:
-		s := proto.Size(x.LocalCredentials)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 type GrpcService_GoogleGrpc_CallCredentials struct {
@@ -798,9 +648,9 @@ func (m *GrpcService_GoogleGrpc_CallCredentials) GetFromPlugin() *GrpcService_Go
 	return nil
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*GrpcService_GoogleGrpc_CallCredentials) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _GrpcService_GoogleGrpc_CallCredentials_OneofMarshaler, _GrpcService_GoogleGrpc_CallCredentials_OneofUnmarshaler, _GrpcService_GoogleGrpc_CallCredentials_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*GrpcService_GoogleGrpc_CallCredentials) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*GrpcService_GoogleGrpc_CallCredentials_AccessToken)(nil),
 		(*GrpcService_GoogleGrpc_CallCredentials_GoogleComputeEngine)(nil),
 		(*GrpcService_GoogleGrpc_CallCredentials_GoogleRefreshToken)(nil),
@@ -808,136 +658,6 @@ func (*GrpcService_GoogleGrpc_CallCredentials) XXX_OneofFuncs() (func(msg proto.
 		(*GrpcService_GoogleGrpc_CallCredentials_GoogleIam)(nil),
 		(*GrpcService_GoogleGrpc_CallCredentials_FromPlugin)(nil),
 	}
-}
-
-func _GrpcService_GoogleGrpc_CallCredentials_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*GrpcService_GoogleGrpc_CallCredentials)
-	// credential_specifier
-	switch x := m.CredentialSpecifier.(type) {
-	case *GrpcService_GoogleGrpc_CallCredentials_AccessToken:
-		_ = b.EncodeVarint(1<<3 | proto.WireBytes)
-		_ = b.EncodeStringBytes(x.AccessToken)
-	case *GrpcService_GoogleGrpc_CallCredentials_GoogleComputeEngine:
-		_ = b.EncodeVarint(2<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.GoogleComputeEngine); err != nil {
-			return err
-		}
-	case *GrpcService_GoogleGrpc_CallCredentials_GoogleRefreshToken:
-		_ = b.EncodeVarint(3<<3 | proto.WireBytes)
-		_ = b.EncodeStringBytes(x.GoogleRefreshToken)
-	case *GrpcService_GoogleGrpc_CallCredentials_ServiceAccountJwtAccess:
-		_ = b.EncodeVarint(4<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.ServiceAccountJwtAccess); err != nil {
-			return err
-		}
-	case *GrpcService_GoogleGrpc_CallCredentials_GoogleIam:
-		_ = b.EncodeVarint(5<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.GoogleIam); err != nil {
-			return err
-		}
-	case *GrpcService_GoogleGrpc_CallCredentials_FromPlugin:
-		_ = b.EncodeVarint(6<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.FromPlugin); err != nil {
-			return err
-		}
-	case nil:
-	default:
-		return fmt.Errorf("GrpcService_GoogleGrpc_CallCredentials.CredentialSpecifier has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _GrpcService_GoogleGrpc_CallCredentials_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*GrpcService_GoogleGrpc_CallCredentials)
-	switch tag {
-	case 1: // credential_specifier.access_token
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeStringBytes()
-		m.CredentialSpecifier = &GrpcService_GoogleGrpc_CallCredentials_AccessToken{x}
-		return true, err
-	case 2: // credential_specifier.google_compute_engine
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(types.Empty)
-		err := b.DecodeMessage(msg)
-		m.CredentialSpecifier = &GrpcService_GoogleGrpc_CallCredentials_GoogleComputeEngine{msg}
-		return true, err
-	case 3: // credential_specifier.google_refresh_token
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeStringBytes()
-		m.CredentialSpecifier = &GrpcService_GoogleGrpc_CallCredentials_GoogleRefreshToken{x}
-		return true, err
-	case 4: // credential_specifier.service_account_jwt_access
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(GrpcService_GoogleGrpc_CallCredentials_ServiceAccountJWTAccessCredentials)
-		err := b.DecodeMessage(msg)
-		m.CredentialSpecifier = &GrpcService_GoogleGrpc_CallCredentials_ServiceAccountJwtAccess{msg}
-		return true, err
-	case 5: // credential_specifier.google_iam
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(GrpcService_GoogleGrpc_CallCredentials_GoogleIAMCredentials)
-		err := b.DecodeMessage(msg)
-		m.CredentialSpecifier = &GrpcService_GoogleGrpc_CallCredentials_GoogleIam{msg}
-		return true, err
-	case 6: // credential_specifier.from_plugin
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(GrpcService_GoogleGrpc_CallCredentials_MetadataCredentialsFromPlugin)
-		err := b.DecodeMessage(msg)
-		m.CredentialSpecifier = &GrpcService_GoogleGrpc_CallCredentials_FromPlugin{msg}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _GrpcService_GoogleGrpc_CallCredentials_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*GrpcService_GoogleGrpc_CallCredentials)
-	// credential_specifier
-	switch x := m.CredentialSpecifier.(type) {
-	case *GrpcService_GoogleGrpc_CallCredentials_AccessToken:
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(len(x.AccessToken)))
-		n += len(x.AccessToken)
-	case *GrpcService_GoogleGrpc_CallCredentials_GoogleComputeEngine:
-		s := proto.Size(x.GoogleComputeEngine)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *GrpcService_GoogleGrpc_CallCredentials_GoogleRefreshToken:
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(len(x.GoogleRefreshToken)))
-		n += len(x.GoogleRefreshToken)
-	case *GrpcService_GoogleGrpc_CallCredentials_ServiceAccountJwtAccess:
-		s := proto.Size(x.ServiceAccountJwtAccess)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *GrpcService_GoogleGrpc_CallCredentials_GoogleIam:
-		s := proto.Size(x.GoogleIam)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *GrpcService_GoogleGrpc_CallCredentials_FromPlugin:
-		s := proto.Size(x.FromPlugin)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 type GrpcService_GoogleGrpc_CallCredentials_ServiceAccountJWTAccessCredentials struct {
@@ -1152,78 +872,12 @@ func (m *GrpcService_GoogleGrpc_CallCredentials_MetadataCredentialsFromPlugin) G
 	return nil
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*GrpcService_GoogleGrpc_CallCredentials_MetadataCredentialsFromPlugin) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _GrpcService_GoogleGrpc_CallCredentials_MetadataCredentialsFromPlugin_OneofMarshaler, _GrpcService_GoogleGrpc_CallCredentials_MetadataCredentialsFromPlugin_OneofUnmarshaler, _GrpcService_GoogleGrpc_CallCredentials_MetadataCredentialsFromPlugin_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*GrpcService_GoogleGrpc_CallCredentials_MetadataCredentialsFromPlugin) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*GrpcService_GoogleGrpc_CallCredentials_MetadataCredentialsFromPlugin_Config)(nil),
 		(*GrpcService_GoogleGrpc_CallCredentials_MetadataCredentialsFromPlugin_TypedConfig)(nil),
 	}
-}
-
-func _GrpcService_GoogleGrpc_CallCredentials_MetadataCredentialsFromPlugin_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*GrpcService_GoogleGrpc_CallCredentials_MetadataCredentialsFromPlugin)
-	// config_type
-	switch x := m.ConfigType.(type) {
-	case *GrpcService_GoogleGrpc_CallCredentials_MetadataCredentialsFromPlugin_Config:
-		_ = b.EncodeVarint(2<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.Config); err != nil {
-			return err
-		}
-	case *GrpcService_GoogleGrpc_CallCredentials_MetadataCredentialsFromPlugin_TypedConfig:
-		_ = b.EncodeVarint(3<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.TypedConfig); err != nil {
-			return err
-		}
-	case nil:
-	default:
-		return fmt.Errorf("GrpcService_GoogleGrpc_CallCredentials_MetadataCredentialsFromPlugin.ConfigType has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _GrpcService_GoogleGrpc_CallCredentials_MetadataCredentialsFromPlugin_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*GrpcService_GoogleGrpc_CallCredentials_MetadataCredentialsFromPlugin)
-	switch tag {
-	case 2: // config_type.config
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(types.Struct)
-		err := b.DecodeMessage(msg)
-		m.ConfigType = &GrpcService_GoogleGrpc_CallCredentials_MetadataCredentialsFromPlugin_Config{msg}
-		return true, err
-	case 3: // config_type.typed_config
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(types.Any)
-		err := b.DecodeMessage(msg)
-		m.ConfigType = &GrpcService_GoogleGrpc_CallCredentials_MetadataCredentialsFromPlugin_TypedConfig{msg}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _GrpcService_GoogleGrpc_CallCredentials_MetadataCredentialsFromPlugin_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*GrpcService_GoogleGrpc_CallCredentials_MetadataCredentialsFromPlugin)
-	// config_type
-	switch x := m.ConfigType.(type) {
-	case *GrpcService_GoogleGrpc_CallCredentials_MetadataCredentialsFromPlugin_Config:
-		s := proto.Size(x.Config)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *GrpcService_GoogleGrpc_CallCredentials_MetadataCredentialsFromPlugin_TypedConfig:
-		s := proto.Size(x.TypedConfig)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 func init() {

--- a/pkg/api/envoy/api/v2/core/health_check.pb.go
+++ b/pkg/api/envoy/api/v2/core/health_check.pb.go
@@ -23,7 +23,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // Endpoint health status.
 type HealthStatus int32
@@ -349,116 +349,14 @@ func (m *HealthCheck) GetAlwaysLogHealthCheckFailures() bool {
 	return false
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*HealthCheck) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _HealthCheck_OneofMarshaler, _HealthCheck_OneofUnmarshaler, _HealthCheck_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*HealthCheck) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*HealthCheck_HttpHealthCheck_)(nil),
 		(*HealthCheck_TcpHealthCheck_)(nil),
 		(*HealthCheck_GrpcHealthCheck_)(nil),
 		(*HealthCheck_CustomHealthCheck_)(nil),
 	}
-}
-
-func _HealthCheck_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*HealthCheck)
-	// health_checker
-	switch x := m.HealthChecker.(type) {
-	case *HealthCheck_HttpHealthCheck_:
-		_ = b.EncodeVarint(8<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.HttpHealthCheck); err != nil {
-			return err
-		}
-	case *HealthCheck_TcpHealthCheck_:
-		_ = b.EncodeVarint(9<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.TcpHealthCheck); err != nil {
-			return err
-		}
-	case *HealthCheck_GrpcHealthCheck_:
-		_ = b.EncodeVarint(11<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.GrpcHealthCheck); err != nil {
-			return err
-		}
-	case *HealthCheck_CustomHealthCheck_:
-		_ = b.EncodeVarint(13<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.CustomHealthCheck); err != nil {
-			return err
-		}
-	case nil:
-	default:
-		return fmt.Errorf("HealthCheck.HealthChecker has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _HealthCheck_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*HealthCheck)
-	switch tag {
-	case 8: // health_checker.http_health_check
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(HealthCheck_HttpHealthCheck)
-		err := b.DecodeMessage(msg)
-		m.HealthChecker = &HealthCheck_HttpHealthCheck_{msg}
-		return true, err
-	case 9: // health_checker.tcp_health_check
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(HealthCheck_TcpHealthCheck)
-		err := b.DecodeMessage(msg)
-		m.HealthChecker = &HealthCheck_TcpHealthCheck_{msg}
-		return true, err
-	case 11: // health_checker.grpc_health_check
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(HealthCheck_GrpcHealthCheck)
-		err := b.DecodeMessage(msg)
-		m.HealthChecker = &HealthCheck_GrpcHealthCheck_{msg}
-		return true, err
-	case 13: // health_checker.custom_health_check
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(HealthCheck_CustomHealthCheck)
-		err := b.DecodeMessage(msg)
-		m.HealthChecker = &HealthCheck_CustomHealthCheck_{msg}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _HealthCheck_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*HealthCheck)
-	// health_checker
-	switch x := m.HealthChecker.(type) {
-	case *HealthCheck_HttpHealthCheck_:
-		s := proto.Size(x.HttpHealthCheck)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *HealthCheck_TcpHealthCheck_:
-		s := proto.Size(x.TcpHealthCheck)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *HealthCheck_GrpcHealthCheck_:
-		s := proto.Size(x.GrpcHealthCheck)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *HealthCheck_CustomHealthCheck_:
-		s := proto.Size(x.CustomHealthCheck)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 // Describes the encoding of the payload bytes in the payload.
@@ -542,70 +440,12 @@ func (m *HealthCheck_Payload) GetBinary() []byte {
 	return nil
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*HealthCheck_Payload) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _HealthCheck_Payload_OneofMarshaler, _HealthCheck_Payload_OneofUnmarshaler, _HealthCheck_Payload_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*HealthCheck_Payload) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*HealthCheck_Payload_Text)(nil),
 		(*HealthCheck_Payload_Binary)(nil),
 	}
-}
-
-func _HealthCheck_Payload_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*HealthCheck_Payload)
-	// payload
-	switch x := m.Payload.(type) {
-	case *HealthCheck_Payload_Text:
-		_ = b.EncodeVarint(1<<3 | proto.WireBytes)
-		_ = b.EncodeStringBytes(x.Text)
-	case *HealthCheck_Payload_Binary:
-		_ = b.EncodeVarint(2<<3 | proto.WireBytes)
-		_ = b.EncodeRawBytes(x.Binary)
-	case nil:
-	default:
-		return fmt.Errorf("HealthCheck_Payload.Payload has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _HealthCheck_Payload_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*HealthCheck_Payload)
-	switch tag {
-	case 1: // payload.text
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeStringBytes()
-		m.Payload = &HealthCheck_Payload_Text{x}
-		return true, err
-	case 2: // payload.binary
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeRawBytes(true)
-		m.Payload = &HealthCheck_Payload_Binary{x}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _HealthCheck_Payload_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*HealthCheck_Payload)
-	// payload
-	switch x := m.Payload.(type) {
-	case *HealthCheck_Payload_Text:
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(len(x.Text)))
-		n += len(x.Text)
-	case *HealthCheck_Payload_Binary:
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(len(x.Binary)))
-		n += len(x.Binary)
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 // [#comment:next free field: 10]
@@ -1010,78 +850,12 @@ func (m *HealthCheck_CustomHealthCheck) GetTypedConfig() *types.Any {
 	return nil
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*HealthCheck_CustomHealthCheck) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _HealthCheck_CustomHealthCheck_OneofMarshaler, _HealthCheck_CustomHealthCheck_OneofUnmarshaler, _HealthCheck_CustomHealthCheck_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*HealthCheck_CustomHealthCheck) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*HealthCheck_CustomHealthCheck_Config)(nil),
 		(*HealthCheck_CustomHealthCheck_TypedConfig)(nil),
 	}
-}
-
-func _HealthCheck_CustomHealthCheck_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*HealthCheck_CustomHealthCheck)
-	// config_type
-	switch x := m.ConfigType.(type) {
-	case *HealthCheck_CustomHealthCheck_Config:
-		_ = b.EncodeVarint(2<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.Config); err != nil {
-			return err
-		}
-	case *HealthCheck_CustomHealthCheck_TypedConfig:
-		_ = b.EncodeVarint(3<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.TypedConfig); err != nil {
-			return err
-		}
-	case nil:
-	default:
-		return fmt.Errorf("HealthCheck_CustomHealthCheck.ConfigType has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _HealthCheck_CustomHealthCheck_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*HealthCheck_CustomHealthCheck)
-	switch tag {
-	case 2: // config_type.config
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(types.Struct)
-		err := b.DecodeMessage(msg)
-		m.ConfigType = &HealthCheck_CustomHealthCheck_Config{msg}
-		return true, err
-	case 3: // config_type.typed_config
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(types.Any)
-		err := b.DecodeMessage(msg)
-		m.ConfigType = &HealthCheck_CustomHealthCheck_TypedConfig{msg}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _HealthCheck_CustomHealthCheck_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*HealthCheck_CustomHealthCheck)
-	// config_type
-	switch x := m.ConfigType.(type) {
-	case *HealthCheck_CustomHealthCheck_Config:
-		s := proto.Size(x.Config)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *HealthCheck_CustomHealthCheck_TypedConfig:
-		s := proto.Size(x.TypedConfig)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 func init() {

--- a/pkg/api/envoy/api/v2/core/http_uri.pb.go
+++ b/pkg/api/envoy/api/v2/core/http_uri.pb.go
@@ -22,7 +22,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // Envoy external URI descriptor
 type HttpUri struct {
@@ -123,55 +123,11 @@ func (m *HttpUri) GetTimeout() *types.Duration {
 	return nil
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*HttpUri) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _HttpUri_OneofMarshaler, _HttpUri_OneofUnmarshaler, _HttpUri_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*HttpUri) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*HttpUri_Cluster)(nil),
 	}
-}
-
-func _HttpUri_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*HttpUri)
-	// http_upstream_type
-	switch x := m.HttpUpstreamType.(type) {
-	case *HttpUri_Cluster:
-		_ = b.EncodeVarint(2<<3 | proto.WireBytes)
-		_ = b.EncodeStringBytes(x.Cluster)
-	case nil:
-	default:
-		return fmt.Errorf("HttpUri.HttpUpstreamType has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _HttpUri_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*HttpUri)
-	switch tag {
-	case 2: // http_upstream_type.cluster
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeStringBytes()
-		m.HttpUpstreamType = &HttpUri_Cluster{x}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _HttpUri_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*HttpUri)
-	// http_upstream_type
-	switch x := m.HttpUpstreamType.(type) {
-	case *HttpUri_Cluster:
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(len(x.Cluster)))
-		n += len(x.Cluster)
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 func init() {

--- a/pkg/api/envoy/api/v2/core/protocol.pb.go
+++ b/pkg/api/envoy/api/v2/core/protocol.pb.go
@@ -22,7 +22,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // [#not-implemented-hide:]
 type TcpProtocolOptions struct {

--- a/pkg/api/envoy/api/v2/discovery.pb.go
+++ b/pkg/api/envoy/api/v2/discovery.pb.go
@@ -23,7 +23,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // A DiscoveryRequest requests a set of versioned resources of the same type for
 // a given Envoy node on some API.

--- a/pkg/api/envoy/api/v2/eds.pb.go
+++ b/pkg/api/envoy/api/v2/eds.pb.go
@@ -29,7 +29,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // Each route from RDS will map to a single cluster or traffic split across
 // clusters using weights expressed in the RDS WeightedCluster.

--- a/pkg/api/envoy/api/v2/endpoint/endpoint.pb.go
+++ b/pkg/api/envoy/api/v2/endpoint/endpoint.pb.go
@@ -23,7 +23,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // Upstream host identifier.
 type Endpoint struct {
@@ -274,74 +274,12 @@ func (m *LbEndpoint) GetLoadBalancingWeight() *types.UInt32Value {
 	return nil
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*LbEndpoint) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _LbEndpoint_OneofMarshaler, _LbEndpoint_OneofUnmarshaler, _LbEndpoint_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*LbEndpoint) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*LbEndpoint_Endpoint)(nil),
 		(*LbEndpoint_EndpointName)(nil),
 	}
-}
-
-func _LbEndpoint_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*LbEndpoint)
-	// host_identifier
-	switch x := m.HostIdentifier.(type) {
-	case *LbEndpoint_Endpoint:
-		_ = b.EncodeVarint(1<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.Endpoint); err != nil {
-			return err
-		}
-	case *LbEndpoint_EndpointName:
-		_ = b.EncodeVarint(5<<3 | proto.WireBytes)
-		_ = b.EncodeStringBytes(x.EndpointName)
-	case nil:
-	default:
-		return fmt.Errorf("LbEndpoint.HostIdentifier has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _LbEndpoint_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*LbEndpoint)
-	switch tag {
-	case 1: // host_identifier.endpoint
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(Endpoint)
-		err := b.DecodeMessage(msg)
-		m.HostIdentifier = &LbEndpoint_Endpoint{msg}
-		return true, err
-	case 5: // host_identifier.endpoint_name
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeStringBytes()
-		m.HostIdentifier = &LbEndpoint_EndpointName{x}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _LbEndpoint_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*LbEndpoint)
-	// host_identifier
-	switch x := m.HostIdentifier.(type) {
-	case *LbEndpoint_Endpoint:
-		s := proto.Size(x.Endpoint)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *LbEndpoint_EndpointName:
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(len(x.EndpointName)))
-		n += len(x.EndpointName)
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 // A group of endpoints belonging to a Locality.

--- a/pkg/api/envoy/api/v2/endpoint/load_report.pb.go
+++ b/pkg/api/envoy/api/v2/endpoint/load_report.pb.go
@@ -24,7 +24,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // These are stats Envoy reports to GLB every so often. Report frequency is
 // defined by

--- a/pkg/api/envoy/api/v2/lds.pb.go
+++ b/pkg/api/envoy/api/v2/lds.pb.go
@@ -29,7 +29,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 type Listener_DrainType int32
 

--- a/pkg/api/envoy/api/v2/listener/listener.pb.go
+++ b/pkg/api/envoy/api/v2/listener/listener.pb.go
@@ -24,7 +24,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 type FilterChainMatch_ConnectionSourceType int32
 
@@ -150,78 +150,12 @@ func (m *Filter) GetTypedConfig() *types.Any {
 	return nil
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*Filter) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _Filter_OneofMarshaler, _Filter_OneofUnmarshaler, _Filter_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*Filter) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*Filter_Config)(nil),
 		(*Filter_TypedConfig)(nil),
 	}
-}
-
-func _Filter_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*Filter)
-	// config_type
-	switch x := m.ConfigType.(type) {
-	case *Filter_Config:
-		_ = b.EncodeVarint(2<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.Config); err != nil {
-			return err
-		}
-	case *Filter_TypedConfig:
-		_ = b.EncodeVarint(4<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.TypedConfig); err != nil {
-			return err
-		}
-	case nil:
-	default:
-		return fmt.Errorf("Filter.ConfigType has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _Filter_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*Filter)
-	switch tag {
-	case 2: // config_type.config
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(types.Struct)
-		err := b.DecodeMessage(msg)
-		m.ConfigType = &Filter_Config{msg}
-		return true, err
-	case 4: // config_type.typed_config
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(types.Any)
-		err := b.DecodeMessage(msg)
-		m.ConfigType = &Filter_TypedConfig{msg}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _Filter_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*Filter)
-	// config_type
-	switch x := m.ConfigType.(type) {
-	case *Filter_Config:
-		s := proto.Size(x.Config)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *Filter_TypedConfig:
-		s := proto.Size(x.TypedConfig)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 // Specifies the match criteria for selecting a specific filter chain for a
@@ -635,78 +569,12 @@ func (m *ListenerFilter) GetTypedConfig() *types.Any {
 	return nil
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*ListenerFilter) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _ListenerFilter_OneofMarshaler, _ListenerFilter_OneofUnmarshaler, _ListenerFilter_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*ListenerFilter) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*ListenerFilter_Config)(nil),
 		(*ListenerFilter_TypedConfig)(nil),
 	}
-}
-
-func _ListenerFilter_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*ListenerFilter)
-	// config_type
-	switch x := m.ConfigType.(type) {
-	case *ListenerFilter_Config:
-		_ = b.EncodeVarint(2<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.Config); err != nil {
-			return err
-		}
-	case *ListenerFilter_TypedConfig:
-		_ = b.EncodeVarint(3<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.TypedConfig); err != nil {
-			return err
-		}
-	case nil:
-	default:
-		return fmt.Errorf("ListenerFilter.ConfigType has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _ListenerFilter_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*ListenerFilter)
-	switch tag {
-	case 2: // config_type.config
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(types.Struct)
-		err := b.DecodeMessage(msg)
-		m.ConfigType = &ListenerFilter_Config{msg}
-		return true, err
-	case 3: // config_type.typed_config
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(types.Any)
-		err := b.DecodeMessage(msg)
-		m.ConfigType = &ListenerFilter_TypedConfig{msg}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _ListenerFilter_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*ListenerFilter)
-	// config_type
-	switch x := m.ConfigType.(type) {
-	case *ListenerFilter_Config:
-		s := proto.Size(x.Config)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *ListenerFilter_TypedConfig:
-		s := proto.Size(x.TypedConfig)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 func init() {

--- a/pkg/api/envoy/api/v2/listener/udp_listener_config.pb.go
+++ b/pkg/api/envoy/api/v2/listener/udp_listener_config.pb.go
@@ -21,7 +21,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 type UdpListenerConfig struct {
 	// Used to look up UDP listener factory, matches "raw_udp_listener" or
@@ -117,78 +117,12 @@ func (m *UdpListenerConfig) GetTypedConfig() *types.Any {
 	return nil
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*UdpListenerConfig) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _UdpListenerConfig_OneofMarshaler, _UdpListenerConfig_OneofUnmarshaler, _UdpListenerConfig_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*UdpListenerConfig) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*UdpListenerConfig_Config)(nil),
 		(*UdpListenerConfig_TypedConfig)(nil),
 	}
-}
-
-func _UdpListenerConfig_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*UdpListenerConfig)
-	// config_type
-	switch x := m.ConfigType.(type) {
-	case *UdpListenerConfig_Config:
-		_ = b.EncodeVarint(2<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.Config); err != nil {
-			return err
-		}
-	case *UdpListenerConfig_TypedConfig:
-		_ = b.EncodeVarint(3<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.TypedConfig); err != nil {
-			return err
-		}
-	case nil:
-	default:
-		return fmt.Errorf("UdpListenerConfig.ConfigType has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _UdpListenerConfig_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*UdpListenerConfig)
-	switch tag {
-	case 2: // config_type.config
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(types.Struct)
-		err := b.DecodeMessage(msg)
-		m.ConfigType = &UdpListenerConfig_Config{msg}
-		return true, err
-	case 3: // config_type.typed_config
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(types.Any)
-		err := b.DecodeMessage(msg)
-		m.ConfigType = &UdpListenerConfig_TypedConfig{msg}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _UdpListenerConfig_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*UdpListenerConfig)
-	// config_type
-	switch x := m.ConfigType.(type) {
-	case *UdpListenerConfig_Config:
-		s := proto.Size(x.Config)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *UdpListenerConfig_TypedConfig:
-		s := proto.Size(x.TypedConfig)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 func init() {

--- a/pkg/api/envoy/api/v2/ratelimit/ratelimit.pb.go
+++ b/pkg/api/envoy/api/v2/ratelimit/ratelimit.pb.go
@@ -21,7 +21,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // A RateLimitDescriptor is a list of hierarchical entries that are used by the service to
 // determine the final rate limit key and overall allowed limit. Here are some examples of how

--- a/pkg/api/envoy/api/v2/rds.pb.go
+++ b/pkg/api/envoy/api/v2/rds.pb.go
@@ -29,7 +29,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // [#comment:next free field: 10]
 type RouteConfiguration struct {

--- a/pkg/api/envoy/api/v2/route/route.pb.go
+++ b/pkg/api/envoy/api/v2/route/route.pb.go
@@ -25,7 +25,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 type VirtualHost_TlsRequirementType int32
 
@@ -616,97 +616,13 @@ func (m *Route) GetTracing() *Tracing {
 	return nil
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*Route) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _Route_OneofMarshaler, _Route_OneofUnmarshaler, _Route_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*Route) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*Route_Route)(nil),
 		(*Route_Redirect)(nil),
 		(*Route_DirectResponse)(nil),
 	}
-}
-
-func _Route_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*Route)
-	// action
-	switch x := m.Action.(type) {
-	case *Route_Route:
-		_ = b.EncodeVarint(2<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.Route); err != nil {
-			return err
-		}
-	case *Route_Redirect:
-		_ = b.EncodeVarint(3<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.Redirect); err != nil {
-			return err
-		}
-	case *Route_DirectResponse:
-		_ = b.EncodeVarint(7<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.DirectResponse); err != nil {
-			return err
-		}
-	case nil:
-	default:
-		return fmt.Errorf("Route.Action has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _Route_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*Route)
-	switch tag {
-	case 2: // action.route
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(RouteAction)
-		err := b.DecodeMessage(msg)
-		m.Action = &Route_Route{msg}
-		return true, err
-	case 3: // action.redirect
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(RedirectAction)
-		err := b.DecodeMessage(msg)
-		m.Action = &Route_Redirect{msg}
-		return true, err
-	case 7: // action.direct_response
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(DirectResponseAction)
-		err := b.DecodeMessage(msg)
-		m.Action = &Route_DirectResponse{msg}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _Route_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*Route)
-	// action
-	switch x := m.Action.(type) {
-	case *Route_Route:
-		s := proto.Size(x.Route)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *Route_Redirect:
-		s := proto.Size(x.Redirect)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *Route_DirectResponse:
-		s := proto.Size(x.DirectResponse)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 // Compared to the :ref:`cluster <envoy_api_field_route.RouteAction.cluster>` field that specifies a
@@ -1116,104 +1032,14 @@ func (m *RouteMatch) GetGrpc() *RouteMatch_GrpcRouteMatchOptions {
 	return nil
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*RouteMatch) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _RouteMatch_OneofMarshaler, _RouteMatch_OneofUnmarshaler, _RouteMatch_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*RouteMatch) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*RouteMatch_Prefix)(nil),
 		(*RouteMatch_Path)(nil),
 		(*RouteMatch_Regex)(nil),
 		(*RouteMatch_SafeRegex)(nil),
 	}
-}
-
-func _RouteMatch_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*RouteMatch)
-	// path_specifier
-	switch x := m.PathSpecifier.(type) {
-	case *RouteMatch_Prefix:
-		_ = b.EncodeVarint(1<<3 | proto.WireBytes)
-		_ = b.EncodeStringBytes(x.Prefix)
-	case *RouteMatch_Path:
-		_ = b.EncodeVarint(2<<3 | proto.WireBytes)
-		_ = b.EncodeStringBytes(x.Path)
-	case *RouteMatch_Regex:
-		_ = b.EncodeVarint(3<<3 | proto.WireBytes)
-		_ = b.EncodeStringBytes(x.Regex)
-	case *RouteMatch_SafeRegex:
-		_ = b.EncodeVarint(10<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.SafeRegex); err != nil {
-			return err
-		}
-	case nil:
-	default:
-		return fmt.Errorf("RouteMatch.PathSpecifier has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _RouteMatch_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*RouteMatch)
-	switch tag {
-	case 1: // path_specifier.prefix
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeStringBytes()
-		m.PathSpecifier = &RouteMatch_Prefix{x}
-		return true, err
-	case 2: // path_specifier.path
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeStringBytes()
-		m.PathSpecifier = &RouteMatch_Path{x}
-		return true, err
-	case 3: // path_specifier.regex
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeStringBytes()
-		m.PathSpecifier = &RouteMatch_Regex{x}
-		return true, err
-	case 10: // path_specifier.safe_regex
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(matcher.RegexMatcher)
-		err := b.DecodeMessage(msg)
-		m.PathSpecifier = &RouteMatch_SafeRegex{msg}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _RouteMatch_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*RouteMatch)
-	// path_specifier
-	switch x := m.PathSpecifier.(type) {
-	case *RouteMatch_Prefix:
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(len(x.Prefix)))
-		n += len(x.Prefix)
-	case *RouteMatch_Path:
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(len(x.Path)))
-		n += len(x.Path)
-	case *RouteMatch_Regex:
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(len(x.Regex)))
-		n += len(x.Regex)
-	case *RouteMatch_SafeRegex:
-		s := proto.Size(x.SafeRegex)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 type RouteMatch_GrpcRouteMatchOptions struct {
@@ -1440,78 +1266,12 @@ func (m *CorsPolicy) GetShadowEnabled() *core.RuntimeFractionalPercent {
 	return nil
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*CorsPolicy) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _CorsPolicy_OneofMarshaler, _CorsPolicy_OneofUnmarshaler, _CorsPolicy_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*CorsPolicy) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*CorsPolicy_Enabled)(nil),
 		(*CorsPolicy_FilterEnabled)(nil),
 	}
-}
-
-func _CorsPolicy_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*CorsPolicy)
-	// enabled_specifier
-	switch x := m.EnabledSpecifier.(type) {
-	case *CorsPolicy_Enabled:
-		_ = b.EncodeVarint(7<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.Enabled); err != nil {
-			return err
-		}
-	case *CorsPolicy_FilterEnabled:
-		_ = b.EncodeVarint(9<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.FilterEnabled); err != nil {
-			return err
-		}
-	case nil:
-	default:
-		return fmt.Errorf("CorsPolicy.EnabledSpecifier has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _CorsPolicy_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*CorsPolicy)
-	switch tag {
-	case 7: // enabled_specifier.enabled
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(types.BoolValue)
-		err := b.DecodeMessage(msg)
-		m.EnabledSpecifier = &CorsPolicy_Enabled{msg}
-		return true, err
-	case 9: // enabled_specifier.filter_enabled
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(core.RuntimeFractionalPercent)
-		err := b.DecodeMessage(msg)
-		m.EnabledSpecifier = &CorsPolicy_FilterEnabled{msg}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _CorsPolicy_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*CorsPolicy)
-	// enabled_specifier
-	switch x := m.EnabledSpecifier.(type) {
-	case *CorsPolicy_Enabled:
-		s := proto.Size(x.Enabled)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *CorsPolicy_FilterEnabled:
-		s := proto.Size(x.FilterEnabled)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 // [#comment:next free field: 30]
@@ -1901,9 +1661,9 @@ func (m *RouteAction) GetHedgePolicy() *HedgePolicy {
 	return nil
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*RouteAction) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _RouteAction_OneofMarshaler, _RouteAction_OneofUnmarshaler, _RouteAction_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*RouteAction) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*RouteAction_Cluster)(nil),
 		(*RouteAction_ClusterHeader)(nil),
 		(*RouteAction_WeightedClusters)(nil),
@@ -1911,140 +1671,6 @@ func (*RouteAction) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) e
 		(*RouteAction_AutoHostRewrite)(nil),
 		(*RouteAction_AutoHostRewriteHeader)(nil),
 	}
-}
-
-func _RouteAction_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*RouteAction)
-	// cluster_specifier
-	switch x := m.ClusterSpecifier.(type) {
-	case *RouteAction_Cluster:
-		_ = b.EncodeVarint(1<<3 | proto.WireBytes)
-		_ = b.EncodeStringBytes(x.Cluster)
-	case *RouteAction_ClusterHeader:
-		_ = b.EncodeVarint(2<<3 | proto.WireBytes)
-		_ = b.EncodeStringBytes(x.ClusterHeader)
-	case *RouteAction_WeightedClusters:
-		_ = b.EncodeVarint(3<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.WeightedClusters); err != nil {
-			return err
-		}
-	case nil:
-	default:
-		return fmt.Errorf("RouteAction.ClusterSpecifier has unexpected type %T", x)
-	}
-	// host_rewrite_specifier
-	switch x := m.HostRewriteSpecifier.(type) {
-	case *RouteAction_HostRewrite:
-		_ = b.EncodeVarint(6<<3 | proto.WireBytes)
-		_ = b.EncodeStringBytes(x.HostRewrite)
-	case *RouteAction_AutoHostRewrite:
-		_ = b.EncodeVarint(7<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.AutoHostRewrite); err != nil {
-			return err
-		}
-	case *RouteAction_AutoHostRewriteHeader:
-		_ = b.EncodeVarint(29<<3 | proto.WireBytes)
-		_ = b.EncodeStringBytes(x.AutoHostRewriteHeader)
-	case nil:
-	default:
-		return fmt.Errorf("RouteAction.HostRewriteSpecifier has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _RouteAction_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*RouteAction)
-	switch tag {
-	case 1: // cluster_specifier.cluster
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeStringBytes()
-		m.ClusterSpecifier = &RouteAction_Cluster{x}
-		return true, err
-	case 2: // cluster_specifier.cluster_header
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeStringBytes()
-		m.ClusterSpecifier = &RouteAction_ClusterHeader{x}
-		return true, err
-	case 3: // cluster_specifier.weighted_clusters
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(WeightedCluster)
-		err := b.DecodeMessage(msg)
-		m.ClusterSpecifier = &RouteAction_WeightedClusters{msg}
-		return true, err
-	case 6: // host_rewrite_specifier.host_rewrite
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeStringBytes()
-		m.HostRewriteSpecifier = &RouteAction_HostRewrite{x}
-		return true, err
-	case 7: // host_rewrite_specifier.auto_host_rewrite
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(types.BoolValue)
-		err := b.DecodeMessage(msg)
-		m.HostRewriteSpecifier = &RouteAction_AutoHostRewrite{msg}
-		return true, err
-	case 29: // host_rewrite_specifier.auto_host_rewrite_header
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeStringBytes()
-		m.HostRewriteSpecifier = &RouteAction_AutoHostRewriteHeader{x}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _RouteAction_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*RouteAction)
-	// cluster_specifier
-	switch x := m.ClusterSpecifier.(type) {
-	case *RouteAction_Cluster:
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(len(x.Cluster)))
-		n += len(x.Cluster)
-	case *RouteAction_ClusterHeader:
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(len(x.ClusterHeader)))
-		n += len(x.ClusterHeader)
-	case *RouteAction_WeightedClusters:
-		s := proto.Size(x.WeightedClusters)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	// host_rewrite_specifier
-	switch x := m.HostRewriteSpecifier.(type) {
-	case *RouteAction_HostRewrite:
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(len(x.HostRewrite)))
-		n += len(x.HostRewrite)
-	case *RouteAction_AutoHostRewrite:
-		s := proto.Size(x.AutoHostRewrite)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *RouteAction_AutoHostRewriteHeader:
-		n += 2 // tag and wire
-		n += proto.SizeVarint(uint64(len(x.AutoHostRewriteHeader)))
-		n += len(x.AutoHostRewriteHeader)
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 // The router is capable of shadowing traffic from one cluster to another. The current
@@ -2272,97 +1898,13 @@ func (m *RouteAction_HashPolicy) GetTerminal() bool {
 	return false
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*RouteAction_HashPolicy) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _RouteAction_HashPolicy_OneofMarshaler, _RouteAction_HashPolicy_OneofUnmarshaler, _RouteAction_HashPolicy_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*RouteAction_HashPolicy) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*RouteAction_HashPolicy_Header_)(nil),
 		(*RouteAction_HashPolicy_Cookie_)(nil),
 		(*RouteAction_HashPolicy_ConnectionProperties_)(nil),
 	}
-}
-
-func _RouteAction_HashPolicy_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*RouteAction_HashPolicy)
-	// policy_specifier
-	switch x := m.PolicySpecifier.(type) {
-	case *RouteAction_HashPolicy_Header_:
-		_ = b.EncodeVarint(1<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.Header); err != nil {
-			return err
-		}
-	case *RouteAction_HashPolicy_Cookie_:
-		_ = b.EncodeVarint(2<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.Cookie); err != nil {
-			return err
-		}
-	case *RouteAction_HashPolicy_ConnectionProperties_:
-		_ = b.EncodeVarint(3<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.ConnectionProperties); err != nil {
-			return err
-		}
-	case nil:
-	default:
-		return fmt.Errorf("RouteAction_HashPolicy.PolicySpecifier has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _RouteAction_HashPolicy_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*RouteAction_HashPolicy)
-	switch tag {
-	case 1: // policy_specifier.header
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(RouteAction_HashPolicy_Header)
-		err := b.DecodeMessage(msg)
-		m.PolicySpecifier = &RouteAction_HashPolicy_Header_{msg}
-		return true, err
-	case 2: // policy_specifier.cookie
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(RouteAction_HashPolicy_Cookie)
-		err := b.DecodeMessage(msg)
-		m.PolicySpecifier = &RouteAction_HashPolicy_Cookie_{msg}
-		return true, err
-	case 3: // policy_specifier.connection_properties
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(RouteAction_HashPolicy_ConnectionProperties)
-		err := b.DecodeMessage(msg)
-		m.PolicySpecifier = &RouteAction_HashPolicy_ConnectionProperties_{msg}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _RouteAction_HashPolicy_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*RouteAction_HashPolicy)
-	// policy_specifier
-	switch x := m.PolicySpecifier.(type) {
-	case *RouteAction_HashPolicy_Header_:
-		s := proto.Size(x.Header)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *RouteAction_HashPolicy_Cookie_:
-		s := proto.Size(x.Cookie)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *RouteAction_HashPolicy_ConnectionProperties_:
-		s := proto.Size(x.ConnectionProperties)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 type RouteAction_HashPolicy_Header struct {
@@ -2842,78 +2384,12 @@ func (m *RetryPolicy_RetryPriority) GetTypedConfig() *types.Any {
 	return nil
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*RetryPolicy_RetryPriority) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _RetryPolicy_RetryPriority_OneofMarshaler, _RetryPolicy_RetryPriority_OneofUnmarshaler, _RetryPolicy_RetryPriority_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*RetryPolicy_RetryPriority) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*RetryPolicy_RetryPriority_Config)(nil),
 		(*RetryPolicy_RetryPriority_TypedConfig)(nil),
 	}
-}
-
-func _RetryPolicy_RetryPriority_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*RetryPolicy_RetryPriority)
-	// config_type
-	switch x := m.ConfigType.(type) {
-	case *RetryPolicy_RetryPriority_Config:
-		_ = b.EncodeVarint(2<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.Config); err != nil {
-			return err
-		}
-	case *RetryPolicy_RetryPriority_TypedConfig:
-		_ = b.EncodeVarint(3<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.TypedConfig); err != nil {
-			return err
-		}
-	case nil:
-	default:
-		return fmt.Errorf("RetryPolicy_RetryPriority.ConfigType has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _RetryPolicy_RetryPriority_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*RetryPolicy_RetryPriority)
-	switch tag {
-	case 2: // config_type.config
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(types.Struct)
-		err := b.DecodeMessage(msg)
-		m.ConfigType = &RetryPolicy_RetryPriority_Config{msg}
-		return true, err
-	case 3: // config_type.typed_config
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(types.Any)
-		err := b.DecodeMessage(msg)
-		m.ConfigType = &RetryPolicy_RetryPriority_TypedConfig{msg}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _RetryPolicy_RetryPriority_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*RetryPolicy_RetryPriority)
-	// config_type
-	switch x := m.ConfigType.(type) {
-	case *RetryPolicy_RetryPriority_Config:
-		s := proto.Size(x.Config)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *RetryPolicy_RetryPriority_TypedConfig:
-		s := proto.Size(x.TypedConfig)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 type RetryPolicy_RetryHostPredicate struct {
@@ -3004,78 +2480,12 @@ func (m *RetryPolicy_RetryHostPredicate) GetTypedConfig() *types.Any {
 	return nil
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*RetryPolicy_RetryHostPredicate) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _RetryPolicy_RetryHostPredicate_OneofMarshaler, _RetryPolicy_RetryHostPredicate_OneofUnmarshaler, _RetryPolicy_RetryHostPredicate_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*RetryPolicy_RetryHostPredicate) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*RetryPolicy_RetryHostPredicate_Config)(nil),
 		(*RetryPolicy_RetryHostPredicate_TypedConfig)(nil),
 	}
-}
-
-func _RetryPolicy_RetryHostPredicate_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*RetryPolicy_RetryHostPredicate)
-	// config_type
-	switch x := m.ConfigType.(type) {
-	case *RetryPolicy_RetryHostPredicate_Config:
-		_ = b.EncodeVarint(2<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.Config); err != nil {
-			return err
-		}
-	case *RetryPolicy_RetryHostPredicate_TypedConfig:
-		_ = b.EncodeVarint(3<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.TypedConfig); err != nil {
-			return err
-		}
-	case nil:
-	default:
-		return fmt.Errorf("RetryPolicy_RetryHostPredicate.ConfigType has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _RetryPolicy_RetryHostPredicate_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*RetryPolicy_RetryHostPredicate)
-	switch tag {
-	case 2: // config_type.config
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(types.Struct)
-		err := b.DecodeMessage(msg)
-		m.ConfigType = &RetryPolicy_RetryHostPredicate_Config{msg}
-		return true, err
-	case 3: // config_type.typed_config
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(types.Any)
-		err := b.DecodeMessage(msg)
-		m.ConfigType = &RetryPolicy_RetryHostPredicate_TypedConfig{msg}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _RetryPolicy_RetryHostPredicate_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*RetryPolicy_RetryHostPredicate)
-	// config_type
-	switch x := m.ConfigType.(type) {
-	case *RetryPolicy_RetryHostPredicate_Config:
-		s := proto.Size(x.Config)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *RetryPolicy_RetryHostPredicate_TypedConfig:
-		s := proto.Size(x.TypedConfig)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 type RetryPolicy_RetryBackOff struct {
@@ -3382,115 +2792,14 @@ func (m *RedirectAction) GetStripQuery() bool {
 	return false
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*RedirectAction) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _RedirectAction_OneofMarshaler, _RedirectAction_OneofUnmarshaler, _RedirectAction_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*RedirectAction) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*RedirectAction_HttpsRedirect)(nil),
 		(*RedirectAction_SchemeRedirect)(nil),
 		(*RedirectAction_PathRedirect)(nil),
 		(*RedirectAction_PrefixRewrite)(nil),
 	}
-}
-
-func _RedirectAction_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*RedirectAction)
-	// scheme_rewrite_specifier
-	switch x := m.SchemeRewriteSpecifier.(type) {
-	case *RedirectAction_HttpsRedirect:
-		t := uint64(0)
-		if x.HttpsRedirect {
-			t = 1
-		}
-		_ = b.EncodeVarint(4<<3 | proto.WireVarint)
-		_ = b.EncodeVarint(t)
-	case *RedirectAction_SchemeRedirect:
-		_ = b.EncodeVarint(7<<3 | proto.WireBytes)
-		_ = b.EncodeStringBytes(x.SchemeRedirect)
-	case nil:
-	default:
-		return fmt.Errorf("RedirectAction.SchemeRewriteSpecifier has unexpected type %T", x)
-	}
-	// path_rewrite_specifier
-	switch x := m.PathRewriteSpecifier.(type) {
-	case *RedirectAction_PathRedirect:
-		_ = b.EncodeVarint(2<<3 | proto.WireBytes)
-		_ = b.EncodeStringBytes(x.PathRedirect)
-	case *RedirectAction_PrefixRewrite:
-		_ = b.EncodeVarint(5<<3 | proto.WireBytes)
-		_ = b.EncodeStringBytes(x.PrefixRewrite)
-	case nil:
-	default:
-		return fmt.Errorf("RedirectAction.PathRewriteSpecifier has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _RedirectAction_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*RedirectAction)
-	switch tag {
-	case 4: // scheme_rewrite_specifier.https_redirect
-		if wire != proto.WireVarint {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeVarint()
-		m.SchemeRewriteSpecifier = &RedirectAction_HttpsRedirect{x != 0}
-		return true, err
-	case 7: // scheme_rewrite_specifier.scheme_redirect
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeStringBytes()
-		m.SchemeRewriteSpecifier = &RedirectAction_SchemeRedirect{x}
-		return true, err
-	case 2: // path_rewrite_specifier.path_redirect
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeStringBytes()
-		m.PathRewriteSpecifier = &RedirectAction_PathRedirect{x}
-		return true, err
-	case 5: // path_rewrite_specifier.prefix_rewrite
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeStringBytes()
-		m.PathRewriteSpecifier = &RedirectAction_PrefixRewrite{x}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _RedirectAction_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*RedirectAction)
-	// scheme_rewrite_specifier
-	switch x := m.SchemeRewriteSpecifier.(type) {
-	case *RedirectAction_HttpsRedirect:
-		n += 1 // tag and wire
-		n += 1
-	case *RedirectAction_SchemeRedirect:
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(len(x.SchemeRedirect)))
-		n += len(x.SchemeRedirect)
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	// path_rewrite_specifier
-	switch x := m.PathRewriteSpecifier.(type) {
-	case *RedirectAction_PathRedirect:
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(len(x.PathRedirect)))
-		n += len(x.PathRedirect)
-	case *RedirectAction_PrefixRewrite:
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(len(x.PrefixRewrite)))
-		n += len(x.PrefixRewrite)
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 type DirectResponseAction struct {
@@ -4014,9 +3323,9 @@ func (m *RateLimit_Action) GetHeaderValueMatch() *RateLimit_Action_HeaderValueMa
 	return nil
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*RateLimit_Action) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _RateLimit_Action_OneofMarshaler, _RateLimit_Action_OneofUnmarshaler, _RateLimit_Action_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*RateLimit_Action) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*RateLimit_Action_SourceCluster_)(nil),
 		(*RateLimit_Action_DestinationCluster_)(nil),
 		(*RateLimit_Action_RequestHeaders_)(nil),
@@ -4024,144 +3333,6 @@ func (*RateLimit_Action) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buff
 		(*RateLimit_Action_GenericKey_)(nil),
 		(*RateLimit_Action_HeaderValueMatch_)(nil),
 	}
-}
-
-func _RateLimit_Action_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*RateLimit_Action)
-	// action_specifier
-	switch x := m.ActionSpecifier.(type) {
-	case *RateLimit_Action_SourceCluster_:
-		_ = b.EncodeVarint(1<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.SourceCluster); err != nil {
-			return err
-		}
-	case *RateLimit_Action_DestinationCluster_:
-		_ = b.EncodeVarint(2<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.DestinationCluster); err != nil {
-			return err
-		}
-	case *RateLimit_Action_RequestHeaders_:
-		_ = b.EncodeVarint(3<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.RequestHeaders); err != nil {
-			return err
-		}
-	case *RateLimit_Action_RemoteAddress_:
-		_ = b.EncodeVarint(4<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.RemoteAddress); err != nil {
-			return err
-		}
-	case *RateLimit_Action_GenericKey_:
-		_ = b.EncodeVarint(5<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.GenericKey); err != nil {
-			return err
-		}
-	case *RateLimit_Action_HeaderValueMatch_:
-		_ = b.EncodeVarint(6<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.HeaderValueMatch); err != nil {
-			return err
-		}
-	case nil:
-	default:
-		return fmt.Errorf("RateLimit_Action.ActionSpecifier has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _RateLimit_Action_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*RateLimit_Action)
-	switch tag {
-	case 1: // action_specifier.source_cluster
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(RateLimit_Action_SourceCluster)
-		err := b.DecodeMessage(msg)
-		m.ActionSpecifier = &RateLimit_Action_SourceCluster_{msg}
-		return true, err
-	case 2: // action_specifier.destination_cluster
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(RateLimit_Action_DestinationCluster)
-		err := b.DecodeMessage(msg)
-		m.ActionSpecifier = &RateLimit_Action_DestinationCluster_{msg}
-		return true, err
-	case 3: // action_specifier.request_headers
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(RateLimit_Action_RequestHeaders)
-		err := b.DecodeMessage(msg)
-		m.ActionSpecifier = &RateLimit_Action_RequestHeaders_{msg}
-		return true, err
-	case 4: // action_specifier.remote_address
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(RateLimit_Action_RemoteAddress)
-		err := b.DecodeMessage(msg)
-		m.ActionSpecifier = &RateLimit_Action_RemoteAddress_{msg}
-		return true, err
-	case 5: // action_specifier.generic_key
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(RateLimit_Action_GenericKey)
-		err := b.DecodeMessage(msg)
-		m.ActionSpecifier = &RateLimit_Action_GenericKey_{msg}
-		return true, err
-	case 6: // action_specifier.header_value_match
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(RateLimit_Action_HeaderValueMatch)
-		err := b.DecodeMessage(msg)
-		m.ActionSpecifier = &RateLimit_Action_HeaderValueMatch_{msg}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _RateLimit_Action_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*RateLimit_Action)
-	// action_specifier
-	switch x := m.ActionSpecifier.(type) {
-	case *RateLimit_Action_SourceCluster_:
-		s := proto.Size(x.SourceCluster)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *RateLimit_Action_DestinationCluster_:
-		s := proto.Size(x.DestinationCluster)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *RateLimit_Action_RequestHeaders_:
-		s := proto.Size(x.RequestHeaders)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *RateLimit_Action_RemoteAddress_:
-		s := proto.Size(x.RemoteAddress)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *RateLimit_Action_GenericKey_:
-		s := proto.Size(x.GenericKey)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *RateLimit_Action_HeaderValueMatch_:
-		s := proto.Size(x.HeaderValueMatch)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 // The following descriptor entry is appended to the descriptor:
@@ -4696,9 +3867,9 @@ func (m *HeaderMatcher) GetInvertMatch() bool {
 	return false
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*HeaderMatcher) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _HeaderMatcher_OneofMarshaler, _HeaderMatcher_OneofUnmarshaler, _HeaderMatcher_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*HeaderMatcher) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*HeaderMatcher_ExactMatch)(nil),
 		(*HeaderMatcher_RegexMatch)(nil),
 		(*HeaderMatcher_SafeRegexMatch)(nil),
@@ -4707,145 +3878,6 @@ func (*HeaderMatcher) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer)
 		(*HeaderMatcher_PrefixMatch)(nil),
 		(*HeaderMatcher_SuffixMatch)(nil),
 	}
-}
-
-func _HeaderMatcher_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*HeaderMatcher)
-	// header_match_specifier
-	switch x := m.HeaderMatchSpecifier.(type) {
-	case *HeaderMatcher_ExactMatch:
-		_ = b.EncodeVarint(4<<3 | proto.WireBytes)
-		_ = b.EncodeStringBytes(x.ExactMatch)
-	case *HeaderMatcher_RegexMatch:
-		_ = b.EncodeVarint(5<<3 | proto.WireBytes)
-		_ = b.EncodeStringBytes(x.RegexMatch)
-	case *HeaderMatcher_SafeRegexMatch:
-		_ = b.EncodeVarint(11<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.SafeRegexMatch); err != nil {
-			return err
-		}
-	case *HeaderMatcher_RangeMatch:
-		_ = b.EncodeVarint(6<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.RangeMatch); err != nil {
-			return err
-		}
-	case *HeaderMatcher_PresentMatch:
-		t := uint64(0)
-		if x.PresentMatch {
-			t = 1
-		}
-		_ = b.EncodeVarint(7<<3 | proto.WireVarint)
-		_ = b.EncodeVarint(t)
-	case *HeaderMatcher_PrefixMatch:
-		_ = b.EncodeVarint(9<<3 | proto.WireBytes)
-		_ = b.EncodeStringBytes(x.PrefixMatch)
-	case *HeaderMatcher_SuffixMatch:
-		_ = b.EncodeVarint(10<<3 | proto.WireBytes)
-		_ = b.EncodeStringBytes(x.SuffixMatch)
-	case nil:
-	default:
-		return fmt.Errorf("HeaderMatcher.HeaderMatchSpecifier has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _HeaderMatcher_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*HeaderMatcher)
-	switch tag {
-	case 4: // header_match_specifier.exact_match
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeStringBytes()
-		m.HeaderMatchSpecifier = &HeaderMatcher_ExactMatch{x}
-		return true, err
-	case 5: // header_match_specifier.regex_match
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeStringBytes()
-		m.HeaderMatchSpecifier = &HeaderMatcher_RegexMatch{x}
-		return true, err
-	case 11: // header_match_specifier.safe_regex_match
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(matcher.RegexMatcher)
-		err := b.DecodeMessage(msg)
-		m.HeaderMatchSpecifier = &HeaderMatcher_SafeRegexMatch{msg}
-		return true, err
-	case 6: // header_match_specifier.range_match
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(_type.Int64Range)
-		err := b.DecodeMessage(msg)
-		m.HeaderMatchSpecifier = &HeaderMatcher_RangeMatch{msg}
-		return true, err
-	case 7: // header_match_specifier.present_match
-		if wire != proto.WireVarint {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeVarint()
-		m.HeaderMatchSpecifier = &HeaderMatcher_PresentMatch{x != 0}
-		return true, err
-	case 9: // header_match_specifier.prefix_match
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeStringBytes()
-		m.HeaderMatchSpecifier = &HeaderMatcher_PrefixMatch{x}
-		return true, err
-	case 10: // header_match_specifier.suffix_match
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeStringBytes()
-		m.HeaderMatchSpecifier = &HeaderMatcher_SuffixMatch{x}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _HeaderMatcher_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*HeaderMatcher)
-	// header_match_specifier
-	switch x := m.HeaderMatchSpecifier.(type) {
-	case *HeaderMatcher_ExactMatch:
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(len(x.ExactMatch)))
-		n += len(x.ExactMatch)
-	case *HeaderMatcher_RegexMatch:
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(len(x.RegexMatch)))
-		n += len(x.RegexMatch)
-	case *HeaderMatcher_SafeRegexMatch:
-		s := proto.Size(x.SafeRegexMatch)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *HeaderMatcher_RangeMatch:
-		s := proto.Size(x.RangeMatch)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *HeaderMatcher_PresentMatch:
-		n += 1 // tag and wire
-		n += 1
-	case *HeaderMatcher_PrefixMatch:
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(len(x.PrefixMatch)))
-		n += len(x.PrefixMatch)
-	case *HeaderMatcher_SuffixMatch:
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(len(x.SuffixMatch)))
-		n += len(x.SuffixMatch)
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 // Query parameter matching treats the query string of a request's :path header
@@ -4971,77 +4003,12 @@ func (m *QueryParameterMatcher) GetPresentMatch() bool {
 	return false
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*QueryParameterMatcher) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _QueryParameterMatcher_OneofMarshaler, _QueryParameterMatcher_OneofUnmarshaler, _QueryParameterMatcher_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*QueryParameterMatcher) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*QueryParameterMatcher_StringMatch)(nil),
 		(*QueryParameterMatcher_PresentMatch)(nil),
 	}
-}
-
-func _QueryParameterMatcher_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*QueryParameterMatcher)
-	// query_parameter_match_specifier
-	switch x := m.QueryParameterMatchSpecifier.(type) {
-	case *QueryParameterMatcher_StringMatch:
-		_ = b.EncodeVarint(5<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.StringMatch); err != nil {
-			return err
-		}
-	case *QueryParameterMatcher_PresentMatch:
-		t := uint64(0)
-		if x.PresentMatch {
-			t = 1
-		}
-		_ = b.EncodeVarint(6<<3 | proto.WireVarint)
-		_ = b.EncodeVarint(t)
-	case nil:
-	default:
-		return fmt.Errorf("QueryParameterMatcher.QueryParameterMatchSpecifier has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _QueryParameterMatcher_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*QueryParameterMatcher)
-	switch tag {
-	case 5: // query_parameter_match_specifier.string_match
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(matcher.StringMatcher)
-		err := b.DecodeMessage(msg)
-		m.QueryParameterMatchSpecifier = &QueryParameterMatcher_StringMatch{msg}
-		return true, err
-	case 6: // query_parameter_match_specifier.present_match
-		if wire != proto.WireVarint {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeVarint()
-		m.QueryParameterMatchSpecifier = &QueryParameterMatcher_PresentMatch{x != 0}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _QueryParameterMatcher_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*QueryParameterMatcher)
-	// query_parameter_match_specifier
-	switch x := m.QueryParameterMatchSpecifier.(type) {
-	case *QueryParameterMatcher_StringMatch:
-		s := proto.Size(x.StringMatch)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *QueryParameterMatcher_PresentMatch:
-		n += 1 // tag and wire
-		n += 1
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 func init() {

--- a/pkg/api/envoy/api/v2/srds.pb.go
+++ b/pkg/api/envoy/api/v2/srds.pb.go
@@ -26,7 +26,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // Specifies a routing scope, which associates a
 // :ref:`Key<envoy_api_msg_ScopedRouteConfiguration.Key>` to a
@@ -281,55 +281,11 @@ func (m *ScopedRouteConfiguration_Key_Fragment) GetStringKey() string {
 	return ""
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*ScopedRouteConfiguration_Key_Fragment) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _ScopedRouteConfiguration_Key_Fragment_OneofMarshaler, _ScopedRouteConfiguration_Key_Fragment_OneofUnmarshaler, _ScopedRouteConfiguration_Key_Fragment_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*ScopedRouteConfiguration_Key_Fragment) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*ScopedRouteConfiguration_Key_Fragment_StringKey)(nil),
 	}
-}
-
-func _ScopedRouteConfiguration_Key_Fragment_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*ScopedRouteConfiguration_Key_Fragment)
-	// type
-	switch x := m.Type.(type) {
-	case *ScopedRouteConfiguration_Key_Fragment_StringKey:
-		_ = b.EncodeVarint(1<<3 | proto.WireBytes)
-		_ = b.EncodeStringBytes(x.StringKey)
-	case nil:
-	default:
-		return fmt.Errorf("ScopedRouteConfiguration_Key_Fragment.Type has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _ScopedRouteConfiguration_Key_Fragment_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*ScopedRouteConfiguration_Key_Fragment)
-	switch tag {
-	case 1: // type.string_key
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeStringBytes()
-		m.Type = &ScopedRouteConfiguration_Key_Fragment_StringKey{x}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _ScopedRouteConfiguration_Key_Fragment_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*ScopedRouteConfiguration_Key_Fragment)
-	// type
-	switch x := m.Type.(type) {
-	case *ScopedRouteConfiguration_Key_Fragment_StringKey:
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(len(x.StringKey)))
-		n += len(x.StringKey)
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 func init() {

--- a/pkg/api/envoy/api/v3alpha/auth/cert.pb.go
+++ b/pkg/api/envoy/api/v3alpha/auth/cert.pb.go
@@ -23,7 +23,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 type TlsParameters_TlsProtocol int32
 
@@ -286,78 +286,12 @@ func (m *PrivateKeyProvider) GetTypedConfig() *types.Any {
 	return nil
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*PrivateKeyProvider) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _PrivateKeyProvider_OneofMarshaler, _PrivateKeyProvider_OneofUnmarshaler, _PrivateKeyProvider_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*PrivateKeyProvider) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*PrivateKeyProvider_Config)(nil),
 		(*PrivateKeyProvider_TypedConfig)(nil),
 	}
-}
-
-func _PrivateKeyProvider_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*PrivateKeyProvider)
-	// config_type
-	switch x := m.ConfigType.(type) {
-	case *PrivateKeyProvider_Config:
-		_ = b.EncodeVarint(2<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.Config); err != nil {
-			return err
-		}
-	case *PrivateKeyProvider_TypedConfig:
-		_ = b.EncodeVarint(3<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.TypedConfig); err != nil {
-			return err
-		}
-	case nil:
-	default:
-		return fmt.Errorf("PrivateKeyProvider.ConfigType has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _PrivateKeyProvider_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*PrivateKeyProvider)
-	switch tag {
-	case 2: // config_type.config
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(types.Struct)
-		err := b.DecodeMessage(msg)
-		m.ConfigType = &PrivateKeyProvider_Config{msg}
-		return true, err
-	case 3: // config_type.typed_config
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(types.Any)
-		err := b.DecodeMessage(msg)
-		m.ConfigType = &PrivateKeyProvider_TypedConfig{msg}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _PrivateKeyProvider_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*PrivateKeyProvider)
-	// config_type
-	switch x := m.ConfigType.(type) {
-	case *PrivateKeyProvider_Config:
-		s := proto.Size(x.Config)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *PrivateKeyProvider_TypedConfig:
-		s := proto.Size(x.TypedConfig)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 type TlsCertificate struct {
@@ -867,97 +801,13 @@ func (m *CommonTlsContext) GetAlpnProtocols() []string {
 	return nil
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*CommonTlsContext) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _CommonTlsContext_OneofMarshaler, _CommonTlsContext_OneofUnmarshaler, _CommonTlsContext_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*CommonTlsContext) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*CommonTlsContext_ValidationContext)(nil),
 		(*CommonTlsContext_ValidationContextSdsSecretConfig)(nil),
 		(*CommonTlsContext_CombinedValidationContext)(nil),
 	}
-}
-
-func _CommonTlsContext_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*CommonTlsContext)
-	// validation_context_type
-	switch x := m.ValidationContextType.(type) {
-	case *CommonTlsContext_ValidationContext:
-		_ = b.EncodeVarint(3<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.ValidationContext); err != nil {
-			return err
-		}
-	case *CommonTlsContext_ValidationContextSdsSecretConfig:
-		_ = b.EncodeVarint(7<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.ValidationContextSdsSecretConfig); err != nil {
-			return err
-		}
-	case *CommonTlsContext_CombinedValidationContext:
-		_ = b.EncodeVarint(8<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.CombinedValidationContext); err != nil {
-			return err
-		}
-	case nil:
-	default:
-		return fmt.Errorf("CommonTlsContext.ValidationContextType has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _CommonTlsContext_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*CommonTlsContext)
-	switch tag {
-	case 3: // validation_context_type.validation_context
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(CertificateValidationContext)
-		err := b.DecodeMessage(msg)
-		m.ValidationContextType = &CommonTlsContext_ValidationContext{msg}
-		return true, err
-	case 7: // validation_context_type.validation_context_sds_secret_config
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(SdsSecretConfig)
-		err := b.DecodeMessage(msg)
-		m.ValidationContextType = &CommonTlsContext_ValidationContextSdsSecretConfig{msg}
-		return true, err
-	case 8: // validation_context_type.combined_validation_context
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(CommonTlsContext_CombinedCertificateValidationContext)
-		err := b.DecodeMessage(msg)
-		m.ValidationContextType = &CommonTlsContext_CombinedValidationContext{msg}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _CommonTlsContext_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*CommonTlsContext)
-	// validation_context_type
-	switch x := m.ValidationContextType.(type) {
-	case *CommonTlsContext_ValidationContext:
-		s := proto.Size(x.ValidationContext)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *CommonTlsContext_ValidationContextSdsSecretConfig:
-		s := proto.Size(x.ValidationContextSdsSecretConfig)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *CommonTlsContext_CombinedValidationContext:
-		s := proto.Size(x.CombinedValidationContext)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 type CommonTlsContext_CombinedCertificateValidationContext struct {
@@ -1213,78 +1063,12 @@ func (m *DownstreamTlsContext) GetSessionTicketKeysSdsSecretConfig() *SdsSecretC
 	return nil
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*DownstreamTlsContext) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _DownstreamTlsContext_OneofMarshaler, _DownstreamTlsContext_OneofUnmarshaler, _DownstreamTlsContext_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*DownstreamTlsContext) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*DownstreamTlsContext_SessionTicketKeys)(nil),
 		(*DownstreamTlsContext_SessionTicketKeysSdsSecretConfig)(nil),
 	}
-}
-
-func _DownstreamTlsContext_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*DownstreamTlsContext)
-	// session_ticket_keys_type
-	switch x := m.SessionTicketKeysType.(type) {
-	case *DownstreamTlsContext_SessionTicketKeys:
-		_ = b.EncodeVarint(4<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.SessionTicketKeys); err != nil {
-			return err
-		}
-	case *DownstreamTlsContext_SessionTicketKeysSdsSecretConfig:
-		_ = b.EncodeVarint(5<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.SessionTicketKeysSdsSecretConfig); err != nil {
-			return err
-		}
-	case nil:
-	default:
-		return fmt.Errorf("DownstreamTlsContext.SessionTicketKeysType has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _DownstreamTlsContext_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*DownstreamTlsContext)
-	switch tag {
-	case 4: // session_ticket_keys_type.session_ticket_keys
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(TlsSessionTicketKeys)
-		err := b.DecodeMessage(msg)
-		m.SessionTicketKeysType = &DownstreamTlsContext_SessionTicketKeys{msg}
-		return true, err
-	case 5: // session_ticket_keys_type.session_ticket_keys_sds_secret_config
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(SdsSecretConfig)
-		err := b.DecodeMessage(msg)
-		m.SessionTicketKeysType = &DownstreamTlsContext_SessionTicketKeysSdsSecretConfig{msg}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _DownstreamTlsContext_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*DownstreamTlsContext)
-	// session_ticket_keys_type
-	switch x := m.SessionTicketKeysType.(type) {
-	case *DownstreamTlsContext_SessionTicketKeys:
-		s := proto.Size(x.SessionTicketKeys)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *DownstreamTlsContext_SessionTicketKeysSdsSecretConfig:
-		s := proto.Size(x.SessionTicketKeysSdsSecretConfig)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 // [#proto-status: experimental]
@@ -1448,97 +1232,13 @@ func (m *Secret) GetValidationContext() *CertificateValidationContext {
 	return nil
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*Secret) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _Secret_OneofMarshaler, _Secret_OneofUnmarshaler, _Secret_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*Secret) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*Secret_TlsCertificate)(nil),
 		(*Secret_SessionTicketKeys)(nil),
 		(*Secret_ValidationContext)(nil),
 	}
-}
-
-func _Secret_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*Secret)
-	// type
-	switch x := m.Type.(type) {
-	case *Secret_TlsCertificate:
-		_ = b.EncodeVarint(2<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.TlsCertificate); err != nil {
-			return err
-		}
-	case *Secret_SessionTicketKeys:
-		_ = b.EncodeVarint(3<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.SessionTicketKeys); err != nil {
-			return err
-		}
-	case *Secret_ValidationContext:
-		_ = b.EncodeVarint(4<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.ValidationContext); err != nil {
-			return err
-		}
-	case nil:
-	default:
-		return fmt.Errorf("Secret.Type has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _Secret_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*Secret)
-	switch tag {
-	case 2: // type.tls_certificate
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(TlsCertificate)
-		err := b.DecodeMessage(msg)
-		m.Type = &Secret_TlsCertificate{msg}
-		return true, err
-	case 3: // type.session_ticket_keys
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(TlsSessionTicketKeys)
-		err := b.DecodeMessage(msg)
-		m.Type = &Secret_SessionTicketKeys{msg}
-		return true, err
-	case 4: // type.validation_context
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(CertificateValidationContext)
-		err := b.DecodeMessage(msg)
-		m.Type = &Secret_ValidationContext{msg}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _Secret_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*Secret)
-	// type
-	switch x := m.Type.(type) {
-	case *Secret_TlsCertificate:
-		s := proto.Size(x.TlsCertificate)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *Secret_SessionTicketKeys:
-		s := proto.Size(x.SessionTicketKeys)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *Secret_ValidationContext:
-		s := proto.Size(x.ValidationContext)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 func init() {

--- a/pkg/api/envoy/api/v3alpha/cds.pb.go
+++ b/pkg/api/envoy/api/v3alpha/cds.pb.go
@@ -31,7 +31,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // Refer to :ref:`service discovery type <arch_overview_service_discovery_types>`
 // for an explanation on each type.
@@ -870,142 +870,15 @@ func (m *Cluster) GetFilters() []*cluster.Filter {
 	return nil
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*Cluster) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _Cluster_OneofMarshaler, _Cluster_OneofUnmarshaler, _Cluster_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*Cluster) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*Cluster_Type)(nil),
 		(*Cluster_ClusterType)(nil),
 		(*Cluster_RingHashLbConfig_)(nil),
 		(*Cluster_OriginalDstLbConfig_)(nil),
 		(*Cluster_LeastRequestLbConfig_)(nil),
 	}
-}
-
-func _Cluster_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*Cluster)
-	// cluster_discovery_type
-	switch x := m.ClusterDiscoveryType.(type) {
-	case *Cluster_Type:
-		_ = b.EncodeVarint(2<<3 | proto.WireVarint)
-		_ = b.EncodeVarint(uint64(x.Type))
-	case *Cluster_ClusterType:
-		_ = b.EncodeVarint(38<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.ClusterType); err != nil {
-			return err
-		}
-	case nil:
-	default:
-		return fmt.Errorf("Cluster.ClusterDiscoveryType has unexpected type %T", x)
-	}
-	// lb_config
-	switch x := m.LbConfig.(type) {
-	case *Cluster_RingHashLbConfig_:
-		_ = b.EncodeVarint(23<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.RingHashLbConfig); err != nil {
-			return err
-		}
-	case *Cluster_OriginalDstLbConfig_:
-		_ = b.EncodeVarint(34<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.OriginalDstLbConfig); err != nil {
-			return err
-		}
-	case *Cluster_LeastRequestLbConfig_:
-		_ = b.EncodeVarint(37<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.LeastRequestLbConfig); err != nil {
-			return err
-		}
-	case nil:
-	default:
-		return fmt.Errorf("Cluster.LbConfig has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _Cluster_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*Cluster)
-	switch tag {
-	case 2: // cluster_discovery_type.type
-		if wire != proto.WireVarint {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeVarint()
-		m.ClusterDiscoveryType = &Cluster_Type{Cluster_DiscoveryType(x)}
-		return true, err
-	case 38: // cluster_discovery_type.cluster_type
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(Cluster_CustomClusterType)
-		err := b.DecodeMessage(msg)
-		m.ClusterDiscoveryType = &Cluster_ClusterType{msg}
-		return true, err
-	case 23: // lb_config.ring_hash_lb_config
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(Cluster_RingHashLbConfig)
-		err := b.DecodeMessage(msg)
-		m.LbConfig = &Cluster_RingHashLbConfig_{msg}
-		return true, err
-	case 34: // lb_config.original_dst_lb_config
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(Cluster_OriginalDstLbConfig)
-		err := b.DecodeMessage(msg)
-		m.LbConfig = &Cluster_OriginalDstLbConfig_{msg}
-		return true, err
-	case 37: // lb_config.least_request_lb_config
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(Cluster_LeastRequestLbConfig)
-		err := b.DecodeMessage(msg)
-		m.LbConfig = &Cluster_LeastRequestLbConfig_{msg}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _Cluster_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*Cluster)
-	// cluster_discovery_type
-	switch x := m.ClusterDiscoveryType.(type) {
-	case *Cluster_Type:
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(x.Type))
-	case *Cluster_ClusterType:
-		s := proto.Size(x.ClusterType)
-		n += 2 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	// lb_config
-	switch x := m.LbConfig.(type) {
-	case *Cluster_RingHashLbConfig_:
-		s := proto.Size(x.RingHashLbConfig)
-		n += 2 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *Cluster_OriginalDstLbConfig_:
-		s := proto.Size(x.OriginalDstLbConfig)
-		n += 2 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *Cluster_LeastRequestLbConfig_:
-		s := proto.Size(x.LeastRequestLbConfig)
-		n += 2 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 // Extended cluster type.
@@ -1671,78 +1544,12 @@ func (m *Cluster_CommonLbConfig) GetCloseConnectionsOnHostSetChange() bool {
 	return false
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*Cluster_CommonLbConfig) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _Cluster_CommonLbConfig_OneofMarshaler, _Cluster_CommonLbConfig_OneofUnmarshaler, _Cluster_CommonLbConfig_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*Cluster_CommonLbConfig) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*Cluster_CommonLbConfig_ZoneAwareLbConfig_)(nil),
 		(*Cluster_CommonLbConfig_LocalityWeightedLbConfig_)(nil),
 	}
-}
-
-func _Cluster_CommonLbConfig_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*Cluster_CommonLbConfig)
-	// locality_config_specifier
-	switch x := m.LocalityConfigSpecifier.(type) {
-	case *Cluster_CommonLbConfig_ZoneAwareLbConfig_:
-		_ = b.EncodeVarint(2<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.ZoneAwareLbConfig); err != nil {
-			return err
-		}
-	case *Cluster_CommonLbConfig_LocalityWeightedLbConfig_:
-		_ = b.EncodeVarint(3<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.LocalityWeightedLbConfig); err != nil {
-			return err
-		}
-	case nil:
-	default:
-		return fmt.Errorf("Cluster_CommonLbConfig.LocalityConfigSpecifier has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _Cluster_CommonLbConfig_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*Cluster_CommonLbConfig)
-	switch tag {
-	case 2: // locality_config_specifier.zone_aware_lb_config
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(Cluster_CommonLbConfig_ZoneAwareLbConfig)
-		err := b.DecodeMessage(msg)
-		m.LocalityConfigSpecifier = &Cluster_CommonLbConfig_ZoneAwareLbConfig_{msg}
-		return true, err
-	case 3: // locality_config_specifier.locality_weighted_lb_config
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(Cluster_CommonLbConfig_LocalityWeightedLbConfig)
-		err := b.DecodeMessage(msg)
-		m.LocalityConfigSpecifier = &Cluster_CommonLbConfig_LocalityWeightedLbConfig_{msg}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _Cluster_CommonLbConfig_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*Cluster_CommonLbConfig)
-	// locality_config_specifier
-	switch x := m.LocalityConfigSpecifier.(type) {
-	case *Cluster_CommonLbConfig_ZoneAwareLbConfig_:
-		s := proto.Size(x.ZoneAwareLbConfig)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *Cluster_CommonLbConfig_LocalityWeightedLbConfig_:
-		s := proto.Size(x.LocalityWeightedLbConfig)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 // Configuration for :ref:`zone aware routing

--- a/pkg/api/envoy/api/v3alpha/cluster/circuit_breaker.pb.go
+++ b/pkg/api/envoy/api/v3alpha/cluster/circuit_breaker.pb.go
@@ -22,7 +22,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // :ref:`Circuit breaking<arch_overview_circuit_break>` settings can be
 // specified individually for each defined priority.

--- a/pkg/api/envoy/api/v3alpha/cluster/filter.pb.go
+++ b/pkg/api/envoy/api/v3alpha/cluster/filter.pb.go
@@ -22,7 +22,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // [#protodoc-title: Upstream filters]
 //

--- a/pkg/api/envoy/api/v3alpha/cluster/outlier_detection.pb.go
+++ b/pkg/api/envoy/api/v3alpha/cluster/outlier_detection.pb.go
@@ -22,7 +22,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // See the :ref:`architecture overview <arch_overview_outlier_detection>` for
 // more information on outlier detection.

--- a/pkg/api/envoy/api/v3alpha/core/address.pb.go
+++ b/pkg/api/envoy/api/v3alpha/core/address.pb.go
@@ -22,7 +22,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 type SocketAddress_Protocol int32
 
@@ -233,69 +233,12 @@ func (m *SocketAddress) GetIpv4Compat() bool {
 	return false
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*SocketAddress) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _SocketAddress_OneofMarshaler, _SocketAddress_OneofUnmarshaler, _SocketAddress_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*SocketAddress) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*SocketAddress_PortValue)(nil),
 		(*SocketAddress_NamedPort)(nil),
 	}
-}
-
-func _SocketAddress_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*SocketAddress)
-	// port_specifier
-	switch x := m.PortSpecifier.(type) {
-	case *SocketAddress_PortValue:
-		_ = b.EncodeVarint(3<<3 | proto.WireVarint)
-		_ = b.EncodeVarint(uint64(x.PortValue))
-	case *SocketAddress_NamedPort:
-		_ = b.EncodeVarint(4<<3 | proto.WireBytes)
-		_ = b.EncodeStringBytes(x.NamedPort)
-	case nil:
-	default:
-		return fmt.Errorf("SocketAddress.PortSpecifier has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _SocketAddress_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*SocketAddress)
-	switch tag {
-	case 3: // port_specifier.port_value
-		if wire != proto.WireVarint {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeVarint()
-		m.PortSpecifier = &SocketAddress_PortValue{uint32(x)}
-		return true, err
-	case 4: // port_specifier.named_port
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeStringBytes()
-		m.PortSpecifier = &SocketAddress_NamedPort{x}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _SocketAddress_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*SocketAddress)
-	// port_specifier
-	switch x := m.PortSpecifier.(type) {
-	case *SocketAddress_PortValue:
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(x.PortValue))
-	case *SocketAddress_NamedPort:
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(len(x.NamedPort)))
-		n += len(x.NamedPort)
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 type TcpKeepalive struct {
@@ -525,78 +468,12 @@ func (m *Address) GetPipe() *Pipe {
 	return nil
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*Address) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _Address_OneofMarshaler, _Address_OneofUnmarshaler, _Address_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*Address) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*Address_SocketAddress)(nil),
 		(*Address_Pipe)(nil),
 	}
-}
-
-func _Address_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*Address)
-	// address
-	switch x := m.Address.(type) {
-	case *Address_SocketAddress:
-		_ = b.EncodeVarint(1<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.SocketAddress); err != nil {
-			return err
-		}
-	case *Address_Pipe:
-		_ = b.EncodeVarint(2<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.Pipe); err != nil {
-			return err
-		}
-	case nil:
-	default:
-		return fmt.Errorf("Address.Address has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _Address_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*Address)
-	switch tag {
-	case 1: // address.socket_address
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(SocketAddress)
-		err := b.DecodeMessage(msg)
-		m.Address = &Address_SocketAddress{msg}
-		return true, err
-	case 2: // address.pipe
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(Pipe)
-		err := b.DecodeMessage(msg)
-		m.Address = &Address_Pipe{msg}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _Address_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*Address)
-	// address
-	switch x := m.Address.(type) {
-	case *Address_SocketAddress:
-		s := proto.Size(x.SocketAddress)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *Address_Pipe:
-		s := proto.Size(x.Pipe)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 // CidrRange specifies an IP Address and a prefix length to construct

--- a/pkg/api/envoy/api/v3alpha/core/base.pb.go
+++ b/pkg/api/envoy/api/v3alpha/core/base.pb.go
@@ -23,7 +23,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // Envoy supports :ref:`upstream priority routing
 // <arch_overview_http_routing_priority>` both at the route and the virtual
@@ -741,85 +741,13 @@ func (m *DataSource) GetInlineString() string {
 	return ""
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*DataSource) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _DataSource_OneofMarshaler, _DataSource_OneofUnmarshaler, _DataSource_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*DataSource) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*DataSource_Filename)(nil),
 		(*DataSource_InlineBytes)(nil),
 		(*DataSource_InlineString)(nil),
 	}
-}
-
-func _DataSource_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*DataSource)
-	// specifier
-	switch x := m.Specifier.(type) {
-	case *DataSource_Filename:
-		_ = b.EncodeVarint(1<<3 | proto.WireBytes)
-		_ = b.EncodeStringBytes(x.Filename)
-	case *DataSource_InlineBytes:
-		_ = b.EncodeVarint(2<<3 | proto.WireBytes)
-		_ = b.EncodeRawBytes(x.InlineBytes)
-	case *DataSource_InlineString:
-		_ = b.EncodeVarint(3<<3 | proto.WireBytes)
-		_ = b.EncodeStringBytes(x.InlineString)
-	case nil:
-	default:
-		return fmt.Errorf("DataSource.Specifier has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _DataSource_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*DataSource)
-	switch tag {
-	case 1: // specifier.filename
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeStringBytes()
-		m.Specifier = &DataSource_Filename{x}
-		return true, err
-	case 2: // specifier.inline_bytes
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeRawBytes(true)
-		m.Specifier = &DataSource_InlineBytes{x}
-		return true, err
-	case 3: // specifier.inline_string
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeStringBytes()
-		m.Specifier = &DataSource_InlineString{x}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _DataSource_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*DataSource)
-	// specifier
-	switch x := m.Specifier.(type) {
-	case *DataSource_Filename:
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(len(x.Filename)))
-		n += len(x.Filename)
-	case *DataSource_InlineBytes:
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(len(x.InlineBytes)))
-		n += len(x.InlineBytes)
-	case *DataSource_InlineString:
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(len(x.InlineString)))
-		n += len(x.InlineString)
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 // The message specifies how to fetch data from remote and how to verify it.
@@ -961,78 +889,12 @@ func (m *AsyncDataSource) GetRemote() *RemoteDataSource {
 	return nil
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*AsyncDataSource) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _AsyncDataSource_OneofMarshaler, _AsyncDataSource_OneofUnmarshaler, _AsyncDataSource_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*AsyncDataSource) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*AsyncDataSource_Local)(nil),
 		(*AsyncDataSource_Remote)(nil),
 	}
-}
-
-func _AsyncDataSource_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*AsyncDataSource)
-	// specifier
-	switch x := m.Specifier.(type) {
-	case *AsyncDataSource_Local:
-		_ = b.EncodeVarint(1<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.Local); err != nil {
-			return err
-		}
-	case *AsyncDataSource_Remote:
-		_ = b.EncodeVarint(2<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.Remote); err != nil {
-			return err
-		}
-	case nil:
-	default:
-		return fmt.Errorf("AsyncDataSource.Specifier has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _AsyncDataSource_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*AsyncDataSource)
-	switch tag {
-	case 1: // specifier.local
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(DataSource)
-		err := b.DecodeMessage(msg)
-		m.Specifier = &AsyncDataSource_Local{msg}
-		return true, err
-	case 2: // specifier.remote
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(RemoteDataSource)
-		err := b.DecodeMessage(msg)
-		m.Specifier = &AsyncDataSource_Remote{msg}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _AsyncDataSource_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*AsyncDataSource)
-	// specifier
-	switch x := m.Specifier.(type) {
-	case *AsyncDataSource_Local:
-		s := proto.Size(x.Local)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *AsyncDataSource_Remote:
-		s := proto.Size(x.Remote)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 // Configuration for transport socket in :ref:`listeners <config_listeners>` and
@@ -1132,78 +994,12 @@ func (m *TransportSocket) GetTypedConfig() *types.Any {
 	return nil
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*TransportSocket) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _TransportSocket_OneofMarshaler, _TransportSocket_OneofUnmarshaler, _TransportSocket_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*TransportSocket) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*TransportSocket_Config)(nil),
 		(*TransportSocket_TypedConfig)(nil),
 	}
-}
-
-func _TransportSocket_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*TransportSocket)
-	// config_type
-	switch x := m.ConfigType.(type) {
-	case *TransportSocket_Config:
-		_ = b.EncodeVarint(2<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.Config); err != nil {
-			return err
-		}
-	case *TransportSocket_TypedConfig:
-		_ = b.EncodeVarint(3<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.TypedConfig); err != nil {
-			return err
-		}
-	case nil:
-	default:
-		return fmt.Errorf("TransportSocket.ConfigType has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _TransportSocket_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*TransportSocket)
-	switch tag {
-	case 2: // config_type.config
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(types.Struct)
-		err := b.DecodeMessage(msg)
-		m.ConfigType = &TransportSocket_Config{msg}
-		return true, err
-	case 3: // config_type.typed_config
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(types.Any)
-		err := b.DecodeMessage(msg)
-		m.ConfigType = &TransportSocket_TypedConfig{msg}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _TransportSocket_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*TransportSocket)
-	// config_type
-	switch x := m.ConfigType.(type) {
-	case *TransportSocket_Config:
-		s := proto.Size(x.Config)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *TransportSocket_TypedConfig:
-		s := proto.Size(x.TypedConfig)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 // Generic socket option message. This would be used to set socket options that
@@ -1326,69 +1122,12 @@ func (m *SocketOption) GetState() SocketOption_SocketState {
 	return SocketOption_STATE_PREBIND
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*SocketOption) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _SocketOption_OneofMarshaler, _SocketOption_OneofUnmarshaler, _SocketOption_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*SocketOption) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*SocketOption_IntValue)(nil),
 		(*SocketOption_BufValue)(nil),
 	}
-}
-
-func _SocketOption_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*SocketOption)
-	// value
-	switch x := m.Value.(type) {
-	case *SocketOption_IntValue:
-		_ = b.EncodeVarint(4<<3 | proto.WireVarint)
-		_ = b.EncodeVarint(uint64(x.IntValue))
-	case *SocketOption_BufValue:
-		_ = b.EncodeVarint(5<<3 | proto.WireBytes)
-		_ = b.EncodeRawBytes(x.BufValue)
-	case nil:
-	default:
-		return fmt.Errorf("SocketOption.Value has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _SocketOption_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*SocketOption)
-	switch tag {
-	case 4: // value.int_value
-		if wire != proto.WireVarint {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeVarint()
-		m.Value = &SocketOption_IntValue{int64(x)}
-		return true, err
-	case 5: // value.buf_value
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeRawBytes(true)
-		m.Value = &SocketOption_BufValue{x}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _SocketOption_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*SocketOption)
-	// value
-	switch x := m.Value.(type) {
-	case *SocketOption_IntValue:
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(x.IntValue))
-	case *SocketOption_BufValue:
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(len(x.BufValue)))
-		n += len(x.BufValue)
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 // Runtime derived FractionalPercent with defaults for when the numerator or denominator is not

--- a/pkg/api/envoy/api/v3alpha/core/config_source.pb.go
+++ b/pkg/api/envoy/api/v3alpha/core/config_source.pb.go
@@ -22,7 +22,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // APIs may be fetched via either REST or gRPC.
 type ApiConfigSource_ApiType int32
@@ -395,93 +395,13 @@ func (m *ConfigSource) GetInitialFetchTimeout() *types.Duration {
 	return nil
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*ConfigSource) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _ConfigSource_OneofMarshaler, _ConfigSource_OneofUnmarshaler, _ConfigSource_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*ConfigSource) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*ConfigSource_Path)(nil),
 		(*ConfigSource_ApiConfigSource)(nil),
 		(*ConfigSource_Ads)(nil),
 	}
-}
-
-func _ConfigSource_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*ConfigSource)
-	// config_source_specifier
-	switch x := m.ConfigSourceSpecifier.(type) {
-	case *ConfigSource_Path:
-		_ = b.EncodeVarint(1<<3 | proto.WireBytes)
-		_ = b.EncodeStringBytes(x.Path)
-	case *ConfigSource_ApiConfigSource:
-		_ = b.EncodeVarint(2<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.ApiConfigSource); err != nil {
-			return err
-		}
-	case *ConfigSource_Ads:
-		_ = b.EncodeVarint(3<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.Ads); err != nil {
-			return err
-		}
-	case nil:
-	default:
-		return fmt.Errorf("ConfigSource.ConfigSourceSpecifier has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _ConfigSource_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*ConfigSource)
-	switch tag {
-	case 1: // config_source_specifier.path
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeStringBytes()
-		m.ConfigSourceSpecifier = &ConfigSource_Path{x}
-		return true, err
-	case 2: // config_source_specifier.api_config_source
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(ApiConfigSource)
-		err := b.DecodeMessage(msg)
-		m.ConfigSourceSpecifier = &ConfigSource_ApiConfigSource{msg}
-		return true, err
-	case 3: // config_source_specifier.ads
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(AggregatedConfigSource)
-		err := b.DecodeMessage(msg)
-		m.ConfigSourceSpecifier = &ConfigSource_Ads{msg}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _ConfigSource_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*ConfigSource)
-	// config_source_specifier
-	switch x := m.ConfigSourceSpecifier.(type) {
-	case *ConfigSource_Path:
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(len(x.Path)))
-		n += len(x.Path)
-	case *ConfigSource_ApiConfigSource:
-		s := proto.Size(x.ApiConfigSource)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *ConfigSource_Ads:
-		s := proto.Size(x.Ads)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 func init() {

--- a/pkg/api/envoy/api/v3alpha/core/grpc_service.pb.go
+++ b/pkg/api/envoy/api/v3alpha/core/grpc_service.pb.go
@@ -22,7 +22,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // gRPC service configuration. This is used by :ref:`ApiConfigSource
 // <envoy_api_msg_core.ApiConfigSource>` and filter configurations.
@@ -127,78 +127,12 @@ func (m *GrpcService) GetInitialMetadata() []*HeaderValue {
 	return nil
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*GrpcService) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _GrpcService_OneofMarshaler, _GrpcService_OneofUnmarshaler, _GrpcService_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*GrpcService) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*GrpcService_EnvoyGrpc_)(nil),
 		(*GrpcService_GoogleGrpc_)(nil),
 	}
-}
-
-func _GrpcService_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*GrpcService)
-	// target_specifier
-	switch x := m.TargetSpecifier.(type) {
-	case *GrpcService_EnvoyGrpc_:
-		_ = b.EncodeVarint(1<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.EnvoyGrpc); err != nil {
-			return err
-		}
-	case *GrpcService_GoogleGrpc_:
-		_ = b.EncodeVarint(2<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.GoogleGrpc); err != nil {
-			return err
-		}
-	case nil:
-	default:
-		return fmt.Errorf("GrpcService.TargetSpecifier has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _GrpcService_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*GrpcService)
-	switch tag {
-	case 1: // target_specifier.envoy_grpc
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(GrpcService_EnvoyGrpc)
-		err := b.DecodeMessage(msg)
-		m.TargetSpecifier = &GrpcService_EnvoyGrpc_{msg}
-		return true, err
-	case 2: // target_specifier.google_grpc
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(GrpcService_GoogleGrpc)
-		err := b.DecodeMessage(msg)
-		m.TargetSpecifier = &GrpcService_GoogleGrpc_{msg}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _GrpcService_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*GrpcService)
-	// target_specifier
-	switch x := m.TargetSpecifier.(type) {
-	case *GrpcService_EnvoyGrpc_:
-		s := proto.Size(x.EnvoyGrpc)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *GrpcService_GoogleGrpc_:
-		s := proto.Size(x.GoogleGrpc)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 type GrpcService_EnvoyGrpc struct {
@@ -569,97 +503,13 @@ func (m *GrpcService_GoogleGrpc_ChannelCredentials) GetLocalCredentials() *GrpcS
 	return nil
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*GrpcService_GoogleGrpc_ChannelCredentials) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _GrpcService_GoogleGrpc_ChannelCredentials_OneofMarshaler, _GrpcService_GoogleGrpc_ChannelCredentials_OneofUnmarshaler, _GrpcService_GoogleGrpc_ChannelCredentials_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*GrpcService_GoogleGrpc_ChannelCredentials) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*GrpcService_GoogleGrpc_ChannelCredentials_SslCredentials)(nil),
 		(*GrpcService_GoogleGrpc_ChannelCredentials_GoogleDefault)(nil),
 		(*GrpcService_GoogleGrpc_ChannelCredentials_LocalCredentials)(nil),
 	}
-}
-
-func _GrpcService_GoogleGrpc_ChannelCredentials_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*GrpcService_GoogleGrpc_ChannelCredentials)
-	// credential_specifier
-	switch x := m.CredentialSpecifier.(type) {
-	case *GrpcService_GoogleGrpc_ChannelCredentials_SslCredentials:
-		_ = b.EncodeVarint(1<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.SslCredentials); err != nil {
-			return err
-		}
-	case *GrpcService_GoogleGrpc_ChannelCredentials_GoogleDefault:
-		_ = b.EncodeVarint(2<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.GoogleDefault); err != nil {
-			return err
-		}
-	case *GrpcService_GoogleGrpc_ChannelCredentials_LocalCredentials:
-		_ = b.EncodeVarint(3<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.LocalCredentials); err != nil {
-			return err
-		}
-	case nil:
-	default:
-		return fmt.Errorf("GrpcService_GoogleGrpc_ChannelCredentials.CredentialSpecifier has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _GrpcService_GoogleGrpc_ChannelCredentials_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*GrpcService_GoogleGrpc_ChannelCredentials)
-	switch tag {
-	case 1: // credential_specifier.ssl_credentials
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(GrpcService_GoogleGrpc_SslCredentials)
-		err := b.DecodeMessage(msg)
-		m.CredentialSpecifier = &GrpcService_GoogleGrpc_ChannelCredentials_SslCredentials{msg}
-		return true, err
-	case 2: // credential_specifier.google_default
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(types.Empty)
-		err := b.DecodeMessage(msg)
-		m.CredentialSpecifier = &GrpcService_GoogleGrpc_ChannelCredentials_GoogleDefault{msg}
-		return true, err
-	case 3: // credential_specifier.local_credentials
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(GrpcService_GoogleGrpc_GoogleLocalCredentials)
-		err := b.DecodeMessage(msg)
-		m.CredentialSpecifier = &GrpcService_GoogleGrpc_ChannelCredentials_LocalCredentials{msg}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _GrpcService_GoogleGrpc_ChannelCredentials_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*GrpcService_GoogleGrpc_ChannelCredentials)
-	// credential_specifier
-	switch x := m.CredentialSpecifier.(type) {
-	case *GrpcService_GoogleGrpc_ChannelCredentials_SslCredentials:
-		s := proto.Size(x.SslCredentials)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *GrpcService_GoogleGrpc_ChannelCredentials_GoogleDefault:
-		s := proto.Size(x.GoogleDefault)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *GrpcService_GoogleGrpc_ChannelCredentials_LocalCredentials:
-		s := proto.Size(x.LocalCredentials)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 type GrpcService_GoogleGrpc_CallCredentials struct {
@@ -798,9 +648,9 @@ func (m *GrpcService_GoogleGrpc_CallCredentials) GetFromPlugin() *GrpcService_Go
 	return nil
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*GrpcService_GoogleGrpc_CallCredentials) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _GrpcService_GoogleGrpc_CallCredentials_OneofMarshaler, _GrpcService_GoogleGrpc_CallCredentials_OneofUnmarshaler, _GrpcService_GoogleGrpc_CallCredentials_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*GrpcService_GoogleGrpc_CallCredentials) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*GrpcService_GoogleGrpc_CallCredentials_AccessToken)(nil),
 		(*GrpcService_GoogleGrpc_CallCredentials_GoogleComputeEngine)(nil),
 		(*GrpcService_GoogleGrpc_CallCredentials_GoogleRefreshToken)(nil),
@@ -808,136 +658,6 @@ func (*GrpcService_GoogleGrpc_CallCredentials) XXX_OneofFuncs() (func(msg proto.
 		(*GrpcService_GoogleGrpc_CallCredentials_GoogleIam)(nil),
 		(*GrpcService_GoogleGrpc_CallCredentials_FromPlugin)(nil),
 	}
-}
-
-func _GrpcService_GoogleGrpc_CallCredentials_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*GrpcService_GoogleGrpc_CallCredentials)
-	// credential_specifier
-	switch x := m.CredentialSpecifier.(type) {
-	case *GrpcService_GoogleGrpc_CallCredentials_AccessToken:
-		_ = b.EncodeVarint(1<<3 | proto.WireBytes)
-		_ = b.EncodeStringBytes(x.AccessToken)
-	case *GrpcService_GoogleGrpc_CallCredentials_GoogleComputeEngine:
-		_ = b.EncodeVarint(2<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.GoogleComputeEngine); err != nil {
-			return err
-		}
-	case *GrpcService_GoogleGrpc_CallCredentials_GoogleRefreshToken:
-		_ = b.EncodeVarint(3<<3 | proto.WireBytes)
-		_ = b.EncodeStringBytes(x.GoogleRefreshToken)
-	case *GrpcService_GoogleGrpc_CallCredentials_ServiceAccountJwtAccess:
-		_ = b.EncodeVarint(4<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.ServiceAccountJwtAccess); err != nil {
-			return err
-		}
-	case *GrpcService_GoogleGrpc_CallCredentials_GoogleIam:
-		_ = b.EncodeVarint(5<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.GoogleIam); err != nil {
-			return err
-		}
-	case *GrpcService_GoogleGrpc_CallCredentials_FromPlugin:
-		_ = b.EncodeVarint(6<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.FromPlugin); err != nil {
-			return err
-		}
-	case nil:
-	default:
-		return fmt.Errorf("GrpcService_GoogleGrpc_CallCredentials.CredentialSpecifier has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _GrpcService_GoogleGrpc_CallCredentials_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*GrpcService_GoogleGrpc_CallCredentials)
-	switch tag {
-	case 1: // credential_specifier.access_token
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeStringBytes()
-		m.CredentialSpecifier = &GrpcService_GoogleGrpc_CallCredentials_AccessToken{x}
-		return true, err
-	case 2: // credential_specifier.google_compute_engine
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(types.Empty)
-		err := b.DecodeMessage(msg)
-		m.CredentialSpecifier = &GrpcService_GoogleGrpc_CallCredentials_GoogleComputeEngine{msg}
-		return true, err
-	case 3: // credential_specifier.google_refresh_token
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeStringBytes()
-		m.CredentialSpecifier = &GrpcService_GoogleGrpc_CallCredentials_GoogleRefreshToken{x}
-		return true, err
-	case 4: // credential_specifier.service_account_jwt_access
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(GrpcService_GoogleGrpc_CallCredentials_ServiceAccountJWTAccessCredentials)
-		err := b.DecodeMessage(msg)
-		m.CredentialSpecifier = &GrpcService_GoogleGrpc_CallCredentials_ServiceAccountJwtAccess{msg}
-		return true, err
-	case 5: // credential_specifier.google_iam
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(GrpcService_GoogleGrpc_CallCredentials_GoogleIAMCredentials)
-		err := b.DecodeMessage(msg)
-		m.CredentialSpecifier = &GrpcService_GoogleGrpc_CallCredentials_GoogleIam{msg}
-		return true, err
-	case 6: // credential_specifier.from_plugin
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(GrpcService_GoogleGrpc_CallCredentials_MetadataCredentialsFromPlugin)
-		err := b.DecodeMessage(msg)
-		m.CredentialSpecifier = &GrpcService_GoogleGrpc_CallCredentials_FromPlugin{msg}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _GrpcService_GoogleGrpc_CallCredentials_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*GrpcService_GoogleGrpc_CallCredentials)
-	// credential_specifier
-	switch x := m.CredentialSpecifier.(type) {
-	case *GrpcService_GoogleGrpc_CallCredentials_AccessToken:
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(len(x.AccessToken)))
-		n += len(x.AccessToken)
-	case *GrpcService_GoogleGrpc_CallCredentials_GoogleComputeEngine:
-		s := proto.Size(x.GoogleComputeEngine)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *GrpcService_GoogleGrpc_CallCredentials_GoogleRefreshToken:
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(len(x.GoogleRefreshToken)))
-		n += len(x.GoogleRefreshToken)
-	case *GrpcService_GoogleGrpc_CallCredentials_ServiceAccountJwtAccess:
-		s := proto.Size(x.ServiceAccountJwtAccess)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *GrpcService_GoogleGrpc_CallCredentials_GoogleIam:
-		s := proto.Size(x.GoogleIam)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *GrpcService_GoogleGrpc_CallCredentials_FromPlugin:
-		s := proto.Size(x.FromPlugin)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 type GrpcService_GoogleGrpc_CallCredentials_ServiceAccountJWTAccessCredentials struct {
@@ -1152,78 +872,12 @@ func (m *GrpcService_GoogleGrpc_CallCredentials_MetadataCredentialsFromPlugin) G
 	return nil
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*GrpcService_GoogleGrpc_CallCredentials_MetadataCredentialsFromPlugin) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _GrpcService_GoogleGrpc_CallCredentials_MetadataCredentialsFromPlugin_OneofMarshaler, _GrpcService_GoogleGrpc_CallCredentials_MetadataCredentialsFromPlugin_OneofUnmarshaler, _GrpcService_GoogleGrpc_CallCredentials_MetadataCredentialsFromPlugin_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*GrpcService_GoogleGrpc_CallCredentials_MetadataCredentialsFromPlugin) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*GrpcService_GoogleGrpc_CallCredentials_MetadataCredentialsFromPlugin_Config)(nil),
 		(*GrpcService_GoogleGrpc_CallCredentials_MetadataCredentialsFromPlugin_TypedConfig)(nil),
 	}
-}
-
-func _GrpcService_GoogleGrpc_CallCredentials_MetadataCredentialsFromPlugin_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*GrpcService_GoogleGrpc_CallCredentials_MetadataCredentialsFromPlugin)
-	// config_type
-	switch x := m.ConfigType.(type) {
-	case *GrpcService_GoogleGrpc_CallCredentials_MetadataCredentialsFromPlugin_Config:
-		_ = b.EncodeVarint(2<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.Config); err != nil {
-			return err
-		}
-	case *GrpcService_GoogleGrpc_CallCredentials_MetadataCredentialsFromPlugin_TypedConfig:
-		_ = b.EncodeVarint(3<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.TypedConfig); err != nil {
-			return err
-		}
-	case nil:
-	default:
-		return fmt.Errorf("GrpcService_GoogleGrpc_CallCredentials_MetadataCredentialsFromPlugin.ConfigType has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _GrpcService_GoogleGrpc_CallCredentials_MetadataCredentialsFromPlugin_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*GrpcService_GoogleGrpc_CallCredentials_MetadataCredentialsFromPlugin)
-	switch tag {
-	case 2: // config_type.config
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(types.Struct)
-		err := b.DecodeMessage(msg)
-		m.ConfigType = &GrpcService_GoogleGrpc_CallCredentials_MetadataCredentialsFromPlugin_Config{msg}
-		return true, err
-	case 3: // config_type.typed_config
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(types.Any)
-		err := b.DecodeMessage(msg)
-		m.ConfigType = &GrpcService_GoogleGrpc_CallCredentials_MetadataCredentialsFromPlugin_TypedConfig{msg}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _GrpcService_GoogleGrpc_CallCredentials_MetadataCredentialsFromPlugin_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*GrpcService_GoogleGrpc_CallCredentials_MetadataCredentialsFromPlugin)
-	// config_type
-	switch x := m.ConfigType.(type) {
-	case *GrpcService_GoogleGrpc_CallCredentials_MetadataCredentialsFromPlugin_Config:
-		s := proto.Size(x.Config)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *GrpcService_GoogleGrpc_CallCredentials_MetadataCredentialsFromPlugin_TypedConfig:
-		s := proto.Size(x.TypedConfig)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 func init() {

--- a/pkg/api/envoy/api/v3alpha/core/health_check.pb.go
+++ b/pkg/api/envoy/api/v3alpha/core/health_check.pb.go
@@ -23,7 +23,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // Endpoint health status.
 type HealthStatus int32
@@ -349,116 +349,14 @@ func (m *HealthCheck) GetAlwaysLogHealthCheckFailures() bool {
 	return false
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*HealthCheck) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _HealthCheck_OneofMarshaler, _HealthCheck_OneofUnmarshaler, _HealthCheck_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*HealthCheck) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*HealthCheck_HttpHealthCheck_)(nil),
 		(*HealthCheck_TcpHealthCheck_)(nil),
 		(*HealthCheck_GrpcHealthCheck_)(nil),
 		(*HealthCheck_CustomHealthCheck_)(nil),
 	}
-}
-
-func _HealthCheck_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*HealthCheck)
-	// health_checker
-	switch x := m.HealthChecker.(type) {
-	case *HealthCheck_HttpHealthCheck_:
-		_ = b.EncodeVarint(8<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.HttpHealthCheck); err != nil {
-			return err
-		}
-	case *HealthCheck_TcpHealthCheck_:
-		_ = b.EncodeVarint(9<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.TcpHealthCheck); err != nil {
-			return err
-		}
-	case *HealthCheck_GrpcHealthCheck_:
-		_ = b.EncodeVarint(11<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.GrpcHealthCheck); err != nil {
-			return err
-		}
-	case *HealthCheck_CustomHealthCheck_:
-		_ = b.EncodeVarint(13<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.CustomHealthCheck); err != nil {
-			return err
-		}
-	case nil:
-	default:
-		return fmt.Errorf("HealthCheck.HealthChecker has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _HealthCheck_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*HealthCheck)
-	switch tag {
-	case 8: // health_checker.http_health_check
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(HealthCheck_HttpHealthCheck)
-		err := b.DecodeMessage(msg)
-		m.HealthChecker = &HealthCheck_HttpHealthCheck_{msg}
-		return true, err
-	case 9: // health_checker.tcp_health_check
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(HealthCheck_TcpHealthCheck)
-		err := b.DecodeMessage(msg)
-		m.HealthChecker = &HealthCheck_TcpHealthCheck_{msg}
-		return true, err
-	case 11: // health_checker.grpc_health_check
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(HealthCheck_GrpcHealthCheck)
-		err := b.DecodeMessage(msg)
-		m.HealthChecker = &HealthCheck_GrpcHealthCheck_{msg}
-		return true, err
-	case 13: // health_checker.custom_health_check
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(HealthCheck_CustomHealthCheck)
-		err := b.DecodeMessage(msg)
-		m.HealthChecker = &HealthCheck_CustomHealthCheck_{msg}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _HealthCheck_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*HealthCheck)
-	// health_checker
-	switch x := m.HealthChecker.(type) {
-	case *HealthCheck_HttpHealthCheck_:
-		s := proto.Size(x.HttpHealthCheck)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *HealthCheck_TcpHealthCheck_:
-		s := proto.Size(x.TcpHealthCheck)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *HealthCheck_GrpcHealthCheck_:
-		s := proto.Size(x.GrpcHealthCheck)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *HealthCheck_CustomHealthCheck_:
-		s := proto.Size(x.CustomHealthCheck)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 // Describes the encoding of the payload bytes in the payload.
@@ -542,70 +440,12 @@ func (m *HealthCheck_Payload) GetBinary() []byte {
 	return nil
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*HealthCheck_Payload) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _HealthCheck_Payload_OneofMarshaler, _HealthCheck_Payload_OneofUnmarshaler, _HealthCheck_Payload_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*HealthCheck_Payload) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*HealthCheck_Payload_Text)(nil),
 		(*HealthCheck_Payload_Binary)(nil),
 	}
-}
-
-func _HealthCheck_Payload_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*HealthCheck_Payload)
-	// payload
-	switch x := m.Payload.(type) {
-	case *HealthCheck_Payload_Text:
-		_ = b.EncodeVarint(1<<3 | proto.WireBytes)
-		_ = b.EncodeStringBytes(x.Text)
-	case *HealthCheck_Payload_Binary:
-		_ = b.EncodeVarint(2<<3 | proto.WireBytes)
-		_ = b.EncodeRawBytes(x.Binary)
-	case nil:
-	default:
-		return fmt.Errorf("HealthCheck_Payload.Payload has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _HealthCheck_Payload_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*HealthCheck_Payload)
-	switch tag {
-	case 1: // payload.text
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeStringBytes()
-		m.Payload = &HealthCheck_Payload_Text{x}
-		return true, err
-	case 2: // payload.binary
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeRawBytes(true)
-		m.Payload = &HealthCheck_Payload_Binary{x}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _HealthCheck_Payload_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*HealthCheck_Payload)
-	// payload
-	switch x := m.Payload.(type) {
-	case *HealthCheck_Payload_Text:
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(len(x.Text)))
-		n += len(x.Text)
-	case *HealthCheck_Payload_Binary:
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(len(x.Binary)))
-		n += len(x.Binary)
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 // [#comment:next free field: 10]
@@ -1010,78 +850,12 @@ func (m *HealthCheck_CustomHealthCheck) GetTypedConfig() *types.Any {
 	return nil
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*HealthCheck_CustomHealthCheck) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _HealthCheck_CustomHealthCheck_OneofMarshaler, _HealthCheck_CustomHealthCheck_OneofUnmarshaler, _HealthCheck_CustomHealthCheck_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*HealthCheck_CustomHealthCheck) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*HealthCheck_CustomHealthCheck_Config)(nil),
 		(*HealthCheck_CustomHealthCheck_TypedConfig)(nil),
 	}
-}
-
-func _HealthCheck_CustomHealthCheck_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*HealthCheck_CustomHealthCheck)
-	// config_type
-	switch x := m.ConfigType.(type) {
-	case *HealthCheck_CustomHealthCheck_Config:
-		_ = b.EncodeVarint(2<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.Config); err != nil {
-			return err
-		}
-	case *HealthCheck_CustomHealthCheck_TypedConfig:
-		_ = b.EncodeVarint(3<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.TypedConfig); err != nil {
-			return err
-		}
-	case nil:
-	default:
-		return fmt.Errorf("HealthCheck_CustomHealthCheck.ConfigType has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _HealthCheck_CustomHealthCheck_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*HealthCheck_CustomHealthCheck)
-	switch tag {
-	case 2: // config_type.config
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(types.Struct)
-		err := b.DecodeMessage(msg)
-		m.ConfigType = &HealthCheck_CustomHealthCheck_Config{msg}
-		return true, err
-	case 3: // config_type.typed_config
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(types.Any)
-		err := b.DecodeMessage(msg)
-		m.ConfigType = &HealthCheck_CustomHealthCheck_TypedConfig{msg}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _HealthCheck_CustomHealthCheck_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*HealthCheck_CustomHealthCheck)
-	// config_type
-	switch x := m.ConfigType.(type) {
-	case *HealthCheck_CustomHealthCheck_Config:
-		s := proto.Size(x.Config)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *HealthCheck_CustomHealthCheck_TypedConfig:
-		s := proto.Size(x.TypedConfig)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 func init() {

--- a/pkg/api/envoy/api/v3alpha/core/http_uri.pb.go
+++ b/pkg/api/envoy/api/v3alpha/core/http_uri.pb.go
@@ -22,7 +22,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // Envoy external URI descriptor
 type HttpUri struct {
@@ -123,55 +123,11 @@ func (m *HttpUri) GetTimeout() *types.Duration {
 	return nil
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*HttpUri) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _HttpUri_OneofMarshaler, _HttpUri_OneofUnmarshaler, _HttpUri_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*HttpUri) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*HttpUri_Cluster)(nil),
 	}
-}
-
-func _HttpUri_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*HttpUri)
-	// http_upstream_type
-	switch x := m.HttpUpstreamType.(type) {
-	case *HttpUri_Cluster:
-		_ = b.EncodeVarint(2<<3 | proto.WireBytes)
-		_ = b.EncodeStringBytes(x.Cluster)
-	case nil:
-	default:
-		return fmt.Errorf("HttpUri.HttpUpstreamType has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _HttpUri_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*HttpUri)
-	switch tag {
-	case 2: // http_upstream_type.cluster
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeStringBytes()
-		m.HttpUpstreamType = &HttpUri_Cluster{x}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _HttpUri_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*HttpUri)
-	// http_upstream_type
-	switch x := m.HttpUpstreamType.(type) {
-	case *HttpUri_Cluster:
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(len(x.Cluster)))
-		n += len(x.Cluster)
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 func init() {

--- a/pkg/api/envoy/api/v3alpha/core/protocol.pb.go
+++ b/pkg/api/envoy/api/v3alpha/core/protocol.pb.go
@@ -22,7 +22,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // [#not-implemented-hide:]
 type TcpProtocolOptions struct {

--- a/pkg/api/envoy/api/v3alpha/discovery.pb.go
+++ b/pkg/api/envoy/api/v3alpha/discovery.pb.go
@@ -23,7 +23,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // A DiscoveryRequest requests a set of versioned resources of the same type for
 // a given Envoy node on some API.

--- a/pkg/api/envoy/api/v3alpha/eds.pb.go
+++ b/pkg/api/envoy/api/v3alpha/eds.pb.go
@@ -29,7 +29,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // Each route from RDS will map to a single cluster or traffic split across
 // clusters using weights expressed in the RDS WeightedCluster.

--- a/pkg/api/envoy/api/v3alpha/endpoint/endpoint.pb.go
+++ b/pkg/api/envoy/api/v3alpha/endpoint/endpoint.pb.go
@@ -23,7 +23,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // Upstream host identifier.
 type Endpoint struct {
@@ -274,74 +274,12 @@ func (m *LbEndpoint) GetLoadBalancingWeight() *types.UInt32Value {
 	return nil
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*LbEndpoint) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _LbEndpoint_OneofMarshaler, _LbEndpoint_OneofUnmarshaler, _LbEndpoint_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*LbEndpoint) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*LbEndpoint_Endpoint)(nil),
 		(*LbEndpoint_EndpointName)(nil),
 	}
-}
-
-func _LbEndpoint_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*LbEndpoint)
-	// host_identifier
-	switch x := m.HostIdentifier.(type) {
-	case *LbEndpoint_Endpoint:
-		_ = b.EncodeVarint(1<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.Endpoint); err != nil {
-			return err
-		}
-	case *LbEndpoint_EndpointName:
-		_ = b.EncodeVarint(5<<3 | proto.WireBytes)
-		_ = b.EncodeStringBytes(x.EndpointName)
-	case nil:
-	default:
-		return fmt.Errorf("LbEndpoint.HostIdentifier has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _LbEndpoint_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*LbEndpoint)
-	switch tag {
-	case 1: // host_identifier.endpoint
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(Endpoint)
-		err := b.DecodeMessage(msg)
-		m.HostIdentifier = &LbEndpoint_Endpoint{msg}
-		return true, err
-	case 5: // host_identifier.endpoint_name
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeStringBytes()
-		m.HostIdentifier = &LbEndpoint_EndpointName{x}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _LbEndpoint_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*LbEndpoint)
-	// host_identifier
-	switch x := m.HostIdentifier.(type) {
-	case *LbEndpoint_Endpoint:
-		s := proto.Size(x.Endpoint)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *LbEndpoint_EndpointName:
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(len(x.EndpointName)))
-		n += len(x.EndpointName)
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 // A group of endpoints belonging to a Locality.

--- a/pkg/api/envoy/api/v3alpha/endpoint/load_report.pb.go
+++ b/pkg/api/envoy/api/v3alpha/endpoint/load_report.pb.go
@@ -24,7 +24,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // These are stats Envoy reports to GLB every so often. Report frequency is
 // defined by

--- a/pkg/api/envoy/api/v3alpha/lds.pb.go
+++ b/pkg/api/envoy/api/v3alpha/lds.pb.go
@@ -29,7 +29,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 type Listener_DrainType int32
 

--- a/pkg/api/envoy/api/v3alpha/listener/listener.pb.go
+++ b/pkg/api/envoy/api/v3alpha/listener/listener.pb.go
@@ -24,7 +24,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 type FilterChainMatch_ConnectionSourceType int32
 
@@ -150,78 +150,12 @@ func (m *Filter) GetTypedConfig() *types.Any {
 	return nil
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*Filter) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _Filter_OneofMarshaler, _Filter_OneofUnmarshaler, _Filter_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*Filter) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*Filter_Config)(nil),
 		(*Filter_TypedConfig)(nil),
 	}
-}
-
-func _Filter_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*Filter)
-	// config_type
-	switch x := m.ConfigType.(type) {
-	case *Filter_Config:
-		_ = b.EncodeVarint(2<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.Config); err != nil {
-			return err
-		}
-	case *Filter_TypedConfig:
-		_ = b.EncodeVarint(4<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.TypedConfig); err != nil {
-			return err
-		}
-	case nil:
-	default:
-		return fmt.Errorf("Filter.ConfigType has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _Filter_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*Filter)
-	switch tag {
-	case 2: // config_type.config
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(types.Struct)
-		err := b.DecodeMessage(msg)
-		m.ConfigType = &Filter_Config{msg}
-		return true, err
-	case 4: // config_type.typed_config
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(types.Any)
-		err := b.DecodeMessage(msg)
-		m.ConfigType = &Filter_TypedConfig{msg}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _Filter_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*Filter)
-	// config_type
-	switch x := m.ConfigType.(type) {
-	case *Filter_Config:
-		s := proto.Size(x.Config)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *Filter_TypedConfig:
-		s := proto.Size(x.TypedConfig)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 // Specifies the match criteria for selecting a specific filter chain for a
@@ -635,78 +569,12 @@ func (m *ListenerFilter) GetTypedConfig() *types.Any {
 	return nil
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*ListenerFilter) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _ListenerFilter_OneofMarshaler, _ListenerFilter_OneofUnmarshaler, _ListenerFilter_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*ListenerFilter) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*ListenerFilter_Config)(nil),
 		(*ListenerFilter_TypedConfig)(nil),
 	}
-}
-
-func _ListenerFilter_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*ListenerFilter)
-	// config_type
-	switch x := m.ConfigType.(type) {
-	case *ListenerFilter_Config:
-		_ = b.EncodeVarint(2<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.Config); err != nil {
-			return err
-		}
-	case *ListenerFilter_TypedConfig:
-		_ = b.EncodeVarint(3<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.TypedConfig); err != nil {
-			return err
-		}
-	case nil:
-	default:
-		return fmt.Errorf("ListenerFilter.ConfigType has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _ListenerFilter_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*ListenerFilter)
-	switch tag {
-	case 2: // config_type.config
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(types.Struct)
-		err := b.DecodeMessage(msg)
-		m.ConfigType = &ListenerFilter_Config{msg}
-		return true, err
-	case 3: // config_type.typed_config
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(types.Any)
-		err := b.DecodeMessage(msg)
-		m.ConfigType = &ListenerFilter_TypedConfig{msg}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _ListenerFilter_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*ListenerFilter)
-	// config_type
-	switch x := m.ConfigType.(type) {
-	case *ListenerFilter_Config:
-		s := proto.Size(x.Config)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *ListenerFilter_TypedConfig:
-		s := proto.Size(x.TypedConfig)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 func init() {

--- a/pkg/api/envoy/api/v3alpha/listener/udp_listener_config.pb.go
+++ b/pkg/api/envoy/api/v3alpha/listener/udp_listener_config.pb.go
@@ -21,7 +21,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 type UdpListenerConfig struct {
 	// Used to look up UDP listener factory, matches "raw_udp_listener" or
@@ -117,78 +117,12 @@ func (m *UdpListenerConfig) GetTypedConfig() *types.Any {
 	return nil
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*UdpListenerConfig) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _UdpListenerConfig_OneofMarshaler, _UdpListenerConfig_OneofUnmarshaler, _UdpListenerConfig_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*UdpListenerConfig) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*UdpListenerConfig_Config)(nil),
 		(*UdpListenerConfig_TypedConfig)(nil),
 	}
-}
-
-func _UdpListenerConfig_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*UdpListenerConfig)
-	// config_type
-	switch x := m.ConfigType.(type) {
-	case *UdpListenerConfig_Config:
-		_ = b.EncodeVarint(2<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.Config); err != nil {
-			return err
-		}
-	case *UdpListenerConfig_TypedConfig:
-		_ = b.EncodeVarint(3<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.TypedConfig); err != nil {
-			return err
-		}
-	case nil:
-	default:
-		return fmt.Errorf("UdpListenerConfig.ConfigType has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _UdpListenerConfig_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*UdpListenerConfig)
-	switch tag {
-	case 2: // config_type.config
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(types.Struct)
-		err := b.DecodeMessage(msg)
-		m.ConfigType = &UdpListenerConfig_Config{msg}
-		return true, err
-	case 3: // config_type.typed_config
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(types.Any)
-		err := b.DecodeMessage(msg)
-		m.ConfigType = &UdpListenerConfig_TypedConfig{msg}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _UdpListenerConfig_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*UdpListenerConfig)
-	// config_type
-	switch x := m.ConfigType.(type) {
-	case *UdpListenerConfig_Config:
-		s := proto.Size(x.Config)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *UdpListenerConfig_TypedConfig:
-		s := proto.Size(x.TypedConfig)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 func init() {

--- a/pkg/api/envoy/api/v3alpha/ratelimit/ratelimit.pb.go
+++ b/pkg/api/envoy/api/v3alpha/ratelimit/ratelimit.pb.go
@@ -21,7 +21,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // A RateLimitDescriptor is a list of hierarchical entries that are used by the service to
 // determine the final rate limit key and overall allowed limit. Here are some examples of how

--- a/pkg/api/envoy/api/v3alpha/rds.pb.go
+++ b/pkg/api/envoy/api/v3alpha/rds.pb.go
@@ -29,7 +29,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // [#comment:next free field: 10]
 type RouteConfiguration struct {

--- a/pkg/api/envoy/api/v3alpha/route/route.pb.go
+++ b/pkg/api/envoy/api/v3alpha/route/route.pb.go
@@ -25,7 +25,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 type VirtualHost_TlsRequirementType int32
 
@@ -616,97 +616,13 @@ func (m *Route) GetTracing() *Tracing {
 	return nil
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*Route) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _Route_OneofMarshaler, _Route_OneofUnmarshaler, _Route_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*Route) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*Route_Route)(nil),
 		(*Route_Redirect)(nil),
 		(*Route_DirectResponse)(nil),
 	}
-}
-
-func _Route_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*Route)
-	// action
-	switch x := m.Action.(type) {
-	case *Route_Route:
-		_ = b.EncodeVarint(2<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.Route); err != nil {
-			return err
-		}
-	case *Route_Redirect:
-		_ = b.EncodeVarint(3<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.Redirect); err != nil {
-			return err
-		}
-	case *Route_DirectResponse:
-		_ = b.EncodeVarint(7<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.DirectResponse); err != nil {
-			return err
-		}
-	case nil:
-	default:
-		return fmt.Errorf("Route.Action has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _Route_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*Route)
-	switch tag {
-	case 2: // action.route
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(RouteAction)
-		err := b.DecodeMessage(msg)
-		m.Action = &Route_Route{msg}
-		return true, err
-	case 3: // action.redirect
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(RedirectAction)
-		err := b.DecodeMessage(msg)
-		m.Action = &Route_Redirect{msg}
-		return true, err
-	case 7: // action.direct_response
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(DirectResponseAction)
-		err := b.DecodeMessage(msg)
-		m.Action = &Route_DirectResponse{msg}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _Route_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*Route)
-	// action
-	switch x := m.Action.(type) {
-	case *Route_Route:
-		s := proto.Size(x.Route)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *Route_Redirect:
-		s := proto.Size(x.Redirect)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *Route_DirectResponse:
-		s := proto.Size(x.DirectResponse)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 // Compared to the :ref:`cluster <envoy_api_field_route.RouteAction.cluster>` field that specifies a
@@ -1116,104 +1032,14 @@ func (m *RouteMatch) GetGrpc() *RouteMatch_GrpcRouteMatchOptions {
 	return nil
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*RouteMatch) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _RouteMatch_OneofMarshaler, _RouteMatch_OneofUnmarshaler, _RouteMatch_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*RouteMatch) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*RouteMatch_Prefix)(nil),
 		(*RouteMatch_Path)(nil),
 		(*RouteMatch_Regex)(nil),
 		(*RouteMatch_SafeRegex)(nil),
 	}
-}
-
-func _RouteMatch_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*RouteMatch)
-	// path_specifier
-	switch x := m.PathSpecifier.(type) {
-	case *RouteMatch_Prefix:
-		_ = b.EncodeVarint(1<<3 | proto.WireBytes)
-		_ = b.EncodeStringBytes(x.Prefix)
-	case *RouteMatch_Path:
-		_ = b.EncodeVarint(2<<3 | proto.WireBytes)
-		_ = b.EncodeStringBytes(x.Path)
-	case *RouteMatch_Regex:
-		_ = b.EncodeVarint(3<<3 | proto.WireBytes)
-		_ = b.EncodeStringBytes(x.Regex)
-	case *RouteMatch_SafeRegex:
-		_ = b.EncodeVarint(10<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.SafeRegex); err != nil {
-			return err
-		}
-	case nil:
-	default:
-		return fmt.Errorf("RouteMatch.PathSpecifier has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _RouteMatch_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*RouteMatch)
-	switch tag {
-	case 1: // path_specifier.prefix
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeStringBytes()
-		m.PathSpecifier = &RouteMatch_Prefix{x}
-		return true, err
-	case 2: // path_specifier.path
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeStringBytes()
-		m.PathSpecifier = &RouteMatch_Path{x}
-		return true, err
-	case 3: // path_specifier.regex
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeStringBytes()
-		m.PathSpecifier = &RouteMatch_Regex{x}
-		return true, err
-	case 10: // path_specifier.safe_regex
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(matcher.RegexMatcher)
-		err := b.DecodeMessage(msg)
-		m.PathSpecifier = &RouteMatch_SafeRegex{msg}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _RouteMatch_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*RouteMatch)
-	// path_specifier
-	switch x := m.PathSpecifier.(type) {
-	case *RouteMatch_Prefix:
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(len(x.Prefix)))
-		n += len(x.Prefix)
-	case *RouteMatch_Path:
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(len(x.Path)))
-		n += len(x.Path)
-	case *RouteMatch_Regex:
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(len(x.Regex)))
-		n += len(x.Regex)
-	case *RouteMatch_SafeRegex:
-		s := proto.Size(x.SafeRegex)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 type RouteMatch_GrpcRouteMatchOptions struct {
@@ -1441,78 +1267,12 @@ func (m *CorsPolicy) GetShadowEnabled() *core.RuntimeFractionalPercent {
 	return nil
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*CorsPolicy) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _CorsPolicy_OneofMarshaler, _CorsPolicy_OneofUnmarshaler, _CorsPolicy_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*CorsPolicy) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*CorsPolicy_Enabled)(nil),
 		(*CorsPolicy_FilterEnabled)(nil),
 	}
-}
-
-func _CorsPolicy_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*CorsPolicy)
-	// enabled_specifier
-	switch x := m.EnabledSpecifier.(type) {
-	case *CorsPolicy_Enabled:
-		_ = b.EncodeVarint(7<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.Enabled); err != nil {
-			return err
-		}
-	case *CorsPolicy_FilterEnabled:
-		_ = b.EncodeVarint(9<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.FilterEnabled); err != nil {
-			return err
-		}
-	case nil:
-	default:
-		return fmt.Errorf("CorsPolicy.EnabledSpecifier has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _CorsPolicy_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*CorsPolicy)
-	switch tag {
-	case 7: // enabled_specifier.enabled
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(types.BoolValue)
-		err := b.DecodeMessage(msg)
-		m.EnabledSpecifier = &CorsPolicy_Enabled{msg}
-		return true, err
-	case 9: // enabled_specifier.filter_enabled
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(core.RuntimeFractionalPercent)
-		err := b.DecodeMessage(msg)
-		m.EnabledSpecifier = &CorsPolicy_FilterEnabled{msg}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _CorsPolicy_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*CorsPolicy)
-	// enabled_specifier
-	switch x := m.EnabledSpecifier.(type) {
-	case *CorsPolicy_Enabled:
-		s := proto.Size(x.Enabled)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *CorsPolicy_FilterEnabled:
-		s := proto.Size(x.FilterEnabled)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 // [#comment:next free field: 30]
@@ -1902,9 +1662,9 @@ func (m *RouteAction) GetHedgePolicy() *HedgePolicy {
 	return nil
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*RouteAction) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _RouteAction_OneofMarshaler, _RouteAction_OneofUnmarshaler, _RouteAction_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*RouteAction) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*RouteAction_Cluster)(nil),
 		(*RouteAction_ClusterHeader)(nil),
 		(*RouteAction_WeightedClusters)(nil),
@@ -1912,140 +1672,6 @@ func (*RouteAction) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) e
 		(*RouteAction_AutoHostRewrite)(nil),
 		(*RouteAction_AutoHostRewriteHeader)(nil),
 	}
-}
-
-func _RouteAction_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*RouteAction)
-	// cluster_specifier
-	switch x := m.ClusterSpecifier.(type) {
-	case *RouteAction_Cluster:
-		_ = b.EncodeVarint(1<<3 | proto.WireBytes)
-		_ = b.EncodeStringBytes(x.Cluster)
-	case *RouteAction_ClusterHeader:
-		_ = b.EncodeVarint(2<<3 | proto.WireBytes)
-		_ = b.EncodeStringBytes(x.ClusterHeader)
-	case *RouteAction_WeightedClusters:
-		_ = b.EncodeVarint(3<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.WeightedClusters); err != nil {
-			return err
-		}
-	case nil:
-	default:
-		return fmt.Errorf("RouteAction.ClusterSpecifier has unexpected type %T", x)
-	}
-	// host_rewrite_specifier
-	switch x := m.HostRewriteSpecifier.(type) {
-	case *RouteAction_HostRewrite:
-		_ = b.EncodeVarint(6<<3 | proto.WireBytes)
-		_ = b.EncodeStringBytes(x.HostRewrite)
-	case *RouteAction_AutoHostRewrite:
-		_ = b.EncodeVarint(7<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.AutoHostRewrite); err != nil {
-			return err
-		}
-	case *RouteAction_AutoHostRewriteHeader:
-		_ = b.EncodeVarint(29<<3 | proto.WireBytes)
-		_ = b.EncodeStringBytes(x.AutoHostRewriteHeader)
-	case nil:
-	default:
-		return fmt.Errorf("RouteAction.HostRewriteSpecifier has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _RouteAction_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*RouteAction)
-	switch tag {
-	case 1: // cluster_specifier.cluster
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeStringBytes()
-		m.ClusterSpecifier = &RouteAction_Cluster{x}
-		return true, err
-	case 2: // cluster_specifier.cluster_header
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeStringBytes()
-		m.ClusterSpecifier = &RouteAction_ClusterHeader{x}
-		return true, err
-	case 3: // cluster_specifier.weighted_clusters
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(WeightedCluster)
-		err := b.DecodeMessage(msg)
-		m.ClusterSpecifier = &RouteAction_WeightedClusters{msg}
-		return true, err
-	case 6: // host_rewrite_specifier.host_rewrite
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeStringBytes()
-		m.HostRewriteSpecifier = &RouteAction_HostRewrite{x}
-		return true, err
-	case 7: // host_rewrite_specifier.auto_host_rewrite
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(types.BoolValue)
-		err := b.DecodeMessage(msg)
-		m.HostRewriteSpecifier = &RouteAction_AutoHostRewrite{msg}
-		return true, err
-	case 29: // host_rewrite_specifier.auto_host_rewrite_header
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeStringBytes()
-		m.HostRewriteSpecifier = &RouteAction_AutoHostRewriteHeader{x}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _RouteAction_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*RouteAction)
-	// cluster_specifier
-	switch x := m.ClusterSpecifier.(type) {
-	case *RouteAction_Cluster:
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(len(x.Cluster)))
-		n += len(x.Cluster)
-	case *RouteAction_ClusterHeader:
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(len(x.ClusterHeader)))
-		n += len(x.ClusterHeader)
-	case *RouteAction_WeightedClusters:
-		s := proto.Size(x.WeightedClusters)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	// host_rewrite_specifier
-	switch x := m.HostRewriteSpecifier.(type) {
-	case *RouteAction_HostRewrite:
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(len(x.HostRewrite)))
-		n += len(x.HostRewrite)
-	case *RouteAction_AutoHostRewrite:
-		s := proto.Size(x.AutoHostRewrite)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *RouteAction_AutoHostRewriteHeader:
-		n += 2 // tag and wire
-		n += proto.SizeVarint(uint64(len(x.AutoHostRewriteHeader)))
-		n += len(x.AutoHostRewriteHeader)
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 // The router is capable of shadowing traffic from one cluster to another. The current
@@ -2274,97 +1900,13 @@ func (m *RouteAction_HashPolicy) GetTerminal() bool {
 	return false
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*RouteAction_HashPolicy) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _RouteAction_HashPolicy_OneofMarshaler, _RouteAction_HashPolicy_OneofUnmarshaler, _RouteAction_HashPolicy_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*RouteAction_HashPolicy) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*RouteAction_HashPolicy_Header_)(nil),
 		(*RouteAction_HashPolicy_Cookie_)(nil),
 		(*RouteAction_HashPolicy_ConnectionProperties_)(nil),
 	}
-}
-
-func _RouteAction_HashPolicy_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*RouteAction_HashPolicy)
-	// policy_specifier
-	switch x := m.PolicySpecifier.(type) {
-	case *RouteAction_HashPolicy_Header_:
-		_ = b.EncodeVarint(1<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.Header); err != nil {
-			return err
-		}
-	case *RouteAction_HashPolicy_Cookie_:
-		_ = b.EncodeVarint(2<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.Cookie); err != nil {
-			return err
-		}
-	case *RouteAction_HashPolicy_ConnectionProperties_:
-		_ = b.EncodeVarint(3<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.ConnectionProperties); err != nil {
-			return err
-		}
-	case nil:
-	default:
-		return fmt.Errorf("RouteAction_HashPolicy.PolicySpecifier has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _RouteAction_HashPolicy_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*RouteAction_HashPolicy)
-	switch tag {
-	case 1: // policy_specifier.header
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(RouteAction_HashPolicy_Header)
-		err := b.DecodeMessage(msg)
-		m.PolicySpecifier = &RouteAction_HashPolicy_Header_{msg}
-		return true, err
-	case 2: // policy_specifier.cookie
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(RouteAction_HashPolicy_Cookie)
-		err := b.DecodeMessage(msg)
-		m.PolicySpecifier = &RouteAction_HashPolicy_Cookie_{msg}
-		return true, err
-	case 3: // policy_specifier.connection_properties
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(RouteAction_HashPolicy_ConnectionProperties)
-		err := b.DecodeMessage(msg)
-		m.PolicySpecifier = &RouteAction_HashPolicy_ConnectionProperties_{msg}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _RouteAction_HashPolicy_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*RouteAction_HashPolicy)
-	// policy_specifier
-	switch x := m.PolicySpecifier.(type) {
-	case *RouteAction_HashPolicy_Header_:
-		s := proto.Size(x.Header)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *RouteAction_HashPolicy_Cookie_:
-		s := proto.Size(x.Cookie)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *RouteAction_HashPolicy_ConnectionProperties_:
-		s := proto.Size(x.ConnectionProperties)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 type RouteAction_HashPolicy_Header struct {
@@ -2844,78 +2386,12 @@ func (m *RetryPolicy_RetryPriority) GetTypedConfig() *types.Any {
 	return nil
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*RetryPolicy_RetryPriority) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _RetryPolicy_RetryPriority_OneofMarshaler, _RetryPolicy_RetryPriority_OneofUnmarshaler, _RetryPolicy_RetryPriority_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*RetryPolicy_RetryPriority) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*RetryPolicy_RetryPriority_Config)(nil),
 		(*RetryPolicy_RetryPriority_TypedConfig)(nil),
 	}
-}
-
-func _RetryPolicy_RetryPriority_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*RetryPolicy_RetryPriority)
-	// config_type
-	switch x := m.ConfigType.(type) {
-	case *RetryPolicy_RetryPriority_Config:
-		_ = b.EncodeVarint(2<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.Config); err != nil {
-			return err
-		}
-	case *RetryPolicy_RetryPriority_TypedConfig:
-		_ = b.EncodeVarint(3<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.TypedConfig); err != nil {
-			return err
-		}
-	case nil:
-	default:
-		return fmt.Errorf("RetryPolicy_RetryPriority.ConfigType has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _RetryPolicy_RetryPriority_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*RetryPolicy_RetryPriority)
-	switch tag {
-	case 2: // config_type.config
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(types.Struct)
-		err := b.DecodeMessage(msg)
-		m.ConfigType = &RetryPolicy_RetryPriority_Config{msg}
-		return true, err
-	case 3: // config_type.typed_config
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(types.Any)
-		err := b.DecodeMessage(msg)
-		m.ConfigType = &RetryPolicy_RetryPriority_TypedConfig{msg}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _RetryPolicy_RetryPriority_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*RetryPolicy_RetryPriority)
-	// config_type
-	switch x := m.ConfigType.(type) {
-	case *RetryPolicy_RetryPriority_Config:
-		s := proto.Size(x.Config)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *RetryPolicy_RetryPriority_TypedConfig:
-		s := proto.Size(x.TypedConfig)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 type RetryPolicy_RetryHostPredicate struct {
@@ -3006,78 +2482,12 @@ func (m *RetryPolicy_RetryHostPredicate) GetTypedConfig() *types.Any {
 	return nil
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*RetryPolicy_RetryHostPredicate) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _RetryPolicy_RetryHostPredicate_OneofMarshaler, _RetryPolicy_RetryHostPredicate_OneofUnmarshaler, _RetryPolicy_RetryHostPredicate_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*RetryPolicy_RetryHostPredicate) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*RetryPolicy_RetryHostPredicate_Config)(nil),
 		(*RetryPolicy_RetryHostPredicate_TypedConfig)(nil),
 	}
-}
-
-func _RetryPolicy_RetryHostPredicate_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*RetryPolicy_RetryHostPredicate)
-	// config_type
-	switch x := m.ConfigType.(type) {
-	case *RetryPolicy_RetryHostPredicate_Config:
-		_ = b.EncodeVarint(2<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.Config); err != nil {
-			return err
-		}
-	case *RetryPolicy_RetryHostPredicate_TypedConfig:
-		_ = b.EncodeVarint(3<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.TypedConfig); err != nil {
-			return err
-		}
-	case nil:
-	default:
-		return fmt.Errorf("RetryPolicy_RetryHostPredicate.ConfigType has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _RetryPolicy_RetryHostPredicate_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*RetryPolicy_RetryHostPredicate)
-	switch tag {
-	case 2: // config_type.config
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(types.Struct)
-		err := b.DecodeMessage(msg)
-		m.ConfigType = &RetryPolicy_RetryHostPredicate_Config{msg}
-		return true, err
-	case 3: // config_type.typed_config
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(types.Any)
-		err := b.DecodeMessage(msg)
-		m.ConfigType = &RetryPolicy_RetryHostPredicate_TypedConfig{msg}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _RetryPolicy_RetryHostPredicate_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*RetryPolicy_RetryHostPredicate)
-	// config_type
-	switch x := m.ConfigType.(type) {
-	case *RetryPolicy_RetryHostPredicate_Config:
-		s := proto.Size(x.Config)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *RetryPolicy_RetryHostPredicate_TypedConfig:
-		s := proto.Size(x.TypedConfig)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 type RetryPolicy_RetryBackOff struct {
@@ -3384,115 +2794,14 @@ func (m *RedirectAction) GetStripQuery() bool {
 	return false
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*RedirectAction) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _RedirectAction_OneofMarshaler, _RedirectAction_OneofUnmarshaler, _RedirectAction_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*RedirectAction) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*RedirectAction_HttpsRedirect)(nil),
 		(*RedirectAction_SchemeRedirect)(nil),
 		(*RedirectAction_PathRedirect)(nil),
 		(*RedirectAction_PrefixRewrite)(nil),
 	}
-}
-
-func _RedirectAction_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*RedirectAction)
-	// scheme_rewrite_specifier
-	switch x := m.SchemeRewriteSpecifier.(type) {
-	case *RedirectAction_HttpsRedirect:
-		t := uint64(0)
-		if x.HttpsRedirect {
-			t = 1
-		}
-		_ = b.EncodeVarint(4<<3 | proto.WireVarint)
-		_ = b.EncodeVarint(t)
-	case *RedirectAction_SchemeRedirect:
-		_ = b.EncodeVarint(7<<3 | proto.WireBytes)
-		_ = b.EncodeStringBytes(x.SchemeRedirect)
-	case nil:
-	default:
-		return fmt.Errorf("RedirectAction.SchemeRewriteSpecifier has unexpected type %T", x)
-	}
-	// path_rewrite_specifier
-	switch x := m.PathRewriteSpecifier.(type) {
-	case *RedirectAction_PathRedirect:
-		_ = b.EncodeVarint(2<<3 | proto.WireBytes)
-		_ = b.EncodeStringBytes(x.PathRedirect)
-	case *RedirectAction_PrefixRewrite:
-		_ = b.EncodeVarint(5<<3 | proto.WireBytes)
-		_ = b.EncodeStringBytes(x.PrefixRewrite)
-	case nil:
-	default:
-		return fmt.Errorf("RedirectAction.PathRewriteSpecifier has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _RedirectAction_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*RedirectAction)
-	switch tag {
-	case 4: // scheme_rewrite_specifier.https_redirect
-		if wire != proto.WireVarint {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeVarint()
-		m.SchemeRewriteSpecifier = &RedirectAction_HttpsRedirect{x != 0}
-		return true, err
-	case 7: // scheme_rewrite_specifier.scheme_redirect
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeStringBytes()
-		m.SchemeRewriteSpecifier = &RedirectAction_SchemeRedirect{x}
-		return true, err
-	case 2: // path_rewrite_specifier.path_redirect
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeStringBytes()
-		m.PathRewriteSpecifier = &RedirectAction_PathRedirect{x}
-		return true, err
-	case 5: // path_rewrite_specifier.prefix_rewrite
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeStringBytes()
-		m.PathRewriteSpecifier = &RedirectAction_PrefixRewrite{x}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _RedirectAction_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*RedirectAction)
-	// scheme_rewrite_specifier
-	switch x := m.SchemeRewriteSpecifier.(type) {
-	case *RedirectAction_HttpsRedirect:
-		n += 1 // tag and wire
-		n += 1
-	case *RedirectAction_SchemeRedirect:
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(len(x.SchemeRedirect)))
-		n += len(x.SchemeRedirect)
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	// path_rewrite_specifier
-	switch x := m.PathRewriteSpecifier.(type) {
-	case *RedirectAction_PathRedirect:
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(len(x.PathRedirect)))
-		n += len(x.PathRedirect)
-	case *RedirectAction_PrefixRewrite:
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(len(x.PrefixRewrite)))
-		n += len(x.PrefixRewrite)
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 type DirectResponseAction struct {
@@ -4016,9 +3325,9 @@ func (m *RateLimit_Action) GetHeaderValueMatch() *RateLimit_Action_HeaderValueMa
 	return nil
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*RateLimit_Action) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _RateLimit_Action_OneofMarshaler, _RateLimit_Action_OneofUnmarshaler, _RateLimit_Action_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*RateLimit_Action) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*RateLimit_Action_SourceCluster_)(nil),
 		(*RateLimit_Action_DestinationCluster_)(nil),
 		(*RateLimit_Action_RequestHeaders_)(nil),
@@ -4026,144 +3335,6 @@ func (*RateLimit_Action) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buff
 		(*RateLimit_Action_GenericKey_)(nil),
 		(*RateLimit_Action_HeaderValueMatch_)(nil),
 	}
-}
-
-func _RateLimit_Action_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*RateLimit_Action)
-	// action_specifier
-	switch x := m.ActionSpecifier.(type) {
-	case *RateLimit_Action_SourceCluster_:
-		_ = b.EncodeVarint(1<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.SourceCluster); err != nil {
-			return err
-		}
-	case *RateLimit_Action_DestinationCluster_:
-		_ = b.EncodeVarint(2<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.DestinationCluster); err != nil {
-			return err
-		}
-	case *RateLimit_Action_RequestHeaders_:
-		_ = b.EncodeVarint(3<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.RequestHeaders); err != nil {
-			return err
-		}
-	case *RateLimit_Action_RemoteAddress_:
-		_ = b.EncodeVarint(4<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.RemoteAddress); err != nil {
-			return err
-		}
-	case *RateLimit_Action_GenericKey_:
-		_ = b.EncodeVarint(5<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.GenericKey); err != nil {
-			return err
-		}
-	case *RateLimit_Action_HeaderValueMatch_:
-		_ = b.EncodeVarint(6<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.HeaderValueMatch); err != nil {
-			return err
-		}
-	case nil:
-	default:
-		return fmt.Errorf("RateLimit_Action.ActionSpecifier has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _RateLimit_Action_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*RateLimit_Action)
-	switch tag {
-	case 1: // action_specifier.source_cluster
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(RateLimit_Action_SourceCluster)
-		err := b.DecodeMessage(msg)
-		m.ActionSpecifier = &RateLimit_Action_SourceCluster_{msg}
-		return true, err
-	case 2: // action_specifier.destination_cluster
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(RateLimit_Action_DestinationCluster)
-		err := b.DecodeMessage(msg)
-		m.ActionSpecifier = &RateLimit_Action_DestinationCluster_{msg}
-		return true, err
-	case 3: // action_specifier.request_headers
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(RateLimit_Action_RequestHeaders)
-		err := b.DecodeMessage(msg)
-		m.ActionSpecifier = &RateLimit_Action_RequestHeaders_{msg}
-		return true, err
-	case 4: // action_specifier.remote_address
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(RateLimit_Action_RemoteAddress)
-		err := b.DecodeMessage(msg)
-		m.ActionSpecifier = &RateLimit_Action_RemoteAddress_{msg}
-		return true, err
-	case 5: // action_specifier.generic_key
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(RateLimit_Action_GenericKey)
-		err := b.DecodeMessage(msg)
-		m.ActionSpecifier = &RateLimit_Action_GenericKey_{msg}
-		return true, err
-	case 6: // action_specifier.header_value_match
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(RateLimit_Action_HeaderValueMatch)
-		err := b.DecodeMessage(msg)
-		m.ActionSpecifier = &RateLimit_Action_HeaderValueMatch_{msg}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _RateLimit_Action_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*RateLimit_Action)
-	// action_specifier
-	switch x := m.ActionSpecifier.(type) {
-	case *RateLimit_Action_SourceCluster_:
-		s := proto.Size(x.SourceCluster)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *RateLimit_Action_DestinationCluster_:
-		s := proto.Size(x.DestinationCluster)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *RateLimit_Action_RequestHeaders_:
-		s := proto.Size(x.RequestHeaders)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *RateLimit_Action_RemoteAddress_:
-		s := proto.Size(x.RemoteAddress)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *RateLimit_Action_GenericKey_:
-		s := proto.Size(x.GenericKey)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *RateLimit_Action_HeaderValueMatch_:
-		s := proto.Size(x.HeaderValueMatch)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 // The following descriptor entry is appended to the descriptor:
@@ -4698,9 +3869,9 @@ func (m *HeaderMatcher) GetInvertMatch() bool {
 	return false
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*HeaderMatcher) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _HeaderMatcher_OneofMarshaler, _HeaderMatcher_OneofUnmarshaler, _HeaderMatcher_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*HeaderMatcher) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*HeaderMatcher_ExactMatch)(nil),
 		(*HeaderMatcher_RegexMatch)(nil),
 		(*HeaderMatcher_SafeRegexMatch)(nil),
@@ -4709,145 +3880,6 @@ func (*HeaderMatcher) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer)
 		(*HeaderMatcher_PrefixMatch)(nil),
 		(*HeaderMatcher_SuffixMatch)(nil),
 	}
-}
-
-func _HeaderMatcher_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*HeaderMatcher)
-	// header_match_specifier
-	switch x := m.HeaderMatchSpecifier.(type) {
-	case *HeaderMatcher_ExactMatch:
-		_ = b.EncodeVarint(4<<3 | proto.WireBytes)
-		_ = b.EncodeStringBytes(x.ExactMatch)
-	case *HeaderMatcher_RegexMatch:
-		_ = b.EncodeVarint(5<<3 | proto.WireBytes)
-		_ = b.EncodeStringBytes(x.RegexMatch)
-	case *HeaderMatcher_SafeRegexMatch:
-		_ = b.EncodeVarint(11<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.SafeRegexMatch); err != nil {
-			return err
-		}
-	case *HeaderMatcher_RangeMatch:
-		_ = b.EncodeVarint(6<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.RangeMatch); err != nil {
-			return err
-		}
-	case *HeaderMatcher_PresentMatch:
-		t := uint64(0)
-		if x.PresentMatch {
-			t = 1
-		}
-		_ = b.EncodeVarint(7<<3 | proto.WireVarint)
-		_ = b.EncodeVarint(t)
-	case *HeaderMatcher_PrefixMatch:
-		_ = b.EncodeVarint(9<<3 | proto.WireBytes)
-		_ = b.EncodeStringBytes(x.PrefixMatch)
-	case *HeaderMatcher_SuffixMatch:
-		_ = b.EncodeVarint(10<<3 | proto.WireBytes)
-		_ = b.EncodeStringBytes(x.SuffixMatch)
-	case nil:
-	default:
-		return fmt.Errorf("HeaderMatcher.HeaderMatchSpecifier has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _HeaderMatcher_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*HeaderMatcher)
-	switch tag {
-	case 4: // header_match_specifier.exact_match
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeStringBytes()
-		m.HeaderMatchSpecifier = &HeaderMatcher_ExactMatch{x}
-		return true, err
-	case 5: // header_match_specifier.regex_match
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeStringBytes()
-		m.HeaderMatchSpecifier = &HeaderMatcher_RegexMatch{x}
-		return true, err
-	case 11: // header_match_specifier.safe_regex_match
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(matcher.RegexMatcher)
-		err := b.DecodeMessage(msg)
-		m.HeaderMatchSpecifier = &HeaderMatcher_SafeRegexMatch{msg}
-		return true, err
-	case 6: // header_match_specifier.range_match
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(_type.Int64Range)
-		err := b.DecodeMessage(msg)
-		m.HeaderMatchSpecifier = &HeaderMatcher_RangeMatch{msg}
-		return true, err
-	case 7: // header_match_specifier.present_match
-		if wire != proto.WireVarint {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeVarint()
-		m.HeaderMatchSpecifier = &HeaderMatcher_PresentMatch{x != 0}
-		return true, err
-	case 9: // header_match_specifier.prefix_match
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeStringBytes()
-		m.HeaderMatchSpecifier = &HeaderMatcher_PrefixMatch{x}
-		return true, err
-	case 10: // header_match_specifier.suffix_match
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeStringBytes()
-		m.HeaderMatchSpecifier = &HeaderMatcher_SuffixMatch{x}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _HeaderMatcher_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*HeaderMatcher)
-	// header_match_specifier
-	switch x := m.HeaderMatchSpecifier.(type) {
-	case *HeaderMatcher_ExactMatch:
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(len(x.ExactMatch)))
-		n += len(x.ExactMatch)
-	case *HeaderMatcher_RegexMatch:
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(len(x.RegexMatch)))
-		n += len(x.RegexMatch)
-	case *HeaderMatcher_SafeRegexMatch:
-		s := proto.Size(x.SafeRegexMatch)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *HeaderMatcher_RangeMatch:
-		s := proto.Size(x.RangeMatch)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *HeaderMatcher_PresentMatch:
-		n += 1 // tag and wire
-		n += 1
-	case *HeaderMatcher_PrefixMatch:
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(len(x.PrefixMatch)))
-		n += len(x.PrefixMatch)
-	case *HeaderMatcher_SuffixMatch:
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(len(x.SuffixMatch)))
-		n += len(x.SuffixMatch)
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 // Query parameter matching treats the query string of a request's :path header
@@ -4973,77 +4005,12 @@ func (m *QueryParameterMatcher) GetPresentMatch() bool {
 	return false
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*QueryParameterMatcher) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _QueryParameterMatcher_OneofMarshaler, _QueryParameterMatcher_OneofUnmarshaler, _QueryParameterMatcher_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*QueryParameterMatcher) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*QueryParameterMatcher_StringMatch)(nil),
 		(*QueryParameterMatcher_PresentMatch)(nil),
 	}
-}
-
-func _QueryParameterMatcher_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*QueryParameterMatcher)
-	// query_parameter_match_specifier
-	switch x := m.QueryParameterMatchSpecifier.(type) {
-	case *QueryParameterMatcher_StringMatch:
-		_ = b.EncodeVarint(5<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.StringMatch); err != nil {
-			return err
-		}
-	case *QueryParameterMatcher_PresentMatch:
-		t := uint64(0)
-		if x.PresentMatch {
-			t = 1
-		}
-		_ = b.EncodeVarint(6<<3 | proto.WireVarint)
-		_ = b.EncodeVarint(t)
-	case nil:
-	default:
-		return fmt.Errorf("QueryParameterMatcher.QueryParameterMatchSpecifier has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _QueryParameterMatcher_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*QueryParameterMatcher)
-	switch tag {
-	case 5: // query_parameter_match_specifier.string_match
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(matcher.StringMatcher)
-		err := b.DecodeMessage(msg)
-		m.QueryParameterMatchSpecifier = &QueryParameterMatcher_StringMatch{msg}
-		return true, err
-	case 6: // query_parameter_match_specifier.present_match
-		if wire != proto.WireVarint {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeVarint()
-		m.QueryParameterMatchSpecifier = &QueryParameterMatcher_PresentMatch{x != 0}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _QueryParameterMatcher_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*QueryParameterMatcher)
-	// query_parameter_match_specifier
-	switch x := m.QueryParameterMatchSpecifier.(type) {
-	case *QueryParameterMatcher_StringMatch:
-		s := proto.Size(x.StringMatch)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *QueryParameterMatcher_PresentMatch:
-		n += 1 // tag and wire
-		n += 1
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 func init() {

--- a/pkg/api/envoy/api/v3alpha/srds.pb.go
+++ b/pkg/api/envoy/api/v3alpha/srds.pb.go
@@ -26,7 +26,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // Specifies a routing scope, which associates a
 // :ref:`Key<envoy_api_msg_ScopedRouteConfiguration.Key>` to a
@@ -281,55 +281,11 @@ func (m *ScopedRouteConfiguration_Key_Fragment) GetStringKey() string {
 	return ""
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*ScopedRouteConfiguration_Key_Fragment) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _ScopedRouteConfiguration_Key_Fragment_OneofMarshaler, _ScopedRouteConfiguration_Key_Fragment_OneofUnmarshaler, _ScopedRouteConfiguration_Key_Fragment_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*ScopedRouteConfiguration_Key_Fragment) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*ScopedRouteConfiguration_Key_Fragment_StringKey)(nil),
 	}
-}
-
-func _ScopedRouteConfiguration_Key_Fragment_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*ScopedRouteConfiguration_Key_Fragment)
-	// type
-	switch x := m.Type.(type) {
-	case *ScopedRouteConfiguration_Key_Fragment_StringKey:
-		_ = b.EncodeVarint(1<<3 | proto.WireBytes)
-		_ = b.EncodeStringBytes(x.StringKey)
-	case nil:
-	default:
-		return fmt.Errorf("ScopedRouteConfiguration_Key_Fragment.Type has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _ScopedRouteConfiguration_Key_Fragment_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*ScopedRouteConfiguration_Key_Fragment)
-	switch tag {
-	case 1: // type.string_key
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeStringBytes()
-		m.Type = &ScopedRouteConfiguration_Key_Fragment_StringKey{x}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _ScopedRouteConfiguration_Key_Fragment_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*ScopedRouteConfiguration_Key_Fragment)
-	// type
-	switch x := m.Type.(type) {
-	case *ScopedRouteConfiguration_Key_Fragment_StringKey:
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(len(x.StringKey)))
-		n += len(x.StringKey)
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 func init() {

--- a/pkg/api/envoy/config/accesslog/v2/als.pb.go
+++ b/pkg/api/envoy/config/accesslog/v2/als.pb.go
@@ -23,7 +23,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // Configuration for the built-in *envoy.http_grpc_access_log*
 // :ref:`AccessLog <envoy_api_msg_config.filter.accesslog.v2.AccessLog>`. This configuration will

--- a/pkg/api/envoy/config/accesslog/v2/file.pb.go
+++ b/pkg/api/envoy/config/accesslog/v2/file.pb.go
@@ -22,7 +22,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // Custom configuration for an :ref:`AccessLog <envoy_api_msg_config.filter.accesslog.v2.AccessLog>`
 // that writes log entries directly to a file. Configures the built-in *envoy.file_access_log*
@@ -120,74 +120,12 @@ func (m *FileAccessLog) GetJsonFormat() *types.Struct {
 	return nil
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*FileAccessLog) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _FileAccessLog_OneofMarshaler, _FileAccessLog_OneofUnmarshaler, _FileAccessLog_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*FileAccessLog) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*FileAccessLog_Format)(nil),
 		(*FileAccessLog_JsonFormat)(nil),
 	}
-}
-
-func _FileAccessLog_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*FileAccessLog)
-	// access_log_format
-	switch x := m.AccessLogFormat.(type) {
-	case *FileAccessLog_Format:
-		_ = b.EncodeVarint(2<<3 | proto.WireBytes)
-		_ = b.EncodeStringBytes(x.Format)
-	case *FileAccessLog_JsonFormat:
-		_ = b.EncodeVarint(3<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.JsonFormat); err != nil {
-			return err
-		}
-	case nil:
-	default:
-		return fmt.Errorf("FileAccessLog.AccessLogFormat has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _FileAccessLog_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*FileAccessLog)
-	switch tag {
-	case 2: // access_log_format.format
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeStringBytes()
-		m.AccessLogFormat = &FileAccessLog_Format{x}
-		return true, err
-	case 3: // access_log_format.json_format
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(types.Struct)
-		err := b.DecodeMessage(msg)
-		m.AccessLogFormat = &FileAccessLog_JsonFormat{msg}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _FileAccessLog_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*FileAccessLog)
-	// access_log_format
-	switch x := m.AccessLogFormat.(type) {
-	case *FileAccessLog_Format:
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(len(x.Format)))
-		n += len(x.Format)
-	case *FileAccessLog_JsonFormat:
-		s := proto.Size(x.JsonFormat)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 func init() {

--- a/pkg/api/envoy/config/accesslog/v3alpha/als.pb.go
+++ b/pkg/api/envoy/config/accesslog/v3alpha/als.pb.go
@@ -23,7 +23,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // Configuration for the built-in *envoy.http_grpc_access_log*
 // :ref:`AccessLog <envoy_api_msg_config.filter.accesslog.v3alpha.AccessLog>`. This configuration

--- a/pkg/api/envoy/config/accesslog/v3alpha/file.pb.go
+++ b/pkg/api/envoy/config/accesslog/v3alpha/file.pb.go
@@ -22,7 +22,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // Custom configuration for an :ref:`AccessLog
 // <envoy_api_msg_config.filter.accesslog.v3alpha.AccessLog>` that writes log entries directly to a
@@ -120,74 +120,12 @@ func (m *FileAccessLog) GetJsonFormat() *types.Struct {
 	return nil
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*FileAccessLog) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _FileAccessLog_OneofMarshaler, _FileAccessLog_OneofUnmarshaler, _FileAccessLog_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*FileAccessLog) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*FileAccessLog_Format)(nil),
 		(*FileAccessLog_JsonFormat)(nil),
 	}
-}
-
-func _FileAccessLog_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*FileAccessLog)
-	// access_log_format
-	switch x := m.AccessLogFormat.(type) {
-	case *FileAccessLog_Format:
-		_ = b.EncodeVarint(2<<3 | proto.WireBytes)
-		_ = b.EncodeStringBytes(x.Format)
-	case *FileAccessLog_JsonFormat:
-		_ = b.EncodeVarint(3<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.JsonFormat); err != nil {
-			return err
-		}
-	case nil:
-	default:
-		return fmt.Errorf("FileAccessLog.AccessLogFormat has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _FileAccessLog_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*FileAccessLog)
-	switch tag {
-	case 2: // access_log_format.format
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeStringBytes()
-		m.AccessLogFormat = &FileAccessLog_Format{x}
-		return true, err
-	case 3: // access_log_format.json_format
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(types.Struct)
-		err := b.DecodeMessage(msg)
-		m.AccessLogFormat = &FileAccessLog_JsonFormat{msg}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _FileAccessLog_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*FileAccessLog)
-	// access_log_format
-	switch x := m.AccessLogFormat.(type) {
-	case *FileAccessLog_Format:
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(len(x.Format)))
-		n += len(x.Format)
-	case *FileAccessLog_JsonFormat:
-		s := proto.Size(x.JsonFormat)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 func init() {

--- a/pkg/api/envoy/config/bootstrap/v2/bootstrap.pb.go
+++ b/pkg/api/envoy/config/bootstrap/v2/bootstrap.pb.go
@@ -28,7 +28,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // Bootstrap :ref:`configuration overview <config_overview_v2_bootstrap>`.
 type Bootstrap struct {
@@ -904,116 +904,14 @@ func (m *RuntimeLayer) GetRtdsLayer() *RuntimeLayer_RtdsLayer {
 	return nil
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*RuntimeLayer) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _RuntimeLayer_OneofMarshaler, _RuntimeLayer_OneofUnmarshaler, _RuntimeLayer_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*RuntimeLayer) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*RuntimeLayer_StaticLayer)(nil),
 		(*RuntimeLayer_DiskLayer_)(nil),
 		(*RuntimeLayer_AdminLayer_)(nil),
 		(*RuntimeLayer_RtdsLayer_)(nil),
 	}
-}
-
-func _RuntimeLayer_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*RuntimeLayer)
-	// layer_specifier
-	switch x := m.LayerSpecifier.(type) {
-	case *RuntimeLayer_StaticLayer:
-		_ = b.EncodeVarint(2<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.StaticLayer); err != nil {
-			return err
-		}
-	case *RuntimeLayer_DiskLayer_:
-		_ = b.EncodeVarint(3<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.DiskLayer); err != nil {
-			return err
-		}
-	case *RuntimeLayer_AdminLayer_:
-		_ = b.EncodeVarint(4<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.AdminLayer); err != nil {
-			return err
-		}
-	case *RuntimeLayer_RtdsLayer_:
-		_ = b.EncodeVarint(5<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.RtdsLayer); err != nil {
-			return err
-		}
-	case nil:
-	default:
-		return fmt.Errorf("RuntimeLayer.LayerSpecifier has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _RuntimeLayer_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*RuntimeLayer)
-	switch tag {
-	case 2: // layer_specifier.static_layer
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(types.Struct)
-		err := b.DecodeMessage(msg)
-		m.LayerSpecifier = &RuntimeLayer_StaticLayer{msg}
-		return true, err
-	case 3: // layer_specifier.disk_layer
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(RuntimeLayer_DiskLayer)
-		err := b.DecodeMessage(msg)
-		m.LayerSpecifier = &RuntimeLayer_DiskLayer_{msg}
-		return true, err
-	case 4: // layer_specifier.admin_layer
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(RuntimeLayer_AdminLayer)
-		err := b.DecodeMessage(msg)
-		m.LayerSpecifier = &RuntimeLayer_AdminLayer_{msg}
-		return true, err
-	case 5: // layer_specifier.rtds_layer
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(RuntimeLayer_RtdsLayer)
-		err := b.DecodeMessage(msg)
-		m.LayerSpecifier = &RuntimeLayer_RtdsLayer_{msg}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _RuntimeLayer_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*RuntimeLayer)
-	// layer_specifier
-	switch x := m.LayerSpecifier.(type) {
-	case *RuntimeLayer_StaticLayer:
-		s := proto.Size(x.StaticLayer)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *RuntimeLayer_DiskLayer_:
-		s := proto.Size(x.DiskLayer)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *RuntimeLayer_AdminLayer_:
-		s := proto.Size(x.AdminLayer)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *RuntimeLayer_RtdsLayer_:
-		s := proto.Size(x.RtdsLayer)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 // :ref:`Disk runtime <config_runtime_local_disk>` layer.

--- a/pkg/api/envoy/config/bootstrap/v3alpha/bootstrap.pb.go
+++ b/pkg/api/envoy/config/bootstrap/v3alpha/bootstrap.pb.go
@@ -28,7 +28,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // Bootstrap :ref:`configuration overview <config_overview_v2_bootstrap>`.
 type Bootstrap struct {
@@ -903,116 +903,14 @@ func (m *RuntimeLayer) GetRtdsLayer() *RuntimeLayer_RtdsLayer {
 	return nil
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*RuntimeLayer) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _RuntimeLayer_OneofMarshaler, _RuntimeLayer_OneofUnmarshaler, _RuntimeLayer_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*RuntimeLayer) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*RuntimeLayer_StaticLayer)(nil),
 		(*RuntimeLayer_DiskLayer_)(nil),
 		(*RuntimeLayer_AdminLayer_)(nil),
 		(*RuntimeLayer_RtdsLayer_)(nil),
 	}
-}
-
-func _RuntimeLayer_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*RuntimeLayer)
-	// layer_specifier
-	switch x := m.LayerSpecifier.(type) {
-	case *RuntimeLayer_StaticLayer:
-		_ = b.EncodeVarint(2<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.StaticLayer); err != nil {
-			return err
-		}
-	case *RuntimeLayer_DiskLayer_:
-		_ = b.EncodeVarint(3<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.DiskLayer); err != nil {
-			return err
-		}
-	case *RuntimeLayer_AdminLayer_:
-		_ = b.EncodeVarint(4<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.AdminLayer); err != nil {
-			return err
-		}
-	case *RuntimeLayer_RtdsLayer_:
-		_ = b.EncodeVarint(5<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.RtdsLayer); err != nil {
-			return err
-		}
-	case nil:
-	default:
-		return fmt.Errorf("RuntimeLayer.LayerSpecifier has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _RuntimeLayer_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*RuntimeLayer)
-	switch tag {
-	case 2: // layer_specifier.static_layer
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(types.Struct)
-		err := b.DecodeMessage(msg)
-		m.LayerSpecifier = &RuntimeLayer_StaticLayer{msg}
-		return true, err
-	case 3: // layer_specifier.disk_layer
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(RuntimeLayer_DiskLayer)
-		err := b.DecodeMessage(msg)
-		m.LayerSpecifier = &RuntimeLayer_DiskLayer_{msg}
-		return true, err
-	case 4: // layer_specifier.admin_layer
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(RuntimeLayer_AdminLayer)
-		err := b.DecodeMessage(msg)
-		m.LayerSpecifier = &RuntimeLayer_AdminLayer_{msg}
-		return true, err
-	case 5: // layer_specifier.rtds_layer
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(RuntimeLayer_RtdsLayer)
-		err := b.DecodeMessage(msg)
-		m.LayerSpecifier = &RuntimeLayer_RtdsLayer_{msg}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _RuntimeLayer_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*RuntimeLayer)
-	// layer_specifier
-	switch x := m.LayerSpecifier.(type) {
-	case *RuntimeLayer_StaticLayer:
-		s := proto.Size(x.StaticLayer)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *RuntimeLayer_DiskLayer_:
-		s := proto.Size(x.DiskLayer)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *RuntimeLayer_AdminLayer_:
-		s := proto.Size(x.AdminLayer)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *RuntimeLayer_RtdsLayer_:
-		s := proto.Size(x.RtdsLayer)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 // :ref:`Disk runtime <config_runtime_local_disk>` layer.

--- a/pkg/api/envoy/config/cluster/dynamic_forward_proxy/v2alpha/cluster.pb.go
+++ b/pkg/api/envoy/config/cluster/dynamic_forward_proxy/v2alpha/cluster.pb.go
@@ -22,7 +22,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // Configuration for the dynamic forward proxy cluster. See the :ref:`architecture overview
 // <arch_overview_http_dynamic_forward_proxy>` for more information.

--- a/pkg/api/envoy/config/cluster/dynamic_forward_proxy/v3alpha/cluster.pb.go
+++ b/pkg/api/envoy/config/cluster/dynamic_forward_proxy/v3alpha/cluster.pb.go
@@ -22,7 +22,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // Configuration for the dynamic forward proxy cluster. See the :ref:`architecture overview
 // <arch_overview_http_dynamic_forward_proxy>` for more information.

--- a/pkg/api/envoy/config/cluster/redis/redis_cluster.pb.go
+++ b/pkg/api/envoy/config/cluster/redis/redis_cluster.pb.go
@@ -22,7 +22,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 type RedisClusterConfig struct {
 	// Interval between successive topology refresh requests. If not set, this defaults to 5s.

--- a/pkg/api/envoy/config/common/dynamic_forward_proxy/v2alpha/dns_cache.pb.go
+++ b/pkg/api/envoy/config/common/dynamic_forward_proxy/v2alpha/dns_cache.pb.go
@@ -23,7 +23,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // Configuration for the dynamic forward proxy DNS cache. See the :ref:`architecture overview
 // <arch_overview_http_dynamic_forward_proxy>` for more information.

--- a/pkg/api/envoy/config/common/dynamic_forward_proxy/v3alpha/dns_cache.pb.go
+++ b/pkg/api/envoy/config/common/dynamic_forward_proxy/v3alpha/dns_cache.pb.go
@@ -23,7 +23,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // Configuration for the dynamic forward proxy DNS cache. See the :ref:`architecture overview
 // <arch_overview_http_dynamic_forward_proxy>` for more information.

--- a/pkg/api/envoy/config/common/tap/v2alpha/common.pb.go
+++ b/pkg/api/envoy/config/common/tap/v2alpha/common.pb.go
@@ -23,7 +23,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // Common configuration for all tap extensions.
 type CommonExtensionConfig struct {
@@ -118,97 +118,13 @@ func (m *CommonExtensionConfig) GetTapdsConfig() *CommonExtensionConfig_TapDSCon
 	return nil
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*CommonExtensionConfig) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _CommonExtensionConfig_OneofMarshaler, _CommonExtensionConfig_OneofUnmarshaler, _CommonExtensionConfig_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*CommonExtensionConfig) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*CommonExtensionConfig_AdminConfig)(nil),
 		(*CommonExtensionConfig_StaticConfig)(nil),
 		(*CommonExtensionConfig_TapdsConfig)(nil),
 	}
-}
-
-func _CommonExtensionConfig_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*CommonExtensionConfig)
-	// config_type
-	switch x := m.ConfigType.(type) {
-	case *CommonExtensionConfig_AdminConfig:
-		_ = b.EncodeVarint(1<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.AdminConfig); err != nil {
-			return err
-		}
-	case *CommonExtensionConfig_StaticConfig:
-		_ = b.EncodeVarint(2<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.StaticConfig); err != nil {
-			return err
-		}
-	case *CommonExtensionConfig_TapdsConfig:
-		_ = b.EncodeVarint(3<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.TapdsConfig); err != nil {
-			return err
-		}
-	case nil:
-	default:
-		return fmt.Errorf("CommonExtensionConfig.ConfigType has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _CommonExtensionConfig_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*CommonExtensionConfig)
-	switch tag {
-	case 1: // config_type.admin_config
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(AdminConfig)
-		err := b.DecodeMessage(msg)
-		m.ConfigType = &CommonExtensionConfig_AdminConfig{msg}
-		return true, err
-	case 2: // config_type.static_config
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(v2alpha.TapConfig)
-		err := b.DecodeMessage(msg)
-		m.ConfigType = &CommonExtensionConfig_StaticConfig{msg}
-		return true, err
-	case 3: // config_type.tapds_config
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(CommonExtensionConfig_TapDSConfig)
-		err := b.DecodeMessage(msg)
-		m.ConfigType = &CommonExtensionConfig_TapdsConfig{msg}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _CommonExtensionConfig_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*CommonExtensionConfig)
-	// config_type
-	switch x := m.ConfigType.(type) {
-	case *CommonExtensionConfig_AdminConfig:
-		s := proto.Size(x.AdminConfig)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *CommonExtensionConfig_StaticConfig:
-		s := proto.Size(x.StaticConfig)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *CommonExtensionConfig_TapdsConfig:
-		s := proto.Size(x.TapdsConfig)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 // [#not-implemented-hide:]

--- a/pkg/api/envoy/config/common/tap/v3alpha/common.pb.go
+++ b/pkg/api/envoy/config/common/tap/v3alpha/common.pb.go
@@ -23,7 +23,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // Common configuration for all tap extensions.
 type CommonExtensionConfig struct {
@@ -118,97 +118,13 @@ func (m *CommonExtensionConfig) GetTapdsConfig() *CommonExtensionConfig_TapDSCon
 	return nil
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*CommonExtensionConfig) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _CommonExtensionConfig_OneofMarshaler, _CommonExtensionConfig_OneofUnmarshaler, _CommonExtensionConfig_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*CommonExtensionConfig) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*CommonExtensionConfig_AdminConfig)(nil),
 		(*CommonExtensionConfig_StaticConfig)(nil),
 		(*CommonExtensionConfig_TapdsConfig)(nil),
 	}
-}
-
-func _CommonExtensionConfig_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*CommonExtensionConfig)
-	// config_type
-	switch x := m.ConfigType.(type) {
-	case *CommonExtensionConfig_AdminConfig:
-		_ = b.EncodeVarint(1<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.AdminConfig); err != nil {
-			return err
-		}
-	case *CommonExtensionConfig_StaticConfig:
-		_ = b.EncodeVarint(2<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.StaticConfig); err != nil {
-			return err
-		}
-	case *CommonExtensionConfig_TapdsConfig:
-		_ = b.EncodeVarint(3<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.TapdsConfig); err != nil {
-			return err
-		}
-	case nil:
-	default:
-		return fmt.Errorf("CommonExtensionConfig.ConfigType has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _CommonExtensionConfig_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*CommonExtensionConfig)
-	switch tag {
-	case 1: // config_type.admin_config
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(AdminConfig)
-		err := b.DecodeMessage(msg)
-		m.ConfigType = &CommonExtensionConfig_AdminConfig{msg}
-		return true, err
-	case 2: // config_type.static_config
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(v3alpha.TapConfig)
-		err := b.DecodeMessage(msg)
-		m.ConfigType = &CommonExtensionConfig_StaticConfig{msg}
-		return true, err
-	case 3: // config_type.tapds_config
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(CommonExtensionConfig_TapDSConfig)
-		err := b.DecodeMessage(msg)
-		m.ConfigType = &CommonExtensionConfig_TapdsConfig{msg}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _CommonExtensionConfig_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*CommonExtensionConfig)
-	// config_type
-	switch x := m.ConfigType.(type) {
-	case *CommonExtensionConfig_AdminConfig:
-		s := proto.Size(x.AdminConfig)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *CommonExtensionConfig_StaticConfig:
-		s := proto.Size(x.StaticConfig)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *CommonExtensionConfig_TapdsConfig:
-		s := proto.Size(x.TapdsConfig)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 // [#not-implemented-hide:]

--- a/pkg/api/envoy/config/filter/accesslog/v2/accesslog.pb.go
+++ b/pkg/api/envoy/config/filter/accesslog/v2/accesslog.pb.go
@@ -25,7 +25,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 type ComparisonFilter_Op int32
 
@@ -241,78 +241,12 @@ func (m *AccessLog) GetTypedConfig() *types.Any {
 	return nil
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*AccessLog) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _AccessLog_OneofMarshaler, _AccessLog_OneofUnmarshaler, _AccessLog_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*AccessLog) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*AccessLog_Config)(nil),
 		(*AccessLog_TypedConfig)(nil),
 	}
-}
-
-func _AccessLog_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*AccessLog)
-	// config_type
-	switch x := m.ConfigType.(type) {
-	case *AccessLog_Config:
-		_ = b.EncodeVarint(3<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.Config); err != nil {
-			return err
-		}
-	case *AccessLog_TypedConfig:
-		_ = b.EncodeVarint(4<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.TypedConfig); err != nil {
-			return err
-		}
-	case nil:
-	default:
-		return fmt.Errorf("AccessLog.ConfigType has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _AccessLog_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*AccessLog)
-	switch tag {
-	case 3: // config_type.config
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(types.Struct)
-		err := b.DecodeMessage(msg)
-		m.ConfigType = &AccessLog_Config{msg}
-		return true, err
-	case 4: // config_type.typed_config
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(types.Any)
-		err := b.DecodeMessage(msg)
-		m.ConfigType = &AccessLog_TypedConfig{msg}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _AccessLog_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*AccessLog)
-	// config_type
-	switch x := m.ConfigType.(type) {
-	case *AccessLog_Config:
-		s := proto.Size(x.Config)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *AccessLog_TypedConfig:
-		s := proto.Size(x.TypedConfig)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 type AccessLogFilter struct {
@@ -503,9 +437,9 @@ func (m *AccessLogFilter) GetExtensionFilter() *ExtensionFilter {
 	return nil
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*AccessLogFilter) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _AccessLogFilter_OneofMarshaler, _AccessLogFilter_OneofUnmarshaler, _AccessLogFilter_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*AccessLogFilter) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*AccessLogFilter_StatusCodeFilter)(nil),
 		(*AccessLogFilter_DurationFilter)(nil),
 		(*AccessLogFilter_NotHealthCheckFilter)(nil),
@@ -518,234 +452,6 @@ func (*AccessLogFilter) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffe
 		(*AccessLogFilter_GrpcStatusFilter)(nil),
 		(*AccessLogFilter_ExtensionFilter)(nil),
 	}
-}
-
-func _AccessLogFilter_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*AccessLogFilter)
-	// filter_specifier
-	switch x := m.FilterSpecifier.(type) {
-	case *AccessLogFilter_StatusCodeFilter:
-		_ = b.EncodeVarint(1<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.StatusCodeFilter); err != nil {
-			return err
-		}
-	case *AccessLogFilter_DurationFilter:
-		_ = b.EncodeVarint(2<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.DurationFilter); err != nil {
-			return err
-		}
-	case *AccessLogFilter_NotHealthCheckFilter:
-		_ = b.EncodeVarint(3<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.NotHealthCheckFilter); err != nil {
-			return err
-		}
-	case *AccessLogFilter_TraceableFilter:
-		_ = b.EncodeVarint(4<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.TraceableFilter); err != nil {
-			return err
-		}
-	case *AccessLogFilter_RuntimeFilter:
-		_ = b.EncodeVarint(5<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.RuntimeFilter); err != nil {
-			return err
-		}
-	case *AccessLogFilter_AndFilter:
-		_ = b.EncodeVarint(6<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.AndFilter); err != nil {
-			return err
-		}
-	case *AccessLogFilter_OrFilter:
-		_ = b.EncodeVarint(7<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.OrFilter); err != nil {
-			return err
-		}
-	case *AccessLogFilter_HeaderFilter:
-		_ = b.EncodeVarint(8<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.HeaderFilter); err != nil {
-			return err
-		}
-	case *AccessLogFilter_ResponseFlagFilter:
-		_ = b.EncodeVarint(9<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.ResponseFlagFilter); err != nil {
-			return err
-		}
-	case *AccessLogFilter_GrpcStatusFilter:
-		_ = b.EncodeVarint(10<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.GrpcStatusFilter); err != nil {
-			return err
-		}
-	case *AccessLogFilter_ExtensionFilter:
-		_ = b.EncodeVarint(11<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.ExtensionFilter); err != nil {
-			return err
-		}
-	case nil:
-	default:
-		return fmt.Errorf("AccessLogFilter.FilterSpecifier has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _AccessLogFilter_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*AccessLogFilter)
-	switch tag {
-	case 1: // filter_specifier.status_code_filter
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(StatusCodeFilter)
-		err := b.DecodeMessage(msg)
-		m.FilterSpecifier = &AccessLogFilter_StatusCodeFilter{msg}
-		return true, err
-	case 2: // filter_specifier.duration_filter
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(DurationFilter)
-		err := b.DecodeMessage(msg)
-		m.FilterSpecifier = &AccessLogFilter_DurationFilter{msg}
-		return true, err
-	case 3: // filter_specifier.not_health_check_filter
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(NotHealthCheckFilter)
-		err := b.DecodeMessage(msg)
-		m.FilterSpecifier = &AccessLogFilter_NotHealthCheckFilter{msg}
-		return true, err
-	case 4: // filter_specifier.traceable_filter
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(TraceableFilter)
-		err := b.DecodeMessage(msg)
-		m.FilterSpecifier = &AccessLogFilter_TraceableFilter{msg}
-		return true, err
-	case 5: // filter_specifier.runtime_filter
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(RuntimeFilter)
-		err := b.DecodeMessage(msg)
-		m.FilterSpecifier = &AccessLogFilter_RuntimeFilter{msg}
-		return true, err
-	case 6: // filter_specifier.and_filter
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(AndFilter)
-		err := b.DecodeMessage(msg)
-		m.FilterSpecifier = &AccessLogFilter_AndFilter{msg}
-		return true, err
-	case 7: // filter_specifier.or_filter
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(OrFilter)
-		err := b.DecodeMessage(msg)
-		m.FilterSpecifier = &AccessLogFilter_OrFilter{msg}
-		return true, err
-	case 8: // filter_specifier.header_filter
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(HeaderFilter)
-		err := b.DecodeMessage(msg)
-		m.FilterSpecifier = &AccessLogFilter_HeaderFilter{msg}
-		return true, err
-	case 9: // filter_specifier.response_flag_filter
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(ResponseFlagFilter)
-		err := b.DecodeMessage(msg)
-		m.FilterSpecifier = &AccessLogFilter_ResponseFlagFilter{msg}
-		return true, err
-	case 10: // filter_specifier.grpc_status_filter
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(GrpcStatusFilter)
-		err := b.DecodeMessage(msg)
-		m.FilterSpecifier = &AccessLogFilter_GrpcStatusFilter{msg}
-		return true, err
-	case 11: // filter_specifier.extension_filter
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(ExtensionFilter)
-		err := b.DecodeMessage(msg)
-		m.FilterSpecifier = &AccessLogFilter_ExtensionFilter{msg}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _AccessLogFilter_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*AccessLogFilter)
-	// filter_specifier
-	switch x := m.FilterSpecifier.(type) {
-	case *AccessLogFilter_StatusCodeFilter:
-		s := proto.Size(x.StatusCodeFilter)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *AccessLogFilter_DurationFilter:
-		s := proto.Size(x.DurationFilter)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *AccessLogFilter_NotHealthCheckFilter:
-		s := proto.Size(x.NotHealthCheckFilter)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *AccessLogFilter_TraceableFilter:
-		s := proto.Size(x.TraceableFilter)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *AccessLogFilter_RuntimeFilter:
-		s := proto.Size(x.RuntimeFilter)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *AccessLogFilter_AndFilter:
-		s := proto.Size(x.AndFilter)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *AccessLogFilter_OrFilter:
-		s := proto.Size(x.OrFilter)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *AccessLogFilter_HeaderFilter:
-		s := proto.Size(x.HeaderFilter)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *AccessLogFilter_ResponseFlagFilter:
-		s := proto.Size(x.ResponseFlagFilter)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *AccessLogFilter_GrpcStatusFilter:
-		s := proto.Size(x.GrpcStatusFilter)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *AccessLogFilter_ExtensionFilter:
-		s := proto.Size(x.ExtensionFilter)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 // Filter on an integer comparison.
@@ -1421,78 +1127,12 @@ func (m *ExtensionFilter) GetTypedConfig() *types.Any {
 	return nil
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*ExtensionFilter) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _ExtensionFilter_OneofMarshaler, _ExtensionFilter_OneofUnmarshaler, _ExtensionFilter_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*ExtensionFilter) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*ExtensionFilter_Config)(nil),
 		(*ExtensionFilter_TypedConfig)(nil),
 	}
-}
-
-func _ExtensionFilter_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*ExtensionFilter)
-	// config_type
-	switch x := m.ConfigType.(type) {
-	case *ExtensionFilter_Config:
-		_ = b.EncodeVarint(2<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.Config); err != nil {
-			return err
-		}
-	case *ExtensionFilter_TypedConfig:
-		_ = b.EncodeVarint(3<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.TypedConfig); err != nil {
-			return err
-		}
-	case nil:
-	default:
-		return fmt.Errorf("ExtensionFilter.ConfigType has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _ExtensionFilter_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*ExtensionFilter)
-	switch tag {
-	case 2: // config_type.config
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(types.Struct)
-		err := b.DecodeMessage(msg)
-		m.ConfigType = &ExtensionFilter_Config{msg}
-		return true, err
-	case 3: // config_type.typed_config
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(types.Any)
-		err := b.DecodeMessage(msg)
-		m.ConfigType = &ExtensionFilter_TypedConfig{msg}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _ExtensionFilter_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*ExtensionFilter)
-	// config_type
-	switch x := m.ConfigType.(type) {
-	case *ExtensionFilter_Config:
-		s := proto.Size(x.Config)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *ExtensionFilter_TypedConfig:
-		s := proto.Size(x.TypedConfig)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 func init() {

--- a/pkg/api/envoy/config/filter/accesslog/v3alpha/accesslog.pb.go
+++ b/pkg/api/envoy/config/filter/accesslog/v3alpha/accesslog.pb.go
@@ -25,7 +25,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 type ComparisonFilter_Op int32
 
@@ -241,78 +241,12 @@ func (m *AccessLog) GetTypedConfig() *types.Any {
 	return nil
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*AccessLog) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _AccessLog_OneofMarshaler, _AccessLog_OneofUnmarshaler, _AccessLog_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*AccessLog) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*AccessLog_Config)(nil),
 		(*AccessLog_TypedConfig)(nil),
 	}
-}
-
-func _AccessLog_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*AccessLog)
-	// config_type
-	switch x := m.ConfigType.(type) {
-	case *AccessLog_Config:
-		_ = b.EncodeVarint(3<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.Config); err != nil {
-			return err
-		}
-	case *AccessLog_TypedConfig:
-		_ = b.EncodeVarint(4<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.TypedConfig); err != nil {
-			return err
-		}
-	case nil:
-	default:
-		return fmt.Errorf("AccessLog.ConfigType has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _AccessLog_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*AccessLog)
-	switch tag {
-	case 3: // config_type.config
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(types.Struct)
-		err := b.DecodeMessage(msg)
-		m.ConfigType = &AccessLog_Config{msg}
-		return true, err
-	case 4: // config_type.typed_config
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(types.Any)
-		err := b.DecodeMessage(msg)
-		m.ConfigType = &AccessLog_TypedConfig{msg}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _AccessLog_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*AccessLog)
-	// config_type
-	switch x := m.ConfigType.(type) {
-	case *AccessLog_Config:
-		s := proto.Size(x.Config)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *AccessLog_TypedConfig:
-		s := proto.Size(x.TypedConfig)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 type AccessLogFilter struct {
@@ -503,9 +437,9 @@ func (m *AccessLogFilter) GetExtensionFilter() *ExtensionFilter {
 	return nil
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*AccessLogFilter) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _AccessLogFilter_OneofMarshaler, _AccessLogFilter_OneofUnmarshaler, _AccessLogFilter_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*AccessLogFilter) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*AccessLogFilter_StatusCodeFilter)(nil),
 		(*AccessLogFilter_DurationFilter)(nil),
 		(*AccessLogFilter_NotHealthCheckFilter)(nil),
@@ -518,234 +452,6 @@ func (*AccessLogFilter) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffe
 		(*AccessLogFilter_GrpcStatusFilter)(nil),
 		(*AccessLogFilter_ExtensionFilter)(nil),
 	}
-}
-
-func _AccessLogFilter_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*AccessLogFilter)
-	// filter_specifier
-	switch x := m.FilterSpecifier.(type) {
-	case *AccessLogFilter_StatusCodeFilter:
-		_ = b.EncodeVarint(1<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.StatusCodeFilter); err != nil {
-			return err
-		}
-	case *AccessLogFilter_DurationFilter:
-		_ = b.EncodeVarint(2<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.DurationFilter); err != nil {
-			return err
-		}
-	case *AccessLogFilter_NotHealthCheckFilter:
-		_ = b.EncodeVarint(3<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.NotHealthCheckFilter); err != nil {
-			return err
-		}
-	case *AccessLogFilter_TraceableFilter:
-		_ = b.EncodeVarint(4<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.TraceableFilter); err != nil {
-			return err
-		}
-	case *AccessLogFilter_RuntimeFilter:
-		_ = b.EncodeVarint(5<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.RuntimeFilter); err != nil {
-			return err
-		}
-	case *AccessLogFilter_AndFilter:
-		_ = b.EncodeVarint(6<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.AndFilter); err != nil {
-			return err
-		}
-	case *AccessLogFilter_OrFilter:
-		_ = b.EncodeVarint(7<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.OrFilter); err != nil {
-			return err
-		}
-	case *AccessLogFilter_HeaderFilter:
-		_ = b.EncodeVarint(8<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.HeaderFilter); err != nil {
-			return err
-		}
-	case *AccessLogFilter_ResponseFlagFilter:
-		_ = b.EncodeVarint(9<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.ResponseFlagFilter); err != nil {
-			return err
-		}
-	case *AccessLogFilter_GrpcStatusFilter:
-		_ = b.EncodeVarint(10<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.GrpcStatusFilter); err != nil {
-			return err
-		}
-	case *AccessLogFilter_ExtensionFilter:
-		_ = b.EncodeVarint(11<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.ExtensionFilter); err != nil {
-			return err
-		}
-	case nil:
-	default:
-		return fmt.Errorf("AccessLogFilter.FilterSpecifier has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _AccessLogFilter_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*AccessLogFilter)
-	switch tag {
-	case 1: // filter_specifier.status_code_filter
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(StatusCodeFilter)
-		err := b.DecodeMessage(msg)
-		m.FilterSpecifier = &AccessLogFilter_StatusCodeFilter{msg}
-		return true, err
-	case 2: // filter_specifier.duration_filter
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(DurationFilter)
-		err := b.DecodeMessage(msg)
-		m.FilterSpecifier = &AccessLogFilter_DurationFilter{msg}
-		return true, err
-	case 3: // filter_specifier.not_health_check_filter
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(NotHealthCheckFilter)
-		err := b.DecodeMessage(msg)
-		m.FilterSpecifier = &AccessLogFilter_NotHealthCheckFilter{msg}
-		return true, err
-	case 4: // filter_specifier.traceable_filter
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(TraceableFilter)
-		err := b.DecodeMessage(msg)
-		m.FilterSpecifier = &AccessLogFilter_TraceableFilter{msg}
-		return true, err
-	case 5: // filter_specifier.runtime_filter
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(RuntimeFilter)
-		err := b.DecodeMessage(msg)
-		m.FilterSpecifier = &AccessLogFilter_RuntimeFilter{msg}
-		return true, err
-	case 6: // filter_specifier.and_filter
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(AndFilter)
-		err := b.DecodeMessage(msg)
-		m.FilterSpecifier = &AccessLogFilter_AndFilter{msg}
-		return true, err
-	case 7: // filter_specifier.or_filter
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(OrFilter)
-		err := b.DecodeMessage(msg)
-		m.FilterSpecifier = &AccessLogFilter_OrFilter{msg}
-		return true, err
-	case 8: // filter_specifier.header_filter
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(HeaderFilter)
-		err := b.DecodeMessage(msg)
-		m.FilterSpecifier = &AccessLogFilter_HeaderFilter{msg}
-		return true, err
-	case 9: // filter_specifier.response_flag_filter
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(ResponseFlagFilter)
-		err := b.DecodeMessage(msg)
-		m.FilterSpecifier = &AccessLogFilter_ResponseFlagFilter{msg}
-		return true, err
-	case 10: // filter_specifier.grpc_status_filter
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(GrpcStatusFilter)
-		err := b.DecodeMessage(msg)
-		m.FilterSpecifier = &AccessLogFilter_GrpcStatusFilter{msg}
-		return true, err
-	case 11: // filter_specifier.extension_filter
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(ExtensionFilter)
-		err := b.DecodeMessage(msg)
-		m.FilterSpecifier = &AccessLogFilter_ExtensionFilter{msg}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _AccessLogFilter_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*AccessLogFilter)
-	// filter_specifier
-	switch x := m.FilterSpecifier.(type) {
-	case *AccessLogFilter_StatusCodeFilter:
-		s := proto.Size(x.StatusCodeFilter)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *AccessLogFilter_DurationFilter:
-		s := proto.Size(x.DurationFilter)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *AccessLogFilter_NotHealthCheckFilter:
-		s := proto.Size(x.NotHealthCheckFilter)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *AccessLogFilter_TraceableFilter:
-		s := proto.Size(x.TraceableFilter)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *AccessLogFilter_RuntimeFilter:
-		s := proto.Size(x.RuntimeFilter)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *AccessLogFilter_AndFilter:
-		s := proto.Size(x.AndFilter)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *AccessLogFilter_OrFilter:
-		s := proto.Size(x.OrFilter)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *AccessLogFilter_HeaderFilter:
-		s := proto.Size(x.HeaderFilter)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *AccessLogFilter_ResponseFlagFilter:
-		s := proto.Size(x.ResponseFlagFilter)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *AccessLogFilter_GrpcStatusFilter:
-		s := proto.Size(x.GrpcStatusFilter)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *AccessLogFilter_ExtensionFilter:
-		s := proto.Size(x.ExtensionFilter)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 // Filter on an integer comparison.
@@ -1421,78 +1127,12 @@ func (m *ExtensionFilter) GetTypedConfig() *types.Any {
 	return nil
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*ExtensionFilter) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _ExtensionFilter_OneofMarshaler, _ExtensionFilter_OneofUnmarshaler, _ExtensionFilter_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*ExtensionFilter) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*ExtensionFilter_Config)(nil),
 		(*ExtensionFilter_TypedConfig)(nil),
 	}
-}
-
-func _ExtensionFilter_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*ExtensionFilter)
-	// config_type
-	switch x := m.ConfigType.(type) {
-	case *ExtensionFilter_Config:
-		_ = b.EncodeVarint(2<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.Config); err != nil {
-			return err
-		}
-	case *ExtensionFilter_TypedConfig:
-		_ = b.EncodeVarint(3<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.TypedConfig); err != nil {
-			return err
-		}
-	case nil:
-	default:
-		return fmt.Errorf("ExtensionFilter.ConfigType has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _ExtensionFilter_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*ExtensionFilter)
-	switch tag {
-	case 2: // config_type.config
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(types.Struct)
-		err := b.DecodeMessage(msg)
-		m.ConfigType = &ExtensionFilter_Config{msg}
-		return true, err
-	case 3: // config_type.typed_config
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(types.Any)
-		err := b.DecodeMessage(msg)
-		m.ConfigType = &ExtensionFilter_TypedConfig{msg}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _ExtensionFilter_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*ExtensionFilter)
-	// config_type
-	switch x := m.ConfigType.(type) {
-	case *ExtensionFilter_Config:
-		s := proto.Size(x.Config)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *ExtensionFilter_TypedConfig:
-		s := proto.Size(x.TypedConfig)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 func init() {

--- a/pkg/api/envoy/config/filter/dubbo/router/v2alpha1/router.pb.go
+++ b/pkg/api/envoy/config/filter/dubbo/router/v2alpha1/router.pb.go
@@ -20,7 +20,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 type Router struct {
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`

--- a/pkg/api/envoy/config/filter/dubbo/router/v3alpha/router.pb.go
+++ b/pkg/api/envoy/config/filter/dubbo/router/v3alpha/router.pb.go
@@ -20,7 +20,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 type Router struct {
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`

--- a/pkg/api/envoy/config/filter/fault/v2/fault.pb.go
+++ b/pkg/api/envoy/config/filter/fault/v2/fault.pb.go
@@ -23,7 +23,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 type FaultDelay_FaultDelayType int32
 
@@ -149,78 +149,12 @@ func (m *FaultDelay) GetPercentage() *_type.FractionalPercent {
 	return nil
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*FaultDelay) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _FaultDelay_OneofMarshaler, _FaultDelay_OneofUnmarshaler, _FaultDelay_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*FaultDelay) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*FaultDelay_FixedDelay)(nil),
 		(*FaultDelay_HeaderDelay_)(nil),
 	}
-}
-
-func _FaultDelay_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*FaultDelay)
-	// fault_delay_secifier
-	switch x := m.FaultDelaySecifier.(type) {
-	case *FaultDelay_FixedDelay:
-		_ = b.EncodeVarint(3<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.FixedDelay); err != nil {
-			return err
-		}
-	case *FaultDelay_HeaderDelay_:
-		_ = b.EncodeVarint(5<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.HeaderDelay); err != nil {
-			return err
-		}
-	case nil:
-	default:
-		return fmt.Errorf("FaultDelay.FaultDelaySecifier has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _FaultDelay_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*FaultDelay)
-	switch tag {
-	case 3: // fault_delay_secifier.fixed_delay
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(types.Duration)
-		err := b.DecodeMessage(msg)
-		m.FaultDelaySecifier = &FaultDelay_FixedDelay{msg}
-		return true, err
-	case 5: // fault_delay_secifier.header_delay
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(FaultDelay_HeaderDelay)
-		err := b.DecodeMessage(msg)
-		m.FaultDelaySecifier = &FaultDelay_HeaderDelay_{msg}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _FaultDelay_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*FaultDelay)
-	// fault_delay_secifier
-	switch x := m.FaultDelaySecifier.(type) {
-	case *FaultDelay_FixedDelay:
-		s := proto.Size(x.FixedDelay)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *FaultDelay_HeaderDelay_:
-		s := proto.Size(x.HeaderDelay)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 // Fault delays are controlled via an HTTP header (if applicable). See the
@@ -355,78 +289,12 @@ func (m *FaultRateLimit) GetPercentage() *_type.FractionalPercent {
 	return nil
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*FaultRateLimit) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _FaultRateLimit_OneofMarshaler, _FaultRateLimit_OneofUnmarshaler, _FaultRateLimit_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*FaultRateLimit) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*FaultRateLimit_FixedLimit_)(nil),
 		(*FaultRateLimit_HeaderLimit_)(nil),
 	}
-}
-
-func _FaultRateLimit_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*FaultRateLimit)
-	// limit_type
-	switch x := m.LimitType.(type) {
-	case *FaultRateLimit_FixedLimit_:
-		_ = b.EncodeVarint(1<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.FixedLimit); err != nil {
-			return err
-		}
-	case *FaultRateLimit_HeaderLimit_:
-		_ = b.EncodeVarint(3<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.HeaderLimit); err != nil {
-			return err
-		}
-	case nil:
-	default:
-		return fmt.Errorf("FaultRateLimit.LimitType has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _FaultRateLimit_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*FaultRateLimit)
-	switch tag {
-	case 1: // limit_type.fixed_limit
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(FaultRateLimit_FixedLimit)
-		err := b.DecodeMessage(msg)
-		m.LimitType = &FaultRateLimit_FixedLimit_{msg}
-		return true, err
-	case 3: // limit_type.header_limit
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(FaultRateLimit_HeaderLimit)
-		err := b.DecodeMessage(msg)
-		m.LimitType = &FaultRateLimit_HeaderLimit_{msg}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _FaultRateLimit_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*FaultRateLimit)
-	// limit_type
-	switch x := m.LimitType.(type) {
-	case *FaultRateLimit_FixedLimit_:
-		s := proto.Size(x.FixedLimit)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *FaultRateLimit_HeaderLimit_:
-		s := proto.Size(x.HeaderLimit)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 // Describes a fixed/constant rate limit.

--- a/pkg/api/envoy/config/filter/fault/v3alpha/fault.pb.go
+++ b/pkg/api/envoy/config/filter/fault/v3alpha/fault.pb.go
@@ -23,7 +23,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 type FaultDelay_FaultDelayType int32
 
@@ -149,78 +149,12 @@ func (m *FaultDelay) GetPercentage() *_type.FractionalPercent {
 	return nil
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*FaultDelay) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _FaultDelay_OneofMarshaler, _FaultDelay_OneofUnmarshaler, _FaultDelay_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*FaultDelay) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*FaultDelay_FixedDelay)(nil),
 		(*FaultDelay_HeaderDelay_)(nil),
 	}
-}
-
-func _FaultDelay_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*FaultDelay)
-	// fault_delay_secifier
-	switch x := m.FaultDelaySecifier.(type) {
-	case *FaultDelay_FixedDelay:
-		_ = b.EncodeVarint(3<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.FixedDelay); err != nil {
-			return err
-		}
-	case *FaultDelay_HeaderDelay_:
-		_ = b.EncodeVarint(5<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.HeaderDelay); err != nil {
-			return err
-		}
-	case nil:
-	default:
-		return fmt.Errorf("FaultDelay.FaultDelaySecifier has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _FaultDelay_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*FaultDelay)
-	switch tag {
-	case 3: // fault_delay_secifier.fixed_delay
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(types.Duration)
-		err := b.DecodeMessage(msg)
-		m.FaultDelaySecifier = &FaultDelay_FixedDelay{msg}
-		return true, err
-	case 5: // fault_delay_secifier.header_delay
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(FaultDelay_HeaderDelay)
-		err := b.DecodeMessage(msg)
-		m.FaultDelaySecifier = &FaultDelay_HeaderDelay_{msg}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _FaultDelay_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*FaultDelay)
-	// fault_delay_secifier
-	switch x := m.FaultDelaySecifier.(type) {
-	case *FaultDelay_FixedDelay:
-		s := proto.Size(x.FixedDelay)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *FaultDelay_HeaderDelay_:
-		s := proto.Size(x.HeaderDelay)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 // Fault delays are controlled via an HTTP header (if applicable). See the
@@ -355,78 +289,12 @@ func (m *FaultRateLimit) GetPercentage() *_type.FractionalPercent {
 	return nil
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*FaultRateLimit) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _FaultRateLimit_OneofMarshaler, _FaultRateLimit_OneofUnmarshaler, _FaultRateLimit_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*FaultRateLimit) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*FaultRateLimit_FixedLimit_)(nil),
 		(*FaultRateLimit_HeaderLimit_)(nil),
 	}
-}
-
-func _FaultRateLimit_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*FaultRateLimit)
-	// limit_type
-	switch x := m.LimitType.(type) {
-	case *FaultRateLimit_FixedLimit_:
-		_ = b.EncodeVarint(1<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.FixedLimit); err != nil {
-			return err
-		}
-	case *FaultRateLimit_HeaderLimit_:
-		_ = b.EncodeVarint(3<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.HeaderLimit); err != nil {
-			return err
-		}
-	case nil:
-	default:
-		return fmt.Errorf("FaultRateLimit.LimitType has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _FaultRateLimit_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*FaultRateLimit)
-	switch tag {
-	case 1: // limit_type.fixed_limit
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(FaultRateLimit_FixedLimit)
-		err := b.DecodeMessage(msg)
-		m.LimitType = &FaultRateLimit_FixedLimit_{msg}
-		return true, err
-	case 3: // limit_type.header_limit
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(FaultRateLimit_HeaderLimit)
-		err := b.DecodeMessage(msg)
-		m.LimitType = &FaultRateLimit_HeaderLimit_{msg}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _FaultRateLimit_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*FaultRateLimit)
-	// limit_type
-	switch x := m.LimitType.(type) {
-	case *FaultRateLimit_FixedLimit_:
-		s := proto.Size(x.FixedLimit)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *FaultRateLimit_HeaderLimit_:
-		s := proto.Size(x.HeaderLimit)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 // Describes a fixed/constant rate limit.

--- a/pkg/api/envoy/config/filter/http/adaptive_concurrency/v2alpha/adaptive_concurrency.pb.go
+++ b/pkg/api/envoy/config/filter/http/adaptive_concurrency/v2alpha/adaptive_concurrency.pb.go
@@ -24,7 +24,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // Configuration parameters for the gradient controller.
 type GradientControllerConfig struct {
@@ -296,59 +296,11 @@ func (m *AdaptiveConcurrency) GetGradientControllerConfig() *GradientControllerC
 	return nil
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*AdaptiveConcurrency) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _AdaptiveConcurrency_OneofMarshaler, _AdaptiveConcurrency_OneofUnmarshaler, _AdaptiveConcurrency_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*AdaptiveConcurrency) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*AdaptiveConcurrency_GradientControllerConfig)(nil),
 	}
-}
-
-func _AdaptiveConcurrency_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*AdaptiveConcurrency)
-	// concurrency_controller_config
-	switch x := m.ConcurrencyControllerConfig.(type) {
-	case *AdaptiveConcurrency_GradientControllerConfig:
-		_ = b.EncodeVarint(1<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.GradientControllerConfig); err != nil {
-			return err
-		}
-	case nil:
-	default:
-		return fmt.Errorf("AdaptiveConcurrency.ConcurrencyControllerConfig has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _AdaptiveConcurrency_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*AdaptiveConcurrency)
-	switch tag {
-	case 1: // concurrency_controller_config.gradient_controller_config
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(GradientControllerConfig)
-		err := b.DecodeMessage(msg)
-		m.ConcurrencyControllerConfig = &AdaptiveConcurrency_GradientControllerConfig{msg}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _AdaptiveConcurrency_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*AdaptiveConcurrency)
-	// concurrency_controller_config
-	switch x := m.ConcurrencyControllerConfig.(type) {
-	case *AdaptiveConcurrency_GradientControllerConfig:
-		s := proto.Size(x.GradientControllerConfig)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 func init() {

--- a/pkg/api/envoy/config/filter/http/buffer/v2/buffer.pb.go
+++ b/pkg/api/envoy/config/filter/http/buffer/v2/buffer.pb.go
@@ -22,7 +22,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 type Buffer struct {
 	// The maximum request size that the filter will buffer before the connection
@@ -153,77 +153,12 @@ func (m *BufferPerRoute) GetBuffer() *Buffer {
 	return nil
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*BufferPerRoute) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _BufferPerRoute_OneofMarshaler, _BufferPerRoute_OneofUnmarshaler, _BufferPerRoute_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*BufferPerRoute) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*BufferPerRoute_Disabled)(nil),
 		(*BufferPerRoute_Buffer)(nil),
 	}
-}
-
-func _BufferPerRoute_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*BufferPerRoute)
-	// override
-	switch x := m.Override.(type) {
-	case *BufferPerRoute_Disabled:
-		t := uint64(0)
-		if x.Disabled {
-			t = 1
-		}
-		_ = b.EncodeVarint(1<<3 | proto.WireVarint)
-		_ = b.EncodeVarint(t)
-	case *BufferPerRoute_Buffer:
-		_ = b.EncodeVarint(2<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.Buffer); err != nil {
-			return err
-		}
-	case nil:
-	default:
-		return fmt.Errorf("BufferPerRoute.Override has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _BufferPerRoute_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*BufferPerRoute)
-	switch tag {
-	case 1: // override.disabled
-		if wire != proto.WireVarint {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeVarint()
-		m.Override = &BufferPerRoute_Disabled{x != 0}
-		return true, err
-	case 2: // override.buffer
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(Buffer)
-		err := b.DecodeMessage(msg)
-		m.Override = &BufferPerRoute_Buffer{msg}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _BufferPerRoute_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*BufferPerRoute)
-	// override
-	switch x := m.Override.(type) {
-	case *BufferPerRoute_Disabled:
-		n += 1 // tag and wire
-		n += 1
-	case *BufferPerRoute_Buffer:
-		s := proto.Size(x.Buffer)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 func init() {

--- a/pkg/api/envoy/config/filter/http/buffer/v3alpha/buffer.pb.go
+++ b/pkg/api/envoy/config/filter/http/buffer/v3alpha/buffer.pb.go
@@ -22,7 +22,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 type Buffer struct {
 	// The maximum request size that the filter will buffer before the connection
@@ -153,77 +153,12 @@ func (m *BufferPerRoute) GetBuffer() *Buffer {
 	return nil
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*BufferPerRoute) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _BufferPerRoute_OneofMarshaler, _BufferPerRoute_OneofUnmarshaler, _BufferPerRoute_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*BufferPerRoute) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*BufferPerRoute_Disabled)(nil),
 		(*BufferPerRoute_Buffer)(nil),
 	}
-}
-
-func _BufferPerRoute_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*BufferPerRoute)
-	// override
-	switch x := m.Override.(type) {
-	case *BufferPerRoute_Disabled:
-		t := uint64(0)
-		if x.Disabled {
-			t = 1
-		}
-		_ = b.EncodeVarint(1<<3 | proto.WireVarint)
-		_ = b.EncodeVarint(t)
-	case *BufferPerRoute_Buffer:
-		_ = b.EncodeVarint(2<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.Buffer); err != nil {
-			return err
-		}
-	case nil:
-	default:
-		return fmt.Errorf("BufferPerRoute.Override has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _BufferPerRoute_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*BufferPerRoute)
-	switch tag {
-	case 1: // override.disabled
-		if wire != proto.WireVarint {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeVarint()
-		m.Override = &BufferPerRoute_Disabled{x != 0}
-		return true, err
-	case 2: // override.buffer
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(Buffer)
-		err := b.DecodeMessage(msg)
-		m.Override = &BufferPerRoute_Buffer{msg}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _BufferPerRoute_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*BufferPerRoute)
-	// override
-	switch x := m.Override.(type) {
-	case *BufferPerRoute_Disabled:
-		n += 1 // tag and wire
-		n += 1
-	case *BufferPerRoute_Buffer:
-		s := proto.Size(x.Buffer)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 func init() {

--- a/pkg/api/envoy/config/filter/http/csrf/v2/csrf.pb.go
+++ b/pkg/api/envoy/config/filter/http/csrf/v2/csrf.pb.go
@@ -23,7 +23,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // CSRF filter config.
 type CsrfPolicy struct {

--- a/pkg/api/envoy/config/filter/http/csrf/v3alpha/csrf.pb.go
+++ b/pkg/api/envoy/config/filter/http/csrf/v3alpha/csrf.pb.go
@@ -23,7 +23,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // CSRF filter config.
 type CsrfPolicy struct {

--- a/pkg/api/envoy/config/filter/http/dynamic_forward_proxy/v2alpha/dynamic_forward_proxy.pb.go
+++ b/pkg/api/envoy/config/filter/http/dynamic_forward_proxy/v2alpha/dynamic_forward_proxy.pb.go
@@ -22,7 +22,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // Configuration for the dynamic forward proxy HTTP filter. See the :ref:`architecture overview
 // <arch_overview_http_dynamic_forward_proxy>` for more information.

--- a/pkg/api/envoy/config/filter/http/dynamic_forward_proxy/v3alpha/dynamic_forward_proxy.pb.go
+++ b/pkg/api/envoy/config/filter/http/dynamic_forward_proxy/v3alpha/dynamic_forward_proxy.pb.go
@@ -22,7 +22,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // Configuration for the dynamic forward proxy HTTP filter. See the :ref:`architecture overview
 // <arch_overview_http_dynamic_forward_proxy>` for more information.

--- a/pkg/api/envoy/config/filter/http/ext_authz/v2/ext_authz.pb.go
+++ b/pkg/api/envoy/config/filter/http/ext_authz/v2/ext_authz.pb.go
@@ -24,7 +24,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 type ExtAuthz struct {
 	// External authorization service configuration.
@@ -199,78 +199,12 @@ func (m *ExtAuthz) GetMetadataContextNamespaces() []string {
 	return nil
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*ExtAuthz) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _ExtAuthz_OneofMarshaler, _ExtAuthz_OneofUnmarshaler, _ExtAuthz_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*ExtAuthz) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*ExtAuthz_GrpcService)(nil),
 		(*ExtAuthz_HttpService)(nil),
 	}
-}
-
-func _ExtAuthz_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*ExtAuthz)
-	// services
-	switch x := m.Services.(type) {
-	case *ExtAuthz_GrpcService:
-		_ = b.EncodeVarint(1<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.GrpcService); err != nil {
-			return err
-		}
-	case *ExtAuthz_HttpService:
-		_ = b.EncodeVarint(3<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.HttpService); err != nil {
-			return err
-		}
-	case nil:
-	default:
-		return fmt.Errorf("ExtAuthz.Services has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _ExtAuthz_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*ExtAuthz)
-	switch tag {
-	case 1: // services.grpc_service
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(core.GrpcService)
-		err := b.DecodeMessage(msg)
-		m.Services = &ExtAuthz_GrpcService{msg}
-		return true, err
-	case 3: // services.http_service
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(HttpService)
-		err := b.DecodeMessage(msg)
-		m.Services = &ExtAuthz_HttpService{msg}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _ExtAuthz_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*ExtAuthz)
-	// services
-	switch x := m.Services.(type) {
-	case *ExtAuthz_GrpcService:
-		s := proto.Size(x.GrpcService)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *ExtAuthz_HttpService:
-		s := proto.Size(x.HttpService)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 // Configuration for buffering the request data.
@@ -645,77 +579,12 @@ func (m *ExtAuthzPerRoute) GetCheckSettings() *CheckSettings {
 	return nil
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*ExtAuthzPerRoute) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _ExtAuthzPerRoute_OneofMarshaler, _ExtAuthzPerRoute_OneofUnmarshaler, _ExtAuthzPerRoute_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*ExtAuthzPerRoute) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*ExtAuthzPerRoute_Disabled)(nil),
 		(*ExtAuthzPerRoute_CheckSettings)(nil),
 	}
-}
-
-func _ExtAuthzPerRoute_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*ExtAuthzPerRoute)
-	// override
-	switch x := m.Override.(type) {
-	case *ExtAuthzPerRoute_Disabled:
-		t := uint64(0)
-		if x.Disabled {
-			t = 1
-		}
-		_ = b.EncodeVarint(1<<3 | proto.WireVarint)
-		_ = b.EncodeVarint(t)
-	case *ExtAuthzPerRoute_CheckSettings:
-		_ = b.EncodeVarint(2<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.CheckSettings); err != nil {
-			return err
-		}
-	case nil:
-	default:
-		return fmt.Errorf("ExtAuthzPerRoute.Override has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _ExtAuthzPerRoute_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*ExtAuthzPerRoute)
-	switch tag {
-	case 1: // override.disabled
-		if wire != proto.WireVarint {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeVarint()
-		m.Override = &ExtAuthzPerRoute_Disabled{x != 0}
-		return true, err
-	case 2: // override.check_settings
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(CheckSettings)
-		err := b.DecodeMessage(msg)
-		m.Override = &ExtAuthzPerRoute_CheckSettings{msg}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _ExtAuthzPerRoute_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*ExtAuthzPerRoute)
-	// override
-	switch x := m.Override.(type) {
-	case *ExtAuthzPerRoute_Disabled:
-		n += 1 // tag and wire
-		n += 1
-	case *ExtAuthzPerRoute_CheckSettings:
-		s := proto.Size(x.CheckSettings)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 // Extra settings for the check request. You can use this to provide extra context for the

--- a/pkg/api/envoy/config/filter/http/ext_authz/v3alpha/ext_authz.pb.go
+++ b/pkg/api/envoy/config/filter/http/ext_authz/v3alpha/ext_authz.pb.go
@@ -24,7 +24,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 type ExtAuthz struct {
 	// External authorization service configuration.
@@ -200,78 +200,12 @@ func (m *ExtAuthz) GetMetadataContextNamespaces() []string {
 	return nil
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*ExtAuthz) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _ExtAuthz_OneofMarshaler, _ExtAuthz_OneofUnmarshaler, _ExtAuthz_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*ExtAuthz) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*ExtAuthz_GrpcService)(nil),
 		(*ExtAuthz_HttpService)(nil),
 	}
-}
-
-func _ExtAuthz_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*ExtAuthz)
-	// services
-	switch x := m.Services.(type) {
-	case *ExtAuthz_GrpcService:
-		_ = b.EncodeVarint(1<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.GrpcService); err != nil {
-			return err
-		}
-	case *ExtAuthz_HttpService:
-		_ = b.EncodeVarint(3<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.HttpService); err != nil {
-			return err
-		}
-	case nil:
-	default:
-		return fmt.Errorf("ExtAuthz.Services has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _ExtAuthz_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*ExtAuthz)
-	switch tag {
-	case 1: // services.grpc_service
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(core.GrpcService)
-		err := b.DecodeMessage(msg)
-		m.Services = &ExtAuthz_GrpcService{msg}
-		return true, err
-	case 3: // services.http_service
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(HttpService)
-		err := b.DecodeMessage(msg)
-		m.Services = &ExtAuthz_HttpService{msg}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _ExtAuthz_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*ExtAuthz)
-	// services
-	switch x := m.Services.(type) {
-	case *ExtAuthz_GrpcService:
-		s := proto.Size(x.GrpcService)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *ExtAuthz_HttpService:
-		s := proto.Size(x.HttpService)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 // Configuration for buffering the request data.
@@ -646,77 +580,12 @@ func (m *ExtAuthzPerRoute) GetCheckSettings() *CheckSettings {
 	return nil
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*ExtAuthzPerRoute) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _ExtAuthzPerRoute_OneofMarshaler, _ExtAuthzPerRoute_OneofUnmarshaler, _ExtAuthzPerRoute_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*ExtAuthzPerRoute) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*ExtAuthzPerRoute_Disabled)(nil),
 		(*ExtAuthzPerRoute_CheckSettings)(nil),
 	}
-}
-
-func _ExtAuthzPerRoute_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*ExtAuthzPerRoute)
-	// override
-	switch x := m.Override.(type) {
-	case *ExtAuthzPerRoute_Disabled:
-		t := uint64(0)
-		if x.Disabled {
-			t = 1
-		}
-		_ = b.EncodeVarint(1<<3 | proto.WireVarint)
-		_ = b.EncodeVarint(t)
-	case *ExtAuthzPerRoute_CheckSettings:
-		_ = b.EncodeVarint(2<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.CheckSettings); err != nil {
-			return err
-		}
-	case nil:
-	default:
-		return fmt.Errorf("ExtAuthzPerRoute.Override has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _ExtAuthzPerRoute_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*ExtAuthzPerRoute)
-	switch tag {
-	case 1: // override.disabled
-		if wire != proto.WireVarint {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeVarint()
-		m.Override = &ExtAuthzPerRoute_Disabled{x != 0}
-		return true, err
-	case 2: // override.check_settings
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(CheckSettings)
-		err := b.DecodeMessage(msg)
-		m.Override = &ExtAuthzPerRoute_CheckSettings{msg}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _ExtAuthzPerRoute_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*ExtAuthzPerRoute)
-	// override
-	switch x := m.Override.(type) {
-	case *ExtAuthzPerRoute_Disabled:
-		n += 1 // tag and wire
-		n += 1
-	case *ExtAuthzPerRoute_CheckSettings:
-		s := proto.Size(x.CheckSettings)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 // Extra settings for the check request. You can use this to provide extra context for the

--- a/pkg/api/envoy/config/filter/http/fault/v2/fault.pb.go
+++ b/pkg/api/envoy/config/filter/http/fault/v2/fault.pb.go
@@ -25,7 +25,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 type FaultAbort struct {
 	// Types that are valid to be assigned to ErrorType:
@@ -105,54 +105,11 @@ func (m *FaultAbort) GetPercentage() *_type.FractionalPercent {
 	return nil
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*FaultAbort) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _FaultAbort_OneofMarshaler, _FaultAbort_OneofUnmarshaler, _FaultAbort_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*FaultAbort) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*FaultAbort_HttpStatus)(nil),
 	}
-}
-
-func _FaultAbort_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*FaultAbort)
-	// error_type
-	switch x := m.ErrorType.(type) {
-	case *FaultAbort_HttpStatus:
-		_ = b.EncodeVarint(2<<3 | proto.WireVarint)
-		_ = b.EncodeVarint(uint64(x.HttpStatus))
-	case nil:
-	default:
-		return fmt.Errorf("FaultAbort.ErrorType has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _FaultAbort_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*FaultAbort)
-	switch tag {
-	case 2: // error_type.http_status
-		if wire != proto.WireVarint {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeVarint()
-		m.ErrorType = &FaultAbort_HttpStatus{uint32(x)}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _FaultAbort_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*FaultAbort)
-	// error_type
-	switch x := m.ErrorType.(type) {
-	case *FaultAbort_HttpStatus:
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(x.HttpStatus))
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 type HTTPFault struct {

--- a/pkg/api/envoy/config/filter/http/fault/v3alpha/fault.pb.go
+++ b/pkg/api/envoy/config/filter/http/fault/v3alpha/fault.pb.go
@@ -25,7 +25,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 type FaultAbort struct {
 	// Types that are valid to be assigned to ErrorType:
@@ -105,54 +105,11 @@ func (m *FaultAbort) GetPercentage() *_type.FractionalPercent {
 	return nil
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*FaultAbort) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _FaultAbort_OneofMarshaler, _FaultAbort_OneofUnmarshaler, _FaultAbort_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*FaultAbort) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*FaultAbort_HttpStatus)(nil),
 	}
-}
-
-func _FaultAbort_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*FaultAbort)
-	// error_type
-	switch x := m.ErrorType.(type) {
-	case *FaultAbort_HttpStatus:
-		_ = b.EncodeVarint(2<<3 | proto.WireVarint)
-		_ = b.EncodeVarint(uint64(x.HttpStatus))
-	case nil:
-	default:
-		return fmt.Errorf("FaultAbort.ErrorType has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _FaultAbort_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*FaultAbort)
-	switch tag {
-	case 2: // error_type.http_status
-		if wire != proto.WireVarint {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeVarint()
-		m.ErrorType = &FaultAbort_HttpStatus{uint32(x)}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _FaultAbort_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*FaultAbort)
-	// error_type
-	switch x := m.ErrorType.(type) {
-	case *FaultAbort_HttpStatus:
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(x.HttpStatus))
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 type HTTPFault struct {

--- a/pkg/api/envoy/config/filter/http/grpc_http1_reverse_bridge/v2alpha1/config.pb.go
+++ b/pkg/api/envoy/config/filter/http/grpc_http1_reverse_bridge/v2alpha1/config.pb.go
@@ -21,7 +21,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // gRPC reverse bridge filter configuration
 type FilterConfig struct {

--- a/pkg/api/envoy/config/filter/http/grpc_http1_reverse_bridge/v3alpha/config.pb.go
+++ b/pkg/api/envoy/config/filter/http/grpc_http1_reverse_bridge/v3alpha/config.pb.go
@@ -21,7 +21,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // gRPC reverse bridge filter configuration
 type FilterConfig struct {

--- a/pkg/api/envoy/config/filter/http/gzip/v2/gzip.pb.go
+++ b/pkg/api/envoy/config/filter/http/gzip/v2/gzip.pb.go
@@ -22,7 +22,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 type Gzip_CompressionStrategy int32
 

--- a/pkg/api/envoy/config/filter/http/gzip/v3alpha/gzip.pb.go
+++ b/pkg/api/envoy/config/filter/http/gzip/v3alpha/gzip.pb.go
@@ -22,7 +22,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 type Gzip_CompressionStrategy int32
 

--- a/pkg/api/envoy/config/filter/http/header_to_metadata/v2/header_to_metadata.pb.go
+++ b/pkg/api/envoy/config/filter/http/header_to_metadata/v2/header_to_metadata.pb.go
@@ -21,7 +21,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 type Config_ValueType int32
 

--- a/pkg/api/envoy/config/filter/http/header_to_metadata/v3alpha/header_to_metadata.pb.go
+++ b/pkg/api/envoy/config/filter/http/header_to_metadata/v3alpha/header_to_metadata.pb.go
@@ -21,7 +21,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 type Config_ValueType int32
 

--- a/pkg/api/envoy/config/filter/http/health_check/v2/health_check.pb.go
+++ b/pkg/api/envoy/config/filter/http/health_check/v2/health_check.pb.go
@@ -24,7 +24,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 type HealthCheck struct {
 	// Specifies whether the filter operates in pass through mode or not.

--- a/pkg/api/envoy/config/filter/http/health_check/v3alpha/health_check.pb.go
+++ b/pkg/api/envoy/config/filter/http/health_check/v3alpha/health_check.pb.go
@@ -24,7 +24,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 type HealthCheck struct {
 	// Specifies whether the filter operates in pass through mode or not.

--- a/pkg/api/envoy/config/filter/http/ip_tagging/v2/ip_tagging.pb.go
+++ b/pkg/api/envoy/config/filter/http/ip_tagging/v2/ip_tagging.pb.go
@@ -22,7 +22,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // The type of requests the filter should apply to. The supported types
 // are internal, external or both. The

--- a/pkg/api/envoy/config/filter/http/ip_tagging/v3alpha/ip_tagging.pb.go
+++ b/pkg/api/envoy/config/filter/http/ip_tagging/v3alpha/ip_tagging.pb.go
@@ -22,7 +22,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // The type of requests the filter should apply to. The supported types
 // are internal, external or both. The

--- a/pkg/api/envoy/config/filter/http/jwt_authn/v2alpha/config.pb.go
+++ b/pkg/api/envoy/config/filter/http/jwt_authn/v2alpha/config.pb.go
@@ -24,7 +24,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // Please see following for JWT authentication flow:
 //
@@ -274,78 +274,12 @@ func (m *JwtProvider) GetPayloadInMetadata() string {
 	return ""
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*JwtProvider) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _JwtProvider_OneofMarshaler, _JwtProvider_OneofUnmarshaler, _JwtProvider_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*JwtProvider) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*JwtProvider_RemoteJwks)(nil),
 		(*JwtProvider_LocalJwks)(nil),
 	}
-}
-
-func _JwtProvider_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*JwtProvider)
-	// jwks_source_specifier
-	switch x := m.JwksSourceSpecifier.(type) {
-	case *JwtProvider_RemoteJwks:
-		_ = b.EncodeVarint(3<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.RemoteJwks); err != nil {
-			return err
-		}
-	case *JwtProvider_LocalJwks:
-		_ = b.EncodeVarint(4<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.LocalJwks); err != nil {
-			return err
-		}
-	case nil:
-	default:
-		return fmt.Errorf("JwtProvider.JwksSourceSpecifier has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _JwtProvider_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*JwtProvider)
-	switch tag {
-	case 3: // jwks_source_specifier.remote_jwks
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(RemoteJwks)
-		err := b.DecodeMessage(msg)
-		m.JwksSourceSpecifier = &JwtProvider_RemoteJwks{msg}
-		return true, err
-	case 4: // jwks_source_specifier.local_jwks
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(core.DataSource)
-		err := b.DecodeMessage(msg)
-		m.JwksSourceSpecifier = &JwtProvider_LocalJwks{msg}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _JwtProvider_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*JwtProvider)
-	// jwks_source_specifier
-	switch x := m.JwksSourceSpecifier.(type) {
-	case *JwtProvider_RemoteJwks:
-		s := proto.Size(x.RemoteJwks)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *JwtProvider_LocalJwks:
-		s := proto.Size(x.LocalJwks)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 // This message specifies how to fetch JWKS from remote and how to cache it.
@@ -688,131 +622,15 @@ func (m *JwtRequirement) GetAllowMissingOrFailed() *types.Empty {
 	return nil
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*JwtRequirement) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _JwtRequirement_OneofMarshaler, _JwtRequirement_OneofUnmarshaler, _JwtRequirement_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*JwtRequirement) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*JwtRequirement_ProviderName)(nil),
 		(*JwtRequirement_ProviderAndAudiences)(nil),
 		(*JwtRequirement_RequiresAny)(nil),
 		(*JwtRequirement_RequiresAll)(nil),
 		(*JwtRequirement_AllowMissingOrFailed)(nil),
 	}
-}
-
-func _JwtRequirement_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*JwtRequirement)
-	// requires_type
-	switch x := m.RequiresType.(type) {
-	case *JwtRequirement_ProviderName:
-		_ = b.EncodeVarint(1<<3 | proto.WireBytes)
-		_ = b.EncodeStringBytes(x.ProviderName)
-	case *JwtRequirement_ProviderAndAudiences:
-		_ = b.EncodeVarint(2<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.ProviderAndAudiences); err != nil {
-			return err
-		}
-	case *JwtRequirement_RequiresAny:
-		_ = b.EncodeVarint(3<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.RequiresAny); err != nil {
-			return err
-		}
-	case *JwtRequirement_RequiresAll:
-		_ = b.EncodeVarint(4<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.RequiresAll); err != nil {
-			return err
-		}
-	case *JwtRequirement_AllowMissingOrFailed:
-		_ = b.EncodeVarint(5<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.AllowMissingOrFailed); err != nil {
-			return err
-		}
-	case nil:
-	default:
-		return fmt.Errorf("JwtRequirement.RequiresType has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _JwtRequirement_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*JwtRequirement)
-	switch tag {
-	case 1: // requires_type.provider_name
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeStringBytes()
-		m.RequiresType = &JwtRequirement_ProviderName{x}
-		return true, err
-	case 2: // requires_type.provider_and_audiences
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(ProviderWithAudiences)
-		err := b.DecodeMessage(msg)
-		m.RequiresType = &JwtRequirement_ProviderAndAudiences{msg}
-		return true, err
-	case 3: // requires_type.requires_any
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(JwtRequirementOrList)
-		err := b.DecodeMessage(msg)
-		m.RequiresType = &JwtRequirement_RequiresAny{msg}
-		return true, err
-	case 4: // requires_type.requires_all
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(JwtRequirementAndList)
-		err := b.DecodeMessage(msg)
-		m.RequiresType = &JwtRequirement_RequiresAll{msg}
-		return true, err
-	case 5: // requires_type.allow_missing_or_failed
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(types.Empty)
-		err := b.DecodeMessage(msg)
-		m.RequiresType = &JwtRequirement_AllowMissingOrFailed{msg}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _JwtRequirement_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*JwtRequirement)
-	// requires_type
-	switch x := m.RequiresType.(type) {
-	case *JwtRequirement_ProviderName:
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(len(x.ProviderName)))
-		n += len(x.ProviderName)
-	case *JwtRequirement_ProviderAndAudiences:
-		s := proto.Size(x.ProviderAndAudiences)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *JwtRequirement_RequiresAny:
-		s := proto.Size(x.RequiresAny)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *JwtRequirement_RequiresAll:
-		s := proto.Size(x.RequiresAll)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *JwtRequirement_AllowMissingOrFailed:
-		s := proto.Size(x.AllowMissingOrFailed)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 // This message specifies a list of RequiredProvider.

--- a/pkg/api/envoy/config/filter/http/jwt_authn/v3alpha/config.pb.go
+++ b/pkg/api/envoy/config/filter/http/jwt_authn/v3alpha/config.pb.go
@@ -24,7 +24,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // Please see following for JWT authentication flow:
 //
@@ -274,78 +274,12 @@ func (m *JwtProvider) GetPayloadInMetadata() string {
 	return ""
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*JwtProvider) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _JwtProvider_OneofMarshaler, _JwtProvider_OneofUnmarshaler, _JwtProvider_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*JwtProvider) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*JwtProvider_RemoteJwks)(nil),
 		(*JwtProvider_LocalJwks)(nil),
 	}
-}
-
-func _JwtProvider_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*JwtProvider)
-	// jwks_source_specifier
-	switch x := m.JwksSourceSpecifier.(type) {
-	case *JwtProvider_RemoteJwks:
-		_ = b.EncodeVarint(3<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.RemoteJwks); err != nil {
-			return err
-		}
-	case *JwtProvider_LocalJwks:
-		_ = b.EncodeVarint(4<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.LocalJwks); err != nil {
-			return err
-		}
-	case nil:
-	default:
-		return fmt.Errorf("JwtProvider.JwksSourceSpecifier has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _JwtProvider_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*JwtProvider)
-	switch tag {
-	case 3: // jwks_source_specifier.remote_jwks
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(RemoteJwks)
-		err := b.DecodeMessage(msg)
-		m.JwksSourceSpecifier = &JwtProvider_RemoteJwks{msg}
-		return true, err
-	case 4: // jwks_source_specifier.local_jwks
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(core.DataSource)
-		err := b.DecodeMessage(msg)
-		m.JwksSourceSpecifier = &JwtProvider_LocalJwks{msg}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _JwtProvider_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*JwtProvider)
-	// jwks_source_specifier
-	switch x := m.JwksSourceSpecifier.(type) {
-	case *JwtProvider_RemoteJwks:
-		s := proto.Size(x.RemoteJwks)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *JwtProvider_LocalJwks:
-		s := proto.Size(x.LocalJwks)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 // This message specifies how to fetch JWKS from remote and how to cache it.
@@ -688,131 +622,15 @@ func (m *JwtRequirement) GetAllowMissingOrFailed() *types.Empty {
 	return nil
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*JwtRequirement) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _JwtRequirement_OneofMarshaler, _JwtRequirement_OneofUnmarshaler, _JwtRequirement_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*JwtRequirement) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*JwtRequirement_ProviderName)(nil),
 		(*JwtRequirement_ProviderAndAudiences)(nil),
 		(*JwtRequirement_RequiresAny)(nil),
 		(*JwtRequirement_RequiresAll)(nil),
 		(*JwtRequirement_AllowMissingOrFailed)(nil),
 	}
-}
-
-func _JwtRequirement_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*JwtRequirement)
-	// requires_type
-	switch x := m.RequiresType.(type) {
-	case *JwtRequirement_ProviderName:
-		_ = b.EncodeVarint(1<<3 | proto.WireBytes)
-		_ = b.EncodeStringBytes(x.ProviderName)
-	case *JwtRequirement_ProviderAndAudiences:
-		_ = b.EncodeVarint(2<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.ProviderAndAudiences); err != nil {
-			return err
-		}
-	case *JwtRequirement_RequiresAny:
-		_ = b.EncodeVarint(3<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.RequiresAny); err != nil {
-			return err
-		}
-	case *JwtRequirement_RequiresAll:
-		_ = b.EncodeVarint(4<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.RequiresAll); err != nil {
-			return err
-		}
-	case *JwtRequirement_AllowMissingOrFailed:
-		_ = b.EncodeVarint(5<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.AllowMissingOrFailed); err != nil {
-			return err
-		}
-	case nil:
-	default:
-		return fmt.Errorf("JwtRequirement.RequiresType has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _JwtRequirement_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*JwtRequirement)
-	switch tag {
-	case 1: // requires_type.provider_name
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeStringBytes()
-		m.RequiresType = &JwtRequirement_ProviderName{x}
-		return true, err
-	case 2: // requires_type.provider_and_audiences
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(ProviderWithAudiences)
-		err := b.DecodeMessage(msg)
-		m.RequiresType = &JwtRequirement_ProviderAndAudiences{msg}
-		return true, err
-	case 3: // requires_type.requires_any
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(JwtRequirementOrList)
-		err := b.DecodeMessage(msg)
-		m.RequiresType = &JwtRequirement_RequiresAny{msg}
-		return true, err
-	case 4: // requires_type.requires_all
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(JwtRequirementAndList)
-		err := b.DecodeMessage(msg)
-		m.RequiresType = &JwtRequirement_RequiresAll{msg}
-		return true, err
-	case 5: // requires_type.allow_missing_or_failed
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(types.Empty)
-		err := b.DecodeMessage(msg)
-		m.RequiresType = &JwtRequirement_AllowMissingOrFailed{msg}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _JwtRequirement_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*JwtRequirement)
-	// requires_type
-	switch x := m.RequiresType.(type) {
-	case *JwtRequirement_ProviderName:
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(len(x.ProviderName)))
-		n += len(x.ProviderName)
-	case *JwtRequirement_ProviderAndAudiences:
-		s := proto.Size(x.ProviderAndAudiences)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *JwtRequirement_RequiresAny:
-		s := proto.Size(x.RequiresAny)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *JwtRequirement_RequiresAll:
-		s := proto.Size(x.RequiresAll)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *JwtRequirement_AllowMissingOrFailed:
-		s := proto.Size(x.AllowMissingOrFailed)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 // This message specifies a list of RequiredProvider.

--- a/pkg/api/envoy/config/filter/http/lua/v2/lua.pb.go
+++ b/pkg/api/envoy/config/filter/http/lua/v2/lua.pb.go
@@ -21,7 +21,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 type Lua struct {
 	// The Lua code that Envoy will execute. This can be a very small script that

--- a/pkg/api/envoy/config/filter/http/lua/v3alpha/lua.pb.go
+++ b/pkg/api/envoy/config/filter/http/lua/v3alpha/lua.pb.go
@@ -21,7 +21,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 type Lua struct {
 	// The Lua code that Envoy will execute. This can be a very small script that

--- a/pkg/api/envoy/config/filter/http/original_src/v2alpha1/original_src.pb.go
+++ b/pkg/api/envoy/config/filter/http/original_src/v2alpha1/original_src.pb.go
@@ -21,7 +21,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // The Original Src filter binds upstream connections to the original source address determined
 // for the request. This address could come from something like the Proxy Protocol filter, or it

--- a/pkg/api/envoy/config/filter/http/original_src/v3alpha/original_src.pb.go
+++ b/pkg/api/envoy/config/filter/http/original_src/v3alpha/original_src.pb.go
@@ -21,7 +21,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // The Original Src filter binds upstream connections to the original source address determined
 // for the request. This address could come from something like the Proxy Protocol filter, or it

--- a/pkg/api/envoy/config/filter/http/rate_limit/v2/rate_limit.pb.go
+++ b/pkg/api/envoy/config/filter/http/rate_limit/v2/rate_limit.pb.go
@@ -23,7 +23,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 type RateLimit struct {
 	// The rate limit domain to use when calling the rate limit service.

--- a/pkg/api/envoy/config/filter/http/rate_limit/v3alpha/rate_limit.pb.go
+++ b/pkg/api/envoy/config/filter/http/rate_limit/v3alpha/rate_limit.pb.go
@@ -23,7 +23,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 type RateLimit struct {
 	// The rate limit domain to use when calling the rate limit service.

--- a/pkg/api/envoy/config/filter/http/rbac/v2/rbac.pb.go
+++ b/pkg/api/envoy/config/filter/http/rbac/v2/rbac.pb.go
@@ -22,7 +22,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // RBAC filter config.
 type RBAC struct {

--- a/pkg/api/envoy/config/filter/http/rbac/v3alpha/rbac.pb.go
+++ b/pkg/api/envoy/config/filter/http/rbac/v3alpha/rbac.pb.go
@@ -22,7 +22,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // RBAC filter config.
 type RBAC struct {

--- a/pkg/api/envoy/config/filter/http/router/v2/router.pb.go
+++ b/pkg/api/envoy/config/filter/http/router/v2/router.pb.go
@@ -23,7 +23,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 type Router struct {
 	// Whether the router generates dynamic cluster statistics. Defaults to

--- a/pkg/api/envoy/config/filter/http/router/v3alpha/router.pb.go
+++ b/pkg/api/envoy/config/filter/http/router/v3alpha/router.pb.go
@@ -23,7 +23,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 type Router struct {
 	// Whether the router generates dynamic cluster statistics. Defaults to

--- a/pkg/api/envoy/config/filter/http/squash/v2/squash.pb.go
+++ b/pkg/api/envoy/config/filter/http/squash/v2/squash.pb.go
@@ -22,7 +22,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // [#proto-status: experimental]
 type Squash struct {

--- a/pkg/api/envoy/config/filter/http/squash/v3alpha/squash.pb.go
+++ b/pkg/api/envoy/config/filter/http/squash/v3alpha/squash.pb.go
@@ -22,7 +22,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // [#proto-status: experimental]
 type Squash struct {

--- a/pkg/api/envoy/config/filter/http/tap/v2alpha/tap.pb.go
+++ b/pkg/api/envoy/config/filter/http/tap/v2alpha/tap.pb.go
@@ -22,7 +22,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // Top level configuration for the tap filter.
 type Tap struct {

--- a/pkg/api/envoy/config/filter/http/tap/v3alpha/tap.pb.go
+++ b/pkg/api/envoy/config/filter/http/tap/v3alpha/tap.pb.go
@@ -22,7 +22,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // Top level configuration for the tap filter.
 type Tap struct {

--- a/pkg/api/envoy/config/filter/http/transcoder/v2/transcoder.pb.go
+++ b/pkg/api/envoy/config/filter/http/transcoder/v2/transcoder.pb.go
@@ -21,7 +21,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 type GrpcJsonTranscoder struct {
 	// Types that are valid to be assigned to DescriptorSet:
@@ -211,70 +211,12 @@ func (m *GrpcJsonTranscoder) GetIgnoreUnknownQueryParameters() bool {
 	return false
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*GrpcJsonTranscoder) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _GrpcJsonTranscoder_OneofMarshaler, _GrpcJsonTranscoder_OneofUnmarshaler, _GrpcJsonTranscoder_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*GrpcJsonTranscoder) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*GrpcJsonTranscoder_ProtoDescriptor)(nil),
 		(*GrpcJsonTranscoder_ProtoDescriptorBin)(nil),
 	}
-}
-
-func _GrpcJsonTranscoder_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*GrpcJsonTranscoder)
-	// descriptor_set
-	switch x := m.DescriptorSet.(type) {
-	case *GrpcJsonTranscoder_ProtoDescriptor:
-		_ = b.EncodeVarint(1<<3 | proto.WireBytes)
-		_ = b.EncodeStringBytes(x.ProtoDescriptor)
-	case *GrpcJsonTranscoder_ProtoDescriptorBin:
-		_ = b.EncodeVarint(4<<3 | proto.WireBytes)
-		_ = b.EncodeRawBytes(x.ProtoDescriptorBin)
-	case nil:
-	default:
-		return fmt.Errorf("GrpcJsonTranscoder.DescriptorSet has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _GrpcJsonTranscoder_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*GrpcJsonTranscoder)
-	switch tag {
-	case 1: // descriptor_set.proto_descriptor
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeStringBytes()
-		m.DescriptorSet = &GrpcJsonTranscoder_ProtoDescriptor{x}
-		return true, err
-	case 4: // descriptor_set.proto_descriptor_bin
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeRawBytes(true)
-		m.DescriptorSet = &GrpcJsonTranscoder_ProtoDescriptorBin{x}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _GrpcJsonTranscoder_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*GrpcJsonTranscoder)
-	// descriptor_set
-	switch x := m.DescriptorSet.(type) {
-	case *GrpcJsonTranscoder_ProtoDescriptor:
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(len(x.ProtoDescriptor)))
-		n += len(x.ProtoDescriptor)
-	case *GrpcJsonTranscoder_ProtoDescriptorBin:
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(len(x.ProtoDescriptorBin)))
-		n += len(x.ProtoDescriptorBin)
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 type GrpcJsonTranscoder_PrintOptions struct {

--- a/pkg/api/envoy/config/filter/http/transcoder/v3alpha/transcoder.pb.go
+++ b/pkg/api/envoy/config/filter/http/transcoder/v3alpha/transcoder.pb.go
@@ -21,7 +21,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 type GrpcJsonTranscoder struct {
 	// Types that are valid to be assigned to DescriptorSet:
@@ -211,70 +211,12 @@ func (m *GrpcJsonTranscoder) GetIgnoreUnknownQueryParameters() bool {
 	return false
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*GrpcJsonTranscoder) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _GrpcJsonTranscoder_OneofMarshaler, _GrpcJsonTranscoder_OneofUnmarshaler, _GrpcJsonTranscoder_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*GrpcJsonTranscoder) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*GrpcJsonTranscoder_ProtoDescriptor)(nil),
 		(*GrpcJsonTranscoder_ProtoDescriptorBin)(nil),
 	}
-}
-
-func _GrpcJsonTranscoder_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*GrpcJsonTranscoder)
-	// descriptor_set
-	switch x := m.DescriptorSet.(type) {
-	case *GrpcJsonTranscoder_ProtoDescriptor:
-		_ = b.EncodeVarint(1<<3 | proto.WireBytes)
-		_ = b.EncodeStringBytes(x.ProtoDescriptor)
-	case *GrpcJsonTranscoder_ProtoDescriptorBin:
-		_ = b.EncodeVarint(4<<3 | proto.WireBytes)
-		_ = b.EncodeRawBytes(x.ProtoDescriptorBin)
-	case nil:
-	default:
-		return fmt.Errorf("GrpcJsonTranscoder.DescriptorSet has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _GrpcJsonTranscoder_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*GrpcJsonTranscoder)
-	switch tag {
-	case 1: // descriptor_set.proto_descriptor
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeStringBytes()
-		m.DescriptorSet = &GrpcJsonTranscoder_ProtoDescriptor{x}
-		return true, err
-	case 4: // descriptor_set.proto_descriptor_bin
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeRawBytes(true)
-		m.DescriptorSet = &GrpcJsonTranscoder_ProtoDescriptorBin{x}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _GrpcJsonTranscoder_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*GrpcJsonTranscoder)
-	// descriptor_set
-	switch x := m.DescriptorSet.(type) {
-	case *GrpcJsonTranscoder_ProtoDescriptor:
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(len(x.ProtoDescriptor)))
-		n += len(x.ProtoDescriptor)
-	case *GrpcJsonTranscoder_ProtoDescriptorBin:
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(len(x.ProtoDescriptorBin)))
-		n += len(x.ProtoDescriptorBin)
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 type GrpcJsonTranscoder_PrintOptions struct {

--- a/pkg/api/envoy/config/filter/listener/original_src/v2alpha1/original_src.pb.go
+++ b/pkg/api/envoy/config/filter/listener/original_src/v2alpha1/original_src.pb.go
@@ -21,7 +21,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // The Original Src filter binds upstream connections to the original source address determined
 // for the connection. This address could come from something like the Proxy Protocol filter, or it

--- a/pkg/api/envoy/config/filter/listener/original_src/v3alpha/original_src.pb.go
+++ b/pkg/api/envoy/config/filter/listener/original_src/v3alpha/original_src.pb.go
@@ -21,7 +21,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // The Original Src filter binds upstream connections to the original source address determined
 // for the connection. This address could come from something like the Proxy Protocol filter, or it

--- a/pkg/api/envoy/config/filter/network/client_ssl_auth/v2/client_ssl_auth.pb.go
+++ b/pkg/api/envoy/config/filter/network/client_ssl_auth/v2/client_ssl_auth.pb.go
@@ -23,7 +23,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 type ClientSSLAuth struct {
 	// The :ref:`cluster manager <arch_overview_cluster_manager>` cluster that runs

--- a/pkg/api/envoy/config/filter/network/client_ssl_auth/v3alpha/client_ssl_auth.pb.go
+++ b/pkg/api/envoy/config/filter/network/client_ssl_auth/v3alpha/client_ssl_auth.pb.go
@@ -23,7 +23,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 type ClientSSLAuth struct {
 	// The :ref:`cluster manager <arch_overview_cluster_manager>` cluster that runs

--- a/pkg/api/envoy/config/filter/network/dubbo_proxy/v2alpha1/dubbo_proxy.pb.go
+++ b/pkg/api/envoy/config/filter/network/dubbo_proxy/v2alpha1/dubbo_proxy.pb.go
@@ -22,7 +22,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // Dubbo Protocol types supported by Envoy.
 type ProtocolType int32

--- a/pkg/api/envoy/config/filter/network/dubbo_proxy/v2alpha1/route.pb.go
+++ b/pkg/api/envoy/config/filter/network/dubbo_proxy/v2alpha1/route.pb.go
@@ -25,7 +25,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // [#comment:next free field: 6]
 type RouteConfiguration struct {
@@ -313,74 +313,12 @@ func (m *RouteAction) GetWeightedClusters() *route.WeightedCluster {
 	return nil
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*RouteAction) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _RouteAction_OneofMarshaler, _RouteAction_OneofUnmarshaler, _RouteAction_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*RouteAction) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*RouteAction_Cluster)(nil),
 		(*RouteAction_WeightedClusters)(nil),
 	}
-}
-
-func _RouteAction_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*RouteAction)
-	// cluster_specifier
-	switch x := m.ClusterSpecifier.(type) {
-	case *RouteAction_Cluster:
-		_ = b.EncodeVarint(1<<3 | proto.WireBytes)
-		_ = b.EncodeStringBytes(x.Cluster)
-	case *RouteAction_WeightedClusters:
-		_ = b.EncodeVarint(2<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.WeightedClusters); err != nil {
-			return err
-		}
-	case nil:
-	default:
-		return fmt.Errorf("RouteAction.ClusterSpecifier has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _RouteAction_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*RouteAction)
-	switch tag {
-	case 1: // cluster_specifier.cluster
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeStringBytes()
-		m.ClusterSpecifier = &RouteAction_Cluster{x}
-		return true, err
-	case 2: // cluster_specifier.weighted_clusters
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(route.WeightedCluster)
-		err := b.DecodeMessage(msg)
-		m.ClusterSpecifier = &RouteAction_WeightedClusters{msg}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _RouteAction_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*RouteAction)
-	// cluster_specifier
-	switch x := m.ClusterSpecifier.(type) {
-	case *RouteAction_Cluster:
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(len(x.Cluster)))
-		n += len(x.Cluster)
-	case *RouteAction_WeightedClusters:
-		s := proto.Size(x.WeightedClusters)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 // [#comment:next free field: 5]
@@ -526,74 +464,12 @@ func (m *MethodMatch_ParameterMatchSpecifier) GetRangeMatch() *_type.Int64Range 
 	return nil
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*MethodMatch_ParameterMatchSpecifier) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _MethodMatch_ParameterMatchSpecifier_OneofMarshaler, _MethodMatch_ParameterMatchSpecifier_OneofUnmarshaler, _MethodMatch_ParameterMatchSpecifier_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*MethodMatch_ParameterMatchSpecifier) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*MethodMatch_ParameterMatchSpecifier_ExactMatch)(nil),
 		(*MethodMatch_ParameterMatchSpecifier_RangeMatch)(nil),
 	}
-}
-
-func _MethodMatch_ParameterMatchSpecifier_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*MethodMatch_ParameterMatchSpecifier)
-	// parameter_match_specifier
-	switch x := m.ParameterMatchSpecifier.(type) {
-	case *MethodMatch_ParameterMatchSpecifier_ExactMatch:
-		_ = b.EncodeVarint(3<<3 | proto.WireBytes)
-		_ = b.EncodeStringBytes(x.ExactMatch)
-	case *MethodMatch_ParameterMatchSpecifier_RangeMatch:
-		_ = b.EncodeVarint(4<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.RangeMatch); err != nil {
-			return err
-		}
-	case nil:
-	default:
-		return fmt.Errorf("MethodMatch_ParameterMatchSpecifier.ParameterMatchSpecifier has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _MethodMatch_ParameterMatchSpecifier_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*MethodMatch_ParameterMatchSpecifier)
-	switch tag {
-	case 3: // parameter_match_specifier.exact_match
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeStringBytes()
-		m.ParameterMatchSpecifier = &MethodMatch_ParameterMatchSpecifier_ExactMatch{x}
-		return true, err
-	case 4: // parameter_match_specifier.range_match
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(_type.Int64Range)
-		err := b.DecodeMessage(msg)
-		m.ParameterMatchSpecifier = &MethodMatch_ParameterMatchSpecifier_RangeMatch{msg}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _MethodMatch_ParameterMatchSpecifier_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*MethodMatch_ParameterMatchSpecifier)
-	// parameter_match_specifier
-	switch x := m.ParameterMatchSpecifier.(type) {
-	case *MethodMatch_ParameterMatchSpecifier_ExactMatch:
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(len(x.ExactMatch)))
-		n += len(x.ExactMatch)
-	case *MethodMatch_ParameterMatchSpecifier_RangeMatch:
-		s := proto.Size(x.RangeMatch)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 func init() {

--- a/pkg/api/envoy/config/filter/network/dubbo_proxy/v3alpha/dubbo_proxy.pb.go
+++ b/pkg/api/envoy/config/filter/network/dubbo_proxy/v3alpha/dubbo_proxy.pb.go
@@ -22,7 +22,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // Dubbo Protocol types supported by Envoy.
 type ProtocolType int32

--- a/pkg/api/envoy/config/filter/network/dubbo_proxy/v3alpha/route.pb.go
+++ b/pkg/api/envoy/config/filter/network/dubbo_proxy/v3alpha/route.pb.go
@@ -25,7 +25,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // [#comment:next free field: 6]
 type RouteConfiguration struct {
@@ -313,74 +313,12 @@ func (m *RouteAction) GetWeightedClusters() *route.WeightedCluster {
 	return nil
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*RouteAction) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _RouteAction_OneofMarshaler, _RouteAction_OneofUnmarshaler, _RouteAction_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*RouteAction) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*RouteAction_Cluster)(nil),
 		(*RouteAction_WeightedClusters)(nil),
 	}
-}
-
-func _RouteAction_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*RouteAction)
-	// cluster_specifier
-	switch x := m.ClusterSpecifier.(type) {
-	case *RouteAction_Cluster:
-		_ = b.EncodeVarint(1<<3 | proto.WireBytes)
-		_ = b.EncodeStringBytes(x.Cluster)
-	case *RouteAction_WeightedClusters:
-		_ = b.EncodeVarint(2<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.WeightedClusters); err != nil {
-			return err
-		}
-	case nil:
-	default:
-		return fmt.Errorf("RouteAction.ClusterSpecifier has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _RouteAction_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*RouteAction)
-	switch tag {
-	case 1: // cluster_specifier.cluster
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeStringBytes()
-		m.ClusterSpecifier = &RouteAction_Cluster{x}
-		return true, err
-	case 2: // cluster_specifier.weighted_clusters
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(route.WeightedCluster)
-		err := b.DecodeMessage(msg)
-		m.ClusterSpecifier = &RouteAction_WeightedClusters{msg}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _RouteAction_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*RouteAction)
-	// cluster_specifier
-	switch x := m.ClusterSpecifier.(type) {
-	case *RouteAction_Cluster:
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(len(x.Cluster)))
-		n += len(x.Cluster)
-	case *RouteAction_WeightedClusters:
-		s := proto.Size(x.WeightedClusters)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 // [#comment:next free field: 5]
@@ -526,74 +464,12 @@ func (m *MethodMatch_ParameterMatchSpecifier) GetRangeMatch() *_type.Int64Range 
 	return nil
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*MethodMatch_ParameterMatchSpecifier) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _MethodMatch_ParameterMatchSpecifier_OneofMarshaler, _MethodMatch_ParameterMatchSpecifier_OneofUnmarshaler, _MethodMatch_ParameterMatchSpecifier_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*MethodMatch_ParameterMatchSpecifier) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*MethodMatch_ParameterMatchSpecifier_ExactMatch)(nil),
 		(*MethodMatch_ParameterMatchSpecifier_RangeMatch)(nil),
 	}
-}
-
-func _MethodMatch_ParameterMatchSpecifier_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*MethodMatch_ParameterMatchSpecifier)
-	// parameter_match_specifier
-	switch x := m.ParameterMatchSpecifier.(type) {
-	case *MethodMatch_ParameterMatchSpecifier_ExactMatch:
-		_ = b.EncodeVarint(3<<3 | proto.WireBytes)
-		_ = b.EncodeStringBytes(x.ExactMatch)
-	case *MethodMatch_ParameterMatchSpecifier_RangeMatch:
-		_ = b.EncodeVarint(4<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.RangeMatch); err != nil {
-			return err
-		}
-	case nil:
-	default:
-		return fmt.Errorf("MethodMatch_ParameterMatchSpecifier.ParameterMatchSpecifier has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _MethodMatch_ParameterMatchSpecifier_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*MethodMatch_ParameterMatchSpecifier)
-	switch tag {
-	case 3: // parameter_match_specifier.exact_match
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeStringBytes()
-		m.ParameterMatchSpecifier = &MethodMatch_ParameterMatchSpecifier_ExactMatch{x}
-		return true, err
-	case 4: // parameter_match_specifier.range_match
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(_type.Int64Range)
-		err := b.DecodeMessage(msg)
-		m.ParameterMatchSpecifier = &MethodMatch_ParameterMatchSpecifier_RangeMatch{msg}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _MethodMatch_ParameterMatchSpecifier_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*MethodMatch_ParameterMatchSpecifier)
-	// parameter_match_specifier
-	switch x := m.ParameterMatchSpecifier.(type) {
-	case *MethodMatch_ParameterMatchSpecifier_ExactMatch:
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(len(x.ExactMatch)))
-		n += len(x.ExactMatch)
-	case *MethodMatch_ParameterMatchSpecifier_RangeMatch:
-		s := proto.Size(x.RangeMatch)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 func init() {

--- a/pkg/api/envoy/config/filter/network/ext_authz/v2/ext_authz.pb.go
+++ b/pkg/api/envoy/config/filter/network/ext_authz/v2/ext_authz.pb.go
@@ -22,7 +22,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // External Authorization filter calls out to an external service over the
 // gRPC Authorization API defined by

--- a/pkg/api/envoy/config/filter/network/ext_authz/v3alpha/ext_authz.pb.go
+++ b/pkg/api/envoy/config/filter/network/ext_authz/v3alpha/ext_authz.pb.go
@@ -22,7 +22,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // External Authorization filter calls out to an external service over the
 // gRPC Authorization API defined by

--- a/pkg/api/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.pb.go
+++ b/pkg/api/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.pb.go
@@ -26,7 +26,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 type HttpConnectionManager_CodecType int32
 
@@ -693,97 +693,13 @@ func (m *HttpConnectionManager) GetMergeSlashes() bool {
 	return false
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*HttpConnectionManager) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _HttpConnectionManager_OneofMarshaler, _HttpConnectionManager_OneofUnmarshaler, _HttpConnectionManager_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*HttpConnectionManager) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*HttpConnectionManager_Rds)(nil),
 		(*HttpConnectionManager_RouteConfig)(nil),
 		(*HttpConnectionManager_ScopedRoutes)(nil),
 	}
-}
-
-func _HttpConnectionManager_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*HttpConnectionManager)
-	// route_specifier
-	switch x := m.RouteSpecifier.(type) {
-	case *HttpConnectionManager_Rds:
-		_ = b.EncodeVarint(3<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.Rds); err != nil {
-			return err
-		}
-	case *HttpConnectionManager_RouteConfig:
-		_ = b.EncodeVarint(4<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.RouteConfig); err != nil {
-			return err
-		}
-	case *HttpConnectionManager_ScopedRoutes:
-		_ = b.EncodeVarint(31<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.ScopedRoutes); err != nil {
-			return err
-		}
-	case nil:
-	default:
-		return fmt.Errorf("HttpConnectionManager.RouteSpecifier has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _HttpConnectionManager_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*HttpConnectionManager)
-	switch tag {
-	case 3: // route_specifier.rds
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(Rds)
-		err := b.DecodeMessage(msg)
-		m.RouteSpecifier = &HttpConnectionManager_Rds{msg}
-		return true, err
-	case 4: // route_specifier.route_config
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(v2.RouteConfiguration)
-		err := b.DecodeMessage(msg)
-		m.RouteSpecifier = &HttpConnectionManager_RouteConfig{msg}
-		return true, err
-	case 31: // route_specifier.scoped_routes
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(ScopedRoutes)
-		err := b.DecodeMessage(msg)
-		m.RouteSpecifier = &HttpConnectionManager_ScopedRoutes{msg}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _HttpConnectionManager_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*HttpConnectionManager)
-	// route_specifier
-	switch x := m.RouteSpecifier.(type) {
-	case *HttpConnectionManager_Rds:
-		s := proto.Size(x.Rds)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *HttpConnectionManager_RouteConfig:
-		s := proto.Size(x.RouteConfig)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *HttpConnectionManager_ScopedRoutes:
-		s := proto.Size(x.ScopedRoutes)
-		n += 2 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 type HttpConnectionManager_Tracing struct {
@@ -1366,78 +1282,12 @@ func (m *ScopedRoutes) GetScopedRds() *ScopedRds {
 	return nil
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*ScopedRoutes) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _ScopedRoutes_OneofMarshaler, _ScopedRoutes_OneofUnmarshaler, _ScopedRoutes_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*ScopedRoutes) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*ScopedRoutes_ScopedRouteConfigurationsList)(nil),
 		(*ScopedRoutes_ScopedRds)(nil),
 	}
-}
-
-func _ScopedRoutes_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*ScopedRoutes)
-	// config_specifier
-	switch x := m.ConfigSpecifier.(type) {
-	case *ScopedRoutes_ScopedRouteConfigurationsList:
-		_ = b.EncodeVarint(4<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.ScopedRouteConfigurationsList); err != nil {
-			return err
-		}
-	case *ScopedRoutes_ScopedRds:
-		_ = b.EncodeVarint(5<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.ScopedRds); err != nil {
-			return err
-		}
-	case nil:
-	default:
-		return fmt.Errorf("ScopedRoutes.ConfigSpecifier has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _ScopedRoutes_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*ScopedRoutes)
-	switch tag {
-	case 4: // config_specifier.scoped_route_configurations_list
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(ScopedRouteConfigurationsList)
-		err := b.DecodeMessage(msg)
-		m.ConfigSpecifier = &ScopedRoutes_ScopedRouteConfigurationsList{msg}
-		return true, err
-	case 5: // config_specifier.scoped_rds
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(ScopedRds)
-		err := b.DecodeMessage(msg)
-		m.ConfigSpecifier = &ScopedRoutes_ScopedRds{msg}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _ScopedRoutes_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*ScopedRoutes)
-	// config_specifier
-	switch x := m.ConfigSpecifier.(type) {
-	case *ScopedRoutes_ScopedRouteConfigurationsList:
-		s := proto.Size(x.ScopedRouteConfigurationsList)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *ScopedRoutes_ScopedRds:
-		s := proto.Size(x.ScopedRds)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 // Specifies the mechanism for constructing "scope keys" based on HTTP request attributes. These
@@ -1571,59 +1421,11 @@ func (m *ScopedRoutes_ScopeKeyBuilder_FragmentBuilder) GetHeaderValueExtractor()
 	return nil
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*ScopedRoutes_ScopeKeyBuilder_FragmentBuilder) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _ScopedRoutes_ScopeKeyBuilder_FragmentBuilder_OneofMarshaler, _ScopedRoutes_ScopeKeyBuilder_FragmentBuilder_OneofUnmarshaler, _ScopedRoutes_ScopeKeyBuilder_FragmentBuilder_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*ScopedRoutes_ScopeKeyBuilder_FragmentBuilder) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*ScopedRoutes_ScopeKeyBuilder_FragmentBuilder_HeaderValueExtractor_)(nil),
 	}
-}
-
-func _ScopedRoutes_ScopeKeyBuilder_FragmentBuilder_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*ScopedRoutes_ScopeKeyBuilder_FragmentBuilder)
-	// type
-	switch x := m.Type.(type) {
-	case *ScopedRoutes_ScopeKeyBuilder_FragmentBuilder_HeaderValueExtractor_:
-		_ = b.EncodeVarint(1<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.HeaderValueExtractor); err != nil {
-			return err
-		}
-	case nil:
-	default:
-		return fmt.Errorf("ScopedRoutes_ScopeKeyBuilder_FragmentBuilder.Type has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _ScopedRoutes_ScopeKeyBuilder_FragmentBuilder_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*ScopedRoutes_ScopeKeyBuilder_FragmentBuilder)
-	switch tag {
-	case 1: // type.header_value_extractor
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(ScopedRoutes_ScopeKeyBuilder_FragmentBuilder_HeaderValueExtractor)
-		err := b.DecodeMessage(msg)
-		m.Type = &ScopedRoutes_ScopeKeyBuilder_FragmentBuilder_HeaderValueExtractor_{msg}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _ScopedRoutes_ScopeKeyBuilder_FragmentBuilder_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*ScopedRoutes_ScopeKeyBuilder_FragmentBuilder)
-	// type
-	switch x := m.Type.(type) {
-	case *ScopedRoutes_ScopeKeyBuilder_FragmentBuilder_HeaderValueExtractor_:
-		s := proto.Size(x.HeaderValueExtractor)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 // Specifies how the value of a header should be extracted.
@@ -1750,73 +1552,12 @@ func (m *ScopedRoutes_ScopeKeyBuilder_FragmentBuilder_HeaderValueExtractor) GetE
 	return nil
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*ScopedRoutes_ScopeKeyBuilder_FragmentBuilder_HeaderValueExtractor) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _ScopedRoutes_ScopeKeyBuilder_FragmentBuilder_HeaderValueExtractor_OneofMarshaler, _ScopedRoutes_ScopeKeyBuilder_FragmentBuilder_HeaderValueExtractor_OneofUnmarshaler, _ScopedRoutes_ScopeKeyBuilder_FragmentBuilder_HeaderValueExtractor_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*ScopedRoutes_ScopeKeyBuilder_FragmentBuilder_HeaderValueExtractor) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*ScopedRoutes_ScopeKeyBuilder_FragmentBuilder_HeaderValueExtractor_Index)(nil),
 		(*ScopedRoutes_ScopeKeyBuilder_FragmentBuilder_HeaderValueExtractor_Element)(nil),
 	}
-}
-
-func _ScopedRoutes_ScopeKeyBuilder_FragmentBuilder_HeaderValueExtractor_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*ScopedRoutes_ScopeKeyBuilder_FragmentBuilder_HeaderValueExtractor)
-	// extract_type
-	switch x := m.ExtractType.(type) {
-	case *ScopedRoutes_ScopeKeyBuilder_FragmentBuilder_HeaderValueExtractor_Index:
-		_ = b.EncodeVarint(3<<3 | proto.WireVarint)
-		_ = b.EncodeVarint(uint64(x.Index))
-	case *ScopedRoutes_ScopeKeyBuilder_FragmentBuilder_HeaderValueExtractor_Element:
-		_ = b.EncodeVarint(4<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.Element); err != nil {
-			return err
-		}
-	case nil:
-	default:
-		return fmt.Errorf("ScopedRoutes_ScopeKeyBuilder_FragmentBuilder_HeaderValueExtractor.ExtractType has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _ScopedRoutes_ScopeKeyBuilder_FragmentBuilder_HeaderValueExtractor_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*ScopedRoutes_ScopeKeyBuilder_FragmentBuilder_HeaderValueExtractor)
-	switch tag {
-	case 3: // extract_type.index
-		if wire != proto.WireVarint {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeVarint()
-		m.ExtractType = &ScopedRoutes_ScopeKeyBuilder_FragmentBuilder_HeaderValueExtractor_Index{uint32(x)}
-		return true, err
-	case 4: // extract_type.element
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(ScopedRoutes_ScopeKeyBuilder_FragmentBuilder_HeaderValueExtractor_KvElement)
-		err := b.DecodeMessage(msg)
-		m.ExtractType = &ScopedRoutes_ScopeKeyBuilder_FragmentBuilder_HeaderValueExtractor_Element{msg}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _ScopedRoutes_ScopeKeyBuilder_FragmentBuilder_HeaderValueExtractor_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*ScopedRoutes_ScopeKeyBuilder_FragmentBuilder_HeaderValueExtractor)
-	// extract_type
-	switch x := m.ExtractType.(type) {
-	case *ScopedRoutes_ScopeKeyBuilder_FragmentBuilder_HeaderValueExtractor_Index:
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(x.Index))
-	case *ScopedRoutes_ScopeKeyBuilder_FragmentBuilder_HeaderValueExtractor_Element:
-		s := proto.Size(x.Element)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 // Specifies a header field's key value pair to match on.
@@ -2026,78 +1767,12 @@ func (m *HttpFilter) GetTypedConfig() *types.Any {
 	return nil
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*HttpFilter) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _HttpFilter_OneofMarshaler, _HttpFilter_OneofUnmarshaler, _HttpFilter_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*HttpFilter) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*HttpFilter_Config)(nil),
 		(*HttpFilter_TypedConfig)(nil),
 	}
-}
-
-func _HttpFilter_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*HttpFilter)
-	// config_type
-	switch x := m.ConfigType.(type) {
-	case *HttpFilter_Config:
-		_ = b.EncodeVarint(2<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.Config); err != nil {
-			return err
-		}
-	case *HttpFilter_TypedConfig:
-		_ = b.EncodeVarint(4<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.TypedConfig); err != nil {
-			return err
-		}
-	case nil:
-	default:
-		return fmt.Errorf("HttpFilter.ConfigType has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _HttpFilter_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*HttpFilter)
-	switch tag {
-	case 2: // config_type.config
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(types.Struct)
-		err := b.DecodeMessage(msg)
-		m.ConfigType = &HttpFilter_Config{msg}
-		return true, err
-	case 4: // config_type.typed_config
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(types.Any)
-		err := b.DecodeMessage(msg)
-		m.ConfigType = &HttpFilter_TypedConfig{msg}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _HttpFilter_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*HttpFilter)
-	// config_type
-	switch x := m.ConfigType.(type) {
-	case *HttpFilter_Config:
-		s := proto.Size(x.Config)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *HttpFilter_TypedConfig:
-		s := proto.Size(x.TypedConfig)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 func init() {

--- a/pkg/api/envoy/config/filter/network/http_connection_manager/v3alpha/http_connection_manager.pb.go
+++ b/pkg/api/envoy/config/filter/network/http_connection_manager/v3alpha/http_connection_manager.pb.go
@@ -26,7 +26,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 type HttpConnectionManager_CodecType int32
 
@@ -682,97 +682,13 @@ func (m *HttpConnectionManager) GetMergeSlashes() bool {
 	return false
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*HttpConnectionManager) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _HttpConnectionManager_OneofMarshaler, _HttpConnectionManager_OneofUnmarshaler, _HttpConnectionManager_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*HttpConnectionManager) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*HttpConnectionManager_Rds)(nil),
 		(*HttpConnectionManager_RouteConfig)(nil),
 		(*HttpConnectionManager_ScopedRoutes)(nil),
 	}
-}
-
-func _HttpConnectionManager_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*HttpConnectionManager)
-	// route_specifier
-	switch x := m.RouteSpecifier.(type) {
-	case *HttpConnectionManager_Rds:
-		_ = b.EncodeVarint(3<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.Rds); err != nil {
-			return err
-		}
-	case *HttpConnectionManager_RouteConfig:
-		_ = b.EncodeVarint(4<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.RouteConfig); err != nil {
-			return err
-		}
-	case *HttpConnectionManager_ScopedRoutes:
-		_ = b.EncodeVarint(31<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.ScopedRoutes); err != nil {
-			return err
-		}
-	case nil:
-	default:
-		return fmt.Errorf("HttpConnectionManager.RouteSpecifier has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _HttpConnectionManager_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*HttpConnectionManager)
-	switch tag {
-	case 3: // route_specifier.rds
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(Rds)
-		err := b.DecodeMessage(msg)
-		m.RouteSpecifier = &HttpConnectionManager_Rds{msg}
-		return true, err
-	case 4: // route_specifier.route_config
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(v3alpha.RouteConfiguration)
-		err := b.DecodeMessage(msg)
-		m.RouteSpecifier = &HttpConnectionManager_RouteConfig{msg}
-		return true, err
-	case 31: // route_specifier.scoped_routes
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(ScopedRoutes)
-		err := b.DecodeMessage(msg)
-		m.RouteSpecifier = &HttpConnectionManager_ScopedRoutes{msg}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _HttpConnectionManager_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*HttpConnectionManager)
-	// route_specifier
-	switch x := m.RouteSpecifier.(type) {
-	case *HttpConnectionManager_Rds:
-		s := proto.Size(x.Rds)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *HttpConnectionManager_RouteConfig:
-		s := proto.Size(x.RouteConfig)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *HttpConnectionManager_ScopedRoutes:
-		s := proto.Size(x.ScopedRoutes)
-		n += 2 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 type HttpConnectionManager_Tracing struct {
@@ -1338,78 +1254,12 @@ func (m *ScopedRoutes) GetScopedRds() *ScopedRds {
 	return nil
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*ScopedRoutes) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _ScopedRoutes_OneofMarshaler, _ScopedRoutes_OneofUnmarshaler, _ScopedRoutes_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*ScopedRoutes) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*ScopedRoutes_ScopedRouteConfigurationsList)(nil),
 		(*ScopedRoutes_ScopedRds)(nil),
 	}
-}
-
-func _ScopedRoutes_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*ScopedRoutes)
-	// config_specifier
-	switch x := m.ConfigSpecifier.(type) {
-	case *ScopedRoutes_ScopedRouteConfigurationsList:
-		_ = b.EncodeVarint(4<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.ScopedRouteConfigurationsList); err != nil {
-			return err
-		}
-	case *ScopedRoutes_ScopedRds:
-		_ = b.EncodeVarint(5<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.ScopedRds); err != nil {
-			return err
-		}
-	case nil:
-	default:
-		return fmt.Errorf("ScopedRoutes.ConfigSpecifier has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _ScopedRoutes_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*ScopedRoutes)
-	switch tag {
-	case 4: // config_specifier.scoped_route_configurations_list
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(ScopedRouteConfigurationsList)
-		err := b.DecodeMessage(msg)
-		m.ConfigSpecifier = &ScopedRoutes_ScopedRouteConfigurationsList{msg}
-		return true, err
-	case 5: // config_specifier.scoped_rds
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(ScopedRds)
-		err := b.DecodeMessage(msg)
-		m.ConfigSpecifier = &ScopedRoutes_ScopedRds{msg}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _ScopedRoutes_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*ScopedRoutes)
-	// config_specifier
-	switch x := m.ConfigSpecifier.(type) {
-	case *ScopedRoutes_ScopedRouteConfigurationsList:
-		s := proto.Size(x.ScopedRouteConfigurationsList)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *ScopedRoutes_ScopedRds:
-		s := proto.Size(x.ScopedRds)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 // Specifies the mechanism for constructing "scope keys" based on HTTP request attributes. These
@@ -1543,59 +1393,11 @@ func (m *ScopedRoutes_ScopeKeyBuilder_FragmentBuilder) GetHeaderValueExtractor()
 	return nil
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*ScopedRoutes_ScopeKeyBuilder_FragmentBuilder) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _ScopedRoutes_ScopeKeyBuilder_FragmentBuilder_OneofMarshaler, _ScopedRoutes_ScopeKeyBuilder_FragmentBuilder_OneofUnmarshaler, _ScopedRoutes_ScopeKeyBuilder_FragmentBuilder_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*ScopedRoutes_ScopeKeyBuilder_FragmentBuilder) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*ScopedRoutes_ScopeKeyBuilder_FragmentBuilder_HeaderValueExtractor_)(nil),
 	}
-}
-
-func _ScopedRoutes_ScopeKeyBuilder_FragmentBuilder_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*ScopedRoutes_ScopeKeyBuilder_FragmentBuilder)
-	// type
-	switch x := m.Type.(type) {
-	case *ScopedRoutes_ScopeKeyBuilder_FragmentBuilder_HeaderValueExtractor_:
-		_ = b.EncodeVarint(1<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.HeaderValueExtractor); err != nil {
-			return err
-		}
-	case nil:
-	default:
-		return fmt.Errorf("ScopedRoutes_ScopeKeyBuilder_FragmentBuilder.Type has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _ScopedRoutes_ScopeKeyBuilder_FragmentBuilder_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*ScopedRoutes_ScopeKeyBuilder_FragmentBuilder)
-	switch tag {
-	case 1: // type.header_value_extractor
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(ScopedRoutes_ScopeKeyBuilder_FragmentBuilder_HeaderValueExtractor)
-		err := b.DecodeMessage(msg)
-		m.Type = &ScopedRoutes_ScopeKeyBuilder_FragmentBuilder_HeaderValueExtractor_{msg}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _ScopedRoutes_ScopeKeyBuilder_FragmentBuilder_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*ScopedRoutes_ScopeKeyBuilder_FragmentBuilder)
-	// type
-	switch x := m.Type.(type) {
-	case *ScopedRoutes_ScopeKeyBuilder_FragmentBuilder_HeaderValueExtractor_:
-		s := proto.Size(x.HeaderValueExtractor)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 // Specifies how the value of a header should be extracted.
@@ -1722,73 +1524,12 @@ func (m *ScopedRoutes_ScopeKeyBuilder_FragmentBuilder_HeaderValueExtractor) GetE
 	return nil
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*ScopedRoutes_ScopeKeyBuilder_FragmentBuilder_HeaderValueExtractor) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _ScopedRoutes_ScopeKeyBuilder_FragmentBuilder_HeaderValueExtractor_OneofMarshaler, _ScopedRoutes_ScopeKeyBuilder_FragmentBuilder_HeaderValueExtractor_OneofUnmarshaler, _ScopedRoutes_ScopeKeyBuilder_FragmentBuilder_HeaderValueExtractor_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*ScopedRoutes_ScopeKeyBuilder_FragmentBuilder_HeaderValueExtractor) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*ScopedRoutes_ScopeKeyBuilder_FragmentBuilder_HeaderValueExtractor_Index)(nil),
 		(*ScopedRoutes_ScopeKeyBuilder_FragmentBuilder_HeaderValueExtractor_Element)(nil),
 	}
-}
-
-func _ScopedRoutes_ScopeKeyBuilder_FragmentBuilder_HeaderValueExtractor_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*ScopedRoutes_ScopeKeyBuilder_FragmentBuilder_HeaderValueExtractor)
-	// extract_type
-	switch x := m.ExtractType.(type) {
-	case *ScopedRoutes_ScopeKeyBuilder_FragmentBuilder_HeaderValueExtractor_Index:
-		_ = b.EncodeVarint(3<<3 | proto.WireVarint)
-		_ = b.EncodeVarint(uint64(x.Index))
-	case *ScopedRoutes_ScopeKeyBuilder_FragmentBuilder_HeaderValueExtractor_Element:
-		_ = b.EncodeVarint(4<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.Element); err != nil {
-			return err
-		}
-	case nil:
-	default:
-		return fmt.Errorf("ScopedRoutes_ScopeKeyBuilder_FragmentBuilder_HeaderValueExtractor.ExtractType has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _ScopedRoutes_ScopeKeyBuilder_FragmentBuilder_HeaderValueExtractor_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*ScopedRoutes_ScopeKeyBuilder_FragmentBuilder_HeaderValueExtractor)
-	switch tag {
-	case 3: // extract_type.index
-		if wire != proto.WireVarint {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeVarint()
-		m.ExtractType = &ScopedRoutes_ScopeKeyBuilder_FragmentBuilder_HeaderValueExtractor_Index{uint32(x)}
-		return true, err
-	case 4: // extract_type.element
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(ScopedRoutes_ScopeKeyBuilder_FragmentBuilder_HeaderValueExtractor_KvElement)
-		err := b.DecodeMessage(msg)
-		m.ExtractType = &ScopedRoutes_ScopeKeyBuilder_FragmentBuilder_HeaderValueExtractor_Element{msg}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _ScopedRoutes_ScopeKeyBuilder_FragmentBuilder_HeaderValueExtractor_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*ScopedRoutes_ScopeKeyBuilder_FragmentBuilder_HeaderValueExtractor)
-	// extract_type
-	switch x := m.ExtractType.(type) {
-	case *ScopedRoutes_ScopeKeyBuilder_FragmentBuilder_HeaderValueExtractor_Index:
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(x.Index))
-	case *ScopedRoutes_ScopeKeyBuilder_FragmentBuilder_HeaderValueExtractor_Element:
-		s := proto.Size(x.Element)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 // Specifies a header field's key value pair to match on.
@@ -1998,78 +1739,12 @@ func (m *HttpFilter) GetTypedConfig() *types.Any {
 	return nil
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*HttpFilter) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _HttpFilter_OneofMarshaler, _HttpFilter_OneofUnmarshaler, _HttpFilter_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*HttpFilter) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*HttpFilter_Config)(nil),
 		(*HttpFilter_TypedConfig)(nil),
 	}
-}
-
-func _HttpFilter_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*HttpFilter)
-	// config_type
-	switch x := m.ConfigType.(type) {
-	case *HttpFilter_Config:
-		_ = b.EncodeVarint(2<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.Config); err != nil {
-			return err
-		}
-	case *HttpFilter_TypedConfig:
-		_ = b.EncodeVarint(4<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.TypedConfig); err != nil {
-			return err
-		}
-	case nil:
-	default:
-		return fmt.Errorf("HttpFilter.ConfigType has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _HttpFilter_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*HttpFilter)
-	switch tag {
-	case 2: // config_type.config
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(types.Struct)
-		err := b.DecodeMessage(msg)
-		m.ConfigType = &HttpFilter_Config{msg}
-		return true, err
-	case 4: // config_type.typed_config
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(types.Any)
-		err := b.DecodeMessage(msg)
-		m.ConfigType = &HttpFilter_TypedConfig{msg}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _HttpFilter_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*HttpFilter)
-	// config_type
-	switch x := m.ConfigType.(type) {
-	case *HttpFilter_Config:
-		s := proto.Size(x.Config)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *HttpFilter_TypedConfig:
-		s := proto.Size(x.TypedConfig)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 func init() {

--- a/pkg/api/envoy/config/filter/network/mongo_proxy/v2/mongo_proxy.pb.go
+++ b/pkg/api/envoy/config/filter/network/mongo_proxy/v2/mongo_proxy.pb.go
@@ -22,7 +22,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 type MongoProxy struct {
 	// The human readable prefix to use when emitting :ref:`statistics

--- a/pkg/api/envoy/config/filter/network/mongo_proxy/v3alpha/mongo_proxy.pb.go
+++ b/pkg/api/envoy/config/filter/network/mongo_proxy/v3alpha/mongo_proxy.pb.go
@@ -22,7 +22,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 type MongoProxy struct {
 	// The human readable prefix to use when emitting :ref:`statistics

--- a/pkg/api/envoy/config/filter/network/mysql_proxy/v1alpha1/mysql_proxy.pb.go
+++ b/pkg/api/envoy/config/filter/network/mysql_proxy/v1alpha1/mysql_proxy.pb.go
@@ -21,7 +21,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // [#protodoc-title: MySQL proxy]
 // MySQL Proxy :ref:`configuration overview <config_network_filters_mysql_proxy>`.

--- a/pkg/api/envoy/config/filter/network/rate_limit/v2/rate_limit.pb.go
+++ b/pkg/api/envoy/config/filter/network/rate_limit/v2/rate_limit.pb.go
@@ -24,7 +24,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 type RateLimit struct {
 	// The prefix to use when emitting :ref:`statistics <config_network_filters_rate_limit_stats>`.

--- a/pkg/api/envoy/config/filter/network/rate_limit/v3alpha/rate_limit.pb.go
+++ b/pkg/api/envoy/config/filter/network/rate_limit/v3alpha/rate_limit.pb.go
@@ -24,7 +24,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 type RateLimit struct {
 	// The prefix to use when emitting :ref:`statistics <config_network_filters_rate_limit_stats>`.

--- a/pkg/api/envoy/config/filter/network/rbac/v2/rbac.pb.go
+++ b/pkg/api/envoy/config/filter/network/rbac/v2/rbac.pb.go
@@ -22,7 +22,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 type RBAC_EnforcementType int32
 

--- a/pkg/api/envoy/config/filter/network/rbac/v3alpha/rbac.pb.go
+++ b/pkg/api/envoy/config/filter/network/rbac/v3alpha/rbac.pb.go
@@ -22,7 +22,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 type RBAC_EnforcementType int32
 

--- a/pkg/api/envoy/config/filter/network/redis_proxy/v2/redis_proxy.pb.go
+++ b/pkg/api/envoy/config/filter/network/redis_proxy/v2/redis_proxy.pb.go
@@ -23,7 +23,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // ReadPolicy controls how Envoy routes read commands to Redis nodes. This is currently
 // supported for Redis Cluster. All ReadPolicy settings except MASTER may return stale data

--- a/pkg/api/envoy/config/filter/network/redis_proxy/v3alpha/redis_proxy.pb.go
+++ b/pkg/api/envoy/config/filter/network/redis_proxy/v3alpha/redis_proxy.pb.go
@@ -23,7 +23,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // ReadPolicy controls how Envoy routes read commands to Redis nodes. This is currently
 // supported for Redis Cluster. All ReadPolicy settings except MASTER may return stale data

--- a/pkg/api/envoy/config/filter/network/tcp_proxy/v2/tcp_proxy.pb.go
+++ b/pkg/api/envoy/config/filter/network/tcp_proxy/v2/tcp_proxy.pb.go
@@ -24,7 +24,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 type TcpProxy struct {
 	// The prefix to use when emitting :ref:`statistics
@@ -192,74 +192,12 @@ func (m *TcpProxy) GetMaxConnectAttempts() *types.UInt32Value {
 	return nil
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*TcpProxy) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _TcpProxy_OneofMarshaler, _TcpProxy_OneofUnmarshaler, _TcpProxy_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*TcpProxy) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*TcpProxy_Cluster)(nil),
 		(*TcpProxy_WeightedClusters)(nil),
 	}
-}
-
-func _TcpProxy_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*TcpProxy)
-	// cluster_specifier
-	switch x := m.ClusterSpecifier.(type) {
-	case *TcpProxy_Cluster:
-		_ = b.EncodeVarint(2<<3 | proto.WireBytes)
-		_ = b.EncodeStringBytes(x.Cluster)
-	case *TcpProxy_WeightedClusters:
-		_ = b.EncodeVarint(10<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.WeightedClusters); err != nil {
-			return err
-		}
-	case nil:
-	default:
-		return fmt.Errorf("TcpProxy.ClusterSpecifier has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _TcpProxy_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*TcpProxy)
-	switch tag {
-	case 2: // cluster_specifier.cluster
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeStringBytes()
-		m.ClusterSpecifier = &TcpProxy_Cluster{x}
-		return true, err
-	case 10: // cluster_specifier.weighted_clusters
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(TcpProxy_WeightedCluster)
-		err := b.DecodeMessage(msg)
-		m.ClusterSpecifier = &TcpProxy_WeightedClusters{msg}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _TcpProxy_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*TcpProxy)
-	// cluster_specifier
-	switch x := m.ClusterSpecifier.(type) {
-	case *TcpProxy_Cluster:
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(len(x.Cluster)))
-		n += len(x.Cluster)
-	case *TcpProxy_WeightedClusters:
-		s := proto.Size(x.WeightedClusters)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 // [#not-implemented-hide:] Deprecated.

--- a/pkg/api/envoy/config/filter/network/tcp_proxy/v3alpha/tcp_proxy.pb.go
+++ b/pkg/api/envoy/config/filter/network/tcp_proxy/v3alpha/tcp_proxy.pb.go
@@ -24,7 +24,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 type TcpProxy struct {
 	// The prefix to use when emitting :ref:`statistics
@@ -192,74 +192,12 @@ func (m *TcpProxy) GetMaxConnectAttempts() *types.UInt32Value {
 	return nil
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*TcpProxy) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _TcpProxy_OneofMarshaler, _TcpProxy_OneofUnmarshaler, _TcpProxy_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*TcpProxy) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*TcpProxy_Cluster)(nil),
 		(*TcpProxy_WeightedClusters)(nil),
 	}
-}
-
-func _TcpProxy_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*TcpProxy)
-	// cluster_specifier
-	switch x := m.ClusterSpecifier.(type) {
-	case *TcpProxy_Cluster:
-		_ = b.EncodeVarint(2<<3 | proto.WireBytes)
-		_ = b.EncodeStringBytes(x.Cluster)
-	case *TcpProxy_WeightedClusters:
-		_ = b.EncodeVarint(10<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.WeightedClusters); err != nil {
-			return err
-		}
-	case nil:
-	default:
-		return fmt.Errorf("TcpProxy.ClusterSpecifier has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _TcpProxy_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*TcpProxy)
-	switch tag {
-	case 2: // cluster_specifier.cluster
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeStringBytes()
-		m.ClusterSpecifier = &TcpProxy_Cluster{x}
-		return true, err
-	case 10: // cluster_specifier.weighted_clusters
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(TcpProxy_WeightedCluster)
-		err := b.DecodeMessage(msg)
-		m.ClusterSpecifier = &TcpProxy_WeightedClusters{msg}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _TcpProxy_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*TcpProxy)
-	// cluster_specifier
-	switch x := m.ClusterSpecifier.(type) {
-	case *TcpProxy_Cluster:
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(len(x.Cluster)))
-		n += len(x.Cluster)
-	case *TcpProxy_WeightedClusters:
-		s := proto.Size(x.WeightedClusters)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 // [#not-implemented-hide:] Deprecated.

--- a/pkg/api/envoy/config/filter/network/thrift_proxy/v2alpha1/route.pb.go
+++ b/pkg/api/envoy/config/filter/network/thrift_proxy/v2alpha1/route.pb.go
@@ -24,7 +24,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // [#comment:next free field: 3]
 type RouteConfiguration struct {
@@ -257,70 +257,12 @@ func (m *RouteMatch) GetHeaders() []*route.HeaderMatcher {
 	return nil
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*RouteMatch) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _RouteMatch_OneofMarshaler, _RouteMatch_OneofUnmarshaler, _RouteMatch_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*RouteMatch) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*RouteMatch_MethodName)(nil),
 		(*RouteMatch_ServiceName)(nil),
 	}
-}
-
-func _RouteMatch_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*RouteMatch)
-	// match_specifier
-	switch x := m.MatchSpecifier.(type) {
-	case *RouteMatch_MethodName:
-		_ = b.EncodeVarint(1<<3 | proto.WireBytes)
-		_ = b.EncodeStringBytes(x.MethodName)
-	case *RouteMatch_ServiceName:
-		_ = b.EncodeVarint(2<<3 | proto.WireBytes)
-		_ = b.EncodeStringBytes(x.ServiceName)
-	case nil:
-	default:
-		return fmt.Errorf("RouteMatch.MatchSpecifier has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _RouteMatch_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*RouteMatch)
-	switch tag {
-	case 1: // match_specifier.method_name
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeStringBytes()
-		m.MatchSpecifier = &RouteMatch_MethodName{x}
-		return true, err
-	case 2: // match_specifier.service_name
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeStringBytes()
-		m.MatchSpecifier = &RouteMatch_ServiceName{x}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _RouteMatch_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*RouteMatch)
-	// match_specifier
-	switch x := m.MatchSpecifier.(type) {
-	case *RouteMatch_MethodName:
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(len(x.MethodName)))
-		n += len(x.MethodName)
-	case *RouteMatch_ServiceName:
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(len(x.ServiceName)))
-		n += len(x.ServiceName)
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 // [#comment:next free field: 5]
@@ -429,74 +371,12 @@ func (m *RouteAction) GetRateLimits() []*route.RateLimit {
 	return nil
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*RouteAction) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _RouteAction_OneofMarshaler, _RouteAction_OneofUnmarshaler, _RouteAction_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*RouteAction) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*RouteAction_Cluster)(nil),
 		(*RouteAction_WeightedClusters)(nil),
 	}
-}
-
-func _RouteAction_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*RouteAction)
-	// cluster_specifier
-	switch x := m.ClusterSpecifier.(type) {
-	case *RouteAction_Cluster:
-		_ = b.EncodeVarint(1<<3 | proto.WireBytes)
-		_ = b.EncodeStringBytes(x.Cluster)
-	case *RouteAction_WeightedClusters:
-		_ = b.EncodeVarint(2<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.WeightedClusters); err != nil {
-			return err
-		}
-	case nil:
-	default:
-		return fmt.Errorf("RouteAction.ClusterSpecifier has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _RouteAction_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*RouteAction)
-	switch tag {
-	case 1: // cluster_specifier.cluster
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeStringBytes()
-		m.ClusterSpecifier = &RouteAction_Cluster{x}
-		return true, err
-	case 2: // cluster_specifier.weighted_clusters
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(WeightedCluster)
-		err := b.DecodeMessage(msg)
-		m.ClusterSpecifier = &RouteAction_WeightedClusters{msg}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _RouteAction_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*RouteAction)
-	// cluster_specifier
-	switch x := m.ClusterSpecifier.(type) {
-	case *RouteAction_Cluster:
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(len(x.Cluster)))
-		n += len(x.Cluster)
-	case *RouteAction_WeightedClusters:
-		s := proto.Size(x.WeightedClusters)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 // Allows for specification of multiple upstream clusters along with weights that indicate the

--- a/pkg/api/envoy/config/filter/network/thrift_proxy/v2alpha1/thrift_proxy.pb.go
+++ b/pkg/api/envoy/config/filter/network/thrift_proxy/v2alpha1/thrift_proxy.pb.go
@@ -22,7 +22,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // Thrift transport types supported by Envoy.
 type TransportType int32
@@ -294,78 +294,12 @@ func (m *ThriftFilter) GetTypedConfig() *types.Any {
 	return nil
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*ThriftFilter) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _ThriftFilter_OneofMarshaler, _ThriftFilter_OneofUnmarshaler, _ThriftFilter_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*ThriftFilter) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*ThriftFilter_Config)(nil),
 		(*ThriftFilter_TypedConfig)(nil),
 	}
-}
-
-func _ThriftFilter_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*ThriftFilter)
-	// config_type
-	switch x := m.ConfigType.(type) {
-	case *ThriftFilter_Config:
-		_ = b.EncodeVarint(2<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.Config); err != nil {
-			return err
-		}
-	case *ThriftFilter_TypedConfig:
-		_ = b.EncodeVarint(3<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.TypedConfig); err != nil {
-			return err
-		}
-	case nil:
-	default:
-		return fmt.Errorf("ThriftFilter.ConfigType has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _ThriftFilter_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*ThriftFilter)
-	switch tag {
-	case 2: // config_type.config
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(types.Struct)
-		err := b.DecodeMessage(msg)
-		m.ConfigType = &ThriftFilter_Config{msg}
-		return true, err
-	case 3: // config_type.typed_config
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(types.Any)
-		err := b.DecodeMessage(msg)
-		m.ConfigType = &ThriftFilter_TypedConfig{msg}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _ThriftFilter_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*ThriftFilter)
-	// config_type
-	switch x := m.ConfigType.(type) {
-	case *ThriftFilter_Config:
-		s := proto.Size(x.Config)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *ThriftFilter_TypedConfig:
-		s := proto.Size(x.TypedConfig)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 // ThriftProtocolOptions specifies Thrift upstream protocol options. This object is used in

--- a/pkg/api/envoy/config/filter/network/thrift_proxy/v3alpha/route.pb.go
+++ b/pkg/api/envoy/config/filter/network/thrift_proxy/v3alpha/route.pb.go
@@ -24,7 +24,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // [#comment:next free field: 3]
 type RouteConfiguration struct {
@@ -257,70 +257,12 @@ func (m *RouteMatch) GetHeaders() []*route.HeaderMatcher {
 	return nil
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*RouteMatch) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _RouteMatch_OneofMarshaler, _RouteMatch_OneofUnmarshaler, _RouteMatch_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*RouteMatch) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*RouteMatch_MethodName)(nil),
 		(*RouteMatch_ServiceName)(nil),
 	}
-}
-
-func _RouteMatch_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*RouteMatch)
-	// match_specifier
-	switch x := m.MatchSpecifier.(type) {
-	case *RouteMatch_MethodName:
-		_ = b.EncodeVarint(1<<3 | proto.WireBytes)
-		_ = b.EncodeStringBytes(x.MethodName)
-	case *RouteMatch_ServiceName:
-		_ = b.EncodeVarint(2<<3 | proto.WireBytes)
-		_ = b.EncodeStringBytes(x.ServiceName)
-	case nil:
-	default:
-		return fmt.Errorf("RouteMatch.MatchSpecifier has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _RouteMatch_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*RouteMatch)
-	switch tag {
-	case 1: // match_specifier.method_name
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeStringBytes()
-		m.MatchSpecifier = &RouteMatch_MethodName{x}
-		return true, err
-	case 2: // match_specifier.service_name
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeStringBytes()
-		m.MatchSpecifier = &RouteMatch_ServiceName{x}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _RouteMatch_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*RouteMatch)
-	// match_specifier
-	switch x := m.MatchSpecifier.(type) {
-	case *RouteMatch_MethodName:
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(len(x.MethodName)))
-		n += len(x.MethodName)
-	case *RouteMatch_ServiceName:
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(len(x.ServiceName)))
-		n += len(x.ServiceName)
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 // [#comment:next free field: 5]
@@ -429,74 +371,12 @@ func (m *RouteAction) GetRateLimits() []*route.RateLimit {
 	return nil
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*RouteAction) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _RouteAction_OneofMarshaler, _RouteAction_OneofUnmarshaler, _RouteAction_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*RouteAction) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*RouteAction_Cluster)(nil),
 		(*RouteAction_WeightedClusters)(nil),
 	}
-}
-
-func _RouteAction_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*RouteAction)
-	// cluster_specifier
-	switch x := m.ClusterSpecifier.(type) {
-	case *RouteAction_Cluster:
-		_ = b.EncodeVarint(1<<3 | proto.WireBytes)
-		_ = b.EncodeStringBytes(x.Cluster)
-	case *RouteAction_WeightedClusters:
-		_ = b.EncodeVarint(2<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.WeightedClusters); err != nil {
-			return err
-		}
-	case nil:
-	default:
-		return fmt.Errorf("RouteAction.ClusterSpecifier has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _RouteAction_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*RouteAction)
-	switch tag {
-	case 1: // cluster_specifier.cluster
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeStringBytes()
-		m.ClusterSpecifier = &RouteAction_Cluster{x}
-		return true, err
-	case 2: // cluster_specifier.weighted_clusters
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(WeightedCluster)
-		err := b.DecodeMessage(msg)
-		m.ClusterSpecifier = &RouteAction_WeightedClusters{msg}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _RouteAction_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*RouteAction)
-	// cluster_specifier
-	switch x := m.ClusterSpecifier.(type) {
-	case *RouteAction_Cluster:
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(len(x.Cluster)))
-		n += len(x.Cluster)
-	case *RouteAction_WeightedClusters:
-		s := proto.Size(x.WeightedClusters)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 // Allows for specification of multiple upstream clusters along with weights that indicate the

--- a/pkg/api/envoy/config/filter/network/thrift_proxy/v3alpha/thrift_proxy.pb.go
+++ b/pkg/api/envoy/config/filter/network/thrift_proxy/v3alpha/thrift_proxy.pb.go
@@ -22,7 +22,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // Thrift transport types supported by Envoy.
 type TransportType int32
@@ -294,78 +294,12 @@ func (m *ThriftFilter) GetTypedConfig() *types.Any {
 	return nil
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*ThriftFilter) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _ThriftFilter_OneofMarshaler, _ThriftFilter_OneofUnmarshaler, _ThriftFilter_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*ThriftFilter) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*ThriftFilter_Config)(nil),
 		(*ThriftFilter_TypedConfig)(nil),
 	}
-}
-
-func _ThriftFilter_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*ThriftFilter)
-	// config_type
-	switch x := m.ConfigType.(type) {
-	case *ThriftFilter_Config:
-		_ = b.EncodeVarint(2<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.Config); err != nil {
-			return err
-		}
-	case *ThriftFilter_TypedConfig:
-		_ = b.EncodeVarint(3<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.TypedConfig); err != nil {
-			return err
-		}
-	case nil:
-	default:
-		return fmt.Errorf("ThriftFilter.ConfigType has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _ThriftFilter_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*ThriftFilter)
-	switch tag {
-	case 2: // config_type.config
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(types.Struct)
-		err := b.DecodeMessage(msg)
-		m.ConfigType = &ThriftFilter_Config{msg}
-		return true, err
-	case 3: // config_type.typed_config
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(types.Any)
-		err := b.DecodeMessage(msg)
-		m.ConfigType = &ThriftFilter_TypedConfig{msg}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _ThriftFilter_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*ThriftFilter)
-	// config_type
-	switch x := m.ConfigType.(type) {
-	case *ThriftFilter_Config:
-		s := proto.Size(x.Config)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *ThriftFilter_TypedConfig:
-		s := proto.Size(x.TypedConfig)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 // ThriftProtocolOptions specifies Thrift upstream protocol options. This object is used in

--- a/pkg/api/envoy/config/filter/network/zookeeper_proxy/v1alpha1/zookeeper_proxy.pb.go
+++ b/pkg/api/envoy/config/filter/network/zookeeper_proxy/v1alpha1/zookeeper_proxy.pb.go
@@ -22,7 +22,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // [#protodoc-title: ZooKeeper proxy]
 // ZooKeeper Proxy :ref:`configuration overview <config_network_filters_zookeeper_proxy>`.

--- a/pkg/api/envoy/config/filter/thrift/rate_limit/v2alpha1/rate_limit.pb.go
+++ b/pkg/api/envoy/config/filter/thrift/rate_limit/v2alpha1/rate_limit.pb.go
@@ -23,7 +23,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // [#comment:next free field: 5]
 type RateLimit struct {

--- a/pkg/api/envoy/config/filter/thrift/rate_limit/v3alpha/rate_limit.pb.go
+++ b/pkg/api/envoy/config/filter/thrift/rate_limit/v3alpha/rate_limit.pb.go
@@ -23,7 +23,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // [#comment:next free field: 5]
 type RateLimit struct {

--- a/pkg/api/envoy/config/filter/thrift/router/v2alpha1/router.pb.go
+++ b/pkg/api/envoy/config/filter/thrift/router/v2alpha1/router.pb.go
@@ -20,7 +20,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 type Router struct {
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`

--- a/pkg/api/envoy/config/filter/thrift/router/v3alpha/router.pb.go
+++ b/pkg/api/envoy/config/filter/thrift/router/v3alpha/router.pb.go
@@ -20,7 +20,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 type Router struct {
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`

--- a/pkg/api/envoy/config/grpc_credential/v2alpha/aws_iam.pb.go
+++ b/pkg/api/envoy/config/grpc_credential/v2alpha/aws_iam.pb.go
@@ -21,7 +21,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 type AwsIamConfig struct {
 	// The `service namespace

--- a/pkg/api/envoy/config/grpc_credential/v2alpha/file_based_metadata.pb.go
+++ b/pkg/api/envoy/config/grpc_credential/v2alpha/file_based_metadata.pb.go
@@ -21,7 +21,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 type FileBasedMetadataConfig struct {
 	// Location or inline data of secret to use for authentication of the Google gRPC connection

--- a/pkg/api/envoy/config/grpc_credential/v3alpha/aws_iam.pb.go
+++ b/pkg/api/envoy/config/grpc_credential/v3alpha/aws_iam.pb.go
@@ -21,7 +21,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 type AwsIamConfig struct {
 	// The `service namespace

--- a/pkg/api/envoy/config/grpc_credential/v3alpha/file_based_metadata.pb.go
+++ b/pkg/api/envoy/config/grpc_credential/v3alpha/file_based_metadata.pb.go
@@ -21,7 +21,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 type FileBasedMetadataConfig struct {
 	// Location or inline data of secret to use for authentication of the Google gRPC connection

--- a/pkg/api/envoy/config/health_checker/redis/v2/redis.pb.go
+++ b/pkg/api/envoy/config/health_checker/redis/v2/redis.pb.go
@@ -20,7 +20,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 type Redis struct {
 	// If set, optionally perform ``EXISTS <key>`` instead of ``PING``. A return value

--- a/pkg/api/envoy/config/health_checker/redis/v3alpha/redis.pb.go
+++ b/pkg/api/envoy/config/health_checker/redis/v3alpha/redis.pb.go
@@ -20,7 +20,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 type Redis struct {
 	// If set, optionally perform ``EXISTS <key>`` instead of ``PING``. A return value

--- a/pkg/api/envoy/config/metrics/v2/metrics_service.pb.go
+++ b/pkg/api/envoy/config/metrics/v2/metrics_service.pb.go
@@ -22,7 +22,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // Metrics Service is configured as a built-in *envoy.metrics_service* :ref:`StatsSink
 // <envoy_api_msg_config.metrics.v2.StatsSink>`. This opaque configuration will be used to create

--- a/pkg/api/envoy/config/metrics/v2/stats.pb.go
+++ b/pkg/api/envoy/config/metrics/v2/stats.pb.go
@@ -24,7 +24,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // Configuration for pluggable stats sinks.
 type StatsSink struct {
@@ -127,78 +127,12 @@ func (m *StatsSink) GetTypedConfig() *types.Any {
 	return nil
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*StatsSink) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _StatsSink_OneofMarshaler, _StatsSink_OneofUnmarshaler, _StatsSink_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*StatsSink) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*StatsSink_Config)(nil),
 		(*StatsSink_TypedConfig)(nil),
 	}
-}
-
-func _StatsSink_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*StatsSink)
-	// config_type
-	switch x := m.ConfigType.(type) {
-	case *StatsSink_Config:
-		_ = b.EncodeVarint(2<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.Config); err != nil {
-			return err
-		}
-	case *StatsSink_TypedConfig:
-		_ = b.EncodeVarint(3<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.TypedConfig); err != nil {
-			return err
-		}
-	case nil:
-	default:
-		return fmt.Errorf("StatsSink.ConfigType has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _StatsSink_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*StatsSink)
-	switch tag {
-	case 2: // config_type.config
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(types.Struct)
-		err := b.DecodeMessage(msg)
-		m.ConfigType = &StatsSink_Config{msg}
-		return true, err
-	case 3: // config_type.typed_config
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(types.Any)
-		err := b.DecodeMessage(msg)
-		m.ConfigType = &StatsSink_TypedConfig{msg}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _StatsSink_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*StatsSink)
-	// config_type
-	switch x := m.ConfigType.(type) {
-	case *StatsSink_Config:
-		s := proto.Size(x.Config)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *StatsSink_TypedConfig:
-		s := proto.Size(x.TypedConfig)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 // Statistics configuration such as tagging.
@@ -379,96 +313,13 @@ func (m *StatsMatcher) GetInclusionList() *matcher.ListStringMatcher {
 	return nil
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*StatsMatcher) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _StatsMatcher_OneofMarshaler, _StatsMatcher_OneofUnmarshaler, _StatsMatcher_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*StatsMatcher) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*StatsMatcher_RejectAll)(nil),
 		(*StatsMatcher_ExclusionList)(nil),
 		(*StatsMatcher_InclusionList)(nil),
 	}
-}
-
-func _StatsMatcher_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*StatsMatcher)
-	// stats_matcher
-	switch x := m.StatsMatcher.(type) {
-	case *StatsMatcher_RejectAll:
-		t := uint64(0)
-		if x.RejectAll {
-			t = 1
-		}
-		_ = b.EncodeVarint(1<<3 | proto.WireVarint)
-		_ = b.EncodeVarint(t)
-	case *StatsMatcher_ExclusionList:
-		_ = b.EncodeVarint(2<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.ExclusionList); err != nil {
-			return err
-		}
-	case *StatsMatcher_InclusionList:
-		_ = b.EncodeVarint(3<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.InclusionList); err != nil {
-			return err
-		}
-	case nil:
-	default:
-		return fmt.Errorf("StatsMatcher.StatsMatcher has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _StatsMatcher_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*StatsMatcher)
-	switch tag {
-	case 1: // stats_matcher.reject_all
-		if wire != proto.WireVarint {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeVarint()
-		m.StatsMatcher = &StatsMatcher_RejectAll{x != 0}
-		return true, err
-	case 2: // stats_matcher.exclusion_list
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(matcher.ListStringMatcher)
-		err := b.DecodeMessage(msg)
-		m.StatsMatcher = &StatsMatcher_ExclusionList{msg}
-		return true, err
-	case 3: // stats_matcher.inclusion_list
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(matcher.ListStringMatcher)
-		err := b.DecodeMessage(msg)
-		m.StatsMatcher = &StatsMatcher_InclusionList{msg}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _StatsMatcher_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*StatsMatcher)
-	// stats_matcher
-	switch x := m.StatsMatcher.(type) {
-	case *StatsMatcher_RejectAll:
-		n += 1 // tag and wire
-		n += 1
-	case *StatsMatcher_ExclusionList:
-		s := proto.Size(x.ExclusionList)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *StatsMatcher_InclusionList:
-		s := proto.Size(x.InclusionList)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 // Designates a tag name and value pair. The value may be either a fixed value
@@ -575,70 +426,12 @@ func (m *TagSpecifier) GetFixedValue() string {
 	return ""
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*TagSpecifier) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _TagSpecifier_OneofMarshaler, _TagSpecifier_OneofUnmarshaler, _TagSpecifier_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*TagSpecifier) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*TagSpecifier_Regex)(nil),
 		(*TagSpecifier_FixedValue)(nil),
 	}
-}
-
-func _TagSpecifier_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*TagSpecifier)
-	// tag_value
-	switch x := m.TagValue.(type) {
-	case *TagSpecifier_Regex:
-		_ = b.EncodeVarint(2<<3 | proto.WireBytes)
-		_ = b.EncodeStringBytes(x.Regex)
-	case *TagSpecifier_FixedValue:
-		_ = b.EncodeVarint(3<<3 | proto.WireBytes)
-		_ = b.EncodeStringBytes(x.FixedValue)
-	case nil:
-	default:
-		return fmt.Errorf("TagSpecifier.TagValue has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _TagSpecifier_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*TagSpecifier)
-	switch tag {
-	case 2: // tag_value.regex
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeStringBytes()
-		m.TagValue = &TagSpecifier_Regex{x}
-		return true, err
-	case 3: // tag_value.fixed_value
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeStringBytes()
-		m.TagValue = &TagSpecifier_FixedValue{x}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _TagSpecifier_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*TagSpecifier)
-	// tag_value
-	switch x := m.TagValue.(type) {
-	case *TagSpecifier_Regex:
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(len(x.Regex)))
-		n += len(x.Regex)
-	case *TagSpecifier_FixedValue:
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(len(x.FixedValue)))
-		n += len(x.FixedValue)
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 // Stats configuration proto schema for built-in *envoy.statsd* sink. This sink does not support
@@ -757,74 +550,12 @@ func (m *StatsdSink) GetPrefix() string {
 	return ""
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*StatsdSink) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _StatsdSink_OneofMarshaler, _StatsdSink_OneofUnmarshaler, _StatsdSink_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*StatsdSink) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*StatsdSink_Address)(nil),
 		(*StatsdSink_TcpClusterName)(nil),
 	}
-}
-
-func _StatsdSink_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*StatsdSink)
-	// statsd_specifier
-	switch x := m.StatsdSpecifier.(type) {
-	case *StatsdSink_Address:
-		_ = b.EncodeVarint(1<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.Address); err != nil {
-			return err
-		}
-	case *StatsdSink_TcpClusterName:
-		_ = b.EncodeVarint(2<<3 | proto.WireBytes)
-		_ = b.EncodeStringBytes(x.TcpClusterName)
-	case nil:
-	default:
-		return fmt.Errorf("StatsdSink.StatsdSpecifier has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _StatsdSink_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*StatsdSink)
-	switch tag {
-	case 1: // statsd_specifier.address
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(core.Address)
-		err := b.DecodeMessage(msg)
-		m.StatsdSpecifier = &StatsdSink_Address{msg}
-		return true, err
-	case 2: // statsd_specifier.tcp_cluster_name
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeStringBytes()
-		m.StatsdSpecifier = &StatsdSink_TcpClusterName{x}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _StatsdSink_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*StatsdSink)
-	// statsd_specifier
-	switch x := m.StatsdSpecifier.(type) {
-	case *StatsdSink_Address:
-		s := proto.Size(x.Address)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *StatsdSink_TcpClusterName:
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(len(x.TcpClusterName)))
-		n += len(x.TcpClusterName)
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 // Stats configuration proto schema for built-in *envoy.dog_statsd* sink.
@@ -910,59 +641,11 @@ func (m *DogStatsdSink) GetPrefix() string {
 	return ""
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*DogStatsdSink) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _DogStatsdSink_OneofMarshaler, _DogStatsdSink_OneofUnmarshaler, _DogStatsdSink_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*DogStatsdSink) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*DogStatsdSink_Address)(nil),
 	}
-}
-
-func _DogStatsdSink_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*DogStatsdSink)
-	// dog_statsd_specifier
-	switch x := m.DogStatsdSpecifier.(type) {
-	case *DogStatsdSink_Address:
-		_ = b.EncodeVarint(1<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.Address); err != nil {
-			return err
-		}
-	case nil:
-	default:
-		return fmt.Errorf("DogStatsdSink.DogStatsdSpecifier has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _DogStatsdSink_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*DogStatsdSink)
-	switch tag {
-	case 1: // dog_statsd_specifier.address
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(core.Address)
-		err := b.DecodeMessage(msg)
-		m.DogStatsdSpecifier = &DogStatsdSink_Address{msg}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _DogStatsdSink_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*DogStatsdSink)
-	// dog_statsd_specifier
-	switch x := m.DogStatsdSpecifier.(type) {
-	case *DogStatsdSink_Address:
-		s := proto.Size(x.Address)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 // Stats configuration proto schema for built-in *envoy.stat_sinks.hystrix* sink.

--- a/pkg/api/envoy/config/metrics/v3alpha/metrics_service.pb.go
+++ b/pkg/api/envoy/config/metrics/v3alpha/metrics_service.pb.go
@@ -22,7 +22,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // Metrics Service is configured as a built-in *envoy.metrics_service* :ref:`StatsSink
 // <envoy_api_msg_config.metrics.v3alpha.StatsSink>`. This opaque configuration will be used to

--- a/pkg/api/envoy/config/metrics/v3alpha/stats.pb.go
+++ b/pkg/api/envoy/config/metrics/v3alpha/stats.pb.go
@@ -24,7 +24,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // Configuration for pluggable stats sinks.
 type StatsSink struct {
@@ -127,78 +127,12 @@ func (m *StatsSink) GetTypedConfig() *types.Any {
 	return nil
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*StatsSink) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _StatsSink_OneofMarshaler, _StatsSink_OneofUnmarshaler, _StatsSink_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*StatsSink) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*StatsSink_Config)(nil),
 		(*StatsSink_TypedConfig)(nil),
 	}
-}
-
-func _StatsSink_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*StatsSink)
-	// config_type
-	switch x := m.ConfigType.(type) {
-	case *StatsSink_Config:
-		_ = b.EncodeVarint(2<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.Config); err != nil {
-			return err
-		}
-	case *StatsSink_TypedConfig:
-		_ = b.EncodeVarint(3<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.TypedConfig); err != nil {
-			return err
-		}
-	case nil:
-	default:
-		return fmt.Errorf("StatsSink.ConfigType has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _StatsSink_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*StatsSink)
-	switch tag {
-	case 2: // config_type.config
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(types.Struct)
-		err := b.DecodeMessage(msg)
-		m.ConfigType = &StatsSink_Config{msg}
-		return true, err
-	case 3: // config_type.typed_config
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(types.Any)
-		err := b.DecodeMessage(msg)
-		m.ConfigType = &StatsSink_TypedConfig{msg}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _StatsSink_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*StatsSink)
-	// config_type
-	switch x := m.ConfigType.(type) {
-	case *StatsSink_Config:
-		s := proto.Size(x.Config)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *StatsSink_TypedConfig:
-		s := proto.Size(x.TypedConfig)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 // Statistics configuration such as tagging.
@@ -379,96 +313,13 @@ func (m *StatsMatcher) GetInclusionList() *matcher.ListStringMatcher {
 	return nil
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*StatsMatcher) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _StatsMatcher_OneofMarshaler, _StatsMatcher_OneofUnmarshaler, _StatsMatcher_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*StatsMatcher) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*StatsMatcher_RejectAll)(nil),
 		(*StatsMatcher_ExclusionList)(nil),
 		(*StatsMatcher_InclusionList)(nil),
 	}
-}
-
-func _StatsMatcher_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*StatsMatcher)
-	// stats_matcher
-	switch x := m.StatsMatcher.(type) {
-	case *StatsMatcher_RejectAll:
-		t := uint64(0)
-		if x.RejectAll {
-			t = 1
-		}
-		_ = b.EncodeVarint(1<<3 | proto.WireVarint)
-		_ = b.EncodeVarint(t)
-	case *StatsMatcher_ExclusionList:
-		_ = b.EncodeVarint(2<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.ExclusionList); err != nil {
-			return err
-		}
-	case *StatsMatcher_InclusionList:
-		_ = b.EncodeVarint(3<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.InclusionList); err != nil {
-			return err
-		}
-	case nil:
-	default:
-		return fmt.Errorf("StatsMatcher.StatsMatcher has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _StatsMatcher_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*StatsMatcher)
-	switch tag {
-	case 1: // stats_matcher.reject_all
-		if wire != proto.WireVarint {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeVarint()
-		m.StatsMatcher = &StatsMatcher_RejectAll{x != 0}
-		return true, err
-	case 2: // stats_matcher.exclusion_list
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(matcher.ListStringMatcher)
-		err := b.DecodeMessage(msg)
-		m.StatsMatcher = &StatsMatcher_ExclusionList{msg}
-		return true, err
-	case 3: // stats_matcher.inclusion_list
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(matcher.ListStringMatcher)
-		err := b.DecodeMessage(msg)
-		m.StatsMatcher = &StatsMatcher_InclusionList{msg}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _StatsMatcher_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*StatsMatcher)
-	// stats_matcher
-	switch x := m.StatsMatcher.(type) {
-	case *StatsMatcher_RejectAll:
-		n += 1 // tag and wire
-		n += 1
-	case *StatsMatcher_ExclusionList:
-		s := proto.Size(x.ExclusionList)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *StatsMatcher_InclusionList:
-		s := proto.Size(x.InclusionList)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 // Designates a tag name and value pair. The value may be either a fixed value
@@ -576,70 +427,12 @@ func (m *TagSpecifier) GetFixedValue() string {
 	return ""
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*TagSpecifier) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _TagSpecifier_OneofMarshaler, _TagSpecifier_OneofUnmarshaler, _TagSpecifier_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*TagSpecifier) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*TagSpecifier_Regex)(nil),
 		(*TagSpecifier_FixedValue)(nil),
 	}
-}
-
-func _TagSpecifier_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*TagSpecifier)
-	// tag_value
-	switch x := m.TagValue.(type) {
-	case *TagSpecifier_Regex:
-		_ = b.EncodeVarint(2<<3 | proto.WireBytes)
-		_ = b.EncodeStringBytes(x.Regex)
-	case *TagSpecifier_FixedValue:
-		_ = b.EncodeVarint(3<<3 | proto.WireBytes)
-		_ = b.EncodeStringBytes(x.FixedValue)
-	case nil:
-	default:
-		return fmt.Errorf("TagSpecifier.TagValue has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _TagSpecifier_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*TagSpecifier)
-	switch tag {
-	case 2: // tag_value.regex
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeStringBytes()
-		m.TagValue = &TagSpecifier_Regex{x}
-		return true, err
-	case 3: // tag_value.fixed_value
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeStringBytes()
-		m.TagValue = &TagSpecifier_FixedValue{x}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _TagSpecifier_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*TagSpecifier)
-	// tag_value
-	switch x := m.TagValue.(type) {
-	case *TagSpecifier_Regex:
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(len(x.Regex)))
-		n += len(x.Regex)
-	case *TagSpecifier_FixedValue:
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(len(x.FixedValue)))
-		n += len(x.FixedValue)
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 // Stats configuration proto schema for built-in *envoy.statsd* sink. This sink does not support
@@ -758,74 +551,12 @@ func (m *StatsdSink) GetPrefix() string {
 	return ""
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*StatsdSink) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _StatsdSink_OneofMarshaler, _StatsdSink_OneofUnmarshaler, _StatsdSink_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*StatsdSink) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*StatsdSink_Address)(nil),
 		(*StatsdSink_TcpClusterName)(nil),
 	}
-}
-
-func _StatsdSink_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*StatsdSink)
-	// statsd_specifier
-	switch x := m.StatsdSpecifier.(type) {
-	case *StatsdSink_Address:
-		_ = b.EncodeVarint(1<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.Address); err != nil {
-			return err
-		}
-	case *StatsdSink_TcpClusterName:
-		_ = b.EncodeVarint(2<<3 | proto.WireBytes)
-		_ = b.EncodeStringBytes(x.TcpClusterName)
-	case nil:
-	default:
-		return fmt.Errorf("StatsdSink.StatsdSpecifier has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _StatsdSink_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*StatsdSink)
-	switch tag {
-	case 1: // statsd_specifier.address
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(core.Address)
-		err := b.DecodeMessage(msg)
-		m.StatsdSpecifier = &StatsdSink_Address{msg}
-		return true, err
-	case 2: // statsd_specifier.tcp_cluster_name
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeStringBytes()
-		m.StatsdSpecifier = &StatsdSink_TcpClusterName{x}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _StatsdSink_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*StatsdSink)
-	// statsd_specifier
-	switch x := m.StatsdSpecifier.(type) {
-	case *StatsdSink_Address:
-		s := proto.Size(x.Address)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *StatsdSink_TcpClusterName:
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(len(x.TcpClusterName)))
-		n += len(x.TcpClusterName)
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 // Stats configuration proto schema for built-in *envoy.dog_statsd* sink.
@@ -911,59 +642,11 @@ func (m *DogStatsdSink) GetPrefix() string {
 	return ""
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*DogStatsdSink) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _DogStatsdSink_OneofMarshaler, _DogStatsdSink_OneofUnmarshaler, _DogStatsdSink_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*DogStatsdSink) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*DogStatsdSink_Address)(nil),
 	}
-}
-
-func _DogStatsdSink_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*DogStatsdSink)
-	// dog_statsd_specifier
-	switch x := m.DogStatsdSpecifier.(type) {
-	case *DogStatsdSink_Address:
-		_ = b.EncodeVarint(1<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.Address); err != nil {
-			return err
-		}
-	case nil:
-	default:
-		return fmt.Errorf("DogStatsdSink.DogStatsdSpecifier has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _DogStatsdSink_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*DogStatsdSink)
-	switch tag {
-	case 1: // dog_statsd_specifier.address
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(core.Address)
-		err := b.DecodeMessage(msg)
-		m.DogStatsdSpecifier = &DogStatsdSink_Address{msg}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _DogStatsdSink_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*DogStatsdSink)
-	// dog_statsd_specifier
-	switch x := m.DogStatsdSpecifier.(type) {
-	case *DogStatsdSink_Address:
-		s := proto.Size(x.Address)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 // Stats configuration proto schema for built-in *envoy.stat_sinks.hystrix* sink.

--- a/pkg/api/envoy/config/overload/v2alpha/overload.pb.go
+++ b/pkg/api/envoy/config/overload/v2alpha/overload.pb.go
@@ -23,7 +23,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 type ResourceMonitor struct {
 	// The name of the resource monitor to instantiate. Must match a registered
@@ -122,78 +122,12 @@ func (m *ResourceMonitor) GetTypedConfig() *types.Any {
 	return nil
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*ResourceMonitor) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _ResourceMonitor_OneofMarshaler, _ResourceMonitor_OneofUnmarshaler, _ResourceMonitor_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*ResourceMonitor) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*ResourceMonitor_Config)(nil),
 		(*ResourceMonitor_TypedConfig)(nil),
 	}
-}
-
-func _ResourceMonitor_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*ResourceMonitor)
-	// config_type
-	switch x := m.ConfigType.(type) {
-	case *ResourceMonitor_Config:
-		_ = b.EncodeVarint(2<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.Config); err != nil {
-			return err
-		}
-	case *ResourceMonitor_TypedConfig:
-		_ = b.EncodeVarint(3<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.TypedConfig); err != nil {
-			return err
-		}
-	case nil:
-	default:
-		return fmt.Errorf("ResourceMonitor.ConfigType has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _ResourceMonitor_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*ResourceMonitor)
-	switch tag {
-	case 2: // config_type.config
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(types.Struct)
-		err := b.DecodeMessage(msg)
-		m.ConfigType = &ResourceMonitor_Config{msg}
-		return true, err
-	case 3: // config_type.typed_config
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(types.Any)
-		err := b.DecodeMessage(msg)
-		m.ConfigType = &ResourceMonitor_TypedConfig{msg}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _ResourceMonitor_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*ResourceMonitor)
-	// config_type
-	switch x := m.ConfigType.(type) {
-	case *ResourceMonitor_Config:
-		s := proto.Size(x.Config)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *ResourceMonitor_TypedConfig:
-		s := proto.Size(x.TypedConfig)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 type ThresholdTrigger struct {
@@ -322,59 +256,11 @@ func (m *Trigger) GetThreshold() *ThresholdTrigger {
 	return nil
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*Trigger) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _Trigger_OneofMarshaler, _Trigger_OneofUnmarshaler, _Trigger_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*Trigger) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*Trigger_Threshold)(nil),
 	}
-}
-
-func _Trigger_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*Trigger)
-	// trigger_oneof
-	switch x := m.TriggerOneof.(type) {
-	case *Trigger_Threshold:
-		_ = b.EncodeVarint(2<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.Threshold); err != nil {
-			return err
-		}
-	case nil:
-	default:
-		return fmt.Errorf("Trigger.TriggerOneof has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _Trigger_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*Trigger)
-	switch tag {
-	case 2: // trigger_oneof.threshold
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(ThresholdTrigger)
-		err := b.DecodeMessage(msg)
-		m.TriggerOneof = &Trigger_Threshold{msg}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _Trigger_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*Trigger)
-	// trigger_oneof
-	switch x := m.TriggerOneof.(type) {
-	case *Trigger_Threshold:
-		s := proto.Size(x.Threshold)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 type OverloadAction struct {

--- a/pkg/api/envoy/config/overload/v3alpha/overload.pb.go
+++ b/pkg/api/envoy/config/overload/v3alpha/overload.pb.go
@@ -23,7 +23,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 type ResourceMonitor struct {
 	// The name of the resource monitor to instantiate. Must match a registered
@@ -122,78 +122,12 @@ func (m *ResourceMonitor) GetTypedConfig() *types.Any {
 	return nil
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*ResourceMonitor) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _ResourceMonitor_OneofMarshaler, _ResourceMonitor_OneofUnmarshaler, _ResourceMonitor_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*ResourceMonitor) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*ResourceMonitor_Config)(nil),
 		(*ResourceMonitor_TypedConfig)(nil),
 	}
-}
-
-func _ResourceMonitor_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*ResourceMonitor)
-	// config_type
-	switch x := m.ConfigType.(type) {
-	case *ResourceMonitor_Config:
-		_ = b.EncodeVarint(2<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.Config); err != nil {
-			return err
-		}
-	case *ResourceMonitor_TypedConfig:
-		_ = b.EncodeVarint(3<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.TypedConfig); err != nil {
-			return err
-		}
-	case nil:
-	default:
-		return fmt.Errorf("ResourceMonitor.ConfigType has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _ResourceMonitor_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*ResourceMonitor)
-	switch tag {
-	case 2: // config_type.config
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(types.Struct)
-		err := b.DecodeMessage(msg)
-		m.ConfigType = &ResourceMonitor_Config{msg}
-		return true, err
-	case 3: // config_type.typed_config
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(types.Any)
-		err := b.DecodeMessage(msg)
-		m.ConfigType = &ResourceMonitor_TypedConfig{msg}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _ResourceMonitor_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*ResourceMonitor)
-	// config_type
-	switch x := m.ConfigType.(type) {
-	case *ResourceMonitor_Config:
-		s := proto.Size(x.Config)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *ResourceMonitor_TypedConfig:
-		s := proto.Size(x.TypedConfig)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 type ThresholdTrigger struct {
@@ -322,59 +256,11 @@ func (m *Trigger) GetThreshold() *ThresholdTrigger {
 	return nil
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*Trigger) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _Trigger_OneofMarshaler, _Trigger_OneofUnmarshaler, _Trigger_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*Trigger) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*Trigger_Threshold)(nil),
 	}
-}
-
-func _Trigger_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*Trigger)
-	// trigger_oneof
-	switch x := m.TriggerOneof.(type) {
-	case *Trigger_Threshold:
-		_ = b.EncodeVarint(2<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.Threshold); err != nil {
-			return err
-		}
-	case nil:
-	default:
-		return fmt.Errorf("Trigger.TriggerOneof has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _Trigger_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*Trigger)
-	switch tag {
-	case 2: // trigger_oneof.threshold
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(ThresholdTrigger)
-		err := b.DecodeMessage(msg)
-		m.TriggerOneof = &Trigger_Threshold{msg}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _Trigger_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*Trigger)
-	// trigger_oneof
-	switch x := m.TriggerOneof.(type) {
-	case *Trigger_Threshold:
-		s := proto.Size(x.Threshold)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 type OverloadAction struct {

--- a/pkg/api/envoy/config/ratelimit/v2/rls.pb.go
+++ b/pkg/api/envoy/config/ratelimit/v2/rls.pb.go
@@ -22,7 +22,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // Rate limit :ref:`configuration overview <config_rate_limit_service>`.
 type RateLimitServiceConfig struct {

--- a/pkg/api/envoy/config/ratelimit/v3alpha/rls.pb.go
+++ b/pkg/api/envoy/config/ratelimit/v3alpha/rls.pb.go
@@ -22,7 +22,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // Rate limit :ref:`configuration overview <config_rate_limit_service>`.
 type RateLimitServiceConfig struct {

--- a/pkg/api/envoy/config/rbac/v2/rbac.pb.go
+++ b/pkg/api/envoy/config/rbac/v2/rbac.pb.go
@@ -25,7 +25,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // Should we do safe-list or block-list style access control?
 type RBAC_Action int32
@@ -395,9 +395,9 @@ func (m *Permission) GetRequestedServerName() *matcher.StringMatcher {
 	return nil
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*Permission) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _Permission_OneofMarshaler, _Permission_OneofUnmarshaler, _Permission_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*Permission) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*Permission_AndRules)(nil),
 		(*Permission_OrRules)(nil),
 		(*Permission_Any)(nil),
@@ -408,192 +408,6 @@ func (*Permission) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) er
 		(*Permission_NotRule)(nil),
 		(*Permission_RequestedServerName)(nil),
 	}
-}
-
-func _Permission_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*Permission)
-	// rule
-	switch x := m.Rule.(type) {
-	case *Permission_AndRules:
-		_ = b.EncodeVarint(1<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.AndRules); err != nil {
-			return err
-		}
-	case *Permission_OrRules:
-		_ = b.EncodeVarint(2<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.OrRules); err != nil {
-			return err
-		}
-	case *Permission_Any:
-		t := uint64(0)
-		if x.Any {
-			t = 1
-		}
-		_ = b.EncodeVarint(3<<3 | proto.WireVarint)
-		_ = b.EncodeVarint(t)
-	case *Permission_Header:
-		_ = b.EncodeVarint(4<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.Header); err != nil {
-			return err
-		}
-	case *Permission_DestinationIp:
-		_ = b.EncodeVarint(5<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.DestinationIp); err != nil {
-			return err
-		}
-	case *Permission_DestinationPort:
-		_ = b.EncodeVarint(6<<3 | proto.WireVarint)
-		_ = b.EncodeVarint(uint64(x.DestinationPort))
-	case *Permission_Metadata:
-		_ = b.EncodeVarint(7<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.Metadata); err != nil {
-			return err
-		}
-	case *Permission_NotRule:
-		_ = b.EncodeVarint(8<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.NotRule); err != nil {
-			return err
-		}
-	case *Permission_RequestedServerName:
-		_ = b.EncodeVarint(9<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.RequestedServerName); err != nil {
-			return err
-		}
-	case nil:
-	default:
-		return fmt.Errorf("Permission.Rule has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _Permission_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*Permission)
-	switch tag {
-	case 1: // rule.and_rules
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(Permission_Set)
-		err := b.DecodeMessage(msg)
-		m.Rule = &Permission_AndRules{msg}
-		return true, err
-	case 2: // rule.or_rules
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(Permission_Set)
-		err := b.DecodeMessage(msg)
-		m.Rule = &Permission_OrRules{msg}
-		return true, err
-	case 3: // rule.any
-		if wire != proto.WireVarint {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeVarint()
-		m.Rule = &Permission_Any{x != 0}
-		return true, err
-	case 4: // rule.header
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(route.HeaderMatcher)
-		err := b.DecodeMessage(msg)
-		m.Rule = &Permission_Header{msg}
-		return true, err
-	case 5: // rule.destination_ip
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(core.CidrRange)
-		err := b.DecodeMessage(msg)
-		m.Rule = &Permission_DestinationIp{msg}
-		return true, err
-	case 6: // rule.destination_port
-		if wire != proto.WireVarint {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeVarint()
-		m.Rule = &Permission_DestinationPort{uint32(x)}
-		return true, err
-	case 7: // rule.metadata
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(matcher.MetadataMatcher)
-		err := b.DecodeMessage(msg)
-		m.Rule = &Permission_Metadata{msg}
-		return true, err
-	case 8: // rule.not_rule
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(Permission)
-		err := b.DecodeMessage(msg)
-		m.Rule = &Permission_NotRule{msg}
-		return true, err
-	case 9: // rule.requested_server_name
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(matcher.StringMatcher)
-		err := b.DecodeMessage(msg)
-		m.Rule = &Permission_RequestedServerName{msg}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _Permission_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*Permission)
-	// rule
-	switch x := m.Rule.(type) {
-	case *Permission_AndRules:
-		s := proto.Size(x.AndRules)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *Permission_OrRules:
-		s := proto.Size(x.OrRules)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *Permission_Any:
-		n += 1 // tag and wire
-		n += 1
-	case *Permission_Header:
-		s := proto.Size(x.Header)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *Permission_DestinationIp:
-		s := proto.Size(x.DestinationIp)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *Permission_DestinationPort:
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(x.DestinationPort))
-	case *Permission_Metadata:
-		s := proto.Size(x.Metadata)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *Permission_NotRule:
-		s := proto.Size(x.NotRule)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *Permission_RequestedServerName:
-		s := proto.Size(x.RequestedServerName)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 // Used in the `and_rules` and `or_rules` fields in the `rule` oneof. Depending on the context,
@@ -798,9 +612,9 @@ func (m *Principal) GetNotId() *Principal {
 	return nil
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*Principal) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _Principal_OneofMarshaler, _Principal_OneofUnmarshaler, _Principal_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*Principal) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*Principal_AndIds)(nil),
 		(*Principal_OrIds)(nil),
 		(*Principal_Any)(nil),
@@ -810,179 +624,6 @@ func (*Principal) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) err
 		(*Principal_Metadata)(nil),
 		(*Principal_NotId)(nil),
 	}
-}
-
-func _Principal_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*Principal)
-	// identifier
-	switch x := m.Identifier.(type) {
-	case *Principal_AndIds:
-		_ = b.EncodeVarint(1<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.AndIds); err != nil {
-			return err
-		}
-	case *Principal_OrIds:
-		_ = b.EncodeVarint(2<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.OrIds); err != nil {
-			return err
-		}
-	case *Principal_Any:
-		t := uint64(0)
-		if x.Any {
-			t = 1
-		}
-		_ = b.EncodeVarint(3<<3 | proto.WireVarint)
-		_ = b.EncodeVarint(t)
-	case *Principal_Authenticated_:
-		_ = b.EncodeVarint(4<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.Authenticated); err != nil {
-			return err
-		}
-	case *Principal_SourceIp:
-		_ = b.EncodeVarint(5<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.SourceIp); err != nil {
-			return err
-		}
-	case *Principal_Header:
-		_ = b.EncodeVarint(6<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.Header); err != nil {
-			return err
-		}
-	case *Principal_Metadata:
-		_ = b.EncodeVarint(7<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.Metadata); err != nil {
-			return err
-		}
-	case *Principal_NotId:
-		_ = b.EncodeVarint(8<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.NotId); err != nil {
-			return err
-		}
-	case nil:
-	default:
-		return fmt.Errorf("Principal.Identifier has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _Principal_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*Principal)
-	switch tag {
-	case 1: // identifier.and_ids
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(Principal_Set)
-		err := b.DecodeMessage(msg)
-		m.Identifier = &Principal_AndIds{msg}
-		return true, err
-	case 2: // identifier.or_ids
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(Principal_Set)
-		err := b.DecodeMessage(msg)
-		m.Identifier = &Principal_OrIds{msg}
-		return true, err
-	case 3: // identifier.any
-		if wire != proto.WireVarint {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeVarint()
-		m.Identifier = &Principal_Any{x != 0}
-		return true, err
-	case 4: // identifier.authenticated
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(Principal_Authenticated)
-		err := b.DecodeMessage(msg)
-		m.Identifier = &Principal_Authenticated_{msg}
-		return true, err
-	case 5: // identifier.source_ip
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(core.CidrRange)
-		err := b.DecodeMessage(msg)
-		m.Identifier = &Principal_SourceIp{msg}
-		return true, err
-	case 6: // identifier.header
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(route.HeaderMatcher)
-		err := b.DecodeMessage(msg)
-		m.Identifier = &Principal_Header{msg}
-		return true, err
-	case 7: // identifier.metadata
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(matcher.MetadataMatcher)
-		err := b.DecodeMessage(msg)
-		m.Identifier = &Principal_Metadata{msg}
-		return true, err
-	case 8: // identifier.not_id
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(Principal)
-		err := b.DecodeMessage(msg)
-		m.Identifier = &Principal_NotId{msg}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _Principal_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*Principal)
-	// identifier
-	switch x := m.Identifier.(type) {
-	case *Principal_AndIds:
-		s := proto.Size(x.AndIds)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *Principal_OrIds:
-		s := proto.Size(x.OrIds)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *Principal_Any:
-		n += 1 // tag and wire
-		n += 1
-	case *Principal_Authenticated_:
-		s := proto.Size(x.Authenticated)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *Principal_SourceIp:
-		s := proto.Size(x.SourceIp)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *Principal_Header:
-		s := proto.Size(x.Header)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *Principal_Metadata:
-		s := proto.Size(x.Metadata)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *Principal_NotId:
-		s := proto.Size(x.NotId)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 // Used in the `and_ids` and `or_ids` fields in the `identifier` oneof. Depending on the context,

--- a/pkg/api/envoy/config/rbac/v3alpha/rbac.pb.go
+++ b/pkg/api/envoy/config/rbac/v3alpha/rbac.pb.go
@@ -25,7 +25,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // Should we do safe-list or block-list style access control?
 type RBAC_Action int32
@@ -395,9 +395,9 @@ func (m *Permission) GetRequestedServerName() *matcher.StringMatcher {
 	return nil
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*Permission) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _Permission_OneofMarshaler, _Permission_OneofUnmarshaler, _Permission_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*Permission) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*Permission_AndRules)(nil),
 		(*Permission_OrRules)(nil),
 		(*Permission_Any)(nil),
@@ -408,192 +408,6 @@ func (*Permission) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) er
 		(*Permission_NotRule)(nil),
 		(*Permission_RequestedServerName)(nil),
 	}
-}
-
-func _Permission_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*Permission)
-	// rule
-	switch x := m.Rule.(type) {
-	case *Permission_AndRules:
-		_ = b.EncodeVarint(1<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.AndRules); err != nil {
-			return err
-		}
-	case *Permission_OrRules:
-		_ = b.EncodeVarint(2<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.OrRules); err != nil {
-			return err
-		}
-	case *Permission_Any:
-		t := uint64(0)
-		if x.Any {
-			t = 1
-		}
-		_ = b.EncodeVarint(3<<3 | proto.WireVarint)
-		_ = b.EncodeVarint(t)
-	case *Permission_Header:
-		_ = b.EncodeVarint(4<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.Header); err != nil {
-			return err
-		}
-	case *Permission_DestinationIp:
-		_ = b.EncodeVarint(5<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.DestinationIp); err != nil {
-			return err
-		}
-	case *Permission_DestinationPort:
-		_ = b.EncodeVarint(6<<3 | proto.WireVarint)
-		_ = b.EncodeVarint(uint64(x.DestinationPort))
-	case *Permission_Metadata:
-		_ = b.EncodeVarint(7<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.Metadata); err != nil {
-			return err
-		}
-	case *Permission_NotRule:
-		_ = b.EncodeVarint(8<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.NotRule); err != nil {
-			return err
-		}
-	case *Permission_RequestedServerName:
-		_ = b.EncodeVarint(9<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.RequestedServerName); err != nil {
-			return err
-		}
-	case nil:
-	default:
-		return fmt.Errorf("Permission.Rule has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _Permission_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*Permission)
-	switch tag {
-	case 1: // rule.and_rules
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(Permission_Set)
-		err := b.DecodeMessage(msg)
-		m.Rule = &Permission_AndRules{msg}
-		return true, err
-	case 2: // rule.or_rules
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(Permission_Set)
-		err := b.DecodeMessage(msg)
-		m.Rule = &Permission_OrRules{msg}
-		return true, err
-	case 3: // rule.any
-		if wire != proto.WireVarint {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeVarint()
-		m.Rule = &Permission_Any{x != 0}
-		return true, err
-	case 4: // rule.header
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(route.HeaderMatcher)
-		err := b.DecodeMessage(msg)
-		m.Rule = &Permission_Header{msg}
-		return true, err
-	case 5: // rule.destination_ip
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(core.CidrRange)
-		err := b.DecodeMessage(msg)
-		m.Rule = &Permission_DestinationIp{msg}
-		return true, err
-	case 6: // rule.destination_port
-		if wire != proto.WireVarint {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeVarint()
-		m.Rule = &Permission_DestinationPort{uint32(x)}
-		return true, err
-	case 7: // rule.metadata
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(matcher.MetadataMatcher)
-		err := b.DecodeMessage(msg)
-		m.Rule = &Permission_Metadata{msg}
-		return true, err
-	case 8: // rule.not_rule
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(Permission)
-		err := b.DecodeMessage(msg)
-		m.Rule = &Permission_NotRule{msg}
-		return true, err
-	case 9: // rule.requested_server_name
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(matcher.StringMatcher)
-		err := b.DecodeMessage(msg)
-		m.Rule = &Permission_RequestedServerName{msg}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _Permission_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*Permission)
-	// rule
-	switch x := m.Rule.(type) {
-	case *Permission_AndRules:
-		s := proto.Size(x.AndRules)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *Permission_OrRules:
-		s := proto.Size(x.OrRules)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *Permission_Any:
-		n += 1 // tag and wire
-		n += 1
-	case *Permission_Header:
-		s := proto.Size(x.Header)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *Permission_DestinationIp:
-		s := proto.Size(x.DestinationIp)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *Permission_DestinationPort:
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(x.DestinationPort))
-	case *Permission_Metadata:
-		s := proto.Size(x.Metadata)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *Permission_NotRule:
-		s := proto.Size(x.NotRule)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *Permission_RequestedServerName:
-		s := proto.Size(x.RequestedServerName)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 // Used in the `and_rules` and `or_rules` fields in the `rule` oneof. Depending on the context,
@@ -798,9 +612,9 @@ func (m *Principal) GetNotId() *Principal {
 	return nil
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*Principal) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _Principal_OneofMarshaler, _Principal_OneofUnmarshaler, _Principal_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*Principal) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*Principal_AndIds)(nil),
 		(*Principal_OrIds)(nil),
 		(*Principal_Any)(nil),
@@ -810,179 +624,6 @@ func (*Principal) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) err
 		(*Principal_Metadata)(nil),
 		(*Principal_NotId)(nil),
 	}
-}
-
-func _Principal_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*Principal)
-	// identifier
-	switch x := m.Identifier.(type) {
-	case *Principal_AndIds:
-		_ = b.EncodeVarint(1<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.AndIds); err != nil {
-			return err
-		}
-	case *Principal_OrIds:
-		_ = b.EncodeVarint(2<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.OrIds); err != nil {
-			return err
-		}
-	case *Principal_Any:
-		t := uint64(0)
-		if x.Any {
-			t = 1
-		}
-		_ = b.EncodeVarint(3<<3 | proto.WireVarint)
-		_ = b.EncodeVarint(t)
-	case *Principal_Authenticated_:
-		_ = b.EncodeVarint(4<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.Authenticated); err != nil {
-			return err
-		}
-	case *Principal_SourceIp:
-		_ = b.EncodeVarint(5<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.SourceIp); err != nil {
-			return err
-		}
-	case *Principal_Header:
-		_ = b.EncodeVarint(6<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.Header); err != nil {
-			return err
-		}
-	case *Principal_Metadata:
-		_ = b.EncodeVarint(7<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.Metadata); err != nil {
-			return err
-		}
-	case *Principal_NotId:
-		_ = b.EncodeVarint(8<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.NotId); err != nil {
-			return err
-		}
-	case nil:
-	default:
-		return fmt.Errorf("Principal.Identifier has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _Principal_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*Principal)
-	switch tag {
-	case 1: // identifier.and_ids
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(Principal_Set)
-		err := b.DecodeMessage(msg)
-		m.Identifier = &Principal_AndIds{msg}
-		return true, err
-	case 2: // identifier.or_ids
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(Principal_Set)
-		err := b.DecodeMessage(msg)
-		m.Identifier = &Principal_OrIds{msg}
-		return true, err
-	case 3: // identifier.any
-		if wire != proto.WireVarint {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeVarint()
-		m.Identifier = &Principal_Any{x != 0}
-		return true, err
-	case 4: // identifier.authenticated
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(Principal_Authenticated)
-		err := b.DecodeMessage(msg)
-		m.Identifier = &Principal_Authenticated_{msg}
-		return true, err
-	case 5: // identifier.source_ip
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(core.CidrRange)
-		err := b.DecodeMessage(msg)
-		m.Identifier = &Principal_SourceIp{msg}
-		return true, err
-	case 6: // identifier.header
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(route.HeaderMatcher)
-		err := b.DecodeMessage(msg)
-		m.Identifier = &Principal_Header{msg}
-		return true, err
-	case 7: // identifier.metadata
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(matcher.MetadataMatcher)
-		err := b.DecodeMessage(msg)
-		m.Identifier = &Principal_Metadata{msg}
-		return true, err
-	case 8: // identifier.not_id
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(Principal)
-		err := b.DecodeMessage(msg)
-		m.Identifier = &Principal_NotId{msg}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _Principal_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*Principal)
-	// identifier
-	switch x := m.Identifier.(type) {
-	case *Principal_AndIds:
-		s := proto.Size(x.AndIds)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *Principal_OrIds:
-		s := proto.Size(x.OrIds)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *Principal_Any:
-		n += 1 // tag and wire
-		n += 1
-	case *Principal_Authenticated_:
-		s := proto.Size(x.Authenticated)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *Principal_SourceIp:
-		s := proto.Size(x.SourceIp)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *Principal_Header:
-		s := proto.Size(x.Header)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *Principal_Metadata:
-		s := proto.Size(x.Metadata)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *Principal_NotId:
-		s := proto.Size(x.NotId)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 // Used in the `and_ids` and `or_ids` fields in the `identifier` oneof. Depending on the context,

--- a/pkg/api/envoy/config/resource_monitor/fixed_heap/v2alpha/fixed_heap.pb.go
+++ b/pkg/api/envoy/config/resource_monitor/fixed_heap/v2alpha/fixed_heap.pb.go
@@ -21,7 +21,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // The fixed heap resource monitor reports the Envoy process memory pressure, computed as a
 // fraction of currently reserved heap memory divided by a statically configured maximum

--- a/pkg/api/envoy/config/resource_monitor/fixed_heap/v3alpha/fixed_heap.pb.go
+++ b/pkg/api/envoy/config/resource_monitor/fixed_heap/v3alpha/fixed_heap.pb.go
@@ -21,7 +21,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // The fixed heap resource monitor reports the Envoy process memory pressure, computed as a
 // fraction of currently reserved heap memory divided by a statically configured maximum

--- a/pkg/api/envoy/config/resource_monitor/injected_resource/v2alpha/injected_resource.pb.go
+++ b/pkg/api/envoy/config/resource_monitor/injected_resource/v2alpha/injected_resource.pb.go
@@ -21,7 +21,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // The injected resource monitor allows injecting a synthetic resource pressure into Envoy
 // via a text file, which must contain a floating-point number in the range [0..1] representing

--- a/pkg/api/envoy/config/resource_monitor/injected_resource/v3alpha/injected_resource.pb.go
+++ b/pkg/api/envoy/config/resource_monitor/injected_resource/v3alpha/injected_resource.pb.go
@@ -21,7 +21,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // The injected resource monitor allows injecting a synthetic resource pressure into Envoy
 // via a text file, which must contain a floating-point number in the range [0..1] representing

--- a/pkg/api/envoy/config/retry/previous_priorities/previous_priorities_config.pb.go
+++ b/pkg/api/envoy/config/retry/previous_priorities/previous_priorities_config.pb.go
@@ -20,7 +20,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // A retry host selector that attempts to spread retries between priorities, even if certain
 // priorities would not normally be attempted due to higher priorities being available.

--- a/pkg/api/envoy/config/trace/v2/trace.pb.go
+++ b/pkg/api/envoy/config/trace/v2/trace.pb.go
@@ -24,7 +24,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // Available Zipkin collector endpoint versions.
 type ZipkinConfig_CollectorEndpointVersion int32
@@ -265,78 +265,12 @@ func (m *Tracing_Http) GetTypedConfig() *types.Any {
 	return nil
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*Tracing_Http) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _Tracing_Http_OneofMarshaler, _Tracing_Http_OneofUnmarshaler, _Tracing_Http_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*Tracing_Http) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*Tracing_Http_Config)(nil),
 		(*Tracing_Http_TypedConfig)(nil),
 	}
-}
-
-func _Tracing_Http_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*Tracing_Http)
-	// config_type
-	switch x := m.ConfigType.(type) {
-	case *Tracing_Http_Config:
-		_ = b.EncodeVarint(2<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.Config); err != nil {
-			return err
-		}
-	case *Tracing_Http_TypedConfig:
-		_ = b.EncodeVarint(3<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.TypedConfig); err != nil {
-			return err
-		}
-	case nil:
-	default:
-		return fmt.Errorf("Tracing_Http.ConfigType has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _Tracing_Http_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*Tracing_Http)
-	switch tag {
-	case 2: // config_type.config
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(types.Struct)
-		err := b.DecodeMessage(msg)
-		m.ConfigType = &Tracing_Http_Config{msg}
-		return true, err
-	case 3: // config_type.typed_config
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(types.Any)
-		err := b.DecodeMessage(msg)
-		m.ConfigType = &Tracing_Http_TypedConfig{msg}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _Tracing_Http_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*Tracing_Http)
-	// config_type
-	switch x := m.ConfigType.(type) {
-	case *Tracing_Http_Config:
-		s := proto.Size(x.Config)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *Tracing_Http_TypedConfig:
-		s := proto.Size(x.TypedConfig)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 // Configuration for the LightStep tracer.

--- a/pkg/api/envoy/config/trace/v3alpha/trace.pb.go
+++ b/pkg/api/envoy/config/trace/v3alpha/trace.pb.go
@@ -24,7 +24,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // Available Zipkin collector endpoint versions.
 type ZipkinConfig_CollectorEndpointVersion int32
@@ -265,78 +265,12 @@ func (m *Tracing_Http) GetTypedConfig() *types.Any {
 	return nil
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*Tracing_Http) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _Tracing_Http_OneofMarshaler, _Tracing_Http_OneofUnmarshaler, _Tracing_Http_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*Tracing_Http) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*Tracing_Http_Config)(nil),
 		(*Tracing_Http_TypedConfig)(nil),
 	}
-}
-
-func _Tracing_Http_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*Tracing_Http)
-	// config_type
-	switch x := m.ConfigType.(type) {
-	case *Tracing_Http_Config:
-		_ = b.EncodeVarint(2<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.Config); err != nil {
-			return err
-		}
-	case *Tracing_Http_TypedConfig:
-		_ = b.EncodeVarint(3<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.TypedConfig); err != nil {
-			return err
-		}
-	case nil:
-	default:
-		return fmt.Errorf("Tracing_Http.ConfigType has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _Tracing_Http_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*Tracing_Http)
-	switch tag {
-	case 2: // config_type.config
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(types.Struct)
-		err := b.DecodeMessage(msg)
-		m.ConfigType = &Tracing_Http_Config{msg}
-		return true, err
-	case 3: // config_type.typed_config
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(types.Any)
-		err := b.DecodeMessage(msg)
-		m.ConfigType = &Tracing_Http_TypedConfig{msg}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _Tracing_Http_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*Tracing_Http)
-	// config_type
-	switch x := m.ConfigType.(type) {
-	case *Tracing_Http_Config:
-		s := proto.Size(x.Config)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *Tracing_Http_TypedConfig:
-		s := proto.Size(x.TypedConfig)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 // Configuration for the LightStep tracer.

--- a/pkg/api/envoy/config/transport_socket/alts/v2alpha/alts.pb.go
+++ b/pkg/api/envoy/config/transport_socket/alts/v2alpha/alts.pb.go
@@ -21,7 +21,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // Configuration for ALTS transport socket. This provides Google's ALTS protocol to Envoy.
 // https://cloud.google.com/security/encryption-in-transit/application-layer-transport-security/

--- a/pkg/api/envoy/config/transport_socket/alts/v3alpha/alts.pb.go
+++ b/pkg/api/envoy/config/transport_socket/alts/v3alpha/alts.pb.go
@@ -21,7 +21,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // Configuration for ALTS transport socket. This provides Google's ALTS protocol to Envoy.
 // https://cloud.google.com/security/encryption-in-transit/application-layer-transport-security/

--- a/pkg/api/envoy/config/transport_socket/tap/v2alpha/tap.pb.go
+++ b/pkg/api/envoy/config/transport_socket/tap/v2alpha/tap.pb.go
@@ -23,7 +23,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // Configuration for tap transport socket. This wraps another transport socket, providing the
 // ability to interpose and record in plain text any traffic that is surfaced to Envoy.

--- a/pkg/api/envoy/config/transport_socket/tap/v3alpha/tap.pb.go
+++ b/pkg/api/envoy/config/transport_socket/tap/v3alpha/tap.pb.go
@@ -23,7 +23,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // Configuration for tap transport socket. This wraps another transport socket, providing the
 // ability to interpose and record in plain text any traffic that is surfaced to Envoy.

--- a/pkg/api/envoy/data/accesslog/v2/accesslog.pb.go
+++ b/pkg/api/envoy/data/accesslog/v2/accesslog.pb.go
@@ -24,7 +24,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // HTTP version
 type HTTPAccessLogEntry_HTTPVersion int32
@@ -1043,70 +1043,12 @@ func (m *TLSProperties_CertificateProperties_SubjectAltName) GetDns() string {
 	return ""
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*TLSProperties_CertificateProperties_SubjectAltName) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _TLSProperties_CertificateProperties_SubjectAltName_OneofMarshaler, _TLSProperties_CertificateProperties_SubjectAltName_OneofUnmarshaler, _TLSProperties_CertificateProperties_SubjectAltName_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*TLSProperties_CertificateProperties_SubjectAltName) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*TLSProperties_CertificateProperties_SubjectAltName_Uri)(nil),
 		(*TLSProperties_CertificateProperties_SubjectAltName_Dns)(nil),
 	}
-}
-
-func _TLSProperties_CertificateProperties_SubjectAltName_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*TLSProperties_CertificateProperties_SubjectAltName)
-	// san
-	switch x := m.San.(type) {
-	case *TLSProperties_CertificateProperties_SubjectAltName_Uri:
-		_ = b.EncodeVarint(1<<3 | proto.WireBytes)
-		_ = b.EncodeStringBytes(x.Uri)
-	case *TLSProperties_CertificateProperties_SubjectAltName_Dns:
-		_ = b.EncodeVarint(2<<3 | proto.WireBytes)
-		_ = b.EncodeStringBytes(x.Dns)
-	case nil:
-	default:
-		return fmt.Errorf("TLSProperties_CertificateProperties_SubjectAltName.San has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _TLSProperties_CertificateProperties_SubjectAltName_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*TLSProperties_CertificateProperties_SubjectAltName)
-	switch tag {
-	case 1: // san.uri
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeStringBytes()
-		m.San = &TLSProperties_CertificateProperties_SubjectAltName_Uri{x}
-		return true, err
-	case 2: // san.dns
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeStringBytes()
-		m.San = &TLSProperties_CertificateProperties_SubjectAltName_Dns{x}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _TLSProperties_CertificateProperties_SubjectAltName_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*TLSProperties_CertificateProperties_SubjectAltName)
-	// san
-	switch x := m.San.(type) {
-	case *TLSProperties_CertificateProperties_SubjectAltName_Uri:
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(len(x.Uri)))
-		n += len(x.Uri)
-	case *TLSProperties_CertificateProperties_SubjectAltName_Dns:
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(len(x.Dns)))
-		n += len(x.Dns)
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 type HTTPRequestProperties struct {

--- a/pkg/api/envoy/data/accesslog/v3alpha/accesslog.pb.go
+++ b/pkg/api/envoy/data/accesslog/v3alpha/accesslog.pb.go
@@ -24,7 +24,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // HTTP version
 type HTTPAccessLogEntry_HTTPVersion int32
@@ -1043,70 +1043,12 @@ func (m *TLSProperties_CertificateProperties_SubjectAltName) GetDns() string {
 	return ""
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*TLSProperties_CertificateProperties_SubjectAltName) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _TLSProperties_CertificateProperties_SubjectAltName_OneofMarshaler, _TLSProperties_CertificateProperties_SubjectAltName_OneofUnmarshaler, _TLSProperties_CertificateProperties_SubjectAltName_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*TLSProperties_CertificateProperties_SubjectAltName) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*TLSProperties_CertificateProperties_SubjectAltName_Uri)(nil),
 		(*TLSProperties_CertificateProperties_SubjectAltName_Dns)(nil),
 	}
-}
-
-func _TLSProperties_CertificateProperties_SubjectAltName_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*TLSProperties_CertificateProperties_SubjectAltName)
-	// san
-	switch x := m.San.(type) {
-	case *TLSProperties_CertificateProperties_SubjectAltName_Uri:
-		_ = b.EncodeVarint(1<<3 | proto.WireBytes)
-		_ = b.EncodeStringBytes(x.Uri)
-	case *TLSProperties_CertificateProperties_SubjectAltName_Dns:
-		_ = b.EncodeVarint(2<<3 | proto.WireBytes)
-		_ = b.EncodeStringBytes(x.Dns)
-	case nil:
-	default:
-		return fmt.Errorf("TLSProperties_CertificateProperties_SubjectAltName.San has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _TLSProperties_CertificateProperties_SubjectAltName_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*TLSProperties_CertificateProperties_SubjectAltName)
-	switch tag {
-	case 1: // san.uri
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeStringBytes()
-		m.San = &TLSProperties_CertificateProperties_SubjectAltName_Uri{x}
-		return true, err
-	case 2: // san.dns
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeStringBytes()
-		m.San = &TLSProperties_CertificateProperties_SubjectAltName_Dns{x}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _TLSProperties_CertificateProperties_SubjectAltName_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*TLSProperties_CertificateProperties_SubjectAltName)
-	// san
-	switch x := m.San.(type) {
-	case *TLSProperties_CertificateProperties_SubjectAltName_Uri:
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(len(x.Uri)))
-		n += len(x.Uri)
-	case *TLSProperties_CertificateProperties_SubjectAltName_Dns:
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(len(x.Dns)))
-		n += len(x.Dns)
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 type HTTPRequestProperties struct {

--- a/pkg/api/envoy/data/cluster/v2alpha/outlier_detection_event.pb.go
+++ b/pkg/api/envoy/data/cluster/v2alpha/outlier_detection_event.pb.go
@@ -22,7 +22,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // Type of ejection that took place
 type OutlierEjectionType int32
@@ -268,78 +268,12 @@ func (m *OutlierDetectionEvent) GetEjectConsecutiveEvent() *OutlierEjectConsecut
 	return nil
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*OutlierDetectionEvent) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _OutlierDetectionEvent_OneofMarshaler, _OutlierDetectionEvent_OneofUnmarshaler, _OutlierDetectionEvent_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*OutlierDetectionEvent) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*OutlierDetectionEvent_EjectSuccessRateEvent)(nil),
 		(*OutlierDetectionEvent_EjectConsecutiveEvent)(nil),
 	}
-}
-
-func _OutlierDetectionEvent_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*OutlierDetectionEvent)
-	// event
-	switch x := m.Event.(type) {
-	case *OutlierDetectionEvent_EjectSuccessRateEvent:
-		_ = b.EncodeVarint(9<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.EjectSuccessRateEvent); err != nil {
-			return err
-		}
-	case *OutlierDetectionEvent_EjectConsecutiveEvent:
-		_ = b.EncodeVarint(10<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.EjectConsecutiveEvent); err != nil {
-			return err
-		}
-	case nil:
-	default:
-		return fmt.Errorf("OutlierDetectionEvent.Event has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _OutlierDetectionEvent_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*OutlierDetectionEvent)
-	switch tag {
-	case 9: // event.eject_success_rate_event
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(OutlierEjectSuccessRate)
-		err := b.DecodeMessage(msg)
-		m.Event = &OutlierDetectionEvent_EjectSuccessRateEvent{msg}
-		return true, err
-	case 10: // event.eject_consecutive_event
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(OutlierEjectConsecutive)
-		err := b.DecodeMessage(msg)
-		m.Event = &OutlierDetectionEvent_EjectConsecutiveEvent{msg}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _OutlierDetectionEvent_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*OutlierDetectionEvent)
-	// event
-	switch x := m.Event.(type) {
-	case *OutlierDetectionEvent_EjectSuccessRateEvent:
-		s := proto.Size(x.EjectSuccessRateEvent)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *OutlierDetectionEvent_EjectConsecutiveEvent:
-		s := proto.Size(x.EjectConsecutiveEvent)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 type OutlierEjectSuccessRate struct {

--- a/pkg/api/envoy/data/cluster/v3alpha/outlier_detection_event.pb.go
+++ b/pkg/api/envoy/data/cluster/v3alpha/outlier_detection_event.pb.go
@@ -22,7 +22,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // Type of ejection that took place
 type OutlierEjectionType int32
@@ -268,78 +268,12 @@ func (m *OutlierDetectionEvent) GetEjectConsecutiveEvent() *OutlierEjectConsecut
 	return nil
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*OutlierDetectionEvent) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _OutlierDetectionEvent_OneofMarshaler, _OutlierDetectionEvent_OneofUnmarshaler, _OutlierDetectionEvent_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*OutlierDetectionEvent) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*OutlierDetectionEvent_EjectSuccessRateEvent)(nil),
 		(*OutlierDetectionEvent_EjectConsecutiveEvent)(nil),
 	}
-}
-
-func _OutlierDetectionEvent_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*OutlierDetectionEvent)
-	// event
-	switch x := m.Event.(type) {
-	case *OutlierDetectionEvent_EjectSuccessRateEvent:
-		_ = b.EncodeVarint(9<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.EjectSuccessRateEvent); err != nil {
-			return err
-		}
-	case *OutlierDetectionEvent_EjectConsecutiveEvent:
-		_ = b.EncodeVarint(10<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.EjectConsecutiveEvent); err != nil {
-			return err
-		}
-	case nil:
-	default:
-		return fmt.Errorf("OutlierDetectionEvent.Event has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _OutlierDetectionEvent_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*OutlierDetectionEvent)
-	switch tag {
-	case 9: // event.eject_success_rate_event
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(OutlierEjectSuccessRate)
-		err := b.DecodeMessage(msg)
-		m.Event = &OutlierDetectionEvent_EjectSuccessRateEvent{msg}
-		return true, err
-	case 10: // event.eject_consecutive_event
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(OutlierEjectConsecutive)
-		err := b.DecodeMessage(msg)
-		m.Event = &OutlierDetectionEvent_EjectConsecutiveEvent{msg}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _OutlierDetectionEvent_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*OutlierDetectionEvent)
-	// event
-	switch x := m.Event.(type) {
-	case *OutlierDetectionEvent_EjectSuccessRateEvent:
-		s := proto.Size(x.EjectSuccessRateEvent)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *OutlierDetectionEvent_EjectConsecutiveEvent:
-		s := proto.Size(x.EjectConsecutiveEvent)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 type OutlierEjectSuccessRate struct {

--- a/pkg/api/envoy/data/core/v2alpha/health_check_event.pb.go
+++ b/pkg/api/envoy/data/core/v2alpha/health_check_event.pb.go
@@ -23,7 +23,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 type HealthCheckFailureType int32
 
@@ -233,135 +233,15 @@ func (m *HealthCheckEvent) GetTimestamp() *types.Timestamp {
 	return nil
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*HealthCheckEvent) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _HealthCheckEvent_OneofMarshaler, _HealthCheckEvent_OneofUnmarshaler, _HealthCheckEvent_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*HealthCheckEvent) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*HealthCheckEvent_EjectUnhealthyEvent)(nil),
 		(*HealthCheckEvent_AddHealthyEvent)(nil),
 		(*HealthCheckEvent_HealthCheckFailureEvent)(nil),
 		(*HealthCheckEvent_DegradedHealthyHost)(nil),
 		(*HealthCheckEvent_NoLongerDegradedHost)(nil),
 	}
-}
-
-func _HealthCheckEvent_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*HealthCheckEvent)
-	// event
-	switch x := m.Event.(type) {
-	case *HealthCheckEvent_EjectUnhealthyEvent:
-		_ = b.EncodeVarint(4<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.EjectUnhealthyEvent); err != nil {
-			return err
-		}
-	case *HealthCheckEvent_AddHealthyEvent:
-		_ = b.EncodeVarint(5<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.AddHealthyEvent); err != nil {
-			return err
-		}
-	case *HealthCheckEvent_HealthCheckFailureEvent:
-		_ = b.EncodeVarint(7<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.HealthCheckFailureEvent); err != nil {
-			return err
-		}
-	case *HealthCheckEvent_DegradedHealthyHost:
-		_ = b.EncodeVarint(8<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.DegradedHealthyHost); err != nil {
-			return err
-		}
-	case *HealthCheckEvent_NoLongerDegradedHost:
-		_ = b.EncodeVarint(9<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.NoLongerDegradedHost); err != nil {
-			return err
-		}
-	case nil:
-	default:
-		return fmt.Errorf("HealthCheckEvent.Event has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _HealthCheckEvent_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*HealthCheckEvent)
-	switch tag {
-	case 4: // event.eject_unhealthy_event
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(HealthCheckEjectUnhealthy)
-		err := b.DecodeMessage(msg)
-		m.Event = &HealthCheckEvent_EjectUnhealthyEvent{msg}
-		return true, err
-	case 5: // event.add_healthy_event
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(HealthCheckAddHealthy)
-		err := b.DecodeMessage(msg)
-		m.Event = &HealthCheckEvent_AddHealthyEvent{msg}
-		return true, err
-	case 7: // event.health_check_failure_event
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(HealthCheckFailure)
-		err := b.DecodeMessage(msg)
-		m.Event = &HealthCheckEvent_HealthCheckFailureEvent{msg}
-		return true, err
-	case 8: // event.degraded_healthy_host
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(DegradedHealthyHost)
-		err := b.DecodeMessage(msg)
-		m.Event = &HealthCheckEvent_DegradedHealthyHost{msg}
-		return true, err
-	case 9: // event.no_longer_degraded_host
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(NoLongerDegradedHost)
-		err := b.DecodeMessage(msg)
-		m.Event = &HealthCheckEvent_NoLongerDegradedHost{msg}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _HealthCheckEvent_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*HealthCheckEvent)
-	// event
-	switch x := m.Event.(type) {
-	case *HealthCheckEvent_EjectUnhealthyEvent:
-		s := proto.Size(x.EjectUnhealthyEvent)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *HealthCheckEvent_AddHealthyEvent:
-		s := proto.Size(x.AddHealthyEvent)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *HealthCheckEvent_HealthCheckFailureEvent:
-		s := proto.Size(x.HealthCheckFailureEvent)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *HealthCheckEvent_DegradedHealthyHost:
-		s := proto.Size(x.DegradedHealthyHost)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *HealthCheckEvent_NoLongerDegradedHost:
-		s := proto.Size(x.NoLongerDegradedHost)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 type HealthCheckEjectUnhealthy struct {

--- a/pkg/api/envoy/data/core/v3alpha/health_check_event.pb.go
+++ b/pkg/api/envoy/data/core/v3alpha/health_check_event.pb.go
@@ -23,7 +23,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 type HealthCheckFailureType int32
 
@@ -233,135 +233,15 @@ func (m *HealthCheckEvent) GetTimestamp() *types.Timestamp {
 	return nil
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*HealthCheckEvent) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _HealthCheckEvent_OneofMarshaler, _HealthCheckEvent_OneofUnmarshaler, _HealthCheckEvent_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*HealthCheckEvent) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*HealthCheckEvent_EjectUnhealthyEvent)(nil),
 		(*HealthCheckEvent_AddHealthyEvent)(nil),
 		(*HealthCheckEvent_HealthCheckFailureEvent)(nil),
 		(*HealthCheckEvent_DegradedHealthyHost)(nil),
 		(*HealthCheckEvent_NoLongerDegradedHost)(nil),
 	}
-}
-
-func _HealthCheckEvent_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*HealthCheckEvent)
-	// event
-	switch x := m.Event.(type) {
-	case *HealthCheckEvent_EjectUnhealthyEvent:
-		_ = b.EncodeVarint(4<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.EjectUnhealthyEvent); err != nil {
-			return err
-		}
-	case *HealthCheckEvent_AddHealthyEvent:
-		_ = b.EncodeVarint(5<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.AddHealthyEvent); err != nil {
-			return err
-		}
-	case *HealthCheckEvent_HealthCheckFailureEvent:
-		_ = b.EncodeVarint(7<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.HealthCheckFailureEvent); err != nil {
-			return err
-		}
-	case *HealthCheckEvent_DegradedHealthyHost:
-		_ = b.EncodeVarint(8<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.DegradedHealthyHost); err != nil {
-			return err
-		}
-	case *HealthCheckEvent_NoLongerDegradedHost:
-		_ = b.EncodeVarint(9<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.NoLongerDegradedHost); err != nil {
-			return err
-		}
-	case nil:
-	default:
-		return fmt.Errorf("HealthCheckEvent.Event has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _HealthCheckEvent_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*HealthCheckEvent)
-	switch tag {
-	case 4: // event.eject_unhealthy_event
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(HealthCheckEjectUnhealthy)
-		err := b.DecodeMessage(msg)
-		m.Event = &HealthCheckEvent_EjectUnhealthyEvent{msg}
-		return true, err
-	case 5: // event.add_healthy_event
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(HealthCheckAddHealthy)
-		err := b.DecodeMessage(msg)
-		m.Event = &HealthCheckEvent_AddHealthyEvent{msg}
-		return true, err
-	case 7: // event.health_check_failure_event
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(HealthCheckFailure)
-		err := b.DecodeMessage(msg)
-		m.Event = &HealthCheckEvent_HealthCheckFailureEvent{msg}
-		return true, err
-	case 8: // event.degraded_healthy_host
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(DegradedHealthyHost)
-		err := b.DecodeMessage(msg)
-		m.Event = &HealthCheckEvent_DegradedHealthyHost{msg}
-		return true, err
-	case 9: // event.no_longer_degraded_host
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(NoLongerDegradedHost)
-		err := b.DecodeMessage(msg)
-		m.Event = &HealthCheckEvent_NoLongerDegradedHost{msg}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _HealthCheckEvent_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*HealthCheckEvent)
-	// event
-	switch x := m.Event.(type) {
-	case *HealthCheckEvent_EjectUnhealthyEvent:
-		s := proto.Size(x.EjectUnhealthyEvent)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *HealthCheckEvent_AddHealthyEvent:
-		s := proto.Size(x.AddHealthyEvent)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *HealthCheckEvent_HealthCheckFailureEvent:
-		s := proto.Size(x.HealthCheckFailureEvent)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *HealthCheckEvent_DegradedHealthyHost:
-		s := proto.Size(x.DegradedHealthyHost)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *HealthCheckEvent_NoLongerDegradedHost:
-		s := proto.Size(x.NoLongerDegradedHost)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 type HealthCheckEjectUnhealthy struct {

--- a/pkg/api/envoy/data/tap/v2alpha/common.pb.go
+++ b/pkg/api/envoy/data/tap/v2alpha/common.pb.go
@@ -20,7 +20,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // Wrapper for tapped body data. This includes HTTP request/response body, transport socket received
 // and transmitted data, etc.
@@ -117,70 +117,12 @@ func (m *Body) GetTruncated() bool {
 	return false
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*Body) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _Body_OneofMarshaler, _Body_OneofUnmarshaler, _Body_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*Body) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*Body_AsBytes)(nil),
 		(*Body_AsString)(nil),
 	}
-}
-
-func _Body_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*Body)
-	// body_type
-	switch x := m.BodyType.(type) {
-	case *Body_AsBytes:
-		_ = b.EncodeVarint(1<<3 | proto.WireBytes)
-		_ = b.EncodeRawBytes(x.AsBytes)
-	case *Body_AsString:
-		_ = b.EncodeVarint(2<<3 | proto.WireBytes)
-		_ = b.EncodeStringBytes(x.AsString)
-	case nil:
-	default:
-		return fmt.Errorf("Body.BodyType has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _Body_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*Body)
-	switch tag {
-	case 1: // body_type.as_bytes
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeRawBytes(true)
-		m.BodyType = &Body_AsBytes{x}
-		return true, err
-	case 2: // body_type.as_string
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeStringBytes()
-		m.BodyType = &Body_AsString{x}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _Body_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*Body)
-	// body_type
-	switch x := m.BodyType.(type) {
-	case *Body_AsBytes:
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(len(x.AsBytes)))
-		n += len(x.AsBytes)
-	case *Body_AsString:
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(len(x.AsString)))
-		n += len(x.AsString)
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 func init() {

--- a/pkg/api/envoy/data/tap/v2alpha/http.pb.go
+++ b/pkg/api/envoy/data/tap/v2alpha/http.pb.go
@@ -21,7 +21,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // A fully buffered HTTP trace message.
 type HttpBufferedTrace struct {
@@ -287,9 +287,9 @@ func (m *HttpStreamedTraceSegment) GetResponseTrailers() *core.HeaderMap {
 	return nil
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*HttpStreamedTraceSegment) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _HttpStreamedTraceSegment_OneofMarshaler, _HttpStreamedTraceSegment_OneofUnmarshaler, _HttpStreamedTraceSegment_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*HttpStreamedTraceSegment) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*HttpStreamedTraceSegment_RequestHeaders)(nil),
 		(*HttpStreamedTraceSegment_RequestBodyChunk)(nil),
 		(*HttpStreamedTraceSegment_RequestTrailers)(nil),
@@ -297,144 +297,6 @@ func (*HttpStreamedTraceSegment) XXX_OneofFuncs() (func(msg proto.Message, b *pr
 		(*HttpStreamedTraceSegment_ResponseBodyChunk)(nil),
 		(*HttpStreamedTraceSegment_ResponseTrailers)(nil),
 	}
-}
-
-func _HttpStreamedTraceSegment_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*HttpStreamedTraceSegment)
-	// message_piece
-	switch x := m.MessagePiece.(type) {
-	case *HttpStreamedTraceSegment_RequestHeaders:
-		_ = b.EncodeVarint(2<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.RequestHeaders); err != nil {
-			return err
-		}
-	case *HttpStreamedTraceSegment_RequestBodyChunk:
-		_ = b.EncodeVarint(3<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.RequestBodyChunk); err != nil {
-			return err
-		}
-	case *HttpStreamedTraceSegment_RequestTrailers:
-		_ = b.EncodeVarint(4<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.RequestTrailers); err != nil {
-			return err
-		}
-	case *HttpStreamedTraceSegment_ResponseHeaders:
-		_ = b.EncodeVarint(5<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.ResponseHeaders); err != nil {
-			return err
-		}
-	case *HttpStreamedTraceSegment_ResponseBodyChunk:
-		_ = b.EncodeVarint(6<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.ResponseBodyChunk); err != nil {
-			return err
-		}
-	case *HttpStreamedTraceSegment_ResponseTrailers:
-		_ = b.EncodeVarint(7<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.ResponseTrailers); err != nil {
-			return err
-		}
-	case nil:
-	default:
-		return fmt.Errorf("HttpStreamedTraceSegment.MessagePiece has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _HttpStreamedTraceSegment_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*HttpStreamedTraceSegment)
-	switch tag {
-	case 2: // message_piece.request_headers
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(core.HeaderMap)
-		err := b.DecodeMessage(msg)
-		m.MessagePiece = &HttpStreamedTraceSegment_RequestHeaders{msg}
-		return true, err
-	case 3: // message_piece.request_body_chunk
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(Body)
-		err := b.DecodeMessage(msg)
-		m.MessagePiece = &HttpStreamedTraceSegment_RequestBodyChunk{msg}
-		return true, err
-	case 4: // message_piece.request_trailers
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(core.HeaderMap)
-		err := b.DecodeMessage(msg)
-		m.MessagePiece = &HttpStreamedTraceSegment_RequestTrailers{msg}
-		return true, err
-	case 5: // message_piece.response_headers
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(core.HeaderMap)
-		err := b.DecodeMessage(msg)
-		m.MessagePiece = &HttpStreamedTraceSegment_ResponseHeaders{msg}
-		return true, err
-	case 6: // message_piece.response_body_chunk
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(Body)
-		err := b.DecodeMessage(msg)
-		m.MessagePiece = &HttpStreamedTraceSegment_ResponseBodyChunk{msg}
-		return true, err
-	case 7: // message_piece.response_trailers
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(core.HeaderMap)
-		err := b.DecodeMessage(msg)
-		m.MessagePiece = &HttpStreamedTraceSegment_ResponseTrailers{msg}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _HttpStreamedTraceSegment_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*HttpStreamedTraceSegment)
-	// message_piece
-	switch x := m.MessagePiece.(type) {
-	case *HttpStreamedTraceSegment_RequestHeaders:
-		s := proto.Size(x.RequestHeaders)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *HttpStreamedTraceSegment_RequestBodyChunk:
-		s := proto.Size(x.RequestBodyChunk)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *HttpStreamedTraceSegment_RequestTrailers:
-		s := proto.Size(x.RequestTrailers)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *HttpStreamedTraceSegment_ResponseHeaders:
-		s := proto.Size(x.ResponseHeaders)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *HttpStreamedTraceSegment_ResponseBodyChunk:
-		s := proto.Size(x.ResponseBodyChunk)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *HttpStreamedTraceSegment_ResponseTrailers:
-		s := proto.Size(x.ResponseTrailers)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 func init() {

--- a/pkg/api/envoy/data/tap/v2alpha/transport.pb.go
+++ b/pkg/api/envoy/data/tap/v2alpha/transport.pb.go
@@ -22,7 +22,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // Connection properties.
 type Connection struct {
@@ -186,97 +186,13 @@ func (m *SocketEvent) GetClosed() *SocketEvent_Closed {
 	return nil
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*SocketEvent) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _SocketEvent_OneofMarshaler, _SocketEvent_OneofUnmarshaler, _SocketEvent_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*SocketEvent) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*SocketEvent_Read_)(nil),
 		(*SocketEvent_Write_)(nil),
 		(*SocketEvent_Closed_)(nil),
 	}
-}
-
-func _SocketEvent_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*SocketEvent)
-	// event_selector
-	switch x := m.EventSelector.(type) {
-	case *SocketEvent_Read_:
-		_ = b.EncodeVarint(2<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.Read); err != nil {
-			return err
-		}
-	case *SocketEvent_Write_:
-		_ = b.EncodeVarint(3<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.Write); err != nil {
-			return err
-		}
-	case *SocketEvent_Closed_:
-		_ = b.EncodeVarint(4<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.Closed); err != nil {
-			return err
-		}
-	case nil:
-	default:
-		return fmt.Errorf("SocketEvent.EventSelector has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _SocketEvent_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*SocketEvent)
-	switch tag {
-	case 2: // event_selector.read
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(SocketEvent_Read)
-		err := b.DecodeMessage(msg)
-		m.EventSelector = &SocketEvent_Read_{msg}
-		return true, err
-	case 3: // event_selector.write
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(SocketEvent_Write)
-		err := b.DecodeMessage(msg)
-		m.EventSelector = &SocketEvent_Write_{msg}
-		return true, err
-	case 4: // event_selector.closed
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(SocketEvent_Closed)
-		err := b.DecodeMessage(msg)
-		m.EventSelector = &SocketEvent_Closed_{msg}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _SocketEvent_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*SocketEvent)
-	// event_selector
-	switch x := m.EventSelector.(type) {
-	case *SocketEvent_Read_:
-		s := proto.Size(x.Read)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *SocketEvent_Write_:
-		s := proto.Size(x.Write)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *SocketEvent_Closed_:
-		s := proto.Size(x.Closed)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 // Data read by Envoy from the transport socket.
@@ -605,78 +521,12 @@ func (m *SocketStreamedTraceSegment) GetEvent() *SocketEvent {
 	return nil
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*SocketStreamedTraceSegment) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _SocketStreamedTraceSegment_OneofMarshaler, _SocketStreamedTraceSegment_OneofUnmarshaler, _SocketStreamedTraceSegment_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*SocketStreamedTraceSegment) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*SocketStreamedTraceSegment_Connection)(nil),
 		(*SocketStreamedTraceSegment_Event)(nil),
 	}
-}
-
-func _SocketStreamedTraceSegment_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*SocketStreamedTraceSegment)
-	// message_piece
-	switch x := m.MessagePiece.(type) {
-	case *SocketStreamedTraceSegment_Connection:
-		_ = b.EncodeVarint(2<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.Connection); err != nil {
-			return err
-		}
-	case *SocketStreamedTraceSegment_Event:
-		_ = b.EncodeVarint(3<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.Event); err != nil {
-			return err
-		}
-	case nil:
-	default:
-		return fmt.Errorf("SocketStreamedTraceSegment.MessagePiece has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _SocketStreamedTraceSegment_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*SocketStreamedTraceSegment)
-	switch tag {
-	case 2: // message_piece.connection
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(Connection)
-		err := b.DecodeMessage(msg)
-		m.MessagePiece = &SocketStreamedTraceSegment_Connection{msg}
-		return true, err
-	case 3: // message_piece.event
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(SocketEvent)
-		err := b.DecodeMessage(msg)
-		m.MessagePiece = &SocketStreamedTraceSegment_Event{msg}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _SocketStreamedTraceSegment_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*SocketStreamedTraceSegment)
-	// message_piece
-	switch x := m.MessagePiece.(type) {
-	case *SocketStreamedTraceSegment_Connection:
-		s := proto.Size(x.Connection)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *SocketStreamedTraceSegment_Event:
-		s := proto.Size(x.Event)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 func init() {

--- a/pkg/api/envoy/data/tap/v2alpha/wrapper.pb.go
+++ b/pkg/api/envoy/data/tap/v2alpha/wrapper.pb.go
@@ -21,7 +21,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // Wrapper for all fully buffered and streamed tap traces that Envoy emits. This is required for
 // sending traces over gRPC APIs or more easily persisting binary messages to files.
@@ -129,116 +129,14 @@ func (m *TraceWrapper) GetSocketStreamedTraceSegment() *SocketStreamedTraceSegme
 	return nil
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*TraceWrapper) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _TraceWrapper_OneofMarshaler, _TraceWrapper_OneofUnmarshaler, _TraceWrapper_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*TraceWrapper) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*TraceWrapper_HttpBufferedTrace)(nil),
 		(*TraceWrapper_HttpStreamedTraceSegment)(nil),
 		(*TraceWrapper_SocketBufferedTrace)(nil),
 		(*TraceWrapper_SocketStreamedTraceSegment)(nil),
 	}
-}
-
-func _TraceWrapper_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*TraceWrapper)
-	// trace
-	switch x := m.Trace.(type) {
-	case *TraceWrapper_HttpBufferedTrace:
-		_ = b.EncodeVarint(1<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.HttpBufferedTrace); err != nil {
-			return err
-		}
-	case *TraceWrapper_HttpStreamedTraceSegment:
-		_ = b.EncodeVarint(2<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.HttpStreamedTraceSegment); err != nil {
-			return err
-		}
-	case *TraceWrapper_SocketBufferedTrace:
-		_ = b.EncodeVarint(3<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.SocketBufferedTrace); err != nil {
-			return err
-		}
-	case *TraceWrapper_SocketStreamedTraceSegment:
-		_ = b.EncodeVarint(4<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.SocketStreamedTraceSegment); err != nil {
-			return err
-		}
-	case nil:
-	default:
-		return fmt.Errorf("TraceWrapper.Trace has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _TraceWrapper_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*TraceWrapper)
-	switch tag {
-	case 1: // trace.http_buffered_trace
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(HttpBufferedTrace)
-		err := b.DecodeMessage(msg)
-		m.Trace = &TraceWrapper_HttpBufferedTrace{msg}
-		return true, err
-	case 2: // trace.http_streamed_trace_segment
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(HttpStreamedTraceSegment)
-		err := b.DecodeMessage(msg)
-		m.Trace = &TraceWrapper_HttpStreamedTraceSegment{msg}
-		return true, err
-	case 3: // trace.socket_buffered_trace
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(SocketBufferedTrace)
-		err := b.DecodeMessage(msg)
-		m.Trace = &TraceWrapper_SocketBufferedTrace{msg}
-		return true, err
-	case 4: // trace.socket_streamed_trace_segment
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(SocketStreamedTraceSegment)
-		err := b.DecodeMessage(msg)
-		m.Trace = &TraceWrapper_SocketStreamedTraceSegment{msg}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _TraceWrapper_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*TraceWrapper)
-	// trace
-	switch x := m.Trace.(type) {
-	case *TraceWrapper_HttpBufferedTrace:
-		s := proto.Size(x.HttpBufferedTrace)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *TraceWrapper_HttpStreamedTraceSegment:
-		s := proto.Size(x.HttpStreamedTraceSegment)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *TraceWrapper_SocketBufferedTrace:
-		s := proto.Size(x.SocketBufferedTrace)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *TraceWrapper_SocketStreamedTraceSegment:
-		s := proto.Size(x.SocketStreamedTraceSegment)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 func init() {

--- a/pkg/api/envoy/data/tap/v3alpha/common.pb.go
+++ b/pkg/api/envoy/data/tap/v3alpha/common.pb.go
@@ -20,7 +20,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // Wrapper for tapped body data. This includes HTTP request/response body, transport socket received
 // and transmitted data, etc.
@@ -117,70 +117,12 @@ func (m *Body) GetTruncated() bool {
 	return false
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*Body) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _Body_OneofMarshaler, _Body_OneofUnmarshaler, _Body_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*Body) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*Body_AsBytes)(nil),
 		(*Body_AsString)(nil),
 	}
-}
-
-func _Body_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*Body)
-	// body_type
-	switch x := m.BodyType.(type) {
-	case *Body_AsBytes:
-		_ = b.EncodeVarint(1<<3 | proto.WireBytes)
-		_ = b.EncodeRawBytes(x.AsBytes)
-	case *Body_AsString:
-		_ = b.EncodeVarint(2<<3 | proto.WireBytes)
-		_ = b.EncodeStringBytes(x.AsString)
-	case nil:
-	default:
-		return fmt.Errorf("Body.BodyType has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _Body_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*Body)
-	switch tag {
-	case 1: // body_type.as_bytes
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeRawBytes(true)
-		m.BodyType = &Body_AsBytes{x}
-		return true, err
-	case 2: // body_type.as_string
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeStringBytes()
-		m.BodyType = &Body_AsString{x}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _Body_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*Body)
-	// body_type
-	switch x := m.BodyType.(type) {
-	case *Body_AsBytes:
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(len(x.AsBytes)))
-		n += len(x.AsBytes)
-	case *Body_AsString:
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(len(x.AsString)))
-		n += len(x.AsString)
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 func init() {

--- a/pkg/api/envoy/data/tap/v3alpha/http.pb.go
+++ b/pkg/api/envoy/data/tap/v3alpha/http.pb.go
@@ -21,7 +21,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // A fully buffered HTTP trace message.
 type HttpBufferedTrace struct {
@@ -287,9 +287,9 @@ func (m *HttpStreamedTraceSegment) GetResponseTrailers() *core.HeaderMap {
 	return nil
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*HttpStreamedTraceSegment) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _HttpStreamedTraceSegment_OneofMarshaler, _HttpStreamedTraceSegment_OneofUnmarshaler, _HttpStreamedTraceSegment_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*HttpStreamedTraceSegment) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*HttpStreamedTraceSegment_RequestHeaders)(nil),
 		(*HttpStreamedTraceSegment_RequestBodyChunk)(nil),
 		(*HttpStreamedTraceSegment_RequestTrailers)(nil),
@@ -297,144 +297,6 @@ func (*HttpStreamedTraceSegment) XXX_OneofFuncs() (func(msg proto.Message, b *pr
 		(*HttpStreamedTraceSegment_ResponseBodyChunk)(nil),
 		(*HttpStreamedTraceSegment_ResponseTrailers)(nil),
 	}
-}
-
-func _HttpStreamedTraceSegment_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*HttpStreamedTraceSegment)
-	// message_piece
-	switch x := m.MessagePiece.(type) {
-	case *HttpStreamedTraceSegment_RequestHeaders:
-		_ = b.EncodeVarint(2<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.RequestHeaders); err != nil {
-			return err
-		}
-	case *HttpStreamedTraceSegment_RequestBodyChunk:
-		_ = b.EncodeVarint(3<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.RequestBodyChunk); err != nil {
-			return err
-		}
-	case *HttpStreamedTraceSegment_RequestTrailers:
-		_ = b.EncodeVarint(4<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.RequestTrailers); err != nil {
-			return err
-		}
-	case *HttpStreamedTraceSegment_ResponseHeaders:
-		_ = b.EncodeVarint(5<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.ResponseHeaders); err != nil {
-			return err
-		}
-	case *HttpStreamedTraceSegment_ResponseBodyChunk:
-		_ = b.EncodeVarint(6<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.ResponseBodyChunk); err != nil {
-			return err
-		}
-	case *HttpStreamedTraceSegment_ResponseTrailers:
-		_ = b.EncodeVarint(7<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.ResponseTrailers); err != nil {
-			return err
-		}
-	case nil:
-	default:
-		return fmt.Errorf("HttpStreamedTraceSegment.MessagePiece has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _HttpStreamedTraceSegment_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*HttpStreamedTraceSegment)
-	switch tag {
-	case 2: // message_piece.request_headers
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(core.HeaderMap)
-		err := b.DecodeMessage(msg)
-		m.MessagePiece = &HttpStreamedTraceSegment_RequestHeaders{msg}
-		return true, err
-	case 3: // message_piece.request_body_chunk
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(Body)
-		err := b.DecodeMessage(msg)
-		m.MessagePiece = &HttpStreamedTraceSegment_RequestBodyChunk{msg}
-		return true, err
-	case 4: // message_piece.request_trailers
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(core.HeaderMap)
-		err := b.DecodeMessage(msg)
-		m.MessagePiece = &HttpStreamedTraceSegment_RequestTrailers{msg}
-		return true, err
-	case 5: // message_piece.response_headers
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(core.HeaderMap)
-		err := b.DecodeMessage(msg)
-		m.MessagePiece = &HttpStreamedTraceSegment_ResponseHeaders{msg}
-		return true, err
-	case 6: // message_piece.response_body_chunk
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(Body)
-		err := b.DecodeMessage(msg)
-		m.MessagePiece = &HttpStreamedTraceSegment_ResponseBodyChunk{msg}
-		return true, err
-	case 7: // message_piece.response_trailers
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(core.HeaderMap)
-		err := b.DecodeMessage(msg)
-		m.MessagePiece = &HttpStreamedTraceSegment_ResponseTrailers{msg}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _HttpStreamedTraceSegment_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*HttpStreamedTraceSegment)
-	// message_piece
-	switch x := m.MessagePiece.(type) {
-	case *HttpStreamedTraceSegment_RequestHeaders:
-		s := proto.Size(x.RequestHeaders)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *HttpStreamedTraceSegment_RequestBodyChunk:
-		s := proto.Size(x.RequestBodyChunk)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *HttpStreamedTraceSegment_RequestTrailers:
-		s := proto.Size(x.RequestTrailers)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *HttpStreamedTraceSegment_ResponseHeaders:
-		s := proto.Size(x.ResponseHeaders)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *HttpStreamedTraceSegment_ResponseBodyChunk:
-		s := proto.Size(x.ResponseBodyChunk)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *HttpStreamedTraceSegment_ResponseTrailers:
-		s := proto.Size(x.ResponseTrailers)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 func init() {

--- a/pkg/api/envoy/data/tap/v3alpha/transport.pb.go
+++ b/pkg/api/envoy/data/tap/v3alpha/transport.pb.go
@@ -22,7 +22,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // Connection properties.
 type Connection struct {
@@ -186,97 +186,13 @@ func (m *SocketEvent) GetClosed() *SocketEvent_Closed {
 	return nil
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*SocketEvent) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _SocketEvent_OneofMarshaler, _SocketEvent_OneofUnmarshaler, _SocketEvent_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*SocketEvent) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*SocketEvent_Read_)(nil),
 		(*SocketEvent_Write_)(nil),
 		(*SocketEvent_Closed_)(nil),
 	}
-}
-
-func _SocketEvent_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*SocketEvent)
-	// event_selector
-	switch x := m.EventSelector.(type) {
-	case *SocketEvent_Read_:
-		_ = b.EncodeVarint(2<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.Read); err != nil {
-			return err
-		}
-	case *SocketEvent_Write_:
-		_ = b.EncodeVarint(3<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.Write); err != nil {
-			return err
-		}
-	case *SocketEvent_Closed_:
-		_ = b.EncodeVarint(4<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.Closed); err != nil {
-			return err
-		}
-	case nil:
-	default:
-		return fmt.Errorf("SocketEvent.EventSelector has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _SocketEvent_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*SocketEvent)
-	switch tag {
-	case 2: // event_selector.read
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(SocketEvent_Read)
-		err := b.DecodeMessage(msg)
-		m.EventSelector = &SocketEvent_Read_{msg}
-		return true, err
-	case 3: // event_selector.write
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(SocketEvent_Write)
-		err := b.DecodeMessage(msg)
-		m.EventSelector = &SocketEvent_Write_{msg}
-		return true, err
-	case 4: // event_selector.closed
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(SocketEvent_Closed)
-		err := b.DecodeMessage(msg)
-		m.EventSelector = &SocketEvent_Closed_{msg}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _SocketEvent_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*SocketEvent)
-	// event_selector
-	switch x := m.EventSelector.(type) {
-	case *SocketEvent_Read_:
-		s := proto.Size(x.Read)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *SocketEvent_Write_:
-		s := proto.Size(x.Write)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *SocketEvent_Closed_:
-		s := proto.Size(x.Closed)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 // Data read by Envoy from the transport socket.
@@ -605,78 +521,12 @@ func (m *SocketStreamedTraceSegment) GetEvent() *SocketEvent {
 	return nil
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*SocketStreamedTraceSegment) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _SocketStreamedTraceSegment_OneofMarshaler, _SocketStreamedTraceSegment_OneofUnmarshaler, _SocketStreamedTraceSegment_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*SocketStreamedTraceSegment) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*SocketStreamedTraceSegment_Connection)(nil),
 		(*SocketStreamedTraceSegment_Event)(nil),
 	}
-}
-
-func _SocketStreamedTraceSegment_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*SocketStreamedTraceSegment)
-	// message_piece
-	switch x := m.MessagePiece.(type) {
-	case *SocketStreamedTraceSegment_Connection:
-		_ = b.EncodeVarint(2<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.Connection); err != nil {
-			return err
-		}
-	case *SocketStreamedTraceSegment_Event:
-		_ = b.EncodeVarint(3<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.Event); err != nil {
-			return err
-		}
-	case nil:
-	default:
-		return fmt.Errorf("SocketStreamedTraceSegment.MessagePiece has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _SocketStreamedTraceSegment_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*SocketStreamedTraceSegment)
-	switch tag {
-	case 2: // message_piece.connection
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(Connection)
-		err := b.DecodeMessage(msg)
-		m.MessagePiece = &SocketStreamedTraceSegment_Connection{msg}
-		return true, err
-	case 3: // message_piece.event
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(SocketEvent)
-		err := b.DecodeMessage(msg)
-		m.MessagePiece = &SocketStreamedTraceSegment_Event{msg}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _SocketStreamedTraceSegment_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*SocketStreamedTraceSegment)
-	// message_piece
-	switch x := m.MessagePiece.(type) {
-	case *SocketStreamedTraceSegment_Connection:
-		s := proto.Size(x.Connection)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *SocketStreamedTraceSegment_Event:
-		s := proto.Size(x.Event)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 func init() {

--- a/pkg/api/envoy/data/tap/v3alpha/wrapper.pb.go
+++ b/pkg/api/envoy/data/tap/v3alpha/wrapper.pb.go
@@ -21,7 +21,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // Wrapper for all fully buffered and streamed tap traces that Envoy emits. This is required for
 // sending traces over gRPC APIs or more easily persisting binary messages to files.
@@ -129,116 +129,14 @@ func (m *TraceWrapper) GetSocketStreamedTraceSegment() *SocketStreamedTraceSegme
 	return nil
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*TraceWrapper) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _TraceWrapper_OneofMarshaler, _TraceWrapper_OneofUnmarshaler, _TraceWrapper_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*TraceWrapper) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*TraceWrapper_HttpBufferedTrace)(nil),
 		(*TraceWrapper_HttpStreamedTraceSegment)(nil),
 		(*TraceWrapper_SocketBufferedTrace)(nil),
 		(*TraceWrapper_SocketStreamedTraceSegment)(nil),
 	}
-}
-
-func _TraceWrapper_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*TraceWrapper)
-	// trace
-	switch x := m.Trace.(type) {
-	case *TraceWrapper_HttpBufferedTrace:
-		_ = b.EncodeVarint(1<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.HttpBufferedTrace); err != nil {
-			return err
-		}
-	case *TraceWrapper_HttpStreamedTraceSegment:
-		_ = b.EncodeVarint(2<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.HttpStreamedTraceSegment); err != nil {
-			return err
-		}
-	case *TraceWrapper_SocketBufferedTrace:
-		_ = b.EncodeVarint(3<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.SocketBufferedTrace); err != nil {
-			return err
-		}
-	case *TraceWrapper_SocketStreamedTraceSegment:
-		_ = b.EncodeVarint(4<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.SocketStreamedTraceSegment); err != nil {
-			return err
-		}
-	case nil:
-	default:
-		return fmt.Errorf("TraceWrapper.Trace has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _TraceWrapper_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*TraceWrapper)
-	switch tag {
-	case 1: // trace.http_buffered_trace
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(HttpBufferedTrace)
-		err := b.DecodeMessage(msg)
-		m.Trace = &TraceWrapper_HttpBufferedTrace{msg}
-		return true, err
-	case 2: // trace.http_streamed_trace_segment
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(HttpStreamedTraceSegment)
-		err := b.DecodeMessage(msg)
-		m.Trace = &TraceWrapper_HttpStreamedTraceSegment{msg}
-		return true, err
-	case 3: // trace.socket_buffered_trace
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(SocketBufferedTrace)
-		err := b.DecodeMessage(msg)
-		m.Trace = &TraceWrapper_SocketBufferedTrace{msg}
-		return true, err
-	case 4: // trace.socket_streamed_trace_segment
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(SocketStreamedTraceSegment)
-		err := b.DecodeMessage(msg)
-		m.Trace = &TraceWrapper_SocketStreamedTraceSegment{msg}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _TraceWrapper_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*TraceWrapper)
-	// trace
-	switch x := m.Trace.(type) {
-	case *TraceWrapper_HttpBufferedTrace:
-		s := proto.Size(x.HttpBufferedTrace)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *TraceWrapper_HttpStreamedTraceSegment:
-		s := proto.Size(x.HttpStreamedTraceSegment)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *TraceWrapper_SocketBufferedTrace:
-		s := proto.Size(x.SocketBufferedTrace)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *TraceWrapper_SocketStreamedTraceSegment:
-		s := proto.Size(x.SocketStreamedTraceSegment)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 func init() {

--- a/pkg/api/envoy/service/accesslog/v2/als.pb.go
+++ b/pkg/api/envoy/service/accesslog/v2/als.pb.go
@@ -27,7 +27,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // Empty response for the StreamAccessLogs API. Will never be sent. See below.
 type StreamAccessLogsResponse struct {
@@ -164,78 +164,12 @@ func (m *StreamAccessLogsMessage) GetTcpLogs() *StreamAccessLogsMessage_TCPAcces
 	return nil
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*StreamAccessLogsMessage) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _StreamAccessLogsMessage_OneofMarshaler, _StreamAccessLogsMessage_OneofUnmarshaler, _StreamAccessLogsMessage_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*StreamAccessLogsMessage) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*StreamAccessLogsMessage_HttpLogs)(nil),
 		(*StreamAccessLogsMessage_TcpLogs)(nil),
 	}
-}
-
-func _StreamAccessLogsMessage_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*StreamAccessLogsMessage)
-	// log_entries
-	switch x := m.LogEntries.(type) {
-	case *StreamAccessLogsMessage_HttpLogs:
-		_ = b.EncodeVarint(2<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.HttpLogs); err != nil {
-			return err
-		}
-	case *StreamAccessLogsMessage_TcpLogs:
-		_ = b.EncodeVarint(3<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.TcpLogs); err != nil {
-			return err
-		}
-	case nil:
-	default:
-		return fmt.Errorf("StreamAccessLogsMessage.LogEntries has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _StreamAccessLogsMessage_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*StreamAccessLogsMessage)
-	switch tag {
-	case 2: // log_entries.http_logs
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(StreamAccessLogsMessage_HTTPAccessLogEntries)
-		err := b.DecodeMessage(msg)
-		m.LogEntries = &StreamAccessLogsMessage_HttpLogs{msg}
-		return true, err
-	case 3: // log_entries.tcp_logs
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(StreamAccessLogsMessage_TCPAccessLogEntries)
-		err := b.DecodeMessage(msg)
-		m.LogEntries = &StreamAccessLogsMessage_TcpLogs{msg}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _StreamAccessLogsMessage_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*StreamAccessLogsMessage)
-	// log_entries
-	switch x := m.LogEntries.(type) {
-	case *StreamAccessLogsMessage_HttpLogs:
-		s := proto.Size(x.HttpLogs)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *StreamAccessLogsMessage_TcpLogs:
-		s := proto.Size(x.TcpLogs)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 type StreamAccessLogsMessage_Identifier struct {

--- a/pkg/api/envoy/service/accesslog/v3alpha/als.pb.go
+++ b/pkg/api/envoy/service/accesslog/v3alpha/als.pb.go
@@ -27,7 +27,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // Empty response for the StreamAccessLogs API. Will never be sent. See below.
 type StreamAccessLogsResponse struct {
@@ -164,78 +164,12 @@ func (m *StreamAccessLogsMessage) GetTcpLogs() *StreamAccessLogsMessage_TCPAcces
 	return nil
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*StreamAccessLogsMessage) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _StreamAccessLogsMessage_OneofMarshaler, _StreamAccessLogsMessage_OneofUnmarshaler, _StreamAccessLogsMessage_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*StreamAccessLogsMessage) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*StreamAccessLogsMessage_HttpLogs)(nil),
 		(*StreamAccessLogsMessage_TcpLogs)(nil),
 	}
-}
-
-func _StreamAccessLogsMessage_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*StreamAccessLogsMessage)
-	// log_entries
-	switch x := m.LogEntries.(type) {
-	case *StreamAccessLogsMessage_HttpLogs:
-		_ = b.EncodeVarint(2<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.HttpLogs); err != nil {
-			return err
-		}
-	case *StreamAccessLogsMessage_TcpLogs:
-		_ = b.EncodeVarint(3<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.TcpLogs); err != nil {
-			return err
-		}
-	case nil:
-	default:
-		return fmt.Errorf("StreamAccessLogsMessage.LogEntries has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _StreamAccessLogsMessage_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*StreamAccessLogsMessage)
-	switch tag {
-	case 2: // log_entries.http_logs
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(StreamAccessLogsMessage_HTTPAccessLogEntries)
-		err := b.DecodeMessage(msg)
-		m.LogEntries = &StreamAccessLogsMessage_HttpLogs{msg}
-		return true, err
-	case 3: // log_entries.tcp_logs
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(StreamAccessLogsMessage_TCPAccessLogEntries)
-		err := b.DecodeMessage(msg)
-		m.LogEntries = &StreamAccessLogsMessage_TcpLogs{msg}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _StreamAccessLogsMessage_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*StreamAccessLogsMessage)
-	// log_entries
-	switch x := m.LogEntries.(type) {
-	case *StreamAccessLogsMessage_HttpLogs:
-		s := proto.Size(x.HttpLogs)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *StreamAccessLogsMessage_TcpLogs:
-		s := proto.Size(x.TcpLogs)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 type StreamAccessLogsMessage_Identifier struct {

--- a/pkg/api/envoy/service/auth/v2/attribute_context.pb.go
+++ b/pkg/api/envoy/service/auth/v2/attribute_context.pb.go
@@ -22,7 +22,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // An attribute is a piece of metadata that describes an activity on a network.
 // For example, the size of an HTTP request, or the status code of an HTTP response.

--- a/pkg/api/envoy/service/auth/v2/external_auth.pb.go
+++ b/pkg/api/envoy/service/auth/v2/external_auth.pb.go
@@ -28,7 +28,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 type CheckRequest struct {
 	// The request attributes.
@@ -296,78 +296,12 @@ func (m *CheckResponse) GetOkResponse() *OkHttpResponse {
 	return nil
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*CheckResponse) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _CheckResponse_OneofMarshaler, _CheckResponse_OneofUnmarshaler, _CheckResponse_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*CheckResponse) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*CheckResponse_DeniedResponse)(nil),
 		(*CheckResponse_OkResponse)(nil),
 	}
-}
-
-func _CheckResponse_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*CheckResponse)
-	// http_response
-	switch x := m.HttpResponse.(type) {
-	case *CheckResponse_DeniedResponse:
-		_ = b.EncodeVarint(2<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.DeniedResponse); err != nil {
-			return err
-		}
-	case *CheckResponse_OkResponse:
-		_ = b.EncodeVarint(3<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.OkResponse); err != nil {
-			return err
-		}
-	case nil:
-	default:
-		return fmt.Errorf("CheckResponse.HttpResponse has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _CheckResponse_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*CheckResponse)
-	switch tag {
-	case 2: // http_response.denied_response
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(DeniedHttpResponse)
-		err := b.DecodeMessage(msg)
-		m.HttpResponse = &CheckResponse_DeniedResponse{msg}
-		return true, err
-	case 3: // http_response.ok_response
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(OkHttpResponse)
-		err := b.DecodeMessage(msg)
-		m.HttpResponse = &CheckResponse_OkResponse{msg}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _CheckResponse_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*CheckResponse)
-	// http_response
-	switch x := m.HttpResponse.(type) {
-	case *CheckResponse_DeniedResponse:
-		s := proto.Size(x.DeniedResponse)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *CheckResponse_OkResponse:
-		s := proto.Size(x.OkResponse)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 func init() {

--- a/pkg/api/envoy/service/auth/v2alpha/external_auth.pb.go
+++ b/pkg/api/envoy/service/auth/v2alpha/external_auth.pb.go
@@ -23,7 +23,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 func init() {
 	proto.RegisterFile("envoy/service/auth/v2alpha/external_auth.proto", fileDescriptor_878c0ddb0c43de8d)

--- a/pkg/api/envoy/service/auth/v3alpha/attribute_context.pb.go
+++ b/pkg/api/envoy/service/auth/v3alpha/attribute_context.pb.go
@@ -22,7 +22,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // An attribute is a piece of metadata that describes an activity on a network.
 // For example, the size of an HTTP request, or the status code of an HTTP response.

--- a/pkg/api/envoy/service/auth/v3alpha/external_auth.pb.go
+++ b/pkg/api/envoy/service/auth/v3alpha/external_auth.pb.go
@@ -28,7 +28,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 type CheckRequest struct {
 	// The request attributes.
@@ -296,78 +296,12 @@ func (m *CheckResponse) GetOkResponse() *OkHttpResponse {
 	return nil
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*CheckResponse) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _CheckResponse_OneofMarshaler, _CheckResponse_OneofUnmarshaler, _CheckResponse_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*CheckResponse) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*CheckResponse_DeniedResponse)(nil),
 		(*CheckResponse_OkResponse)(nil),
 	}
-}
-
-func _CheckResponse_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*CheckResponse)
-	// http_response
-	switch x := m.HttpResponse.(type) {
-	case *CheckResponse_DeniedResponse:
-		_ = b.EncodeVarint(2<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.DeniedResponse); err != nil {
-			return err
-		}
-	case *CheckResponse_OkResponse:
-		_ = b.EncodeVarint(3<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.OkResponse); err != nil {
-			return err
-		}
-	case nil:
-	default:
-		return fmt.Errorf("CheckResponse.HttpResponse has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _CheckResponse_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*CheckResponse)
-	switch tag {
-	case 2: // http_response.denied_response
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(DeniedHttpResponse)
-		err := b.DecodeMessage(msg)
-		m.HttpResponse = &CheckResponse_DeniedResponse{msg}
-		return true, err
-	case 3: // http_response.ok_response
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(OkHttpResponse)
-		err := b.DecodeMessage(msg)
-		m.HttpResponse = &CheckResponse_OkResponse{msg}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _CheckResponse_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*CheckResponse)
-	// http_response
-	switch x := m.HttpResponse.(type) {
-	case *CheckResponse_DeniedResponse:
-		s := proto.Size(x.DeniedResponse)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *CheckResponse_OkResponse:
-		s := proto.Size(x.OkResponse)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 func init() {

--- a/pkg/api/envoy/service/discovery/v2/ads.pb.go
+++ b/pkg/api/envoy/service/discovery/v2/ads.pb.go
@@ -25,7 +25,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // [#not-implemented-hide:] Not configuration. Workaround c++ protobuf issue with importing
 // services: https://github.com/google/protobuf/issues/4221

--- a/pkg/api/envoy/service/discovery/v2/hds.pb.go
+++ b/pkg/api/envoy/service/discovery/v2/hds.pb.go
@@ -28,7 +28,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // Different Envoy instances may have different capabilities (e.g. Redis)
 // and/or have ports enabled for different protocols.
@@ -352,78 +352,12 @@ func (m *HealthCheckRequestOrEndpointHealthResponse) GetEndpointHealthResponse()
 	return nil
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*HealthCheckRequestOrEndpointHealthResponse) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _HealthCheckRequestOrEndpointHealthResponse_OneofMarshaler, _HealthCheckRequestOrEndpointHealthResponse_OneofUnmarshaler, _HealthCheckRequestOrEndpointHealthResponse_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*HealthCheckRequestOrEndpointHealthResponse) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*HealthCheckRequestOrEndpointHealthResponse_HealthCheckRequest)(nil),
 		(*HealthCheckRequestOrEndpointHealthResponse_EndpointHealthResponse)(nil),
 	}
-}
-
-func _HealthCheckRequestOrEndpointHealthResponse_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*HealthCheckRequestOrEndpointHealthResponse)
-	// request_type
-	switch x := m.RequestType.(type) {
-	case *HealthCheckRequestOrEndpointHealthResponse_HealthCheckRequest:
-		_ = b.EncodeVarint(1<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.HealthCheckRequest); err != nil {
-			return err
-		}
-	case *HealthCheckRequestOrEndpointHealthResponse_EndpointHealthResponse:
-		_ = b.EncodeVarint(2<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.EndpointHealthResponse); err != nil {
-			return err
-		}
-	case nil:
-	default:
-		return fmt.Errorf("HealthCheckRequestOrEndpointHealthResponse.RequestType has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _HealthCheckRequestOrEndpointHealthResponse_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*HealthCheckRequestOrEndpointHealthResponse)
-	switch tag {
-	case 1: // request_type.health_check_request
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(HealthCheckRequest)
-		err := b.DecodeMessage(msg)
-		m.RequestType = &HealthCheckRequestOrEndpointHealthResponse_HealthCheckRequest{msg}
-		return true, err
-	case 2: // request_type.endpoint_health_response
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(EndpointHealthResponse)
-		err := b.DecodeMessage(msg)
-		m.RequestType = &HealthCheckRequestOrEndpointHealthResponse_EndpointHealthResponse{msg}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _HealthCheckRequestOrEndpointHealthResponse_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*HealthCheckRequestOrEndpointHealthResponse)
-	// request_type
-	switch x := m.RequestType.(type) {
-	case *HealthCheckRequestOrEndpointHealthResponse_HealthCheckRequest:
-		s := proto.Size(x.HealthCheckRequest)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *HealthCheckRequestOrEndpointHealthResponse_EndpointHealthResponse:
-		s := proto.Size(x.EndpointHealthResponse)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 type LocalityEndpoints struct {

--- a/pkg/api/envoy/service/discovery/v2/rtds.pb.go
+++ b/pkg/api/envoy/service/discovery/v2/rtds.pb.go
@@ -28,7 +28,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // [#not-implemented-hide:] Not configuration. Workaround c++ protobuf issue with importing
 // services: https://github.com/google/protobuf/issues/4221

--- a/pkg/api/envoy/service/discovery/v2/sds.pb.go
+++ b/pkg/api/envoy/service/discovery/v2/sds.pb.go
@@ -26,7 +26,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // [#not-implemented-hide:] Not configuration. Workaround c++ protobuf issue with importing
 // services: https://github.com/google/protobuf/issues/4221

--- a/pkg/api/envoy/service/discovery/v3alpha/ads.pb.go
+++ b/pkg/api/envoy/service/discovery/v3alpha/ads.pb.go
@@ -25,7 +25,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // [#not-implemented-hide:] Not configuration. Workaround c++ protobuf issue with importing
 // services: https://github.com/google/protobuf/issues/4221

--- a/pkg/api/envoy/service/discovery/v3alpha/hds.pb.go
+++ b/pkg/api/envoy/service/discovery/v3alpha/hds.pb.go
@@ -28,7 +28,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // Different Envoy instances may have different capabilities (e.g. Redis)
 // and/or have ports enabled for different protocols.
@@ -352,78 +352,12 @@ func (m *HealthCheckRequestOrEndpointHealthResponse) GetEndpointHealthResponse()
 	return nil
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*HealthCheckRequestOrEndpointHealthResponse) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _HealthCheckRequestOrEndpointHealthResponse_OneofMarshaler, _HealthCheckRequestOrEndpointHealthResponse_OneofUnmarshaler, _HealthCheckRequestOrEndpointHealthResponse_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*HealthCheckRequestOrEndpointHealthResponse) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*HealthCheckRequestOrEndpointHealthResponse_HealthCheckRequest)(nil),
 		(*HealthCheckRequestOrEndpointHealthResponse_EndpointHealthResponse)(nil),
 	}
-}
-
-func _HealthCheckRequestOrEndpointHealthResponse_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*HealthCheckRequestOrEndpointHealthResponse)
-	// request_type
-	switch x := m.RequestType.(type) {
-	case *HealthCheckRequestOrEndpointHealthResponse_HealthCheckRequest:
-		_ = b.EncodeVarint(1<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.HealthCheckRequest); err != nil {
-			return err
-		}
-	case *HealthCheckRequestOrEndpointHealthResponse_EndpointHealthResponse:
-		_ = b.EncodeVarint(2<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.EndpointHealthResponse); err != nil {
-			return err
-		}
-	case nil:
-	default:
-		return fmt.Errorf("HealthCheckRequestOrEndpointHealthResponse.RequestType has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _HealthCheckRequestOrEndpointHealthResponse_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*HealthCheckRequestOrEndpointHealthResponse)
-	switch tag {
-	case 1: // request_type.health_check_request
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(HealthCheckRequest)
-		err := b.DecodeMessage(msg)
-		m.RequestType = &HealthCheckRequestOrEndpointHealthResponse_HealthCheckRequest{msg}
-		return true, err
-	case 2: // request_type.endpoint_health_response
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(EndpointHealthResponse)
-		err := b.DecodeMessage(msg)
-		m.RequestType = &HealthCheckRequestOrEndpointHealthResponse_EndpointHealthResponse{msg}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _HealthCheckRequestOrEndpointHealthResponse_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*HealthCheckRequestOrEndpointHealthResponse)
-	// request_type
-	switch x := m.RequestType.(type) {
-	case *HealthCheckRequestOrEndpointHealthResponse_HealthCheckRequest:
-		s := proto.Size(x.HealthCheckRequest)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *HealthCheckRequestOrEndpointHealthResponse_EndpointHealthResponse:
-		s := proto.Size(x.EndpointHealthResponse)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 type LocalityEndpoints struct {

--- a/pkg/api/envoy/service/discovery/v3alpha/rtds.pb.go
+++ b/pkg/api/envoy/service/discovery/v3alpha/rtds.pb.go
@@ -28,7 +28,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // [#not-implemented-hide:] Not configuration. Workaround c++ protobuf issue with importing
 // services: https://github.com/google/protobuf/issues/4221

--- a/pkg/api/envoy/service/discovery/v3alpha/sds.pb.go
+++ b/pkg/api/envoy/service/discovery/v3alpha/sds.pb.go
@@ -26,7 +26,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // [#not-implemented-hide:] Not configuration. Workaround c++ protobuf issue with importing
 // services: https://github.com/google/protobuf/issues/4221

--- a/pkg/api/envoy/service/load_stats/v2/lrs.pb.go
+++ b/pkg/api/envoy/service/load_stats/v2/lrs.pb.go
@@ -28,7 +28,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // A load report Envoy sends to the management server.
 // [#not-implemented-hide:] Not configuration. TBD how to doc proto APIs.

--- a/pkg/api/envoy/service/load_stats/v3alpha/lrs.pb.go
+++ b/pkg/api/envoy/service/load_stats/v3alpha/lrs.pb.go
@@ -28,7 +28,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // A load report Envoy sends to the management server.
 // [#not-implemented-hide:] Not configuration. TBD how to doc proto APIs.

--- a/pkg/api/envoy/service/metrics/v2/metrics_service.pb.go
+++ b/pkg/api/envoy/service/metrics/v2/metrics_service.pb.go
@@ -27,7 +27,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 type StreamMetricsResponse struct {
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`

--- a/pkg/api/envoy/service/metrics/v3alpha/metrics_service.pb.go
+++ b/pkg/api/envoy/service/metrics/v3alpha/metrics_service.pb.go
@@ -27,7 +27,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 type StreamMetricsResponse struct {
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`

--- a/pkg/api/envoy/service/ratelimit/v1/rls.pb.go
+++ b/pkg/api/envoy/service/ratelimit/v1/rls.pb.go
@@ -23,7 +23,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 func init() {
 	proto.RegisterFile("envoy/service/ratelimit/v1/rls.proto", fileDescriptor_37d6df72c5a63247)

--- a/pkg/api/envoy/service/ratelimit/v2/rls.pb.go
+++ b/pkg/api/envoy/service/ratelimit/v2/rls.pb.go
@@ -27,7 +27,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 type RateLimitResponse_Code int32
 

--- a/pkg/api/envoy/service/ratelimit/v3alpha/rls.pb.go
+++ b/pkg/api/envoy/service/ratelimit/v3alpha/rls.pb.go
@@ -27,7 +27,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 type RateLimitResponse_Code int32
 

--- a/pkg/api/envoy/service/tap/v2alpha/common.pb.go
+++ b/pkg/api/envoy/service/tap/v2alpha/common.pb.go
@@ -24,7 +24,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // Output format. All output is in the form of one or more :ref:`TraceWrapper
 // <envoy_api_msg_data.tap.v2alpha.TraceWrapper>` messages. This enumeration indicates
@@ -316,9 +316,9 @@ func (m *MatchPredicate) GetHttpResponseTrailersMatch() *HttpHeadersMatch {
 	return nil
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*MatchPredicate) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _MatchPredicate_OneofMarshaler, _MatchPredicate_OneofUnmarshaler, _MatchPredicate_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*MatchPredicate) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*MatchPredicate_OrMatch)(nil),
 		(*MatchPredicate_AndMatch)(nil),
 		(*MatchPredicate_NotMatch)(nil),
@@ -328,179 +328,6 @@ func (*MatchPredicate) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer
 		(*MatchPredicate_HttpResponseHeadersMatch)(nil),
 		(*MatchPredicate_HttpResponseTrailersMatch)(nil),
 	}
-}
-
-func _MatchPredicate_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*MatchPredicate)
-	// rule
-	switch x := m.Rule.(type) {
-	case *MatchPredicate_OrMatch:
-		_ = b.EncodeVarint(1<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.OrMatch); err != nil {
-			return err
-		}
-	case *MatchPredicate_AndMatch:
-		_ = b.EncodeVarint(2<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.AndMatch); err != nil {
-			return err
-		}
-	case *MatchPredicate_NotMatch:
-		_ = b.EncodeVarint(3<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.NotMatch); err != nil {
-			return err
-		}
-	case *MatchPredicate_AnyMatch:
-		t := uint64(0)
-		if x.AnyMatch {
-			t = 1
-		}
-		_ = b.EncodeVarint(4<<3 | proto.WireVarint)
-		_ = b.EncodeVarint(t)
-	case *MatchPredicate_HttpRequestHeadersMatch:
-		_ = b.EncodeVarint(5<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.HttpRequestHeadersMatch); err != nil {
-			return err
-		}
-	case *MatchPredicate_HttpRequestTrailersMatch:
-		_ = b.EncodeVarint(6<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.HttpRequestTrailersMatch); err != nil {
-			return err
-		}
-	case *MatchPredicate_HttpResponseHeadersMatch:
-		_ = b.EncodeVarint(7<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.HttpResponseHeadersMatch); err != nil {
-			return err
-		}
-	case *MatchPredicate_HttpResponseTrailersMatch:
-		_ = b.EncodeVarint(8<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.HttpResponseTrailersMatch); err != nil {
-			return err
-		}
-	case nil:
-	default:
-		return fmt.Errorf("MatchPredicate.Rule has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _MatchPredicate_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*MatchPredicate)
-	switch tag {
-	case 1: // rule.or_match
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(MatchPredicate_MatchSet)
-		err := b.DecodeMessage(msg)
-		m.Rule = &MatchPredicate_OrMatch{msg}
-		return true, err
-	case 2: // rule.and_match
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(MatchPredicate_MatchSet)
-		err := b.DecodeMessage(msg)
-		m.Rule = &MatchPredicate_AndMatch{msg}
-		return true, err
-	case 3: // rule.not_match
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(MatchPredicate)
-		err := b.DecodeMessage(msg)
-		m.Rule = &MatchPredicate_NotMatch{msg}
-		return true, err
-	case 4: // rule.any_match
-		if wire != proto.WireVarint {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeVarint()
-		m.Rule = &MatchPredicate_AnyMatch{x != 0}
-		return true, err
-	case 5: // rule.http_request_headers_match
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(HttpHeadersMatch)
-		err := b.DecodeMessage(msg)
-		m.Rule = &MatchPredicate_HttpRequestHeadersMatch{msg}
-		return true, err
-	case 6: // rule.http_request_trailers_match
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(HttpHeadersMatch)
-		err := b.DecodeMessage(msg)
-		m.Rule = &MatchPredicate_HttpRequestTrailersMatch{msg}
-		return true, err
-	case 7: // rule.http_response_headers_match
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(HttpHeadersMatch)
-		err := b.DecodeMessage(msg)
-		m.Rule = &MatchPredicate_HttpResponseHeadersMatch{msg}
-		return true, err
-	case 8: // rule.http_response_trailers_match
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(HttpHeadersMatch)
-		err := b.DecodeMessage(msg)
-		m.Rule = &MatchPredicate_HttpResponseTrailersMatch{msg}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _MatchPredicate_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*MatchPredicate)
-	// rule
-	switch x := m.Rule.(type) {
-	case *MatchPredicate_OrMatch:
-		s := proto.Size(x.OrMatch)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *MatchPredicate_AndMatch:
-		s := proto.Size(x.AndMatch)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *MatchPredicate_NotMatch:
-		s := proto.Size(x.NotMatch)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *MatchPredicate_AnyMatch:
-		n += 1 // tag and wire
-		n += 1
-	case *MatchPredicate_HttpRequestHeadersMatch:
-		s := proto.Size(x.HttpRequestHeadersMatch)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *MatchPredicate_HttpRequestTrailersMatch:
-		s := proto.Size(x.HttpRequestTrailersMatch)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *MatchPredicate_HttpResponseHeadersMatch:
-		s := proto.Size(x.HttpResponseHeadersMatch)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *MatchPredicate_HttpResponseTrailersMatch:
-		s := proto.Size(x.HttpResponseTrailersMatch)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 // A set of match configurations used for logical operations.
@@ -791,97 +618,13 @@ func (m *OutputSink) GetStreamingGrpc() *StreamingGrpcSink {
 	return nil
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*OutputSink) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _OutputSink_OneofMarshaler, _OutputSink_OneofUnmarshaler, _OutputSink_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*OutputSink) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*OutputSink_StreamingAdmin)(nil),
 		(*OutputSink_FilePerTap)(nil),
 		(*OutputSink_StreamingGrpc)(nil),
 	}
-}
-
-func _OutputSink_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*OutputSink)
-	// output_sink_type
-	switch x := m.OutputSinkType.(type) {
-	case *OutputSink_StreamingAdmin:
-		_ = b.EncodeVarint(2<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.StreamingAdmin); err != nil {
-			return err
-		}
-	case *OutputSink_FilePerTap:
-		_ = b.EncodeVarint(3<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.FilePerTap); err != nil {
-			return err
-		}
-	case *OutputSink_StreamingGrpc:
-		_ = b.EncodeVarint(4<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.StreamingGrpc); err != nil {
-			return err
-		}
-	case nil:
-	default:
-		return fmt.Errorf("OutputSink.OutputSinkType has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _OutputSink_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*OutputSink)
-	switch tag {
-	case 2: // output_sink_type.streaming_admin
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(StreamingAdminSink)
-		err := b.DecodeMessage(msg)
-		m.OutputSinkType = &OutputSink_StreamingAdmin{msg}
-		return true, err
-	case 3: // output_sink_type.file_per_tap
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(FilePerTapSink)
-		err := b.DecodeMessage(msg)
-		m.OutputSinkType = &OutputSink_FilePerTap{msg}
-		return true, err
-	case 4: // output_sink_type.streaming_grpc
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(StreamingGrpcSink)
-		err := b.DecodeMessage(msg)
-		m.OutputSinkType = &OutputSink_StreamingGrpc{msg}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _OutputSink_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*OutputSink)
-	// output_sink_type
-	switch x := m.OutputSinkType.(type) {
-	case *OutputSink_StreamingAdmin:
-		s := proto.Size(x.StreamingAdmin)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *OutputSink_FilePerTap:
-		s := proto.Size(x.FilePerTap)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *OutputSink_StreamingGrpc:
-		s := proto.Size(x.StreamingGrpc)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 // Streaming admin sink configuration.

--- a/pkg/api/envoy/service/tap/v2alpha/tap.pb.go
+++ b/pkg/api/envoy/service/tap/v2alpha/tap.pb.go
@@ -27,7 +27,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // [#not-implemented-hide:] Stream message for the Tap API. Envoy will open a stream to the server
 // and stream taps without ever expecting a response.

--- a/pkg/api/envoy/service/tap/v2alpha/tapds.pb.go
+++ b/pkg/api/envoy/service/tap/v2alpha/tapds.pb.go
@@ -27,7 +27,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // [#not-implemented-hide:] A tap resource is essentially a tap configuration with a name
 // The filter TapDS config references this name.

--- a/pkg/api/envoy/service/tap/v3alpha/common.pb.go
+++ b/pkg/api/envoy/service/tap/v3alpha/common.pb.go
@@ -24,7 +24,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // Output format. All output is in the form of one or more :ref:`TraceWrapper
 // <envoy_api_msg_data.tap.v3alpha.TraceWrapper>` messages. This enumeration indicates
@@ -316,9 +316,9 @@ func (m *MatchPredicate) GetHttpResponseTrailersMatch() *HttpHeadersMatch {
 	return nil
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*MatchPredicate) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _MatchPredicate_OneofMarshaler, _MatchPredicate_OneofUnmarshaler, _MatchPredicate_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*MatchPredicate) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*MatchPredicate_OrMatch)(nil),
 		(*MatchPredicate_AndMatch)(nil),
 		(*MatchPredicate_NotMatch)(nil),
@@ -328,179 +328,6 @@ func (*MatchPredicate) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer
 		(*MatchPredicate_HttpResponseHeadersMatch)(nil),
 		(*MatchPredicate_HttpResponseTrailersMatch)(nil),
 	}
-}
-
-func _MatchPredicate_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*MatchPredicate)
-	// rule
-	switch x := m.Rule.(type) {
-	case *MatchPredicate_OrMatch:
-		_ = b.EncodeVarint(1<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.OrMatch); err != nil {
-			return err
-		}
-	case *MatchPredicate_AndMatch:
-		_ = b.EncodeVarint(2<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.AndMatch); err != nil {
-			return err
-		}
-	case *MatchPredicate_NotMatch:
-		_ = b.EncodeVarint(3<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.NotMatch); err != nil {
-			return err
-		}
-	case *MatchPredicate_AnyMatch:
-		t := uint64(0)
-		if x.AnyMatch {
-			t = 1
-		}
-		_ = b.EncodeVarint(4<<3 | proto.WireVarint)
-		_ = b.EncodeVarint(t)
-	case *MatchPredicate_HttpRequestHeadersMatch:
-		_ = b.EncodeVarint(5<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.HttpRequestHeadersMatch); err != nil {
-			return err
-		}
-	case *MatchPredicate_HttpRequestTrailersMatch:
-		_ = b.EncodeVarint(6<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.HttpRequestTrailersMatch); err != nil {
-			return err
-		}
-	case *MatchPredicate_HttpResponseHeadersMatch:
-		_ = b.EncodeVarint(7<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.HttpResponseHeadersMatch); err != nil {
-			return err
-		}
-	case *MatchPredicate_HttpResponseTrailersMatch:
-		_ = b.EncodeVarint(8<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.HttpResponseTrailersMatch); err != nil {
-			return err
-		}
-	case nil:
-	default:
-		return fmt.Errorf("MatchPredicate.Rule has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _MatchPredicate_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*MatchPredicate)
-	switch tag {
-	case 1: // rule.or_match
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(MatchPredicate_MatchSet)
-		err := b.DecodeMessage(msg)
-		m.Rule = &MatchPredicate_OrMatch{msg}
-		return true, err
-	case 2: // rule.and_match
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(MatchPredicate_MatchSet)
-		err := b.DecodeMessage(msg)
-		m.Rule = &MatchPredicate_AndMatch{msg}
-		return true, err
-	case 3: // rule.not_match
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(MatchPredicate)
-		err := b.DecodeMessage(msg)
-		m.Rule = &MatchPredicate_NotMatch{msg}
-		return true, err
-	case 4: // rule.any_match
-		if wire != proto.WireVarint {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeVarint()
-		m.Rule = &MatchPredicate_AnyMatch{x != 0}
-		return true, err
-	case 5: // rule.http_request_headers_match
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(HttpHeadersMatch)
-		err := b.DecodeMessage(msg)
-		m.Rule = &MatchPredicate_HttpRequestHeadersMatch{msg}
-		return true, err
-	case 6: // rule.http_request_trailers_match
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(HttpHeadersMatch)
-		err := b.DecodeMessage(msg)
-		m.Rule = &MatchPredicate_HttpRequestTrailersMatch{msg}
-		return true, err
-	case 7: // rule.http_response_headers_match
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(HttpHeadersMatch)
-		err := b.DecodeMessage(msg)
-		m.Rule = &MatchPredicate_HttpResponseHeadersMatch{msg}
-		return true, err
-	case 8: // rule.http_response_trailers_match
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(HttpHeadersMatch)
-		err := b.DecodeMessage(msg)
-		m.Rule = &MatchPredicate_HttpResponseTrailersMatch{msg}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _MatchPredicate_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*MatchPredicate)
-	// rule
-	switch x := m.Rule.(type) {
-	case *MatchPredicate_OrMatch:
-		s := proto.Size(x.OrMatch)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *MatchPredicate_AndMatch:
-		s := proto.Size(x.AndMatch)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *MatchPredicate_NotMatch:
-		s := proto.Size(x.NotMatch)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *MatchPredicate_AnyMatch:
-		n += 1 // tag and wire
-		n += 1
-	case *MatchPredicate_HttpRequestHeadersMatch:
-		s := proto.Size(x.HttpRequestHeadersMatch)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *MatchPredicate_HttpRequestTrailersMatch:
-		s := proto.Size(x.HttpRequestTrailersMatch)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *MatchPredicate_HttpResponseHeadersMatch:
-		s := proto.Size(x.HttpResponseHeadersMatch)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *MatchPredicate_HttpResponseTrailersMatch:
-		s := proto.Size(x.HttpResponseTrailersMatch)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 // A set of match configurations used for logical operations.
@@ -791,97 +618,13 @@ func (m *OutputSink) GetStreamingGrpc() *StreamingGrpcSink {
 	return nil
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*OutputSink) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _OutputSink_OneofMarshaler, _OutputSink_OneofUnmarshaler, _OutputSink_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*OutputSink) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*OutputSink_StreamingAdmin)(nil),
 		(*OutputSink_FilePerTap)(nil),
 		(*OutputSink_StreamingGrpc)(nil),
 	}
-}
-
-func _OutputSink_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*OutputSink)
-	// output_sink_type
-	switch x := m.OutputSinkType.(type) {
-	case *OutputSink_StreamingAdmin:
-		_ = b.EncodeVarint(2<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.StreamingAdmin); err != nil {
-			return err
-		}
-	case *OutputSink_FilePerTap:
-		_ = b.EncodeVarint(3<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.FilePerTap); err != nil {
-			return err
-		}
-	case *OutputSink_StreamingGrpc:
-		_ = b.EncodeVarint(4<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.StreamingGrpc); err != nil {
-			return err
-		}
-	case nil:
-	default:
-		return fmt.Errorf("OutputSink.OutputSinkType has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _OutputSink_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*OutputSink)
-	switch tag {
-	case 2: // output_sink_type.streaming_admin
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(StreamingAdminSink)
-		err := b.DecodeMessage(msg)
-		m.OutputSinkType = &OutputSink_StreamingAdmin{msg}
-		return true, err
-	case 3: // output_sink_type.file_per_tap
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(FilePerTapSink)
-		err := b.DecodeMessage(msg)
-		m.OutputSinkType = &OutputSink_FilePerTap{msg}
-		return true, err
-	case 4: // output_sink_type.streaming_grpc
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(StreamingGrpcSink)
-		err := b.DecodeMessage(msg)
-		m.OutputSinkType = &OutputSink_StreamingGrpc{msg}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _OutputSink_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*OutputSink)
-	// output_sink_type
-	switch x := m.OutputSinkType.(type) {
-	case *OutputSink_StreamingAdmin:
-		s := proto.Size(x.StreamingAdmin)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *OutputSink_FilePerTap:
-		s := proto.Size(x.FilePerTap)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *OutputSink_StreamingGrpc:
-		s := proto.Size(x.StreamingGrpc)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 // Streaming admin sink configuration.

--- a/pkg/api/envoy/service/tap/v3alpha/tap.pb.go
+++ b/pkg/api/envoy/service/tap/v3alpha/tap.pb.go
@@ -27,7 +27,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // [#not-implemented-hide:] Stream message for the Tap API. Envoy will open a stream to the server
 // and stream taps without ever expecting a response.

--- a/pkg/api/envoy/service/tap/v3alpha/tapds.pb.go
+++ b/pkg/api/envoy/service/tap/v3alpha/tapds.pb.go
@@ -27,7 +27,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // [#not-implemented-hide:] A tap resource is essentially a tap configuration with a name
 // The filter TapDS config references this name.

--- a/pkg/api/envoy/service/trace/v2/trace_service.pb.go
+++ b/pkg/api/envoy/service/trace/v2/trace_service.pb.go
@@ -28,7 +28,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 type StreamTracesResponse struct {
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`

--- a/pkg/api/envoy/service/trace/v3alpha/trace_service.pb.go
+++ b/pkg/api/envoy/service/trace/v3alpha/trace_service.pb.go
@@ -28,7 +28,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 type StreamTracesResponse struct {
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`

--- a/pkg/api/envoy/type/http_status.pb.go
+++ b/pkg/api/envoy/type/http_status.pb.go
@@ -21,7 +21,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // HTTP response codes supported in Envoy.
 // For more details: https://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml

--- a/pkg/api/envoy/type/matcher/metadata.pb.go
+++ b/pkg/api/envoy/type/matcher/metadata.pb.go
@@ -21,7 +21,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // MetadataMatcher provides a general interface to check if a given value is matched in
 // :ref:`Metadata <envoy_api_msg_core.Metadata>`. It uses `filter` and `path` to retrieve the value
@@ -218,55 +218,11 @@ func (m *MetadataMatcher_PathSegment) GetKey() string {
 	return ""
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*MetadataMatcher_PathSegment) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _MetadataMatcher_PathSegment_OneofMarshaler, _MetadataMatcher_PathSegment_OneofUnmarshaler, _MetadataMatcher_PathSegment_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*MetadataMatcher_PathSegment) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*MetadataMatcher_PathSegment_Key)(nil),
 	}
-}
-
-func _MetadataMatcher_PathSegment_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*MetadataMatcher_PathSegment)
-	// segment
-	switch x := m.Segment.(type) {
-	case *MetadataMatcher_PathSegment_Key:
-		_ = b.EncodeVarint(1<<3 | proto.WireBytes)
-		_ = b.EncodeStringBytes(x.Key)
-	case nil:
-	default:
-		return fmt.Errorf("MetadataMatcher_PathSegment.Segment has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _MetadataMatcher_PathSegment_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*MetadataMatcher_PathSegment)
-	switch tag {
-	case 1: // segment.key
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeStringBytes()
-		m.Segment = &MetadataMatcher_PathSegment_Key{x}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _MetadataMatcher_PathSegment_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*MetadataMatcher_PathSegment)
-	// segment
-	switch x := m.Segment.(type) {
-	case *MetadataMatcher_PathSegment_Key:
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(len(x.Key)))
-		n += len(x.Key)
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 func init() {

--- a/pkg/api/envoy/type/matcher/number.pb.go
+++ b/pkg/api/envoy/type/matcher/number.pb.go
@@ -23,7 +23,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // Specifies the way to match a double value.
 type DoubleMatcher struct {
@@ -106,73 +106,12 @@ func (m *DoubleMatcher) GetExact() float64 {
 	return 0
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*DoubleMatcher) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _DoubleMatcher_OneofMarshaler, _DoubleMatcher_OneofUnmarshaler, _DoubleMatcher_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*DoubleMatcher) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*DoubleMatcher_Range)(nil),
 		(*DoubleMatcher_Exact)(nil),
 	}
-}
-
-func _DoubleMatcher_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*DoubleMatcher)
-	// match_pattern
-	switch x := m.MatchPattern.(type) {
-	case *DoubleMatcher_Range:
-		_ = b.EncodeVarint(1<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.Range); err != nil {
-			return err
-		}
-	case *DoubleMatcher_Exact:
-		_ = b.EncodeVarint(2<<3 | proto.WireFixed64)
-		_ = b.EncodeFixed64(math.Float64bits(x.Exact))
-	case nil:
-	default:
-		return fmt.Errorf("DoubleMatcher.MatchPattern has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _DoubleMatcher_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*DoubleMatcher)
-	switch tag {
-	case 1: // match_pattern.range
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(_type.DoubleRange)
-		err := b.DecodeMessage(msg)
-		m.MatchPattern = &DoubleMatcher_Range{msg}
-		return true, err
-	case 2: // match_pattern.exact
-		if wire != proto.WireFixed64 {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeFixed64()
-		m.MatchPattern = &DoubleMatcher_Exact{math.Float64frombits(x)}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _DoubleMatcher_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*DoubleMatcher)
-	// match_pattern
-	switch x := m.MatchPattern.(type) {
-	case *DoubleMatcher_Range:
-		s := proto.Size(x.Range)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *DoubleMatcher_Exact:
-		n += 1 // tag and wire
-		n += 8
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 func init() {

--- a/pkg/api/envoy/type/matcher/regex.pb.go
+++ b/pkg/api/envoy/type/matcher/regex.pb.go
@@ -22,7 +22,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // A regex matcher designed for safety when used with untrusted input.
 type RegexMatcher struct {
@@ -102,59 +102,11 @@ func (m *RegexMatcher) GetRegex() string {
 	return ""
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*RegexMatcher) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _RegexMatcher_OneofMarshaler, _RegexMatcher_OneofUnmarshaler, _RegexMatcher_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*RegexMatcher) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*RegexMatcher_GoogleRe2)(nil),
 	}
-}
-
-func _RegexMatcher_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*RegexMatcher)
-	// engine_type
-	switch x := m.EngineType.(type) {
-	case *RegexMatcher_GoogleRe2:
-		_ = b.EncodeVarint(1<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.GoogleRe2); err != nil {
-			return err
-		}
-	case nil:
-	default:
-		return fmt.Errorf("RegexMatcher.EngineType has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _RegexMatcher_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*RegexMatcher)
-	switch tag {
-	case 1: // engine_type.google_re2
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(RegexMatcher_GoogleRE2)
-		err := b.DecodeMessage(msg)
-		m.EngineType = &RegexMatcher_GoogleRe2{msg}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _RegexMatcher_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*RegexMatcher)
-	// engine_type
-	switch x := m.EngineType.(type) {
-	case *RegexMatcher_GoogleRe2:
-		s := proto.Size(x.GoogleRe2)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 // Google's `RE2 <https://github.com/google/re2>`_ regex engine. The regex string must adhere to

--- a/pkg/api/envoy/type/matcher/string.pb.go
+++ b/pkg/api/envoy/type/matcher/string.pb.go
@@ -21,7 +21,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // Specifies the way to match a string.
 type StringMatcher struct {
@@ -141,119 +141,15 @@ func (m *StringMatcher) GetSafeRegex() *RegexMatcher {
 	return nil
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*StringMatcher) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _StringMatcher_OneofMarshaler, _StringMatcher_OneofUnmarshaler, _StringMatcher_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*StringMatcher) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*StringMatcher_Exact)(nil),
 		(*StringMatcher_Prefix)(nil),
 		(*StringMatcher_Suffix)(nil),
 		(*StringMatcher_Regex)(nil),
 		(*StringMatcher_SafeRegex)(nil),
 	}
-}
-
-func _StringMatcher_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*StringMatcher)
-	// match_pattern
-	switch x := m.MatchPattern.(type) {
-	case *StringMatcher_Exact:
-		_ = b.EncodeVarint(1<<3 | proto.WireBytes)
-		_ = b.EncodeStringBytes(x.Exact)
-	case *StringMatcher_Prefix:
-		_ = b.EncodeVarint(2<<3 | proto.WireBytes)
-		_ = b.EncodeStringBytes(x.Prefix)
-	case *StringMatcher_Suffix:
-		_ = b.EncodeVarint(3<<3 | proto.WireBytes)
-		_ = b.EncodeStringBytes(x.Suffix)
-	case *StringMatcher_Regex:
-		_ = b.EncodeVarint(4<<3 | proto.WireBytes)
-		_ = b.EncodeStringBytes(x.Regex)
-	case *StringMatcher_SafeRegex:
-		_ = b.EncodeVarint(5<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.SafeRegex); err != nil {
-			return err
-		}
-	case nil:
-	default:
-		return fmt.Errorf("StringMatcher.MatchPattern has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _StringMatcher_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*StringMatcher)
-	switch tag {
-	case 1: // match_pattern.exact
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeStringBytes()
-		m.MatchPattern = &StringMatcher_Exact{x}
-		return true, err
-	case 2: // match_pattern.prefix
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeStringBytes()
-		m.MatchPattern = &StringMatcher_Prefix{x}
-		return true, err
-	case 3: // match_pattern.suffix
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeStringBytes()
-		m.MatchPattern = &StringMatcher_Suffix{x}
-		return true, err
-	case 4: // match_pattern.regex
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeStringBytes()
-		m.MatchPattern = &StringMatcher_Regex{x}
-		return true, err
-	case 5: // match_pattern.safe_regex
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(RegexMatcher)
-		err := b.DecodeMessage(msg)
-		m.MatchPattern = &StringMatcher_SafeRegex{msg}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _StringMatcher_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*StringMatcher)
-	// match_pattern
-	switch x := m.MatchPattern.(type) {
-	case *StringMatcher_Exact:
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(len(x.Exact)))
-		n += len(x.Exact)
-	case *StringMatcher_Prefix:
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(len(x.Prefix)))
-		n += len(x.Prefix)
-	case *StringMatcher_Suffix:
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(len(x.Suffix)))
-		n += len(x.Suffix)
-	case *StringMatcher_Regex:
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(len(x.Regex)))
-		n += len(x.Regex)
-	case *StringMatcher_SafeRegex:
-		s := proto.Size(x.SafeRegex)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 // Specifies a list of ways to match a string.

--- a/pkg/api/envoy/type/matcher/value.pb.go
+++ b/pkg/api/envoy/type/matcher/value.pb.go
@@ -21,7 +21,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // Specifies the way to match a ProtobufWkt::Value. Primitive values and ListValue are supported.
 // StructValue is not supported and is always not matched.
@@ -155,9 +155,9 @@ func (m *ValueMatcher) GetListMatch() *ListMatcher {
 	return nil
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*ValueMatcher) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _ValueMatcher_OneofMarshaler, _ValueMatcher_OneofUnmarshaler, _ValueMatcher_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*ValueMatcher) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*ValueMatcher_NullMatch_)(nil),
 		(*ValueMatcher_DoubleMatch)(nil),
 		(*ValueMatcher_StringMatch)(nil),
@@ -165,142 +165,6 @@ func (*ValueMatcher) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) 
 		(*ValueMatcher_PresentMatch)(nil),
 		(*ValueMatcher_ListMatch)(nil),
 	}
-}
-
-func _ValueMatcher_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*ValueMatcher)
-	// match_pattern
-	switch x := m.MatchPattern.(type) {
-	case *ValueMatcher_NullMatch_:
-		_ = b.EncodeVarint(1<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.NullMatch); err != nil {
-			return err
-		}
-	case *ValueMatcher_DoubleMatch:
-		_ = b.EncodeVarint(2<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.DoubleMatch); err != nil {
-			return err
-		}
-	case *ValueMatcher_StringMatch:
-		_ = b.EncodeVarint(3<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.StringMatch); err != nil {
-			return err
-		}
-	case *ValueMatcher_BoolMatch:
-		t := uint64(0)
-		if x.BoolMatch {
-			t = 1
-		}
-		_ = b.EncodeVarint(4<<3 | proto.WireVarint)
-		_ = b.EncodeVarint(t)
-	case *ValueMatcher_PresentMatch:
-		t := uint64(0)
-		if x.PresentMatch {
-			t = 1
-		}
-		_ = b.EncodeVarint(5<<3 | proto.WireVarint)
-		_ = b.EncodeVarint(t)
-	case *ValueMatcher_ListMatch:
-		_ = b.EncodeVarint(6<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.ListMatch); err != nil {
-			return err
-		}
-	case nil:
-	default:
-		return fmt.Errorf("ValueMatcher.MatchPattern has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _ValueMatcher_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*ValueMatcher)
-	switch tag {
-	case 1: // match_pattern.null_match
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(ValueMatcher_NullMatch)
-		err := b.DecodeMessage(msg)
-		m.MatchPattern = &ValueMatcher_NullMatch_{msg}
-		return true, err
-	case 2: // match_pattern.double_match
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(DoubleMatcher)
-		err := b.DecodeMessage(msg)
-		m.MatchPattern = &ValueMatcher_DoubleMatch{msg}
-		return true, err
-	case 3: // match_pattern.string_match
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(StringMatcher)
-		err := b.DecodeMessage(msg)
-		m.MatchPattern = &ValueMatcher_StringMatch{msg}
-		return true, err
-	case 4: // match_pattern.bool_match
-		if wire != proto.WireVarint {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeVarint()
-		m.MatchPattern = &ValueMatcher_BoolMatch{x != 0}
-		return true, err
-	case 5: // match_pattern.present_match
-		if wire != proto.WireVarint {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeVarint()
-		m.MatchPattern = &ValueMatcher_PresentMatch{x != 0}
-		return true, err
-	case 6: // match_pattern.list_match
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(ListMatcher)
-		err := b.DecodeMessage(msg)
-		m.MatchPattern = &ValueMatcher_ListMatch{msg}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _ValueMatcher_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*ValueMatcher)
-	// match_pattern
-	switch x := m.MatchPattern.(type) {
-	case *ValueMatcher_NullMatch_:
-		s := proto.Size(x.NullMatch)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *ValueMatcher_DoubleMatch:
-		s := proto.Size(x.DoubleMatch)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *ValueMatcher_StringMatch:
-		s := proto.Size(x.StringMatch)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *ValueMatcher_BoolMatch:
-		n += 1 // tag and wire
-		n += 1
-	case *ValueMatcher_PresentMatch:
-		n += 1 // tag and wire
-		n += 1
-	case *ValueMatcher_ListMatch:
-		s := proto.Size(x.ListMatch)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 // NullMatch is an empty message to specify a null value.
@@ -412,59 +276,11 @@ func (m *ListMatcher) GetOneOf() *ValueMatcher {
 	return nil
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*ListMatcher) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _ListMatcher_OneofMarshaler, _ListMatcher_OneofUnmarshaler, _ListMatcher_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*ListMatcher) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*ListMatcher_OneOf)(nil),
 	}
-}
-
-func _ListMatcher_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*ListMatcher)
-	// match_pattern
-	switch x := m.MatchPattern.(type) {
-	case *ListMatcher_OneOf:
-		_ = b.EncodeVarint(1<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.OneOf); err != nil {
-			return err
-		}
-	case nil:
-	default:
-		return fmt.Errorf("ListMatcher.MatchPattern has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _ListMatcher_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*ListMatcher)
-	switch tag {
-	case 1: // match_pattern.one_of
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(ValueMatcher)
-		err := b.DecodeMessage(msg)
-		m.MatchPattern = &ListMatcher_OneOf{msg}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _ListMatcher_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*ListMatcher)
-	// match_pattern
-	switch x := m.MatchPattern.(type) {
-	case *ListMatcher_OneOf:
-		s := proto.Size(x.OneOf)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 func init() {

--- a/pkg/api/envoy/type/percent.pb.go
+++ b/pkg/api/envoy/type/percent.pb.go
@@ -22,7 +22,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // Fraction percentages support several fixed denominator values.
 type FractionalPercent_DenominatorType int32

--- a/pkg/api/envoy/type/range.pb.go
+++ b/pkg/api/envoy/type/range.pb.go
@@ -21,7 +21,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // Specifies the int64 start and end of the range using half-open interval semantics [start,
 // end).


### PR DESCRIPTION
## Description

This moves all of the Envoy build stuff to be in a `cxx/` directory.  It places the binaries in `bin_linux_amd64/` instead of in `envoy-bin/`.  Other than renaming things, there should be no functional changes.

I updated `BUILDING.md` with the new paths.

This is against a branch that does not include Rafi's build-system PR (not master), but I expect it to make its way to master today or Monday.

The intent is that by taking the Envoy-related functionality out of `Makefile` and putting it in an `cxx/envoy.mk`, I can have something that is known to work in order to integrate it with the new build system.

(Also, a few `.go` files in the `./envoy-src/` checkout were confusing Go, so adding a `cxx/go.mod` that says `module ignore` helps out there.)

## Testing

I verified that I could build Envoy with this arrangement, and have bumped BASE_ENVOY_RELVER to `6`.