### PR TITLE
Display license contact information if usage above limit in diag

### DIFF
--- a/python/templates/system-info.html
+++ b/python/templates/system-info.html
@@ -60,4 +60,9 @@
       </table>
     </div>
   </div>
+  {% if licenseinfo and licenseinfo.features_over_limit %}
+  <div class="col-12" style="color:red; font-weight: bold">
+    Contact Datawire for a license key to remove limits on features: {{ ", ".join(licenseinfo.features_over_limit) }}
+  </div>
+  {% endif %}
 </div>


### PR DESCRIPTION
## Description
Display license contact information if usage above limit in diag.
Actual displayed message is TBD.

## Related Issues
None.

## Testing
Manual tests, requires service provider at endpoint `http://127.0.0.1:8500/_/sys/license`.

## Todos
- [ ] Tests
- [ ] Documentation

