### PR TITLE
Fixed typo in module example

### DIFF
--- a/docs/user-guide/tracing-tutorial-datadog.md
+++ b/docs/user-guide/tracing-tutorial-datadog.md
@@ -22,7 +22,8 @@ When using JSON logging with Envoy, Ambassador will automatically append the `dd
 ---
 apiVersion: getambassador.io/v1
 kind: Module
-name: ambassador
+metadata:
+  name: ambassador
 config:
   envoy_log_type: json
 ```


### PR DESCRIPTION
Module was created incorrectly such that it would not deploy into kubernetes as the name was set incorrectly. I have added the correct syntax for it to install into kubernetes.

## Description
Fix typos in the documentation

## Related Issues
List related issues.

## Testing
A few sentences describing what testing you've done, e.g., manual tests, automated tests, deployed in production, etc.

## Todos
- [ ] Tests
- [ ] Documentation

## Other
* If this is a documentation change, please open the pull request at https://github.com/datawire/ambassador-docs instead.
* Code changes should occur against `master`.
