### PR TITLE
Initial listener and mapping changes for zero-click

### DIFF
--- a/python/ambassador/envoy/v2/v2listener.py
+++ b/python/ambassador/envoy/v2/v2listener.py
@@ -587,7 +587,7 @@ class V2Listener(dict):
             config.ir.logger.info("V2L: no filter chains, need cleartext")
             need_cleartext = True
 
-        if config.ir.ambassador_module.get('allow_wizard', True):
+        if config.ir.wizard_allowed:
             config.ir.logger.info("V2L: wizard allowed, need cleartext")
             need_cleartext = True
 

--- a/python/ambassador/envoy/v2/v2listener.py
+++ b/python/ambassador/envoy/v2/v2listener.py
@@ -592,7 +592,9 @@ class V2Listener(dict):
             config.ir.logger.info("V2L: wizard allowed, need cleartext")
             need_cleartext = True
 
-        for host in config.ir.aconf.get_config("hosts") or []:
+        host_dict = config.ir.aconf.get_config("hosts") or {}
+    
+        for host in host_dict.values():
             if host.get('acme-provider', 'zzz').lower() == 'none':
                 config.ir.logger.info(f"V2L: host {host.hostname} has ACME none, need cleartext")
                 need_cleartext = True

--- a/python/ambassador/ir/ir.py
+++ b/python/ambassador/ir/ir.py
@@ -165,11 +165,6 @@ class IR:
             # Uhoh.
             self.ambassador_module.set_active(False)    # This can't be good.
 
-        # Do we have any Host resources?
-        if not self.aconf.get_config("hosts"):
-            self.logger.info("IR: No Host resources, forcing debug mode!")
-            self.ambassador_module.debug_mode = True
-
         # Save circuit breakers, outliers, and services.
         self.breakers = aconf.get_config("CircuitBreaker") or {}
         self.outliers = aconf.get_config("OutlierDetection") or {}
@@ -214,9 +209,9 @@ class IR:
         ListenerFactory.load_all(self, aconf)
         MappingFactory.load_all(self, aconf)
 
-        # If we're in debug mode, take over the root prefix.
-        if self.ambassador_module.debug_mode:
-            self.logger.info(f"DEBUG: need edgy mapping")
+        # If the wizard is allowed, take over the root prefix.
+        if self.ambassador_module.get('allow-wizard', True):
+            self.logger.info(f"WIZARD ALLOWED: need edgy mapping")
 
             counter = 0
             name = 'edgy-mapping'

--- a/python/ambassador/ir/ir.py
+++ b/python/ambassador/ir/ir.py
@@ -168,7 +168,7 @@ class IR:
             self.ambassador_module.set_active(False)    # This can't be good.
 
         # Check on the edge stack and the wizard.
-        self.edge_stack_allowed = True if os.environ.get('AMBASSADOR_', None) else False
+        self.edge_stack_allowed = True if os.environ.get('AMBASSADOR_EDGE_STACK', None) else False
         self.wizard_allowed = self.edge_stack_allowed and self.ambassador_module.get('allow-wizard', True)
 
         _mode_str = 'Edge Stack' if self.edge_stack_allowed else 'OSS'

--- a/python/ambassador/ir/ir.py
+++ b/python/ambassador/ir/ir.py
@@ -214,36 +214,6 @@ class IR:
         ListenerFactory.load_all(self, aconf)
         MappingFactory.load_all(self, aconf)
 
-        # If the wizard is allowed, take over the root prefix.
-        if self.ambassador_module.get('allow-wizard', True):
-            self.logger.info(f"WIZARD ALLOWED: need edgy mapping")
-
-            counter = 0
-            name = 'edgy-mapping'
-
-            http_mappings = self.aconf.get_config('mappings') or {}
-            tcp_mappings = self.aconf.get_config('tcpmappings') or {}
-
-            while name in http_mappings or name in tcp_mappings:
-                name = f"edgy-mappings-{counter}"
-                counter += 1
-
-            base_edgy_mapping = {
-                'rkey': '--internal--',
-                'location': '--internal--',
-                'apiVersion': 'getambassador.io/v1',
-                'kind': 'Mapping',
-                'name': name,
-                'service': 'tour:5000',
-                'rewrite': '/'
-            }
-
-            for pfx in [ '/', '/edgy/' ]:
-                edgy_mapping = IRHTTPMapping(self, self.aconf, prefix=pfx, **base_edgy_mapping)
-
-                self.logger.info(f"DEBUG: adding edgy mapping {edgy_mapping}")
-                self.add_mapping(self.aconf, edgy_mapping)
-
         self.walk_saved_resources(aconf, 'add_mappings')
 
         TLSModuleFactory.finalize(self, aconf)

