### PR TITLE
Don't rely on realpath when we really needn't.

### DIFF
--- a/builder/builder.sh
+++ b/builder/builder.sh
@@ -58,7 +58,7 @@ sync() {
     sourcedir=$2
     container=$3
 
-    real=$(realpath ${sourcedir})
+    real=$(cd ${sourcedir}; pwd)
 
     docker exec -i ${container} mkdir -p /buildroot/${name}
     summarize-sync $name $container $(rsync --exclude-from=${DIR}/sync-excludes.txt --info=name -a --delete -e 'docker exec -i' ${real}/ ${container}:/buildroot/${name})


### PR DESCRIPTION
We can use the `$(cd ...; pwd)` for a bit more portability, especially in the face of Apple's stubbornness about updating `bash`... 😛 