### PR TITLE
port over tls module fields to tlscontext

### DIFF
--- a/python/schemas/v1/TLSContext.schema
+++ b/python/schemas/v1/TLSContext.schema
@@ -27,7 +27,8 @@
         "max_tls_version": { "enum": [ "v1.0", "v1.1", "v1.2", "v1.3" ] },
         "cipher_suites": { "type": "array", "items": { "type": "string" }  },
         "ecdh_curves": { "type": "array", "items": { "type": "string" }  },
-        "secret_namespacing": { "type": "boolean" }
+        "secret_namespacing": { "type": "boolean" },
+        "redirect_cleartext_from": { "type": "integer" }
     },
     "required": [ "apiVersion", "kind", "name" ],
     "additionalProperties": false


### PR DESCRIPTION
#  Description

this commit adds in all fields documented in: `docs/reference/core/tls.md` into TlsContext, it turns out this was only missing redirect_cleartext_from. however I want to make it clear this should be all of them at this point. So TlsContext should be the thing that is used from this point forward.

## Related Issues

#1125 

## Testing

- I've added: `redirect_cleartext_from` to the Tls tests, this should validate that it doesn't affect people using https directly. Than I added a test to make sure when manually requesting http you get a redirect.

## Todos
- [x] Tests
- [x] Documentation (N/A)

