### PR TITLE
Fix permissions of /ambassador to allow non-root without overriding AMBASSADOR_CONFIG_BASE_DIR

### DIFF
--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -124,6 +124,11 @@ COPY --from=artifacts /buildroot/ambassador/demo/services /ambassador/demo-servi
 
 WORKDIR /ambassador
 
+# Fix permissions to allow correctly running as a non root user
+RUN chgrp -R 0 /ambassador && \
+    chmod -R u+x /ambassador && \
+    chmod -R g=u /ambassador /etc/passwd
+
 ENTRYPOINT [ "bash", "/buildroot/ambassador/python/entrypoint.sh" ]
 
 ########################################

--- a/python/tests/test_docker.py
+++ b/python/tests/test_docker.py
@@ -11,7 +11,7 @@ def docker_start(logfile) -> bool:
     # Use a global here so that the child process doesn't get killed
     global child
 
-    cmd = f'docker run --rm --name ambassador -p8888:8080 {os.environ["AMBASSADOR_DOCKER_IMAGE"]} --demo'
+    cmd = f'docker run --rm --name ambassador -u8888:0 -p8888:8080 {os.environ["AMBASSADOR_DOCKER_IMAGE"]} --demo'
 
     child = pexpect.spawn(cmd, encoding='utf-8')
     child.logfile = logfile


### PR DESCRIPTION
Thanks to @dmayle for the catch!

Ambassador uses `AMBASSADOR_CONFIG_BASE_DIR` to decide where on disk it will write things it needs to write. By default, it's `/ambassador`, and in our large chunk of build system work recently, the permissions there didn't get set correctly, so only `root` could write there.

We didn't catch this because, while our end-to-end tests don't run as `root`, they also use a read-only root filesystem, so they override `AMBASSADOR_CONFIG_BASE_DIR` to point into a memory filesystem on `/tmp` (mimicking a customer configuration). To fix _that_ problem, this PR modifies `test_docker.py` to run as non-root without overriding `AMBASSADOR_CONFIG_BASE_DIR`.