### PR TITLE
Pin to zipkin :2.17 instead of :latest

### DIFF
--- a/python/tests/t_tracing.py
+++ b/python/tests/t_tracing.py
@@ -50,7 +50,7 @@ spec:
     spec:
       containers:
       - name: zipkin
-        image: openzipkin/zipkin
+        image: openzipkin/zipkin:2.17
         imagePullPolicy: Always
         ports:
         - name: http
@@ -159,7 +159,7 @@ spec:
     spec:
       containers:
       - name: zipkin
-        image: openzipkin/zipkin
+        image: openzipkin/zipkin:2.17
         imagePullPolicy: Always
         ports:
         - name: http
@@ -250,7 +250,7 @@ spec:
     spec:
       containers:
       - name: zipkin-auth
-        image: openzipkin/zipkin
+        image: openzipkin/zipkin:2.17
         imagePullPolicy: Always
         ports:
         - name: http

--- a/test/attic/1-parallel/015-tracing/k8s/zipkin.yaml
+++ b/test/attic/1-parallel/015-tracing/k8s/zipkin.yaml
@@ -27,7 +27,7 @@ spec:
     spec:
       containers:
       - name: zipkin
-        image: openzipkin/zipkin
+        image: openzipkin/zipkin:2.17
         imagePullPolicy: Always
         ports:
         - name: http

--- a/tools/sandbox/grpc_auth/docker-compose.yml.in
+++ b/tools/sandbox/grpc_auth/docker-compose.yml.in
@@ -45,7 +45,7 @@ services:
       - "61595:80"
   
   zipkin:
-    image: openzipkin/zipkin:latest
+    image: openzipkin/zipkin:2.17
     networks:
       ambassador:
         aliases:

--- a/tools/sandbox/http_auth/docker-compose.yml.in
+++ b/tools/sandbox/http_auth/docker-compose.yml.in
@@ -46,7 +46,7 @@ services:
       - "61595:80"
 
   zipkin:
-    image: openzipkin/zipkin:latest
+    image: openzipkin/zipkin:2.17
     networks:
       ambassador:
         aliases:


### PR DESCRIPTION
zipkin is shipping a broken busybox binary that is 32-bit but
occasionally makes a 64-bit system call, but then dies when the Linux
kernel gives back a 64-bit response instead of a 32-bit response:

    ~ $ ls
    ls: can't open '.': Value too large for defined data type

The busybox people seem to think it's a uclibc bug:
https://bugs.busybox.net/show_bug.cgi?id=11651

The above happens in Kubernaut, which is using a fairly old kernel.  On a
modern 5.3 kernel, it somehow figures out that busybox really wants a
32-bit response, because Linus' mantra is We Never Blame Userspace™, so
they figured out a way to make the "broken" binary work anyway.

Now, we don't get to benefit from that in Kubernaut, so pin to an older
version of zipkin.  The older version still has a broken busybox, but
the ENTRYPOINT script just happens to not call any of the broken commands.

This is an issue now, because :latest was bumped earlier today.