### PR TITLE
travis-cleanup.sh: Fix for the Brave New builder World?

### DIFF
--- a/releng/travis-cleanup.sh
+++ b/releng/travis-cleanup.sh
@@ -18,30 +18,6 @@ set -o errexit
 set -o nounset
 
 printf "== Begin: travis-cleanup.sh ==\n"
+set -o xtrace
 
-#eval $(make export-vars)
-
-echo "GIT_BRANCH ${GIT_BRANCH}"
-echo "CI_DEBUG_KAT_BRANCH ${CI_DEBUG_KAT_BRANCH}"
-
-teardown=yes
-
-if [ \( -n "$CI_DEBUG_KAT_BRANCH" \) ]; then
-	if [ "$GIT_BRANCH" = "$CI_DEBUG_KAT_BRANCH" ]; then
-		echo "Leaving Kat cluster intact for debugging:"
-		echo "===="
-		kubectl cluster-info
-        echo "==== DEV_KUBECONFIG ===="
-	    gzip -9 < ${DEV_KUBECONFIG} | base64
-		
-		teardown=
-	else
-		echo "Not running on debug branch ${CI_DEBUG_KAT_BRANCH}"
-	fi
-else
-	echo "No debug branch is set"
-fi
-
-if [ -n "$teardown" ]; then
-    kubernaut claims delete $(cat ~/kubernaut-claim.txt)
-fi
+kubernaut claims delete $(cat ~/kubernaut-claim.txt)


### PR DESCRIPTION
Because `eval $(make export-vars)` is commented out in `travis-cleanup.sh`, `$GIT_BRANCH` isn't set, so nounset triggers, then errexit triggers, then `kubernaut claims delete` never runs.

And then it fills up the kubernaut pool, and we have to wait for claims to time out.

Resolve the situation by greatly simplifying `travis-cleanup.sh`.