### PR TITLE
Consul connect integration

### DIFF
--- a/cmd/watt/aggregator.go
+++ b/cmd/watt/aggregator.go
@@ -8,11 +8,10 @@ import (
 	"time"
 
 	"github.com/datawire/ambassador/pkg/consulwatch"
-	"github.com/datawire/ambassador/pkg/limiter"
-	"github.com/datawire/ambassador/pkg/watt"
-
 	"github.com/datawire/ambassador/pkg/k8s"
+	"github.com/datawire/ambassador/pkg/limiter"
 	"github.com/datawire/ambassador/pkg/supervisor"
+	"github.com/datawire/ambassador/pkg/watt"
 )
 
 type WatchHook func(p *supervisor.Process, snapshot string) WatchSet
@@ -25,7 +24,7 @@ type aggregator struct {
 	// Output channel used to communicate with the k8s watch manager.
 	k8sWatches chan<- []KubernetesWatchSpec
 	// Output channel used to communicate with the consul watch manager.
-	consulWatches chan<- []ConsulWatchSpec
+	consulWatches chan<- []consulwatch.ConsulWatchSpec
 	// Output channel used to communicate with the invoker.
 	snapshots chan<- string
 	// We won't consider ourselves "bootstrapped" until we hear
@@ -40,7 +39,7 @@ type aggregator struct {
 	notifyMux           sync.Mutex
 }
 
-func NewAggregator(snapshots chan<- string, k8sWatches chan<- []KubernetesWatchSpec, consulWatches chan<- []ConsulWatchSpec,
+func NewAggregator(snapshots chan<- string, k8sWatches chan<- []KubernetesWatchSpec, consulWatches chan<- []consulwatch.ConsulWatchSpec,
 	requiredKinds []string, watchHook WatchHook, limiter limiter.Limiter) *aggregator {
 	return &aggregator{
 		KubernetesEvents:    make(chan k8sEvent),

--- a/cmd/watt/consulwatchman_test.go
+++ b/cmd/watt/consulwatchman_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -137,4 +138,75 @@ func newConsulwatchmanIsolator(t *testing.T) *consulwatchmanIsolator {
 		Work: iso.watchman.Work,
 	})
 	return iso
+}
+
+func TestNewAgent_AmbassadorIDToConsulServiceName(t *testing.T) {
+	tables := []struct {
+		actual   string
+		expected string
+	}{
+		{"", "ambassador"},
+		{"ambassador", "ambassador-ambassador"},
+		{"foo-bar-team", "ambassador-foo-bar-team"},
+	}
+
+	for _, table := range tables {
+		a := newAgent(table.actual, "UNUSED", "UNUSED", nil)
+		assert.Equal(t, table.expected, a.ConsulServiceName)
+	}
+}
+
+func TestNewAgent_SecretName(t *testing.T) {
+
+	tables := []struct {
+		ambassadorID string
+		secretName   string
+		expected     string
+	}{
+		{"", "", "ambassador-consul-connect"},
+		{"foobar", "", "ambassador-foobar-consul-connect"},
+		{"foobar", "bazbot", "bazbot"},
+	}
+
+	for _, table := range tables {
+		a := newAgent(table.ambassadorID, "NAMESPACE", table.secretName, nil)
+		assert.Equal(t, table.expected, a.SecretName)
+	}
+}
+
+func TestFormatKubernetesSecretYAML(t *testing.T) {
+	certificate := "Ceci n'est pas une certificate"
+	privateKey := "Ceci n'est pas une key"
+
+	expected := `---
+kind: Secret
+apiVersion: v1
+metadata:
+    name: "IAmTheWalrus"
+type: "kubernetes.io/tls"
+data:
+    tls.crt: "Q2VjaSBuJ2VzdCBwYXMgdW5lIGNlcnRpZmljYXRl"
+    tls.key: "Q2VjaSBuJ2VzdCBwYXMgdW5lIGtleQ=="
+`
+
+	formatted := formatKubernetesSecretYAML("IAmTheWalrus", strings.Replace(certificate, "\n", "", -1), strings.Replace(privateKey, "\n", "", -1))
+	assert.Equal(t, expected, formatted)
+}
+
+func TestCreateCertificateChain(t *testing.T) {
+	tables := []struct {
+		root         string
+		leaf         string
+		intermediate []string
+		expected     string
+	}{
+		{"ROOT\n", "LEAF\n", []string{}, `LEAF
+ROOT
+`},
+	}
+
+	for _, table := range tables {
+		chain := createCertificateChain(table.root, table.leaf)
+		assert.Equal(t, table.expected, chain)
+	}
 }

--- a/cmd/watt/consulwatchman_test.go
+++ b/cmd/watt/consulwatchman_test.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"strings"
 	"testing"
 	"time"
 
@@ -14,7 +13,7 @@ import (
 )
 
 type consulwatchmanIsolator struct {
-	aggregatorToWatchmanCh        chan []ConsulWatchSpec
+	aggregatorToWatchmanCh        chan []consulwatch.ConsulWatchSpec
 	consulEndpointsToAggregatorCh chan consulwatch.Endpoints
 	watchman                      *consulwatchman
 	sup                           *supervisor.Supervisor
@@ -27,10 +26,10 @@ func TestAddAndRemoveConsulWatchers(t *testing.T) {
 	iso := startConsulwatchmanIsolator(t)
 	defer iso.Stop()
 
-	specs := []ConsulWatchSpec{
-		{ConsulAddress: "127.0.0.1", ServiceName: "foo-in-consul", Datacenter: "dc1"},
-		{ConsulAddress: "127.0.0.1", ServiceName: "bar-in-consul", Datacenter: "dc1"},
-		{ConsulAddress: "127.0.0.1", ServiceName: "baz-in-consul", Datacenter: "dc1"},
+	specs := []consulwatch.ConsulWatchSpec{
+		{ConsulAddress: "127.0.0.1", ServiceName: "foo-in-consul", Datacenter: "dc1", Secret: "secret"},
+		{ConsulAddress: "127.0.0.1", ServiceName: "bar-in-consul", Datacenter: "dc1", Secret: "secret"},
+		{ConsulAddress: "127.0.0.1", ServiceName: "baz-in-consul", Datacenter: "dc1", Secret: "secret"},
 	}
 
 	iso.aggregatorToWatchmanCh <- specs
@@ -48,9 +47,9 @@ func TestAddAndRemoveConsulWatchers(t *testing.T) {
 		assert.Equal(t, k, worker.Name)
 	}
 
-	specs = []ConsulWatchSpec{
-		{ConsulAddress: "127.0.0.1", ServiceName: "bar-in-consul", Datacenter: "dc1"},
-		{ConsulAddress: "127.0.0.1", ServiceName: "baz-in-consul", Datacenter: "dc1"},
+	specs = []consulwatch.ConsulWatchSpec{
+		{ConsulAddress: "127.0.0.1", ServiceName: "bar-in-consul", Datacenter: "dc1", Secret: "secret"},
+		{ConsulAddress: "127.0.0.1", ServiceName: "baz-in-consul", Datacenter: "dc1", Secret: "secret"},
 	}
 
 	iso.aggregatorToWatchmanCh <- specs
@@ -67,9 +66,9 @@ func TestAddAndRemoveConsulWatchers(t *testing.T) {
 		assert.Equal(t, k, worker.Name)
 	}
 
-	specs = []ConsulWatchSpec{
-		{ConsulAddress: "127.0.0.1", ServiceName: "bar-in-consul", Datacenter: "dc1"},
-		{ConsulAddress: "127.0.0.1", ServiceName: "baz-in-consul", Datacenter: "dc1"},
+	specs = []consulwatch.ConsulWatchSpec{
+		{ConsulAddress: "127.0.0.1", ServiceName: "bar-in-consul", Datacenter: "dc1", Secret: "secret"},
+		{ConsulAddress: "127.0.0.1", ServiceName: "baz-in-consul", Datacenter: "dc1", Secret: "secret"},
 	}
 
 	iso.aggregatorToWatchmanCh <- specs
@@ -111,10 +110,12 @@ func (iso *consulwatchmanIsolator) Stop() {
 
 func newConsulwatchmanIsolator(t *testing.T) *consulwatchmanIsolator {
 	iso := &consulwatchmanIsolator{
+		t: t,
+
 		// by using zero length channels for inputs here, we can
 		// control the total ordering of all inputs and therefore
 		// intentionally trigger any order of events we want to test
-		aggregatorToWatchmanCh: make(chan []ConsulWatchSpec),
+		aggregatorToWatchmanCh: make(chan []consulwatch.ConsulWatchSpec),
 
 		// we need to create buffered channels for outputs because
 		// nothing is asynchronously reading them in the test
@@ -138,75 +139,4 @@ func newConsulwatchmanIsolator(t *testing.T) *consulwatchmanIsolator {
 		Work: iso.watchman.Work,
 	})
 	return iso
-}
-
-func TestNewAgent_AmbassadorIDToConsulServiceName(t *testing.T) {
-	tables := []struct {
-		actual   string
-		expected string
-	}{
-		{"", "ambassador"},
-		{"ambassador", "ambassador-ambassador"},
-		{"foo-bar-team", "ambassador-foo-bar-team"},
-	}
-
-	for _, table := range tables {
-		a := newAgent(table.actual, "UNUSED", "UNUSED", nil)
-		assert.Equal(t, table.expected, a.ConsulServiceName)
-	}
-}
-
-func TestNewAgent_SecretName(t *testing.T) {
-
-	tables := []struct {
-		ambassadorID string
-		secretName   string
-		expected     string
-	}{
-		{"", "", "ambassador-consul-connect"},
-		{"foobar", "", "ambassador-foobar-consul-connect"},
-		{"foobar", "bazbot", "bazbot"},
-	}
-
-	for _, table := range tables {
-		a := newAgent(table.ambassadorID, "NAMESPACE", table.secretName, nil)
-		assert.Equal(t, table.expected, a.SecretName)
-	}
-}
-
-func TestFormatKubernetesSecretYAML(t *testing.T) {
-	certificate := "Ceci n'est pas une certificate"
-	privateKey := "Ceci n'est pas une key"
-
-	expected := `---
-kind: Secret
-apiVersion: v1
-metadata:
-    name: "IAmTheWalrus"
-type: "kubernetes.io/tls"
-data:
-    tls.crt: "Q2VjaSBuJ2VzdCBwYXMgdW5lIGNlcnRpZmljYXRl"
-    tls.key: "Q2VjaSBuJ2VzdCBwYXMgdW5lIGtleQ=="
-`
-
-	formatted := formatKubernetesSecretYAML("IAmTheWalrus", strings.Replace(certificate, "\n", "", -1), strings.Replace(privateKey, "\n", "", -1))
-	assert.Equal(t, expected, formatted)
-}
-
-func TestCreateCertificateChain(t *testing.T) {
-	tables := []struct {
-		root         string
-		leaf         string
-		intermediate []string
-		expected     string
-	}{
-		{"ROOT\n", "LEAF\n", []string{}, `LEAF
-ROOT
-`},
-	}
-
-	for _, table := range tables {
-		chain := createCertificateChain(table.root, table.leaf)
-		assert.Equal(t, table.expected, chain)
-	}
 }

--- a/cmd/watt/main.go
+++ b/cmd/watt/main.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/datawire/ambassador/pkg/consulwatch"
 	"github.com/datawire/ambassador/pkg/k8s"
 	"github.com/datawire/ambassador/pkg/limiter"
 	"github.com/datawire/ambassador/pkg/supervisor"
@@ -80,7 +81,7 @@ func _runWatt(cmd *cobra.Command, args []string) int {
 
 	// The aggregator sends the current consul resolver set to the
 	// consul watch manager.
-	aggregatorToConsulwatchmanCh := make(chan []ConsulWatchSpec, 100)
+	aggregatorToConsulwatchmanCh := make(chan []consulwatch.ConsulWatchSpec, 100)
 
 	// The aggregator sends the current k8s watch set to the
 	// kubernetes watch manager.

--- a/cmd/watt/testutils.go
+++ b/cmd/watt/testutils.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/datawire/ambassador/pkg/consulwatch"
 	"github.com/datawire/ambassador/pkg/k8s"
 	"github.com/datawire/ambassador/pkg/supervisor"
 )
@@ -74,8 +75,8 @@ func expect(t *testing.T, ch interface{}, values ...interface{}) {
 				if !exp(val) {
 					panic(fmt.Sprintf("predicate %d failed value %v", idx, value))
 				}
-			case func([]ConsulWatchSpec) bool:
-				val, ok := value.Interface().([]ConsulWatchSpec)
+			case func([]consulwatch.ConsulWatchSpec) bool:
+				val, ok := value.Interface().([]consulwatch.ConsulWatchSpec)
 				if !ok {
 					panic(fmt.Sprintf("expected a []ConsulWatchSpec, got %v", value.Type()))
 				}
@@ -116,7 +117,7 @@ func (m *MockWatchMaker) MakeKubernetesWatch(spec KubernetesWatchSpec) (*supervi
 		fmt.Sprintf("%s|%s|%s|%s", spec.Namespace, spec.Kind, spec.FieldSelector, spec.LabelSelector)), nil
 }
 
-func (m *MockWatchMaker) MakeConsulWatch(spec ConsulWatchSpec) (*supervisor.Worker, error) {
+func (m *MockWatchMaker) MakeConsulWatch(spec consulwatch.ConsulWatchSpec) (*supervisor.Worker, error) {
 	if m.errorBeforeCreate {
 		return nil, fmt.Errorf("failed to create watch (errorBeforeCreate: %t)", m.errorBeforeCreate)
 	}

--- a/cmd/watt/watchmaker_api.go
+++ b/cmd/watt/watchmaker_api.go
@@ -4,12 +4,13 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/datawire/ambassador/pkg/consulwatch"
 	"github.com/datawire/ambassador/pkg/supervisor"
 )
 
 type WatchSet struct {
-	KubernetesWatches []KubernetesWatchSpec `json:"kubernetes-watches"`
-	ConsulWatches     []ConsulWatchSpec     `json:"consul-watches"`
+	KubernetesWatches []KubernetesWatchSpec         `json:"kubernetes-watches"`
+	ConsulWatches     []consulwatch.ConsulWatchSpec `json:"consul-watches"`
 }
 
 // Interpolate values into specific watches in specific places. This is not a generic method but could be made one
@@ -23,9 +24,9 @@ func (w *WatchSet) interpolate() WatchSet {
 	result := WatchSet{KubernetesWatches: w.KubernetesWatches}
 
 	if w.ConsulWatches != nil {
-		modifiedConsulWatchSpecs := make([]ConsulWatchSpec, 0)
+		modifiedConsulWatchSpecs := make([]consulwatch.ConsulWatchSpec, 0)
 		for _, s := range w.ConsulWatches {
-			modifiedConsulWatchSpecs = append(modifiedConsulWatchSpecs, ConsulWatchSpec{
+			modifiedConsulWatchSpecs = append(modifiedConsulWatchSpecs, consulwatch.ConsulWatchSpec{
 				Id:            s.Id,
 				ServiceName:   s.ServiceName,
 				Datacenter:    s.Datacenter,
@@ -58,17 +59,6 @@ func (k KubernetesWatchSpec) WatchId() string {
 	return fmt.Sprintf("%s|%s|%s|%s", k.Kind, star(k.Namespace), star(k.FieldSelector), star(k.LabelSelector))
 }
 
-type ConsulWatchSpec struct {
-	Id            string `json:"id"`
-	ConsulAddress string `json:"consul-address"`
-	Datacenter    string `json:"datacenter"`
-	ServiceName   string `json:"service-name"`
-}
-
-func (c ConsulWatchSpec) WatchId() string {
-	return fmt.Sprintf("%s|%s|%s", c.ConsulAddress, c.Datacenter, c.ServiceName)
-}
-
 // IKubernetesWatchMaker is an interface for KubernetesWatchMaker implementations. It mostly exists to facilitate the
 // creation of testing mocks.
 type IKubernetesWatchMaker interface {
@@ -78,5 +68,5 @@ type IKubernetesWatchMaker interface {
 // IConsulWatchMaker is an interface for ConsulWatchMaker implementations. It mostly exists to facilitate the
 // creation of testing mocks.
 type IConsulWatchMaker interface {
-	MakeConsulWatch(spec ConsulWatchSpec) (*supervisor.Worker, error)
+	MakeConsulWatch(spec consulwatch.ConsulWatchSpec) (*supervisor.Worker, error)
 }

--- a/cmd/watt/watchmaker_api_test.go
+++ b/cmd/watt/watchmaker_api_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 
 	"github.com/bmizerany/assert"
+
+	"github.com/datawire/ambassador/pkg/consulwatch"
 )
 
 func TestWatchSet_Interpolate(t *testing.T) {
@@ -12,7 +14,7 @@ func TestWatchSet_Interpolate(t *testing.T) {
 	_ = os.Setenv("ANOTHER_IP", "172.10.0.2")
 
 	set := WatchSet{
-		ConsulWatches: []ConsulWatchSpec{
+		ConsulWatches: []consulwatch.ConsulWatchSpec{
 			{ConsulAddress: "${HOST_IP}", ServiceName: "foo-in-consul", Datacenter: "dc1"},
 			{ConsulAddress: "$ANOTHER_IP", ServiceName: "bar-in-consul", Datacenter: "dc1"},
 			{ConsulAddress: "127.0.0.1", ServiceName: "baz-in-consul", Datacenter: "dc1"},
@@ -21,14 +23,14 @@ func TestWatchSet_Interpolate(t *testing.T) {
 
 	interpolated := set.interpolate()
 	assert.Equal(t,
-		ConsulWatchSpec{ConsulAddress: "172.10.0.1", ServiceName: "foo-in-consul", Datacenter: "dc1"},
+		consulwatch.ConsulWatchSpec{ConsulAddress: "172.10.0.1", ServiceName: "foo-in-consul", Datacenter: "dc1"},
 		interpolated.ConsulWatches[0])
 
 	assert.Equal(t,
-		ConsulWatchSpec{ConsulAddress: "172.10.0.2", ServiceName: "bar-in-consul", Datacenter: "dc1"},
+		consulwatch.ConsulWatchSpec{ConsulAddress: "172.10.0.2", ServiceName: "bar-in-consul", Datacenter: "dc1"},
 		interpolated.ConsulWatches[1])
 
 	assert.Equal(t,
-		ConsulWatchSpec{ConsulAddress: "127.0.0.1", ServiceName: "baz-in-consul", Datacenter: "dc1"},
+		consulwatch.ConsulWatchSpec{ConsulAddress: "127.0.0.1", ServiceName: "baz-in-consul", Datacenter: "dc1"},
 		interpolated.ConsulWatches[2])
 }

--- a/docs/yaml/ambassador/ambassador-rbac.yaml
+++ b/docs/yaml/ambassador/ambassador-rbac.yaml
@@ -20,11 +20,14 @@ metadata:
   name: ambassador
 rules:
 - apiGroups: [""]
-  resources: [ "endpoints", "namespaces", "secrets", "services" ]
+  resources: [ "endpoints", "namespaces", "services" ]
   verbs: ["get", "list", "watch"]
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["get", "list", "watch", "create", "delete", "patch"]
 - apiGroups: [ "getambassador.io" ]
   resources: [ "*" ]
-  verbs: ["get", "list", "watch"]
+  verbs: ["get", "list", "watch", "create", "delete", "patch"]
 - apiGroups: [ "apiextensions.k8s.io" ]
   resources: [ "customresourcedefinitions" ]
   verbs: ["get", "list", "watch"]

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/Masterminds/semver v1.4.2 // indirect
 	github.com/Masterminds/sprig v2.17.1+incompatible
 	github.com/aokoli/goutils v1.1.0 // indirect
+	github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869
 	github.com/datawire/libk8s v0.0.0-20190923150809-3b461b0ee981
 	github.com/datawire/pf v0.0.0-20180510150411-31a823f9495a
 	github.com/ecodia/golang-awaitility v0.0.0-20180710094957-fb55e59708c7
@@ -19,7 +20,7 @@ require (
 	github.com/google/shlex v0.0.0-20181106134648-c34317bd91bf
 	github.com/google/uuid v1.1.1 // indirect
 	github.com/gorilla/websocket v1.4.0
-	github.com/hashicorp/consul/api v1.1.0
+	github.com/hashicorp/consul/api v1.2.0
 	github.com/huandu/xstrings v1.2.0 // indirect
 	github.com/iancoleman/strcase v0.0.0-20180726023541-3605ed457bf7
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
@@ -46,3 +47,6 @@ require (
 	k8s.io/client-go v11.0.1-0.20190816222228-6d55c1b1f1ca+incompatible
 	sigs.k8s.io/yaml v1.1.0
 )
+
+// Fix invalid pseudo-version that Go 1.13 complains about.
+replace github.com/go-critic/go-critic v0.0.0-20181204210945-1df300866540 => github.com/go-critic/go-critic v0.3.4

--- a/go.sum
+++ b/go.sum
@@ -5,6 +5,7 @@ git.lukeshu.com/go/libsystemd v0.5.3 h1:491FbFw6FUXF449cVOYtrv7p7sJRSKNldLbOU7Aj
 git.lukeshu.com/go/libsystemd v0.5.3/go.mod h1:FfDoP0i92r4p5Vn4NCLxvjkd7rCOe6otPa4L6hZg9WM=
 github.com/Azure/go-autorest v11.1.0+incompatible h1:9DfMsQdUMEtg1jKRTjtkNZsvOuZXJOMl4dN1kiQwAc8=
 github.com/Azure/go-autorest v11.1.0+incompatible/go.mod h1:r+4oMnoxhatjLLJ6zxSWATqVooLgysK6ZNox3g/xq24=
+github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/Masterminds/semver v1.4.2 h1:WBLTQ37jOCzSLtXNdoo8bNM8876KhNqOKvrlGITgsTc=
 github.com/Masterminds/semver v1.4.2/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
@@ -28,7 +29,6 @@ github.com/datawire/libk8s v0.0.0-20190923150809-3b461b0ee981 h1:2NKTcGOUo1OMwHr
 github.com/datawire/libk8s v0.0.0-20190923150809-3b461b0ee981/go.mod h1:GBLaVOglMDiCZZaxcsMaYJvcZuxtAVsUkmtn+zxTSUA=
 github.com/datawire/pf v0.0.0-20180510150411-31a823f9495a h1:VHPuM0sSTEHfjtSX86XQqZKJNUWTWVu2BuV6X8SdGUk=
 github.com/datawire/pf v0.0.0-20180510150411-31a823f9495a/go.mod h1:H8uUmE8qqo7z9u30MYB9riLyRckPHOPBk9ZdCuH+dQQ=
-github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -48,7 +48,6 @@ github.com/envoyproxy/go-control-plane v0.6.9 h1:deEH9W8ZAUGNbCdX+9iNzBOGrAOrnpJ
 github.com/envoyproxy/go-control-plane v0.6.9/go.mod h1:SBwIajubJHhxtWwsL9s8ss4safvEdbitLhGGK48rN6g=
 github.com/envoyproxy/protoc-gen-validate v0.0.15-0.20190405222122-d6164de49109 h1:U1RyeEwqO++6RvIA7bY98AcYIFPQMwrOeWNmw+dvq9w=
 github.com/envoyproxy/protoc-gen-validate v0.0.15-0.20190405222122-d6164de49109/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
-github.com/envoyproxy/protoc-gen-validate v0.1.0 h1:EQciDnbrYxy13PgWoY8AqoxGiPrpgBZ1R8UNe3ddc+A=
 github.com/evanphx/json-patch v4.2.0+incompatible h1:fUDGZCv/7iAN7u0puUVhvKCcsR6vRfwrJatElLBEf0I=
 github.com/evanphx/json-patch v4.2.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
@@ -70,7 +69,6 @@ github.com/go-openapi/swag v0.17.2/go.mod h1:AByQ+nYG6gQg71GINrmuDXCPWdL640yX49/
 github.com/gogo/googleapis v1.3.0 h1:M695OaDJ5ipWvDPcoAg/YL9c3uORAegkEfBqTQF/fTQ=
 github.com/gogo/googleapis v1.3.0/go.mod h1:d+q1s/xVJxZGKWwC/6UfPIF33J+G1Tq4GYv9Y+Tg/EU=
 github.com/gogo/protobuf v0.0.0-20171007142547-342cbe0a0415/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
-github.com/gogo/protobuf v1.2.2-0.20190730201129-28a6bbf47e48 h1:X+zN6RZXsvnrSJaAIQhZezPfAfvsqihKKR8oiLHid34=
 github.com/gogo/protobuf v1.2.2-0.20190730201129-28a6bbf47e48/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
 github.com/gogo/protobuf v1.3.0 h1:G8O7TerXerS4F6sx9OV7/nRfJdnXgHZu/S/7F2SN+UE=
 github.com/gogo/protobuf v1.3.0/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
@@ -79,7 +77,6 @@ github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfU
 github.com/golang/groupcache v0.0.0-20160516000752-02826c3e7903 h1:LbsanbbD6LieFkXbj9YNNBupiGHJgFeLpO0j0Fza1h8=
 github.com/golang/groupcache v0.0.0-20160516000752-02826c3e7903/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
-github.com/golang/protobuf v1.2.0 h1:P3YflyNX/ehuJFLhxviNdFxQPkGK5cDcApsge1SqnvM=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.1 h1:YF8+flBXS5eO826T4nzqPrxfhQThhXl0YzfuUPu4SBg=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
@@ -101,10 +98,10 @@ github.com/gorilla/websocket v1.4.0 h1:WDFjx/TMzVgy9VdMMQi2K2Emtwi2QcUQsztZ/zLaH
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/gregjones/httpcache v0.0.0-20170728041850-787624de3eb7 h1:6TSoaYExHper8PYsJu23GWVNOyYRCSnIFyxKgLSZ54w=
 github.com/gregjones/httpcache v0.0.0-20170728041850-787624de3eb7/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
-github.com/hashicorp/consul/api v1.1.0 h1:BNQPM9ytxj6jbjjdRPioQ94T6YXriSopn0i8COv6SRA=
-github.com/hashicorp/consul/api v1.1.0/go.mod h1:VmuI/Lkw1nC05EYQWNKwWGbkg+FbDBtguAZLlVdkD9Q=
-github.com/hashicorp/consul/sdk v0.1.1 h1:LnuDWGNsoajlhGyHJvuWW6FVqRl8JOTPqS6CPTsYjhY=
-github.com/hashicorp/consul/sdk v0.1.1/go.mod h1:VKf9jXwCTEY1QZP2MOLRhb5i/I/ssyNV1vwHyQBF0x8=
+github.com/hashicorp/consul/api v1.2.0 h1:oPsuzLp2uk7I7rojPKuncWbZ+m5TMoD4Ivs+2Rkeh4Y=
+github.com/hashicorp/consul/api v1.2.0/go.mod h1:1SIkFYi2ZTXUE5Kgt179+4hH33djo11+0Eo2XgTAtkw=
+github.com/hashicorp/consul/sdk v0.2.0 h1:GWFYFmry/k4b1hEoy7kSkmU8e30GAyI4VZHk0fRxeL4=
+github.com/hashicorp/consul/sdk v0.2.0/go.mod h1:VKf9jXwCTEY1QZP2MOLRhb5i/I/ssyNV1vwHyQBF0x8=
 github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-cleanhttp v0.5.1 h1:dH3aiDG9Jvb5r5+bYHsikaOUIpcM0xvgMXVoDkXMzJM=
@@ -192,7 +189,6 @@ github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
-github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
@@ -219,12 +215,10 @@ github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJy
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20181029021203-45a5f77698d3/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
-golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2 h1:VklqNMn3ovrHsnt90PveolxSbWFaJdECFbxSq0Mqo2M=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190605123033-f99c8df09eb5 h1:58fnuSXlxZmFdJyvtTFVmVhcMLU6v5fEb/ok4wyqtNU=
 golang.org/x/crypto v0.0.0-20190605123033-f99c8df09eb5/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
-golang.org/x/net v0.0.0-20180906233101-161cd47e91fd h1:nTDtHvHSdCn1m6ITfMRqtOd/9+7a3s8RBNOZ3eYZzJA=
 golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20181005035420-146acd28ed58/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20181023162649-9b4f9f5ad519/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -237,7 +231,6 @@ golang.org/x/net v0.0.0-20190812203447-cdfb69ac37fc/go.mod h1:mL1N/T3taQHkDXs73r
 golang.org/x/oauth2 v0.0.0-20170412232759-a6bd8cefa181/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be h1:vEDujvNQGv4jgYKudGeI/+DAX4Jffq6hpD55MmoEvKs=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
-golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f h1:wMNYb4v58l5UBM7MYRLPG6ZhfOqbKu7X5eyFl8ZhKvA=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58 h1:8gQV6CLnAEikrhgkHFbMAEhagSSnXWGV915qUMm9mrU=
@@ -251,7 +244,6 @@ golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190606165138-5da285871e9c h1:+EXw7AwNOKzPFXMZ1yNjO40aWCh3PIquJB2fYlv9wcs=
 golang.org/x/sys v0.0.0-20190606165138-5da285871e9c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
@@ -265,7 +257,6 @@ golang.org/x/tools v0.0.0-20190606124116-d0a3d012864b/go.mod h1:/rFqwRUd4F7ZHNgw
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/appengine v1.6.2 h1:j8RI1yW0SkI+paT6uGwMlrMI/6zwYA6/CFil8rxOzGI=
 google.golang.org/appengine v1.6.2/go.mod h1:i06prIuMbXzDqacNJfV5OdTW448YApPu5ww/cMBSeb0=
-google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8 h1:Nw54tB0rB7hY/N0NQvRW8DG4Yk3Q6T9cu9RcFQDu1tc=
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/genproto v0.0.0-20180831171423-11092d34479b h1:lohp5blsw53GBXtLyLNaTXPXS9pJ1tiTw61ZHUoE9Qw=
 google.golang.org/genproto v0.0.0-20180831171423-11092d34479b/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=

--- a/pkg/consulwatch/agent.go
+++ b/pkg/consulwatch/agent.go
@@ -1,0 +1,42 @@
+package consulwatch
+
+type Agent struct {
+	// AmbassadorID is the ID of the Ambassador instance.
+	AmbassadorID string
+
+	// The Agent registers a Consul Service when it starts and then fetches the leaf TLS certificate from the Consul
+	// HTTP API with this name.
+	ConsulServiceName string
+
+	// SecretNamespace is the Namespace where the TLS secret is managed.
+	SecretNamespace string
+
+	// SecretName is the Name of the TLS secret managed by this Agent.
+	SecretName string
+}
+
+func NewAgent(spec ConsulWatchSpec) *Agent {
+	ambassadorID := spec.Id
+	consulServiceName := defConsulServiceName
+
+	// get the secret namespace/name where
+	secretNamespace, secretName := getNamespaceAndName(spec.Secret)
+
+	// The secret name is the full name of the Kubernetes Secret that contains the TLS certificate provided
+	// by Consul. If this value is set then the value of AMBASSADOR_ID is ignored when the name of the TLS secret is
+	// computed.
+	if ambassadorID != "" {
+		consulServiceName += "-" + ambassadorID
+	}
+
+	if secretName == "" {
+		secretName = consulServiceName + "-consul-connect"
+	}
+
+	return &Agent{
+		AmbassadorID:      consulServiceName,
+		SecretNamespace:   secretNamespace,
+		SecretName:        secretName,
+		ConsulServiceName: consulServiceName,
+	}
+}

--- a/pkg/consulwatch/agent_test.go
+++ b/pkg/consulwatch/agent_test.go
@@ -1,0 +1,66 @@
+package consulwatch
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestReplaceInTemplate(t *testing.T) {
+	tables := []struct {
+		values   map[string]interface{}
+		template string
+		expected string
+	}{
+		{
+			map[string]interface{}{
+				"A": "first",
+				"B": "second",
+			},
+			"{{.A}}-{{.B}}",
+			"first-second"},
+	}
+
+	for _, table := range tables {
+		res, err := replaceInTemplate(table.template, table.values)
+		if err != nil {
+			t.Error(err)
+		}
+		assert.Equal(t, table.expected, res)
+	}
+}
+
+func TestNewAgent_AmbassadorIDToConsulServiceName(t *testing.T) {
+	tables := []struct {
+		actual   string
+		expected string
+	}{
+		{"", "ambassador"},
+		{"ambassador", "ambassador-ambassador"},
+		{"foo-bar-team", "ambassador-foo-bar-team"},
+	}
+	secret := "UNUSED/UNUSED"
+
+	for _, table := range tables {
+		a := NewAgent(ConsulWatchSpec{Id: table.actual, Secret: secret})
+		assert.Equal(t, table.expected, a.ConsulServiceName)
+	}
+}
+
+func TestNewAgent_SecretName(t *testing.T) {
+
+	tables := []struct {
+		ambassadorID string
+		secretName   string
+		expected     string
+	}{
+		{"", "", "ambassador-consul-connect"},
+		{"foobar", "", "ambassador-foobar-consul-connect"},
+		{"foobar", "NAMESPACE/bazbot", "bazbot"},
+	}
+
+	for _, table := range tables {
+		a := NewAgent(ConsulWatchSpec{Id: table.ambassadorID, Secret: table.secretName})
+		assert.Equal(t, table.expected, a.SecretName)
+	}
+}

--- a/pkg/consulwatch/certs.go
+++ b/pkg/consulwatch/certs.go
@@ -1,0 +1,112 @@
+package consulwatch
+
+import (
+	"bytes"
+	"encoding/base64"
+	"os/exec"
+	"strings"
+	"text/template"
+
+	"github.com/datawire/ambassador/pkg/k8s"
+	"github.com/datawire/ambassador/pkg/supervisor"
+)
+
+const (
+	// manifest that will be applied when the Consul certificate are obtained
+	manifestTemplate = `
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: "{{.secret_name}}"
+type: "kubernetes.io/tls"
+data:
+  tls.crt: "{{.tls_crt}}"
+  tls.key: "{{.tls_key}}"
+---
+apiVersion: getambassador.io/v1
+kind: TLSContext
+metadata:
+  name: ambassador-consul
+spec:
+  hosts: []
+  secret: "{{.secret_name}}"
+`
+)
+
+// replaceInTemplate performs replacements in an input text
+func replaceInTemplate(text string, replacements map[string]interface{}) (string, error) {
+	tmpl, err := template.New("template").Parse(text)
+	if err != nil {
+		return "", err
+	}
+
+	b := bytes.Buffer{}
+	if err := tmpl.Execute(&b, replacements); err != nil {
+		return "", err
+	}
+	return b.String(), nil
+}
+
+// certChain is a certificates chain that will be translated to a k8s certificate
+type certChain struct {
+	process *supervisor.Process
+	CA      *CARoots
+	Leaf    *Certificate
+}
+
+func newCertChain(process *supervisor.Process) certChain {
+	return certChain{
+		process: process,
+	}
+}
+
+// WriteTo writes the certificates chain to a Kubernetes Secret
+func (c *certChain) WriteTo(secretNamespace, secretName string) error {
+	if c.CA == nil || c.Leaf == nil {
+		return nil // we need both CA & Leaf for creating/updating the secret
+	}
+
+	temp := c.CA.Roots[c.CA.ActiveRootID]
+	caRoot := &temp
+
+	// create the certificate chain
+	chain := c.Leaf.PEM + caRoot.PEM
+
+	// format the kubernetes secret
+	chain64 := base64.StdEncoding.EncodeToString([]byte(chain))
+	key64 := base64.StdEncoding.EncodeToString([]byte(c.Leaf.PrivateKeyPEM))
+	replacements := map[string]interface{}{
+		"secret_name": secretName,
+		"tls_crt":     chain64,
+		"tls_key":     key64,
+	}
+	secret, err := replaceInTemplate(manifestTemplate, replacements)
+	if err != nil {
+		return err
+	}
+
+	logger.Printf("Creating/updating TLS certificate secret: %s/%s", secretNamespace, secretName)
+	kubeinfo := k8s.NewKubeInfo("", "", secretNamespace)
+	args, err := kubeinfo.GetKubectlArray("apply", "-f", "-")
+	if err != nil {
+		return err
+	}
+	kubectl, err := exec.LookPath("kubectl")
+	if err != nil {
+		return err
+	}
+	apply := c.process.Command(kubectl, args...)
+	apply.Stdin = strings.NewReader(secret)
+	err = apply.Start()
+	if err != nil {
+		return err
+	}
+	err = c.process.DoClean(apply.Wait, apply.Process.Kill)
+	if err != nil {
+		return err
+	}
+	logger.Printf("certificate secret: %s/%s", secretNamespace, secretName)
+
+	return nil
+}

--- a/pkg/consulwatch/connectwatcher.go
+++ b/pkg/consulwatch/connectwatcher.go
@@ -1,14 +1,53 @@
 package consulwatch
 
 import (
+	"encoding/base64"
 	"errors"
 	"fmt"
 	"log"
 	"os"
+	"os/exec"
+	"strings"
 
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/consul/api/watch"
+
+	"github.com/datawire/ambassador/pkg/k8s"
+	"github.com/datawire/ambassador/pkg/supervisor"
 )
+
+const (
+	// envAmbassadorID creates a secret for a specific instance of an Ambassador API Gateway. The TLS secret name will
+	// be formatted as "$AMBASSADOR_ID-consul-connect."
+	envAmbassadorID = "_AMBASSADOR_ID"
+
+	// envSecretName is the full name of the Kubernetes Secret that contains the TLS certificate provided
+	// by Consul. If this value is set then the value of AMBASSADOR_ID is ignored when the name of the TLS secret is
+	// computed.
+	envSecretName = "_AMBASSADOR_TLS_SECRET_NAME"
+
+	// envSecretNamespace sets the namespace where the TLS secret is created.
+	envSecretNamespace = "_AMBASSADOR_TLS_SECRET_NAMESPACE"
+)
+
+const (
+	secretTemplate = `---
+kind: Secret
+apiVersion: v1
+metadata:
+    name: "%s"
+type: "kubernetes.io/tls"
+data:
+    tls.crt: "%s"
+    tls.key: "%s"
+`
+)
+
+var logger *log.Logger
+
+func init() {
+	logger = log.New(os.Stdout, "", log.LstdFlags)
+}
 
 type ConnectLeafWatcher struct {
 	consul *api.Client
@@ -141,4 +180,224 @@ func (w *ConnectCARootsWatcher) Start() error {
 
 func (w *ConnectCARootsWatcher) Stop() {
 	w.plan.Stop()
+}
+
+type agent struct {
+	// AmbassadorID is the ID of the Ambassador instance.
+	AmbassadorID string
+
+	// The Agent registers a Consul Service when it starts and then fetches the leaf TLS certificate from the Consul
+	// HTTP API with this name.
+	ConsulServiceName string
+
+	// SecretNamespace is the Namespace where the TLS secret is managed.
+	SecretNamespace string
+
+	// SecretName is the Name of the TLS secret managed by this agent.
+	SecretName string
+
+	// consulAPI is the client used to communicate with the Consul HTTP API server.
+	consul *api.Client
+}
+
+func newAgent(ambassadorID string, secretNamespace string, secretName string, consul *api.Client) *agent {
+	consulServiceName := "ambassador"
+	if ambassadorID != "" {
+		consulServiceName += "-" + ambassadorID
+	}
+
+	if secretName == "" {
+		secretName = consulServiceName + "-consul-connect"
+	}
+
+	return &agent{
+		AmbassadorID:      consulServiceName,
+		SecretNamespace:   secretNamespace,
+		SecretName:        secretName,
+		ConsulServiceName: consulServiceName,
+		consul:            consul,
+	}
+}
+
+// certChain is a certificates chain that will be translated to a k8s certificate
+type certChain struct {
+	process *supervisor.Process
+	CA      *CARoots
+	Leaf    *Certificate
+}
+
+func newCertChain(process *supervisor.Process) certChain {
+	return certChain{
+		process: process,
+	}
+}
+
+func (c *certChain) WriteTo(secretNamespace, secretName string) error {
+	if c.CA == nil || c.Leaf == nil {
+		return nil // we need both CA & Leaf for creating/updating the secret
+	}
+
+	temp := c.CA.Roots[c.CA.ActiveRootID]
+	caRoot := &temp
+
+	// create the certificate chain
+	chain := c.Leaf.PEM + caRoot.PEM
+
+	// format the kubernetes secret
+	chain64 := base64.StdEncoding.EncodeToString([]byte(chain))
+	key64 := base64.StdEncoding.EncodeToString([]byte(c.Leaf.PrivateKeyPEM))
+	secret := fmt.Sprintf(secretTemplate, secretName, chain64, key64)
+
+	logger.Printf("Creating/updating TLS certificate secret: namespace=%s, secret=%s", secretNamespace, secretName)
+	kubeinfo := k8s.NewKubeInfo("", "", secretNamespace)
+	args, err := kubeinfo.GetKubectlArray("apply", "-f", "-")
+	if err != nil {
+		return err
+	}
+	kubectl, err := exec.LookPath("kubectl")
+	if err != nil {
+		return err
+	}
+	apply := c.process.Command(kubectl, args...)
+	apply.Stdin = strings.NewReader(secret)
+	err = apply.Start()
+	if err != nil {
+		return err
+	}
+	err = c.process.DoClean(apply.Wait, apply.Process.Kill)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// ConnectWatcher is a watcher for Consul Connect certificates
+type ConnectWatcher struct {
+	process *supervisor.Process
+	agent   *agent
+	consul  *api.Client
+
+	consulWorker *supervisor.Worker
+
+	caRootWorker       *supervisor.Worker
+	caRootCertificates chan *CARoots
+	caRootWatcher      *ConnectCARootsWatcher
+
+	leafCertificates chan *Certificate
+	leafWatcher      *ConnectLeafWatcher
+	leafWorker       *supervisor.Worker
+}
+
+// NewConnectWatcher creates a new watcher for Consul Connect certificates
+func NewConnectWatcher(p *supervisor.Process, consul *api.Client) *ConnectWatcher {
+	// TODO(alvaro): this shold be obtained from some custom resource
+	agent := newAgent(os.Getenv(envAmbassadorID), os.Getenv(envSecretNamespace), os.Getenv(envSecretName), consul)
+
+	return &ConnectWatcher{
+		process:            p,
+		consul:             consul,
+		agent:              agent,
+		caRootCertificates: make(chan *CARoots),
+		leafCertificates:   make(chan *Certificate),
+	}
+}
+
+// Watch retrieves the TLS certificate issued by the Consul CA and stores it as a Kubernetes
+// secret that Ambassador will use to authenticate with upstream services.
+func (w *ConnectWatcher) Watch() error {
+	var err error
+
+	log.Printf("Watching Root CA for %s\n", w.agent.ConsulServiceName)
+	w.caRootWatcher, err = NewConnectCARootsWatcher(w.consul, logger)
+	if err != nil {
+		return err
+	}
+	w.caRootWatcher.Watch(func(roots *CARoots, e error) {
+		if e != nil {
+			w.process.Logf("Error watching root CA: %v\n", err)
+		}
+
+		w.caRootCertificates <- roots
+	})
+
+	log.Printf("Watching CA leaf for %s\n", w.agent.ConsulServiceName)
+	w.leafWatcher, err = NewConnectLeafWatcher(w.consul, logger, w.agent.ConsulServiceName)
+	if err != nil {
+		return err
+	}
+	w.leafWatcher.Watch(func(certificate *Certificate, e error) {
+		if e != nil {
+			w.process.Logf("Error watching certificates: %v\n", err)
+		}
+		w.leafCertificates <- certificate
+	})
+
+	w.consulWorker = w.process.Go(func(p *supervisor.Process) error {
+		p.Log("Starting Consul certificates watcher...")
+		chain := newCertChain(p)
+
+		// wait for root CA and certificates, and update the
+		// copy in Kubernetes when we get a new version
+	loop:
+		for {
+			select {
+			case cert, ok := <-w.caRootCertificates:
+				if !ok {
+					break loop // return when one of the input channels is closed
+				}
+				chain.CA = cert
+			case cert, ok := <-w.leafCertificates:
+				if !ok {
+					break loop
+				}
+				chain.Leaf = cert
+			case <-p.Shutdown():
+				break loop
+			}
+
+			if err := chain.WriteTo(w.agent.SecretNamespace, w.agent.SecretName); err != nil {
+				p.Log(err)
+				continue
+			}
+		}
+
+		p.Log("Quitting Consul certificates watcher")
+		return nil
+	})
+	w.leafWorker = w.process.Go(func(p *supervisor.Process) error {
+		p.Log("Starting Consul leaf certificates watcher...")
+		if err := w.leafWatcher.Start(); err != nil {
+			p.Logf("failed to start Consul leaf watcher %v", err)
+			return err
+		}
+		return nil
+	})
+	w.caRootWorker = w.process.Go(func(p *supervisor.Process) error {
+		p.Log("Starting Consul CA certificate watcher...")
+		if err := w.caRootWatcher.Start(); err != nil {
+			p.Logf("failed to start Consul CA certificate watcher %v", err)
+			return err
+		}
+		return nil
+	})
+
+	return nil
+}
+
+// Close stops watching Consul Connect
+func (w *ConnectWatcher) Close() {
+	w.process.Logf("Stopping Consul Connect watchers...")
+	w.caRootWatcher.Stop()
+	w.caRootWorker.Wait()
+
+	w.leafWatcher.Stop()
+	w.leafWorker.Wait()
+
+	w.caRootWatcher.Stop()
+	close(w.caRootCertificates)
+
+	w.leafWatcher.Stop()
+	close(w.leafCertificates)
+
+	w.consulWorker.Wait()
 }

--- a/pkg/consulwatch/connectwatcher_test.go
+++ b/pkg/consulwatch/connectwatcher_test.go
@@ -1,0 +1,26 @@
+package consulwatch
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetNamespaceAndName(t *testing.T) {
+
+	tables := []struct {
+		secret            string
+		expectedNamespace string
+		expectedName      string
+	}{
+		{"default/my-secret", "default", "my-secret"},
+		{"my-secret", "", "my-secret"},
+		{"", "", ""},
+	}
+
+	for _, table := range tables {
+		namespace, name := getNamespaceAndName(table.secret)
+		assert.Equal(t, table.expectedNamespace, namespace)
+		assert.Equal(t, table.expectedName, name)
+	}
+}

--- a/pkg/consulwatch/servicewatcher.go
+++ b/pkg/consulwatch/servicewatcher.go
@@ -54,7 +54,7 @@ func (w *ServiceWatcher) Watch(handler func(endpoints Endpoints, err error)) {
 
 		v, ok := raw.([]*consulapi.ServiceEntry)
 		if !ok {
-			handler(endpoints, fmt.Errorf("unexpected raw type expected=%T, actual=%T", []*consulapi.ServiceEntry{}, raw))
+			handler(endpoints, fmt.Errorf("unexpected raw type expected=%T, template=%T", []*consulapi.ServiceEntry{}, raw))
 			return
 		}
 

--- a/pkg/watt/consullock.go
+++ b/pkg/watt/consullock.go
@@ -1,0 +1,354 @@
+package watt
+
+import (
+	"encoding/json"
+	"errors"
+	"strings"
+	"time"
+
+	api "github.com/hashicorp/consul/api"
+)
+
+const (
+	// defaultLockRetryInterval how long we wait after a failed lock acquisition
+	defaultLockRetryInterval = 10 * time.Second
+	// session ttl
+	defautSessionTTL = 30 * time.Second
+	// if can't acquire, block wait to acquire
+	defaultLockWaitTime = 5 * time.Second
+	// block min wait time
+	minLockWaitTime = 10 * time.Millisecond
+
+	TryAcquireMode = iota
+	CallEventModel
+)
+
+var (
+	defaultLogger = func(tmpl string, s ...interface{}) {}
+
+	ErrKeyNameNull = errors.New("key is null")
+	ErrKeyInvalid  = errors.New("Key must not begin with a '/'")
+)
+
+// null logger
+type loggerType func(tmpl string, s ...interface{})
+
+func SetLogger(logger loggerType) {
+	defaultLogger = logger
+}
+
+// DistLock configured for lock acquisition
+type DistLock struct {
+	isClosedDoneChan int32
+	doneChan         chan struct{}
+
+	consulLock   *api.Lock
+	IsLocked     bool
+	ConsulClient *api.Client
+	Key          string
+	SessionID    string
+
+	LockWaitTime      time.Duration
+	LockRetryInterval time.Duration
+	SessionTTL        time.Duration
+}
+
+// DistLockConfig is used to configure creation of client
+type DistLockConfig struct {
+	KeyName           string // key on which lock to acquire
+	LockWaitTime      time.Duration
+	LockRetryInterval time.Duration // interval at which attempt is done to acquire lock
+	SessionTTL        time.Duration // time after which consul session will expire and release the lock
+}
+
+func (c *DistLockConfig) check() error {
+	if c.KeyName == "" {
+		return ErrKeyNameNull
+	}
+
+	if strings.HasPrefix(c.KeyName, "/") {
+		return ErrKeyInvalid
+	}
+
+	return nil
+}
+
+func (c *DistLockConfig) init() {
+	if c.LockRetryInterval == 0 {
+		c.LockRetryInterval = defaultLockRetryInterval
+	}
+	if c.SessionTTL == 0 {
+		c.SessionTTL = defautSessionTTL
+	}
+	if c.LockWaitTime == 0 {
+		c.LockWaitTime = defaultLockWaitTime
+	}
+}
+
+func NewConfig() *DistLockConfig {
+	c := &DistLockConfig{
+		LockRetryInterval: defaultLockRetryInterval,
+		SessionTTL:        defautSessionTTL,
+	}
+
+	return c
+}
+
+// NewDistLock returns a new distributed lock object
+func NewDistLock(consul *api.Client, o *DistLockConfig) (*DistLock, error) {
+	o.init()
+
+	return &DistLock{
+		doneChan: make(chan struct{}),
+		ConsulClient: consul,
+		Key: o.KeyName,
+		LockWaitTime: o.LockWaitTime,
+		LockRetryInterval: o.LockRetryInterval,
+		SessionTTL: o.SessionTTL,
+	}, nil
+}
+
+// RetryLockAcquire attempts to acquire the lock at `LockRetryInterval`
+func (d *DistLock) RetryLockAcquire(value map[string]string, acquired chan<- bool, released chan<- bool, errorChan chan<- error) {
+	ticker := time.NewTicker(d.LockRetryInterval)
+
+	for ; true; <-ticker.C {
+		value["lock_created_time"] = time.Now().Format(time.RFC3339)
+		lock, err := d.acquireLock(d.LockWaitTime, value, CallEventModel, released)
+		if err != nil {
+			defaultLogger("error on acquireLock :", err, "retry in -", d.LockRetryInterval)
+			errorChan <- err
+			continue
+		}
+
+		if lock {
+			defaultLogger("lock acquired with consul session - %s", d.SessionID)
+			ticker.Stop()
+			acquired <- true
+			break
+		}
+	}
+}
+
+func (d *DistLock) tryLockAcquire(wait time.Duration, value map[string]string) (bool, error) {
+	locked, err := d.acquireLock(wait, value, TryAcquireMode, nil)
+	if err != nil {
+		defaultLogger("acquireLock failed, err: %v", err)
+		return locked, err
+	}
+
+	if !locked {
+		defaultLogger("can't acquire lock, session: %s", d.SessionID)
+		return locked, nil
+	}
+
+	d.IsLocked = locked
+	return locked, nil
+}
+
+// TryLockAcquire
+func (d *DistLock) TryLockAcquire(value map[string]string) (bool, error) {
+	return d.tryLockAcquire(d.LockWaitTime, value)
+}
+
+// TryLockAcquire
+func (d *DistLock) TryLockAcquireNonBlock(value map[string]string) (bool, error) {
+	return d.tryLockAcquire(minLockWaitTime, value)
+}
+
+// TryLockAcquireBlock
+func (d *DistLock) TryLockAcquireBlock(waitTime time.Duration, value map[string]string) (bool, error) {
+	return d.tryLockAcquire(waitTime, value)
+}
+
+func (d *DistLock) ReleaseLock() error {
+	if d.SessionID == "" {
+		defaultLogger("cannot destroy empty session")
+		return nil
+	}
+
+	defer func() {
+		defaultLogger("destroyed consul session: %s", d.SessionID)
+		d.IsLocked = false
+		if !d.isDoneChanCloed() {
+			// only call once
+			close(d.doneChan)
+		}
+
+		if d.consulLock != nil {
+			// DELETE /v1/kv/
+			d.consulLock.Destroy()
+		}
+
+		d.SessionID = ""
+	}()
+
+	// PUT /v1/session/destroy/
+	_, err := d.ConsulClient.Session().Destroy(d.SessionID, nil)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Renew incr key ttl
+func (d *DistLock) Renew() {
+	d.ConsulClient.Session().Renew(d.SessionID, nil)
+}
+
+func (d *DistLock) StartRenewProcess() {
+	d.ConsulClient.Session().RenewPeriodic(d.SessionTTL.String(), d.SessionID, nil, d.doneChan)
+}
+
+func (d *DistLock) AsyncStartRenewProcess() {
+	go func() {
+		d.StartRenewProcess()
+	}()
+}
+
+func (d *DistLock) StopRenewProcess() {
+	if !d.isDoneChanCloed() {
+		close(d.doneChan)
+	}
+}
+
+func (d *DistLock) createSession() (string, error) {
+	return createSession(d.ConsulClient, d.Key, d.SessionTTL)
+}
+
+func (d *DistLock) recreateSession() error {
+	sessionID, err := d.createSession()
+	if err != nil {
+		return err
+	}
+
+	d.SessionID = sessionID
+	return nil
+}
+
+func (d *DistLock) isDoneChanCloed() bool {
+	select {
+	case _, ok := <-d.doneChan:
+		if !ok {
+			return true
+		}
+		return false
+
+	default:
+		return false
+	}
+}
+
+func (d *DistLock) acquireLock(waitTime time.Duration, value map[string]string, mode int, released chan<- bool) (bool, error) {
+	if d.SessionID == "" {
+		err := d.recreateSession()
+		if err != nil {
+			return false, err
+		}
+	}
+
+	if d.isDoneChanCloed() {
+		d.doneChan = make(chan struct{})
+	}
+
+	b, err := json.Marshal(value)
+	if err != nil {
+		defaultLogger("error on value marshal", err)
+	}
+
+	lock, err := d.ConsulClient.LockOpts(
+		&api.LockOptions{
+			Key:     d.Key,
+			Value:   b,
+			Session: d.SessionID,
+			// block wait to acquire, consul defualt 15s
+			LockWaitTime: waitTime,
+			// if true, only acquire lock once, return.
+			// if false, while acquire lock with WaitTime
+			LockTryOnce: true,
+		},
+	)
+	if err != nil {
+		return false, err
+	}
+
+	// the sessionID maybe is expired or invalided ID
+	session, _, err := d.ConsulClient.Session().Info(d.SessionID, nil)
+	if err == nil && session == nil {
+		defaultLogger("consul session: %s is invalid now", d.SessionID)
+		d.SessionID = ""
+		return false, nil
+	}
+
+	if err != nil {
+		return false, err
+	}
+
+	resp, err := lock.Lock(d.doneChan)
+	if err != nil {
+		return false, err
+	}
+
+	if resp == nil {
+		return false, nil
+	}
+
+	if mode == TryAcquireMode {
+		go func() {
+			<-resp
+			d.IsLocked = false
+		}()
+	}
+
+	if mode == CallEventModel {
+		go func() {
+			// wait event
+			<-resp
+			// close renew process
+			if !d.isDoneChanCloed() {
+				close(d.doneChan)
+			}
+			defaultLogger("lock released with session: %s", d.SessionID)
+			d.IsLocked = false
+			released <- true
+		}()
+
+		go d.StartRenewProcess()
+	}
+
+	d.consulLock = lock
+	return true, nil
+}
+
+func createSession(client *api.Client, consulKey string, ttl time.Duration) (string, error) {
+	// agentChecks, err := client.Agent().Checks()
+	// if err != nil {
+	// 	defaultLogger("error on getting checks, err: %v", err)
+	// 	return "", err
+	// }
+
+	// checks := []string{}
+	// checks = append(checks, "serfHealth")
+	// for _, j := range agentChecks {
+	// 	checks = append(checks, j.CheckID)
+	// }
+
+	sessionID, _, err := client.Session().Create(
+		&api.SessionEntry{
+			Name: consulKey,
+			// Checks:   checks,
+			Behavior: api.SessionBehaviorDelete,
+			// after release lock, other get lock wating lockDelay time.
+			LockDelay: 1 * time.Microsecond,
+			TTL:       ttl.String(),
+		},
+		nil,
+	)
+	if err != nil {
+		return "", err
+	}
+
+	defaultLogger("created consul session: %s", sessionID)
+	return sessionID, nil
+}

--- a/python/watch_hook.py
+++ b/python/watch_hook.py
@@ -1,17 +1,12 @@
 #!/usr/bin/python
 
-from ambassador.utils import ParsedService as Service
-
-from typing import Dict, List, Optional, Tuple, TYPE_CHECKING
-from typing import cast as typecast
-
-import sys
-
 import json
 import logging
 import os
+import sys
+from typing import Dict, Optional, Tuple, TYPE_CHECKING
 
-from urllib.parse import urlparse
+from ambassador.utils import ParsedService as Service
 
 loglevel = logging.INFO
 
@@ -43,7 +38,7 @@ logger.debug(f'AMBASSADOR_KNATIVE_REQUESTED {ambassador_knative_requested}')
 from ambassador import Config, IR
 from ambassador.config.resourcefetcher import ResourceFetcher
 from ambassador.ir.irserviceresolver import IRServiceResolverFactory
-from ambassador.ir.irtls import TLSModuleFactory, IRAmbassadorTLS
+from ambassador.ir.irtls import TLSModuleFactory
 from ambassador.ir.irambassador import IRAmbassador
 from ambassador.utils import SecretInfo, SavedSecret, SecretHandler
 


### PR DESCRIPTION
## Description

Bring the Consul Connect code to Watt. The system automatically dectects the Consul certificates and cretes 1) a Kubernetes secret wiith those certiicates 2) a `TLSContext` named `ambassador-consul`

## Testing
`kubectl apply`  a `ConsulResolver` like this:

```yaml
apiVersion: getambassador.io/v1
kind: ConsulResolver
metadata:
   name: consul-dc1
 spec:
   # address of your Consul service in Kubernetes
   address: consul-consul-server-0.consul-consul-server.default.svc:8500
   datacenter: dc1
```
When Consul is installed and injection is enabled, you should be able to see the creation of a new secret in Kubernetes and a `TLSContext` pointing to that secret.

## Todos
- [ ] Documentation: it needs some documentation, maybe in this or in a subsequent PR, when we are sure this PR implements what we really want...

