### PR TITLE
Docs: fix broken link to filter reference

### DIFF
--- a/docs/user-guide/oauth-oidc-auth.md
+++ b/docs/user-guide/oauth-oidc-auth.md
@@ -97,4 +97,4 @@ Create a separate `FilterPolicy` that specifies which specific filters are appli
 
 ## Further reading
 
-The [filter reference](/reference/filter-reference) covers the specifics of filters and filter policies in much more detail.
+The [filter reference](/docs/reference/filter-reference.md) covers the specifics of filters and filter policies in much more detail.


### PR DESCRIPTION
## Description
Fixes a broken link in the docs.

Preview: https://github.com/danihodovic/ambassador/blob/docs/fix-broken-link/docs/user-guide/oauth-oidc-auth.md#further-reading

## Related Issues
List related issues.

## Testing
A few sentences describing what testing you've done, e.g., manual tests, automated tests, deployed in production, etc.

## Todos
- [ ] Tests
- [ ] Documentation

## Other
* If this is a documentation change, please open the pull request at https://github.com/datawire/ambassador-docs instead.
* Code changes should occur against `master`.
