### PR TITLE
Error on Multiple Redirects

### DIFF
--- a/python/ambassador/envoy/v2/v2listener.py
+++ b/python/ambassador/envoy/v2/v2listener.py
@@ -269,7 +269,7 @@ def v2filter_authv1(auth: IRAuth, v2config: 'V2Config'):
         if auth.get('add_linkerd_headers', False):
             svc = Service(auth.ir.logger, auth_cluster_uri(auth, cluster))
             headers_to_add.append({
-                'key' : 'l5d-dst-override', 
+                'key' : 'l5d-dst-override',
                 'value': svc.hostname_port
             })
 
@@ -321,7 +321,7 @@ def v2filter_authv1(auth: IRAuth, v2config: 'V2Config'):
 
         if 'failure_mode_allow' in auth:
             auth_info['config']["failure_mode_allow"] = auth.failure_mode_allow
-        
+
         if 'status_on_error' in auth:
             status_on_error: Optional[Dict[str, int]] = auth.get('status_on_error')
             auth_info['config']["status_on_error"] = status_on_error

--- a/python/ambassador/ir/irtlscontext.py
+++ b/python/ambassador/ir/irtlscontext.py
@@ -66,8 +66,11 @@ class IRTLSContext(IRResource):
         self.ecdh_curves = config.get('ecdh_curves')
         self.secret_namespacing = config.get('secret_namespacing', None)
 
-        rcf = config.get('redirect_cleartext_from')
+        # Assume that we have no redirect_cleartext_from...
+        self.redirect_cleartext_from = None
 
+        # Then override if actually an int.
+        rcf = config.get('redirect_cleartext_from')
         if rcf is not None:
             try:
                 self.redirect_cleartext_from = int(rcf)

--- a/python/tests/t_tls.py
+++ b/python/tests/t_tls.py
@@ -650,13 +650,26 @@ redirect_cleartext_from: 8081
         num_errors = len(errors)
         assert num_errors == 3, "expected 3 errors, got {} -\n{}".format(num_errors, errors)
 
-        cert_err = errors[0]
-        pkey_err = errors[1]
-        rcf_err = errors[2]
+        errors_that_should_be_found = {
+          'TLSContext TLSContextTest-same-context-error is missing cert_chain_file': False,
+          'TLSContext TLSContextTest-same-context-error is missing private_key_file': False,
+          'TLSContext: TLSContextTest-rcf-error; configured conflicting redirect_from port: 8081': False
+        }
 
-        assert cert_err[1] == 'TLSContext TLSContextTest-same-context-error is missing cert_chain_file'
-        assert pkey_err[1] == 'TLSContext TLSContextTest-same-context-error is missing private_key_file'
-        assert rcf_err[1] == 'TLSContext: TLSContextTest-rcf-error; configured conflicting redirect_from port: 8081'
+        unknown_errors: List[str] = []
+        for err in errors:
+            text = err[1]
+
+            if text in errors_that_should_be_found:
+                errors_that_should_be_found[text] = True
+            else:
+                unknown_errors.append(f"Unexpected error {text}")
+
+        for err, found in errors_that_should_be_found.items():
+            if not found:
+                unknown_errors.append(f"Missing error {text}")
+
+        assert not unknown_errors, f"Problems with errors: {unknown_errors}"
 
         idx = 0
 

--- a/python/tests/t_tls.py
+++ b/python/tests/t_tls.py
@@ -554,6 +554,16 @@ hosts:
 - tls-context-host-1
 redirect_cleartext_from: 8080
 """)
+      # Ambassador should return and error for this configuration.
+        yield self, self.format("""
+---
+apiVersion: ambassador/v1
+kind: TLSContext
+name: {self.name}-rcf-error
+hosts:
+- tls-context-host-1
+redirect_cleartext_from: 8081
+""")
 
     def scheme(self) -> str:
         return "https"
@@ -638,13 +648,15 @@ redirect_cleartext_from: 8080
         # XXX Ew. If self.results[0].json is empty, the harness won't convert it to a response.
         errors = self.results[0].json
         num_errors = len(errors)
-        assert num_errors == 2, "expected 2 errors, got {} -\n{}".format(num_errors, errors)
+        assert num_errors == 3, "expected 3 errors, got {} -\n{}".format(num_errors, errors)
 
         cert_err = errors[0]
         pkey_err = errors[1]
+        rcf_err = errors[2]
 
         assert cert_err[1] == 'TLSContext TLSContextTest-same-context-error is missing cert_chain_file'
         assert pkey_err[1] == 'TLSContext TLSContextTest-same-context-error is missing private_key_file'
+        assert rcf_err[1] == 'TLSContext: TLSContextTest-rcf-error; configured conflicting redirect_from port: 8081'
 
         idx = 0
 

--- a/python/watch_hook.py
+++ b/python/watch_hook.py
@@ -116,6 +116,7 @@ class FakeIR(IR):
         self.saved_secrets = {}
         self.secret_info = {}
         self.k8s_status_updates = {}
+        self.redirect_cleartext_from = None
 
         self.ambassador_module = IRAmbassador(self, aconf)
 


### PR DESCRIPTION
## Description

Error when multiple redirect_cleartext_ports have been defined in tls_context's. (It's okay to technically configure the same one over and over again).

## Related Issues

#1125 

## Testing

Added some automated tests for erroring out.

## Todos
- [x] Tests
- [ ] Documentation
