### PR TITLE
Increase default regex_max_size to 200

### DIFF
--- a/python/ambassador/envoy/v2/v2route.py
+++ b/python/ambassador/envoy/v2/v2route.py
@@ -33,7 +33,7 @@ def regex_matcher(config: 'V2Config', regex: str, key="regex", safe_key=None) ->
         # 'safe' is the default. You must explicitly say "unsafe" to get the unsafe
         # regex matcher.
         if re_type != 'unsafe':
-            max_size = int(config.ir.ambassador_module.get('regex_max_size', 100))
+            max_size = int(config.ir.ambassador_module.get('regex_max_size', 200))
 
             if not safe_key:
                 safe_key = "safe_" + key


### PR DESCRIPTION
The regex that we generate for the simplest knative service has
an RE2 maximum size of more than 100, which is Envoy's default.
This causes Ambassador to either crash or ignore the new config.

This commit increases the default regex_max_size to 150 which
should be enough for our generated regex.