### PR TITLE
builder.sh: Let `compile` work if stdin isn't a TTY

### DIFF
--- a/builder/builder.sh
+++ b/builder/builder.sh
@@ -133,7 +133,11 @@ case "${cmd}" in
     compile)
         shift
         bootstrap
-        docker exec -it $(builder) /buildroot/builder.sh compile-internal
+        if [[ -t 0 ]]; then
+            docker exec -it $(builder) /buildroot/builder.sh compile-internal
+        else
+            docker exec $(builder) /buildroot/builder.sh compile-internal
+        fi
         ;;
     compile-internal)
         # This runs inside the builder image


### PR DESCRIPTION
Cherry-picking @LukeShu's 20a13dc22ed3aa9e28386f61e6fa272863025f9d for the upcoming releases.