### PR TITLE
support for keepalive envoy section

### DIFF
--- a/docs/reference/core/ambassador.md
+++ b/docs/reference/core/ambassador.md
@@ -123,6 +123,15 @@ spec:
   #   policy: round_robin/least_request/ring_hash/maglev
   #   ...
 
+  # keepalive sets the global keepalive settings.
+  # Ambassador will use for all mappings, unless overridden in a
+  # mapping. No default value is provided by ambassador.
+  # More information at https://www.envoyproxy.io/docs/envoy/latest/api-v2/api/v2/core/address.proto#envoy-api-msg-core-tcpkeepalive
+  # keepalive:
+  #   time: 2
+  #   interval: 2
+  #   probes: 100
+
   # circuit_breakers sets the global circuit breaking configuration that
   # Ambassador will use for all mappings, unless overridden in a
   # mapping.

--- a/docs/reference/keepalive.md
+++ b/docs/reference/keepalive.md
@@ -1,0 +1,66 @@
+# Keepalive
+
+Keepalive option indicates whether SO_KEEPALIVE on the socket should be enabled. 
+
+## Keepalive configuration
+
+Keepalive configuration can be set for all Ambassador mappings in the [ambassador](/reference/core/ambassador) module or set per [mapping](https://www.getambassador.io/reference/mappings#configuring-mappings).
+
+The `keepalive` attribute configures keepalive. The following fields are supported:
+```yaml
+keepalive:
+  time: <integer>
+  interval: <integer>
+  probes: <integer>
+```
+
+### `time`
+(Default: `7200`) The number of seconds a connection needs to be idle before keep-alive probes start being sent.
+
+### `interval`
+(Default: `75`) The number of seconds between keep-alive probes.
+
+### `probes`
+(Default: `9`) Maximum number of keepalive probes to send without response before deciding the connection is dead.
+
+## Examples
+
+Keepalive probes defined on a single mapping:
+
+```yaml
+---
+apiVersion: getambassador.io/v1
+kind:  Mapping
+metadata:
+  name:  tour-backend
+spec:
+prefix: /backend/
+service: tour
+keepalive:
+  time: 100
+  interval: 10
+  probes: 9
+```
+
+A global keepalive configuration:
+
+```yaml
+apiVersion: getambassador.io/v1
+kind:  Module
+metadata:
+  name:  ambassador
+spec:
+  config:
+    keepalive:
+       time: 100
+       interval: 10
+       probes: 9
+---
+apiVersion: getambassador.io/v1
+kind:  Mapping
+metadata:
+  name:  tour-backend
+spec:
+prefix: /backend/
+service: tour
+```

--- a/python/ambassador/envoy/v2/v2cluster.py
+++ b/python/ambassador/envoy/v2/v2cluster.py
@@ -26,7 +26,7 @@ if TYPE_CHECKING:
 class V2Cluster(dict):
     def __init__(self, config: 'V2Config', cluster: IRCluster) -> None:
         super().__init__()
-
+        
         dns_lookup_family = 'V4_ONLY'
 
         if cluster.enable_ipv6:
@@ -81,6 +81,28 @@ class V2Cluster(dict):
                 envoy_ctx = V2TLSContext(ctx=ctx, host_rewrite=cluster.get('host_rewrite', None))
                 if envoy_ctx:
                     fields['tls_context'] = envoy_ctx
+
+
+        keepalive = cluster.get('keepalive', None)
+        #in case of empty keepalive for service, we can try to fallback to default
+        if keepalive is None:
+            if cluster.ir.ambassador_module and cluster.ir.ambassador_module.get('keepalive', None):
+                keepalive = cluster.ir.ambassador_module['keepalive']
+
+        if keepalive is not None:
+            keepalive_options = {}    
+            keepalive_time = keepalive.get('time', None) 
+            keepalive_interval = keepalive.get('interval', None) 
+            keepalive_probes = keepalive.get('probes', None) 
+            
+            if keepalive_time is not None:
+                keepalive_options['keepalive_time'] = keepalive_time
+            if keepalive_interval is not None:
+                keepalive_options['keepalive_interval'] = keepalive_interval
+            if keepalive_probes is not None:
+                keepalive_options['keepalive_probes'] = keepalive_probes
+                
+            fields['upstream_connection_options'] = {'tcp_keepalive' : keepalive_options }
 
         self.update(fields)
 

--- a/python/ambassador/ir/irambassador.py
+++ b/python/ambassador/ir/irambassador.py
@@ -41,6 +41,7 @@ class IRAmbassador (IRResource):
         'cluster_idle_timeout_ms',
         'liveness_probe',
         'load_balancer',
+        'keepalive',
         'readiness_probe',
         'regex_max_size',
         'regex_type',
@@ -224,6 +225,9 @@ class IRAmbassador (IRResource):
                 ir.save_filter(self.buffer)
             else:
                 return False
+
+        if amod and ('keepalive' in amod):
+            self.keepalive = amod['keepalive']
 
         # Finally, default CORS stuff.
         if amod and ('cors' in amod):

--- a/python/ambassador/ir/ircluster.py
+++ b/python/ambassador/ir/ircluster.py
@@ -57,6 +57,7 @@ class IRCluster (IRResource):
                  grpc: Optional[bool] = False,
                  allow_scheme: Optional[bool] = True,
                  load_balancer: Optional[dict] = None,
+                 keepalive: Optional[dict] = None,
                  circuit_breakers: Optional[list] = None,
 
                  rkey: str="-override-",
@@ -261,6 +262,7 @@ class IRCluster (IRResource):
             "lb_type": lb_type,
             "urls": [ url ],
             "load_balancer": load_balancer,
+            "keepalive": keepalive,
             "circuit_breakers": circuit_breakers,
             "service": service,
             'enable_ipv4': enable_ipv4,

--- a/python/ambassador/ir/irhttpmapping.py
+++ b/python/ambassador/ir/irhttpmapping.py
@@ -74,6 +74,7 @@ class IRHTTPMapping (IRBaseMapping):
         "host_rewrite": True,
         "labels": True,       # Only supported in v1, handled in setup
         "load_balancer": True,
+        "keepalive": True,
         "method": True,
         "method_regex": True,
         "modules": True,

--- a/python/ambassador/ir/irhttpmappinggroup.py
+++ b/python/ambassador/ir/irhttpmappinggroup.py
@@ -42,6 +42,7 @@ class IRHTTPMappingGroup (IRBaseMappingGroup):
         # a CoreMappingKey -- if it appears, it can't have multiple values within an IRHTTPMappingGroup.
         'labels': True,
         'load_balancer': True,
+        'keepalive': True,
         'method': True,
         'prefix': True,
         'prefix_regex': True,
@@ -187,6 +188,7 @@ class IRHTTPMappingGroup (IRBaseMappingGroup):
     def add_cluster_for_mapping(ir: 'IR', aconf: Config, mapping: IRBaseMapping,
                                 marker: Optional[str] = None) -> IRCluster:
         # Find or create the cluster for this Mapping...
+
         cluster = IRCluster(ir=ir, aconf=aconf,
                             location=mapping.location,
                             service=mapping.service,
@@ -197,6 +199,7 @@ class IRHTTPMappingGroup (IRBaseMappingGroup):
                             enable_ipv6=mapping.get('enable_ipv6', None),
                             grpc=mapping.get('grpc', False),
                             load_balancer=mapping.get('load_balancer', None),
+                            keepalive=mapping.get('keepalive', None),
                             connect_timeout_ms=mapping.get('connect_timeout_ms', 3000),
                             cluster_idle_timeout_ms=mapping.get('cluster_idle_timeout_ms', None),
                             circuit_breakers=mapping.get('circuit_breakers', None),
@@ -263,6 +266,11 @@ class IRHTTPMappingGroup (IRBaseMappingGroup):
 
         # OK. Save some typing with local variables for default labels and our labels...
         labels: Dict[str, Any] = self.get('labels', None)
+
+        if self.get('keepalive', None) is None:
+            keepalive_default = ir.ambassador_module.get('keepalive', None)
+            if keepalive_default:
+                self['keepalive'] = keepalive_default
 
         if not labels:
             # No labels. Use the default label domain to see if we have some valid defaults.

--- a/python/schemas/v1/Mapping.schema
+++ b/python/schemas/v1/Mapping.schema
@@ -42,6 +42,20 @@
                 "additionalProperties": false
             }
         },
+        "keepalive": {
+            "type": "object",
+            "properties": {
+                 "probes": {
+                    "type": "integer"                     
+                 },
+                 "idle_time": {
+                    "type": "integer"                     
+                 },
+                 "interval: {
+                    "type": "integer"                     
+                 }
+            }
+        },
         "cors": {
             "type": "object",
             "properties": {

--- a/python/schemas/v1/Mapping.schema
+++ b/python/schemas/v1/Mapping.schema
@@ -51,7 +51,7 @@
                  "idle_time": {
                     "type": "integer"                     
                  },
-                 "interval: {
+                 "interval": {
                     "type": "integer"                     
                  }
             }


### PR DESCRIPTION
## Description
Because of how k8s is deployed and how networking works on such environment (on k8s clusters, there is more firewalls/iptables/ipvs/conntrack stuff than trees in the forest),some stale connection appear - and because of that 503 are returned from the ambassador/envoy to the client. Adding support for keep_alive should help :) 

## Testing
TODO - not testing, I have no test environment / tests on local cluster doesn't work on my computer  

## Todos
- [ ] Tests
- [x] Documentation

