### PR TITLE
Make regex_max_size in Ambassador module work

### DIFF
--- a/python/ambassador/ir/irambassador.py
+++ b/python/ambassador/ir/irambassador.py
@@ -42,6 +42,7 @@ class IRAmbassador (IRResource):
         'load_balancer',
         'readiness_probe',
         'regex_type',
+        'regex_max_size',
         'resolver',
         'debug_mode',
         'server_name',


### PR DESCRIPTION
Without this entry it does not work and it defaults to 100.