### PR TITLE
Add a capabilities wrapper

### DIFF
--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -46,7 +46,7 @@ ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/local
 # build it locally -- just using pip won't work.
 
 RUN apk --no-cache add bash curl jq rsync python3 python3-dev build-base libffi-dev openssl-dev sudo \
-                       iptables docker openssh-client libcap yaml-dev cython && \
+                       iptables docker openssh-client libcap libcap-dev yaml-dev cython git && \
     pip3 install -U pip && \
     curl --fail https://dl.google.com/go/go1.13.linux-amd64.tar.gz | tar -C /usr/local -xzf - && \
     curl --fail -L https://storage.googleapis.com/kubernetes-release/release/v1.16.0/bin/linux/amd64/kubectl -o /usr/bin/kubectl && \
@@ -109,6 +109,7 @@ COPY --from=artifacts /buildroot/bin/watt /usr/bin/watt
 COPY --from=artifacts /buildroot/bin/kubestatus /usr/bin/kubestatus
 COPY --from=artifacts /usr/bin/kubectl /usr/bin/kubectl
 COPY --from=artifacts /buildroot/ambassador/python /buildroot/ambassador/python
+COPY --from=artifacts /buildroot/bin/capabilities_wrapper /usr/local/bin/wrapper
 RUN cd /buildroot/ambassador/python && python setup.py install
 
 # XXX: this will go away
@@ -128,6 +129,9 @@ WORKDIR /ambassador
 RUN chgrp -R 0 /ambassador && \
     chmod -R u+x /ambassador && \
     chmod -R g=u /ambassador /etc/passwd
+# The capabilities here grant the wrapper the ability to use the cap_net_bind_service cap
+# and for Envoy to inherit it.
+RUN setcap cap_net_bind_service=p /usr/local/bin/wrapper; setcap cap_net_bind_service=ei /usr/local/bin/envoy
 
 ENTRYPOINT [ "bash", "/buildroot/ambassador/python/entrypoint.sh" ]
 

--- a/cmd/capabilities_wrapper/wrapper.go
+++ b/cmd/capabilities_wrapper/wrapper.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"log"
+	"os"
+	"syscall"
+
+	"golang.org/x/sys/unix"
+)
+
+func main() {
+	log.Println("Starting Envoy with CAP_NET_BIND_SERVICE capability")
+
+	header := unix.CapUserHeader{unix.LINUX_CAPABILITY_VERSION_3, int32(os.Getpid())}
+	data := unix.CapUserData{}
+	if err := unix.Capget(&header, &data); err != nil {
+		log.Fatal(err)
+	}
+
+	data.Inheritable = (1 << unix.CAP_NET_BIND_SERVICE)
+
+	if err := unix.Capset(&header, &data); err != nil {
+		log.Fatal(err)
+	}
+
+	log.Println("Succeeded in setting capabilities")
+
+	if err := syscall.Exec("/usr/local/bin/envoy", os.Args, os.Environ()); err != nil {
+		log.Fatal(err)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -36,6 +36,7 @@ require (
 	github.com/stretchr/testify v1.4.0
 	golang.org/x/crypto v0.0.0-20190605123033-f99c8df09eb5
 	golang.org/x/net v0.0.0-20190812203447-cdfb69ac37fc
+	golang.org/x/sys v0.0.0-20191024073052-e66fe6eb8e0c
 	google.golang.org/genproto v0.0.0-20180831171423-11092d34479b // indirect
 	google.golang.org/grpc v1.23.0
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0

--- a/go.sum
+++ b/go.sum
@@ -251,6 +251,8 @@ golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190606165138-5da285871e9c h1:+EXw7AwNOKzPFXMZ1yNjO40aWCh3PIquJB2fYlv9wcs=
 golang.org/x/sys v0.0.0-20190606165138-5da285871e9c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20191024073052-e66fe6eb8e0c h1:usSYQsGq37L8RjJc5eznJ/AbwBxn3QFFEVkWNPAejLs=
+golang.org/x/sys v0.0.0-20191024073052-e66fe6eb8e0c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=


### PR DESCRIPTION
This wrapper is given the CAP_NET_BIND_SERVICE capability so that it can
run Envoy with that bit set. This will let Envoy run on a low port as a
non privileged user.

Envoy needs to be able to inherit the capability, but I've verified that
this does not suffer from the same problem of not being able to run when
that capability is explicitly dropped.

In a separate PR I will update the entrypoint so that it calls the
wrapper if the capability is available, and Envoy otherwise