--- a/python/ambassador/ir/ir.py
+++ b/python/ambassador/ir/ir.py
@@ -77,6 +77,7 @@ class IR:
     file_checker: Callable[[str], bool]
     resolvers: Dict[str, IRServiceResolver]
     redirect_cleartext_from: Optional[int]
+    wizard_allowed: bool
 
     def __init__(self, aconf: Config, secret_handler=None, file_checker=None) -> None:
         self.ambassador_id = Config.ambassador_id
@@ -85,6 +86,10 @@ class IR:
         self.statsd = aconf.statsd
 
         self.logger = logging.getLogger("ambassador.ir")
+
+        # Is the wizard allowed?
+        self.wizard_allowed = os.environ.get('AMBASSADOR_WIZARD_OK', None) and self.ambassador_module.get('allow-wizard', True)
+        self.logger.debug(f"Wizard is{'' if self.wizard_allowed else ' not'} allowed")
 
         # We're using setattr since since mypy complains about assigning directly to a method.
         secret_root = os.environ.get('AMBASSADOR_CONFIG_BASE_DIR', "/ambassador")

--- a/python/ambassador/ir/ir.py
+++ b/python/ambassador/ir/ir.py
@@ -167,8 +167,9 @@ class IR:
             # Uhoh.
             self.ambassador_module.set_active(False)    # This can't be good.
 
-        # Check on the edge stack and the wizard.
-        self.edge_stack_allowed = True if os.environ.get('AMBASSADOR_EDGE_STACK', None) else False
+        # Check on the edge stack and the wizard. Note that the Edge Stack touchfile is _not_ within
+        # $AMBASSADOR_CONFIG_BASE_DIR: it stays in /ambassador no matter what.
+        self.edge_stack_allowed = os.path.exists('/ambassador/.edge_stack')
         self.wizard_allowed = self.edge_stack_allowed and self.ambassador_module.get('allow-wizard', True)
 
         _mode_str = 'Edge Stack' if self.edge_stack_allowed else 'OSS'

--- a/python/ambassador/ir/irlistener.py
+++ b/python/ambassador/ir/irlistener.py
@@ -121,7 +121,9 @@ class ListenerFactory:
         # fire up multiprotocol listeners on ports 8080 and 8443. This means neither
         # requires TLS, but both have a full set of termination contexts.
 
