### PR TITLE
[legacy-build] Makefile: Use go-mod.mk

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,17 +13,13 @@ VERSION.py
 .pytest_cache
 .mypy_cache
 cluster.yaml
-watt
-/kubestatus
-kat_client
-teleproxy
-kat/kat/client
 /.docker_port_forward
 
 # binaries
-/cmd/ambex/ambex
 /bin_*/
 
+/build/kat/client/kat_client
+/build/kat/client/teleproxy
 /build/kat/server/kat-server
 /tools/sandbox/grpc_auth/docker-compose.yml
 /tools/sandbox/grpc_web/docker-compose.yaml
@@ -54,8 +50,6 @@ unused-e2e
 
 /vendor/
 
-/ambex
-
 .forge
 forge.yaml
 
@@ -83,6 +77,11 @@ kubernaut-claim.txt
 # Remove the tail of this list when the commit making the change gets
 # far enough in to the past.
 
+# 2019-10-13
+/ambex
+/kubestatus
+/watt
+/cmd/ambex/ambex
 # 2019-10-11
 /envoy-src/
 /envoy-bin/
@@ -101,3 +100,5 @@ kubernaut-claim.txt
 /unused-e2e/*/k8s/ambassador-deployment*.yaml
 # 2019-06-14
 /envoy/
+# 2019-04-05 0388efe75c16540c71223320596accbbe3fe6ac2
+/kat/kat/client

--- a/Dockerfile
+++ b/Dockerfile
@@ -103,14 +103,7 @@ COPY python/post_update.py .
 COPY python/watch_hook.py .
 RUN chmod 755 entrypoint.sh grab-snapshots.py kick_ads.sh kubewatch.py post_update.py watch_hook.py
 
-COPY cmd/ambex/ambex /usr/bin/
-RUN chmod 755 /usr/bin/ambex
-COPY bin_linux_amd64/kubectl /usr/bin/
-# XXX Move to base image
-COPY watt .
-RUN chmod 755 watt
-COPY kubestatus .
-RUN chmod 755 kubestatus
+COPY bin_linux_amd64/ambex bin_linux_amd64/kubestatus bin_linux_amd64/watt bin_linux_amd64/kubectl /usr/local/bin/
 
 RUN setcap 'cap_net_bind_service=+ep' /usr/local/bin/envoy
 ENTRYPOINT [ "./entrypoint.sh" ]

--- a/build-aux/go-mod.mk
+++ b/build-aux/go-mod.mk
@@ -6,6 +6,7 @@
 #  - File: ./go.mod
 #  - Variable: go.DISABLE_GO_TEST ?=
 #  - Variable: go.PLATFORMS ?= $(GOOS)_$(GOARCH)
+#  - Variable: go.bins.extra ?=
 #
 ## Lazy inputs ##
 #  - Variable: go.GOBUILD ?= go build
@@ -69,6 +70,7 @@ go.DISABLE_GO_TEST ?=
 go.LDFLAGS ?=
 go.PLATFORMS ?= $(GOOS)_$(GOARCH)
 go.GOLANG_LINT_FLAGS ?= $(if $(wildcard .golangci.yml .golangci.toml .golangci.json),,--disable-all --enable=gofmt --enable=govet)
+go.bins.extra ?=
 CI ?=
 
 #
@@ -120,7 +122,7 @@ endif
   # With pruning sub-module packages (qualified)
     # Usage: $(call go.list,ARGS)
     go.list = $(call path.addprefix,$(go.module),$(_go.list))
-    go.bins := $(call go.list,-f='{{if eq .Name "main"}}{{.ImportPath}}{{end}}' $(addprefix ./,$(_go.pkgs)))
+    go.bins := $(call go.list,-f='{{if eq .Name "main"}}{{.ImportPath}}{{end}}' $(addprefix ./,$(_go.pkgs))) $(go.bins.extra)
 
 go.pkgs ?= ./...
 

--- a/python/ambassador_diag/diagd.py
+++ b/python/ambassador_diag/diagd.py
@@ -976,7 +976,7 @@ class AmbassadorEventWatcher(threading.Thread):
                 with open(f'/tmp/kstat-{kind}-{name}', 'w') as out:
                     out.write(text)
 
-                cmd = [ '/ambassador/kubestatus', kind, '-f', f'metadata.name={name}', '-n', namespace, '-u', '/dev/fd/0' ]
+                cmd = [ 'kubestatus', kind, '-f', f'metadata.name={name}', '-n', namespace, '-u', '/dev/fd/0' ]
                 self.logger.info(f"Running command: {cmd}")
 
                 try:

--- a/python/entrypoint.sh
+++ b/python/entrypoint.sh
@@ -389,7 +389,7 @@ if [[ -z "${AMBASSADOR_NO_KUBEWATCH}" ]]; then
 	    AMBASSADOR_LABEL_SELECTOR_ARG="--labels $AMBASSADOR_LABEL_SELECTOR"
     fi
 
-    launch "watt" /ambassador/watt \
+    launch "watt" watt \
            --port 8002 \
            ${AMBASSADOR_SINGLE_NAMESPACE:+ --namespace "${AMBASSADOR_NAMESPACE}" } \
            --notify 'python /ambassador/post_update.py --watt ' \

--- a/python/tests/t_ingress.py
+++ b/python/tests/t_ingress.py
@@ -1,9 +1,11 @@
 import json
+import os
 import subprocess
 
 from kat.harness import Query
 from abstract_tests import AmbassadorTest, HTTP, ServiceType
 
+kubestatus = f"../bin_{os.environ['GOHOSTOS']}_{os.environ['GOHOSTARCH']}/kubestatus"
 
 class IngressStatusTest1(AmbassadorTest):
     status_update = {
@@ -40,7 +42,7 @@ spec:
     def queries(self):
         text = json.dumps(self.status_update)
 
-        update_cmd = ['../kubestatus', 'Service', '-f', f'metadata.name={self.name.k8s}', '-u', '/dev/fd/0']
+        update_cmd = [kubestatus, 'Service', '-f', f'metadata.name={self.name.k8s}', '-u', '/dev/fd/0']
         subprocess.run(update_cmd, input=text.encode('utf-8'), timeout=5)
 
         yield Query(self.url(self.name + "/"))
@@ -95,7 +97,7 @@ spec:
     def queries(self):
         text = json.dumps(self.status_update)
 
-        update_cmd = ['../kubestatus', 'Service', '-f', f'metadata.name={self.name.k8s}', '-u', '/dev/fd/0']
+        update_cmd = [kubestatus, 'Service', '-f', f'metadata.name={self.name.k8s}', '-u', '/dev/fd/0']
         subprocess.run(update_cmd, input=text.encode('utf-8'), timeout=5)
 
         yield Query(self.url(self.name + "/"))
@@ -155,7 +157,7 @@ spec:
     def queries(self):
         text = json.dumps(self.status_update)
 
-        update_cmd = ['../kubestatus', 'Service', '-f', f'metadata.name={self.name.k8s}', '-u', '/dev/fd/0']
+        update_cmd = [kubestatus, 'Service', '-f', f'metadata.name={self.name.k8s}', '-u', '/dev/fd/0']
         subprocess.run(update_cmd, input=text.encode('utf-8'), timeout=5)
 
         yield Query(self.url(self.name + "/"))


### PR DESCRIPTION
## Description

Switch the Makefile over to using `go-mod.mk`, and have the Dockerfile copy files in from `bin_linux_amd64/`.

 1. Reducing the amount of cruft in the `Makefile` that I need to read through.
 2. Moving toward a saner file layout in the final Docker image.