-        if amod.debug_mode:
+        if amod.get('allow_wizard', True):
+            ir.logger.info('IRL: wizard allowed, overriding listeners')
+
             listeners = [
                 IRListener(
                     ir=ir, aconf=aconf, location=amod.location,

--- a/python/ambassador/ir/irlistener.py
+++ b/python/ambassador/ir/irlistener.py
@@ -195,7 +195,7 @@ class ListenerFactory:
             # We're redirecting cleartext. This means a second listener that has no TLS contexts,
             # and does nothing but redirects.
             new_listener = IRListener(
-                ir=ir, aconf=aconf, location=redirection_context,
+                ir=ir, aconf=aconf, location=redirection_context.location,
                 service_port=redirect_cleartext_from,
                 use_proxy_proto=amod.use_proxy_proto,
                 # Note: no TLS context here, this is a cleartext listener.

--- a/python/ambassador/ir/irlistener.py
+++ b/python/ambassador/ir/irlistener.py
@@ -121,7 +121,7 @@ class ListenerFactory:
         # fire up multiprotocol listeners on ports 8080 and 8443. This means neither
         # requires TLS, but both have a full set of termination contexts.
 
-        if amod.get('allow_wizard', True):
+        if ir.wizard_allowed:
             ir.logger.info('IRL: wizard allowed, overriding listeners')
 
             listeners = [

--- a/python/ambassador/ir/irlistener.py
+++ b/python/ambassador/ir/irlistener.py
@@ -98,7 +98,7 @@ class ListenerFactory:
                 contexts[ctx.name] = ctx
 
                 ctx_kind = "a" if primary_context else "the primary"
-                ir.logger.debug(f"ListenerFactory: ctx {ctx.name} is {ctx_kind} termination context")
+                ir.logger.info(f"ListenerFactory: ctx {ctx.name} is {ctx_kind} termination context")
 
                 if not primary_context:
                     primary_context = ctx

--- a/python/ambassador/ir/irmappingfactory.py
+++ b/python/ambassador/ir/irmappingfactory.py
@@ -10,11 +10,48 @@ if TYPE_CHECKING:
     from .ir import IR
 
 
+def unique_mapping_name(aconf: Config, name: str) -> str:
+    http_mappings = aconf.get_config('mappings') or {}
+    tcp_mappings = aconf.get_config('tcpmappings') or {}
+
+    basename = name
+    counter = 0
+
+    while name in http_mappings or name in tcp_mappings:
+        name = f"{basename}-{counter}"
+        counter += 1
+
+    return name
+
+
 class MappingFactory:
     @classmethod
     def load_all(cls, ir: 'IR', aconf: Config) -> None:
         cls.load_config(ir, aconf, "mappings", IRHTTPMapping)
         cls.load_config(ir, aconf, "tcpmappings", IRTCPMapping)
+
+        # If the wizard is allowed, take over the root prefix.
+        if ir.wizard_allowed:
+            ir.logger.info(f"WIZARD ALLOWED: adding firstboot mapping")
+
+            ir.add_mapping(aconf,
+                           IRHTTPMapping(ir, aconf, rkey='--internal--', location='--internal--',
+                                         name=unique_mapping_name(aconf, 'firstboot-mapping'),
+                                         apiVersion='getambassador.io/v1',
+                                         prefix='/',
+                                         rewrite='/firstboot/',
+                                         service='127.0.0.1:8500'))
+
+        # Whether the wizard is allowed or not, add the mapping for ACME challenges.
+        ir.logger.info(f"MappingFactory: adding ACME challenge mapping")
+
+        ir.add_mapping(aconf,
+                       IRHTTPMapping(ir, aconf, rkey='--internal--', location='--internal--',
+                                     name=unique_mapping_name(aconf, 'acme-mapping'),
+                                     apiVersion='getambassador.io/v1',
+                                     prefix='/.well-known/acme-challenge/',
+                                     rewrite='/.well-known/acme-challenge/',
+                                     service='127.0.0.1:8500'))
 
     @classmethod
     def load_config(cls, ir: 'IR', aconf: Config, config_name: str, mapping_class: Type[IRBaseMapping]) -> None:

--- a/python/ambassador/ir/irmappingfactory.py
+++ b/python/ambassador/ir/irmappingfactory.py
@@ -42,16 +42,17 @@ class MappingFactory:
                                          rewrite='/firstboot/',
                                          service='127.0.0.1:8500'))
 
-        # Whether the wizard is allowed or not, add the mapping for ACME challenges.
-        ir.logger.info(f"MappingFactory: adding ACME challenge mapping")
+        if ir.edge_stack_allowed:
+            # Whether the wizard is allowed or not, add the mapping for ACME challenges.
+            ir.logger.info(f"MappingFactory: adding ACME challenge mapping")
 
-        ir.add_mapping(aconf,
-                       IRHTTPMapping(ir, aconf, rkey='--internal--', location='--internal--',
-                                     name=unique_mapping_name(aconf, 'acme-mapping'),
-                                     apiVersion='getambassador.io/v1',
-                                     prefix='/.well-known/acme-challenge/',
-                                     rewrite='/.well-known/acme-challenge/',
-                                     service='127.0.0.1:8500'))
+            ir.add_mapping(aconf,
+                           IRHTTPMapping(ir, aconf, rkey='--internal--', location='--internal--',
+                                         name=unique_mapping_name(aconf, 'acme-mapping'),
+                                         apiVersion='getambassador.io/v1',
+                                         prefix='/.well-known/acme-challenge/',
+                                         rewrite='/.well-known/acme-challenge/',
+                                         service='127.0.0.1:8500'))
 
     @classmethod
     def load_config(cls, ir: 'IR', aconf: Config, config_name: str, mapping_class: Type[IRBaseMapping]) -> None:

--- a/python/tests/t_tls.py
+++ b/python/tests/t_tls.py
@@ -1024,7 +1024,8 @@ max_tls_version: v1.2
                     maxTLSv="v1.3",
                     error=[ "tls: server selected unsupported protocol version 303",
                             "tls: no supported versions satisfy MinVersion and MaxVersion",
-                            "tls: protocol version not supported" ])
+                            "tls: protocol version not supported",
+                            "read: connection reset by peer"])  # The TLS inspector just closes the connection. Wow.
 
     def check(self):
         tls_0_version = self.results[0].backend.request.tls.negotiated_protocol_version

--- a/python/tests/t_tls.py
+++ b/python/tests/t_tls.py
@@ -212,7 +212,8 @@ service: {self.target.path.fqdn}
         # error message that the Go authors will use, so I'm going ahead and including "certificate required"
         # in the list of allowed error messages below.  If that assumption ends up being wrong: Yes, future
         # person, it's OK to replace the string "certificate required" with the correct one for alert=116.
-        yield Query(self.url(self.name + "/"), insecure=True, minTLSv="v1.3", error=["tls: alert(116)", "tls: certificate required"])
+        yield Query(self.url(self.name + "/"), insecure=True, minTLSv="v1.3",
+                    error=["tls: alert(116)", "tls: certificate required", "read: connection reset"])
 
     def requirements(self):
         for r in super().requirements():


### PR DESCRIPTION
Currently the zero-click stuff is activated by setting AMBASSADOR_EDGE_STACK in the environment. This is likely to need changing. 

Without the environment variable, this should be functionally equivalent to pure OSS behavior. With it, Ambassador will generate multiprotocol listeners and routes to the Edge Stack stuff as needed.