### PR TITLE
Changes to watch_hook for hosts, namespaces, etc.

### DIFF
--- a/cmd/teleproxy/teleproxy_flake_test.go
+++ b/cmd/teleproxy/teleproxy_flake_test.go
@@ -1,0 +1,40 @@
+// +build flake
+
+package main
+
+import (
+	"syscall"
+	"testing"
+)
+
+// We should really do something sane in each case:
+//  - startup with good, switch to bad
+//  - startup with bad, switch to good
+//  - startup with good, switch to alt
+// Currently we only cover good to alternative good, I haven't figured
+// out what makes sense in the other cases
+
+func TestHUPGood2Alt(t *testing.T) {
+	if noDocker != nil {
+		t.Skip(noDocker)
+	}
+	gotHere := false
+	writeGoodFile(HupConfig)
+	withInterrupt(t, hup, func() {
+		if poll(t, "http://httptarget", "HTTPTEST") {
+			writeAltFile(HupConfig)
+			err := hup.Process.Signal(syscall.SIGHUP)
+			if err != nil {
+				t.Errorf("error sending signal: %v", err)
+				return
+			}
+			if poll(t, "http://httptarget", "ALT") {
+				gotHere = true
+				return
+			}
+		}
+	})
+	if !gotHere {
+		t.Errorf("didn't get there")
+	}
+}

--- a/cmd/teleproxy/teleproxy_test.go
+++ b/cmd/teleproxy/teleproxy_test.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
-	"syscall"
 	"testing"
 	"time"
 
@@ -211,37 +210,5 @@ func writeAltFile(dest string) {
 	err = ioutil.WriteFile(dest, alt, 0666)
 	if err != nil {
 		panic(err)
-	}
-}
-
-// We should really do something sane in each case:
-//  - startup with good, switch to bad
-//  - startup with bad, switch to good
-//  - startup with good, switch to alt
-// Currently we only cover good to alternative good, I haven't figured
-// out what makes sense in the other cases
-
-func TestHUPGood2Alt(t *testing.T) {
-	if noDocker != nil {
-		t.Skip(noDocker)
-	}
-	gotHere := false
-	writeGoodFile(HupConfig)
-	withInterrupt(t, hup, func() {
-		if poll(t, "http://httptarget", "HTTPTEST") {
-			writeAltFile(HupConfig)
-			err := hup.Process.Signal(syscall.SIGHUP)
-			if err != nil {
-				t.Errorf("error sending signal: %v", err)
-				return
-			}
-			if poll(t, "http://httptarget", "ALT") {
-				gotHere = true
-				return
-			}
-		}
-	})
-	if !gotHere {
-		t.Errorf("didn't get there")
 	}
 }

--- a/cmd/watt/aggregator.go
+++ b/cmd/watt/aggregator.go
@@ -225,7 +225,7 @@ func lines(st string) []string {
 }
 
 func invokeHook(p *supervisor.Process, hook, snapshot string) WatchSet {
-	cmd := exec.Command(hook)
+	cmd := exec.Command("sh", "-c", hook)
 	cmd.Stdin = strings.NewReader(snapshot)
 	var watches, errors strings.Builder
 	cmd.Stdout = &watches

--- a/python/ambassador/config/acresource.py
+++ b/python/ambassador/config/acresource.py
@@ -39,6 +39,7 @@ class ACResource (Resource):
     :param location: where should a human go to find the source of this resource?
     :param kind: what kind of thing is this?
     :param name: what's the name of this thing?
+    :param namespace: what namespace is this in?
     :param apiVersion: API version, defaults to "ambassador/v0" if not present
     :param serialization: original input serialization of obj, if we have it
     :param kwargs: key-value pairs that form the data object for this resource
@@ -50,6 +51,7 @@ class ACResource (Resource):
     def __init__(self, rkey: str, location: str, *,
                  kind: str,
                  name: Optional[str]=None,
+                 namespace: Optional[str]=None,
                  apiVersion: Optional[str]="ambassador/v0",
                  serialization: Optional[str]=None,
                  **kwargs) -> None:
@@ -69,7 +71,7 @@ class ACResource (Resource):
         # print("ACResource __init__ (%s %s)" % (kind, name))
 
         super().__init__(rkey=rkey, location=location,
-                         kind=kind, name=name,
+                         kind=kind, name=name, namespace=namespace,
                          apiVersion=typecast(str, apiVersion),
                          serialization=serialization,
                          **kwargs)
@@ -82,10 +84,12 @@ class ACResource (Resource):
                       kind: Optional[str]=None,
                       serialization: Optional[str]=None,
                       name: Optional[str]=None,
+                      namespace: Optional[str]=None,
                       apiVersion: Optional[str]=None,
                       **kwargs) -> R:
         new_name = name or other.name
         new_apiVersion = apiVersion or other.apiVersion
+        new_namespace = namespace or other.namespace
 
         # mypy 0.730 is Just Flat Wrong here. It tries to be "more strict" about
         # super(), which is fine, but it also flags this particular super() call
@@ -99,7 +103,7 @@ class ACResource (Resource):
             assert(isinstance(cls, Resource))
 
         return super().from_resource(other, rkey=rkey, location=location, kind=kind,
-                                     name=new_name, apiVersion=new_apiVersion,
+                                     name=new_name, apiVersion=new_apiVersion, namespace=new_namespace,
                                      serialization=serialization, **kwargs)
 
     # ACResource.INTERNAL is the magic ACResource we use to represent something created by

--- a/python/ambassador/config/config.py
+++ b/python/ambassador/config/config.py
@@ -13,9 +13,10 @@
 # limitations under the License
 import socket
 
-from typing import Any, ClassVar, Dict, Iterable, List, Optional, Tuple, Union
+from typing import Any, Callable, ClassVar, Dict, Iterable, List, Optional, Tuple, Union
 from typing import cast as typecast
 
+import importlib
 import json
 import logging
 import os
@@ -24,6 +25,7 @@ import jsonschema
 
 from multi import multi
 from pkg_resources import Requirement, resource_filename
+from google.protobuf import json_format
 
 from ..utils import RichStatus
 
@@ -41,6 +43,13 @@ from .acmapping import ACMapping
 # Custom types
 # StringOrList is either a string or a list of strings.
 StringOrList = Union[str, List[str]]
+
+# Validator is a callable that accepts an ACResource and validates it. The
+# return value is a RichStatus.
+#
+# The assumption here is that Config.get_validator() will return something
+# like a lambda that's tailored to the apiVersion and kind of the resource.
+Validator = Callable[[ACResource], RichStatus]
 
 
 class Config:
@@ -87,8 +96,7 @@ class Config:
     current_resource: Optional[ACResource] = None
     helm_chart: Optional[str]
 
-    # XXX flat wrong
-    schemas: Dict[str, dict]
+    validators: Dict[str, Validator]
     config: Dict[str, Dict[str, ACResource]]
 
     breakers: Dict[str, ACResource]
@@ -144,7 +152,7 @@ class Config:
         self.current_resource = None
         self.helm_chart = None
 
-        self.schemas = {}
+        self.validators = {}
         self.config = {}
 
         self.breakers = {}
@@ -424,39 +432,118 @@ class Config:
         if resource.kind.lower() in Config.NoSchema:
             return RichStatus.OK(msg=f"no schema for {resource.kind} so calling it good")
 
-        # Do we already have this schema loaded?
-        schema_key = "%s-%s" % (apiVersion, resource.kind)
-        schema = self.schemas.get(schema_key, None)
+        # Do we have a validator for this?
+        validator = self.get_validator(apiVersion, resource.kind)
 
-        if not schema:
-            # Not loaded. Go find it on disk.
-            schema_path = os.path.join(self.schema_dir_path, apiVersion,
-                                       "%s.schema" % resource.kind)
+        if validator:
+            rc = validator(resource)
 
-            try:
-                # Load it up...
-                schema = json.load(open(schema_path, "r"))
+            self.logger.debug(f"validation {'OK' if rc else rc}")
+            return rc
 
-                # ...and then cache it, if it exists. Note that we'll never
-                # get here if we find something that doesn't parse.
-                if schema:
-                    self.schemas[schema_key] = typecast(Dict[Any, Any], schema)
-            except OSError:
-                self.logger.debug("no schema at %s, not validating" % schema_path)
-            except json.decoder.JSONDecodeError as e:
-                self.logger.warning("corrupt schema at %s, skipping (%s)" %
-                                    (schema_path, e))
+    def get_validator(self, apiVersion: str, kind: str) -> Validator:
+        schema_key = "%s-%s" % (apiVersion, kind)
 
-        if schema:
-            # We have a schema. Does the object validate OK?
-            try:
-                jsonschema.validate(resource.as_dict(), schema)
-            except jsonschema.exceptions.ValidationError as e:
-                # Nope. Bzzzzt.
-                return RichStatus.fromError("not a valid %s: %s" % (resource.kind, e))
+        validator = self.validators.get(schema_key, None)
+
+        if not validator:
+            validator = self.get_proto_validator(apiVersion, kind)
+
+        if not validator:
+            validator = self.get_jsonschema_validator(apiVersion, kind)
+
+        if not validator:
+            # Ew. Early binding for Python lambdas is kinda weird.
+            validator = lambda resource, args=(apiVersion, kind): self.cannot_validate(*args)
+
+        if validator:
+            self.validators[schema_key] = validator
+
+        return validator
+
+    def cannot_validate(self, apiVersion: str, kind: str) -> RichStatus:
+        self.logger.debug(f"Cannot validate getambassador.io/{apiVersion} {kind}")
+
+        return RichStatus.OK(msg="Not validating getambassador.io/{apiVersion} {kind}")
+
+    def get_proto_validator(self, apiVersion, kind) -> Optional[Validator]:
+        # See if we can import a protoclass...
+        proto_modname = f"ambassador.proto.{apiVersion}.{kind}_pb2"
+        proto_classname = f"{kind}Spec"
+        m = None
+
+        try:
+            m = importlib.import_module(proto_modname)
+        except ModuleNotFoundError:
+            self.logger.debug(f"no proto in {proto_modname}")
+            return None
+
+        protoclass = getattr(m, proto_classname, None)
+
+        if not protoclass:
+            self.logger.debug(f"no class {proto_classname} in {proto_modname}")
+            return None
+
+        self.logger.debug(f"using validate_with_proto for getambassador.io/{apiVersion} {kind}")
+
+        # Ew. Early binding for Python lambdas is kinda weird.
+        return lambda resource, protoclass=protoclass: self.validate_with_proto(resource, protoclass)
+
+    def validate_with_proto(self, resource: ACResource, protoclass: Any) -> RichStatus:
+        # This is... a little odd.
+        #
+        # First, protobuf works with JSON, not dictionaries. Second, by the time we get here,
+        # the metadata has been folded in, and our *Spec protos (HostSpec, etc) don't include
+        # the metadata (by design).
+        #
+        # So. We make a copy, strip the metadata fields, serialize, and _then_ see if  we can
+        # parse it. Yuck.
+
+        rdict = resource.as_dict()
+        rdict.pop('apiVersion', None)
+        rdict.pop('kind', None)
+
+        name = rdict.pop('name', None)
+        generation = rdict.pop('generation', None)
+
+        serialized = json.dumps(rdict)
+
+        try:
+            json_format.Parse(serialized, protoclass())
+        except json_format.ParseError as e:
+            return RichStatus.fromError(e)
+
+        return RichStatus.OK(msg=f"good {resource.kind}")
+
+    def get_jsonschema_validator(self, apiVersion, kind) -> Optional[Validator]:
+        # Do we have a JSONSchema on disk for this?
+        schema_path = os.path.join(self.schema_dir_path, apiVersion, f"{kind}.schema")
+
+        try:
+            schema = json.load(open(schema_path, "r"))
+
+            # Note that we'll never get here if the schema doesn't parse.
+            if schema:
+                self.logger.debug(f"using validate_with_jsonschema for getambassador.io/{apiVersion} {kind}")
+
+                # Ew. Early binding for Python lambdas is kinda weird.
+                return lambda resource, schema=schema: self.validate_with_jsonschema(resource, schema)
+        except OSError:
+            self.logger.debug(f"no schema at {schema_path}, not validating")
+            return None
+        except json.decoder.JSONDecodeError as e:
+            self.logger.warning(f"corrupt schema at {schema_path}, skipping ({e})")
+            return None
+
+    def validate_with_jsonschema(self, resource: ACResource, schema: dict) -> RichStatus:
+        try:
+            jsonschema.validate(resource.as_dict(), schema)
+        except jsonschema.exceptions.ValidationError as e:
+            # Nope. Bzzzzt.
+            return RichStatus.fromError(f"not a valid {resource.kind}: {e}")
 
         # All good. Return an OK.
-        return RichStatus.OK(msg="valid %s" % resource.kind)
+        return RichStatus.OK(msg=f"good {resource.kind}")
 
     def safe_store(self, storage_name: str, resource: ACResource, allow_log: bool=True) -> None:
         """

--- a/python/ambassador/config/config.py
+++ b/python/ambassador/config/config.py
@@ -354,6 +354,10 @@ class Config:
         if 'name' not in resource:
             return RichStatus.fromError("need name")
 
+        # ...and also make sure it has a namespace.
+        if not resource.get('namespace', None):
+            resource['namespace'] = self.ambassador_namespace
+
         # ...and off we go. Save the source info...
         self.save_source(resource)
 
@@ -504,6 +508,7 @@ class Config:
         rdict.pop('kind', None)
 
         name = rdict.pop('name', None)
+        namespace = rdict.pop('namespace', None)
         generation = rdict.pop('generation', None)
 
         serialized = json.dumps(rdict)

--- a/python/ambassador/config/resourcefetcher.py
+++ b/python/ambassador/config/resourcefetcher.py
@@ -193,13 +193,13 @@ class ResourceFetcher:
             # Handle normal Kube objects...
             for key in [ 'service', 'endpoints', 'secret', 'ingresses' ]:
                 for obj in watt_k8s.get(key) or []:
-                    self.logger.debug(f"Handling Kubernetes {key}...")
+                    # self.logger.debug(f"Handling Kubernetes {key}...")
                     self.handle_k8s(obj)
 
             # ...then handle Ambassador CRDs.
             for key in CRDTypes:
                 for obj in watt_k8s.get(key) or []:
-                    self.logger.debug(f"Handling CRD {key}...")
+                    # self.logger.debug(f"Handling CRD {key}...")
                     self.handle_k8s_crd(obj)
 
             watt_consul = watt_dict.get('Consul', {})
@@ -228,17 +228,20 @@ class ResourceFetcher:
             # self.logger.debug("%s: ignoring K8s object, no kind" % self.location)
             return
 
+        metadata = obj.get('metadata') or {}
+        name = metadata.get('name') or '(no name?)'
+
         handler = None
 
         if kind in CRDTypes:
             handler = self.handle_k8s_crd
         else:
             handler_name = f'handle_k8s_{kind.lower()}'
-            self.logger.debug(f"looking for handler {handler_name}")
+            # self.logger.debug(f"looking for handler {handler_name} for K8s {kind} {name}")
             handler = getattr(self, handler_name, None)
 
         if not handler:
-            self.logger.debug("%s: ignoring K8s object, unknown kind" % self.location)
+            self.logger.debug(f"{self.location}: skipping K8s {kind}")
             return
 
         result = handler(obj)
@@ -250,8 +253,7 @@ class ResourceFetcher:
 
     def handle_k8s_crd(self, obj: dict) -> None:
         # CRDs are _not_ allowed to have embedded objects in annotations, because ew.
-
-        self.logger.debug(f"Handling K8s CRD: {obj}")
+        # self.logger.debug(f"Handling K8s CRD: {obj}")
 
         kind = obj.get('kind')
 
@@ -311,7 +313,7 @@ class ResourceFetcher:
         # self.logger.debug("PARSE_OBJECT: incoming %d" % len(objects))
 
         for obj in objects:
-            self.logger.debug("PARSE_OBJECT: checking %s" % obj)
+            # self.logger.debug("PARSE_OBJECT: checking %s" % obj)
 
             if k8s:
                 self.handle_k8s(obj)

--- a/python/ambassador/envoy/v2/v2listener.py
+++ b/python/ambassador/envoy/v2/v2listener.py
@@ -785,7 +785,7 @@ class V2Listener(dict):
 
             # We have a TLS context, so we should make sure they're speaking TLS!
             self.need_tls_inspector = True
-            filter_chain_match = {
+            filter_chain_match: Dict[str, Any] = {
                 'transport_protocol': 'tls'
             }
 

--- a/python/ambassador/ir/ircors.py
+++ b/python/ambassador/ir/ircors.py
@@ -84,7 +84,7 @@ class IRCORS (IRResource):
         raw_dict = super().as_dict()
 
         for key in list(raw_dict):
-            if key in ["_active", "_errored", "_referenced_by", "_rkey", "kind", "location", "name"]:
+            if key in ["_active", "_errored", "_referenced_by", "_rkey", "kind", "location", "name", "namespace"]:
                 raw_dict.pop(key, None)
 
         return raw_dict

--- a/python/ambassador/ir/irresource.py
+++ b/python/ambassador/ir/irresource.py
@@ -38,13 +38,18 @@ class IRResource (Resource):
                  rkey: str,
                  kind: str,
                  name: str,
+                 namespace: Optional[str]=None,
                  location: str = "--internal--",
                  apiVersion: str="ambassador/ir",
                  **kwargs) -> None:
         # print("IRResource __init__ (%s %s)" % (kind, name))
 
+        if not namespace:
+            namespace = ir.ambassador_namespace
+
         super().__init__(rkey=rkey, location=location,
-                         kind=kind, name=name, apiVersion=apiVersion,
+                         kind=kind, name=name, namespace=namespace,
+                         apiVersion=apiVersion,
                          **kwargs)
         self.ir = ir
         self.logger = ir.logger

--- a/python/ambassador/ir/irretrypolicy.py
+++ b/python/ambassador/ir/irretrypolicy.py
@@ -42,7 +42,7 @@ class IRRetryPolicy (IRResource):
         raw_dict = super().as_dict()
 
         for key in list(raw_dict):
-            if key in ["_active", "_errored", "_referenced_by", "_rkey", "kind", "location", "name"]:
+            if key in ["_active", "_errored", "_referenced_by", "_rkey", "kind", "location", "name", "namespace"]:
                 raw_dict.pop(key, None)
 
         return raw_dict

--- a/python/ambassador/ir/irtls.py
+++ b/python/ambassador/ir/irtls.py
@@ -142,6 +142,7 @@ class TLSModuleFactory:
             for legacy_name, legacy_ctx in ir.tls_module.as_dict().items():
                 if (legacy_name.startswith('_') or
                     (legacy_name == 'name') or
+                    (legacy_name == 'namespace') or
                     (legacy_name == 'location') or
                     (legacy_name == 'kind') or
                     (legacy_name == 'enabled')):

--- a/python/ambassador/utils.py
+++ b/python/ambassador/utils.py
@@ -471,7 +471,7 @@ class SecretHandler:
             # Bzzt.
             return None
 
-        return SecretInfo.from_dict(context, secret_name, source, namespace, cert_data)
+        return SecretInfo.from_dict(context, secret_name, namespace, source, cert_data)
 
 
 class NullSecretHandler(SecretHandler):

--- a/python/entrypoint.sh
+++ b/python/entrypoint.sh
@@ -396,7 +396,7 @@ if [[ -z "${AMBASSADOR_NO_KUBEWATCH}" ]]; then
            ${KUBEWATCH_SYNC_KINDS} \
            ${AMBASSADOR_FIELD_SELECTOR_ARG} \
            ${AMBASSADOR_LABEL_SELECTOR_ARG} \
-           --watch /ambassador/watch_hook.py
+           --watch "python /ambassador/watch_hook.py"
 fi
 
 ################################################################################

--- a/python/schemas/v0/AuthService.schema
+++ b/python/schemas/v0/AuthService.schema
@@ -8,6 +8,7 @@
         "generation": { "type": "integer" },
         "kind": { "type": "string" },
         "name": { "type": "string" },
+        "namespace": { "type": "string" },
         "ambassador_id": {
             "anyOf": [
                 { "type": "string" },

--- a/python/schemas/v0/CircuitBreaker.schema
+++ b/python/schemas/v0/CircuitBreaker.schema
@@ -8,6 +8,7 @@
         "generation": { "type": "integer" },
         "kind": { "type": "string" },
         "name": { "type": "string" },
+        "namespace": { "type": "string" },
         "ambassador_id": {
             "anyOf": [
                 { "type": "string" },

--- a/python/schemas/v0/Mapping.schema
+++ b/python/schemas/v0/Mapping.schema
@@ -8,6 +8,7 @@
         "generation": { "type": "integer" },
         "kind": { "type": "string" },
         "name": { "type": "string" },
+        "namespace": { "type": "string" },
         "ambassador_id": {
             "anyOf": [
                 { "type": "string" },

--- a/python/schemas/v0/Module.schema
+++ b/python/schemas/v0/Module.schema
@@ -8,6 +8,7 @@
         "generation": { "type": "integer" },
         "kind": { "type": "string" },
         "name": { "type": "string" },
+        "namespace": { "type": "string" },
         "ambassador_id": {
             "anyOf": [
                 { "type": "string" },

--- a/python/schemas/v0/OutlierDetection.schema
+++ b/python/schemas/v0/OutlierDetection.schema
@@ -8,6 +8,7 @@
         "generation": { "type": "integer" },
         "kind": { "type": "string" },
         "name": { "type": "string" },
+        "namespace": { "type": "string" },
         "ambassador_id": {
             "anyOf": [
                 { "type": "string" },

--- a/python/schemas/v0/RateLimitService.schema
+++ b/python/schemas/v0/RateLimitService.schema
@@ -8,6 +8,7 @@
         "generation": { "type": "integer" },
         "kind": { "type": "string" },
         "name": { "type": "string" },
+        "namespace": { "type": "string" },
         "ambassador_id": {
             "anyOf": [
                 { "type": "string" },

--- a/python/schemas/v0/TracingService.schema
+++ b/python/schemas/v0/TracingService.schema
@@ -8,6 +8,7 @@
         "generation": { "type": "integer" },
         "kind": { "type": "string" },
         "name": { "type": "string" },
+        "namespace": { "type": "string" },
         "ambassador_id": {
             "anyOf": [
                 { "type": "string" },

--- a/python/schemas/v1/AuthService.schema
+++ b/python/schemas/v1/AuthService.schema
@@ -7,6 +7,7 @@
         "generation": { "type": "integer" },
         "kind": { "type": "string" },
         "name": { "type": "string" },
+        "namespace": { "type": "string" },
         "ambassador_id": {
             "anyOf": [
                 { "type": "string" },

--- a/python/schemas/v1/LogService.schema
+++ b/python/schemas/v1/LogService.schema
@@ -8,6 +8,7 @@
         "generation": { "type": "integer" },
         "kind": { "type": "string" },
         "name": { "type": "string" },
+        "namespace": { "type": "string" },
         "ambassador_id": {
             "anyOf": [
                 { "type": "string" },

--- a/python/schemas/v1/Mapping.schema
+++ b/python/schemas/v1/Mapping.schema
@@ -8,6 +8,7 @@
         "generation": { "type": "integer" },
         "kind": { "type": "string" },
         "name": { "type": "string" },
+        "namespace": { "type": "string" },
         "ambassador_id": {
             "anyOf": [
                 { "type": "string" },

--- a/python/schemas/v1/Module.schema
+++ b/python/schemas/v1/Module.schema
@@ -8,6 +8,7 @@
         "generation": { "type": "integer" },
         "kind": { "type": "string" },
         "name": { "type": "string" },
+        "namespace": { "type": "string" },
         "ambassador_id": {
             "anyOf": [
                 { "type": "string" },

--- a/python/schemas/v1/RateLimitService.schema
+++ b/python/schemas/v1/RateLimitService.schema
@@ -8,6 +8,7 @@
         "generation": { "type": "integer" },
         "kind": { "type": "string" },
         "name": { "type": "string" },
+        "namespace": { "type": "string" },
         "ambassador_id": {
             "anyOf": [
                 { "type": "string" },

--- a/python/schemas/v1/TCPMapping.schema
+++ b/python/schemas/v1/TCPMapping.schema
@@ -8,6 +8,7 @@
         "generation": { "type": "integer" },
         "kind": { "type": "string" },
         "name": { "type": "string" },
+        "namespace": { "type": "string" },
         "ambassador_id": {
             "anyOf": [
                 { "type": "string" },

--- a/python/schemas/v1/TLSContext.schema
+++ b/python/schemas/v1/TLSContext.schema
@@ -8,6 +8,7 @@
         "generation": { "type": "integer" },
         "kind": { "type": "string" },
         "name": { "type": "string" },
+        "namespace": { "type": "string" },
         "ambassador_id": {
             "anyOf": [
                 { "type": "string" },

--- a/python/schemas/v1/TracingService.schema
+++ b/python/schemas/v1/TracingService.schema
@@ -8,6 +8,7 @@
         "generation": { "type": "integer" },
         "kind": { "type": "string" },
         "name": { "type": "string" },
+        "namespace": { "type": "string" },
         "ambassador_id": {
             "anyOf": [
                 { "type": "string" },

--- a/python/watch_hook.py
+++ b/python/watch_hook.py
@@ -110,7 +110,7 @@ if args:
     yaml_stream = open(args[0], "r")
 
 aconf = Config()
-fetcher = ResourceFetcher(logger, aconf)
+fetcher = ResourceFetcher(logger, aconf, watch_only=True)
 fetcher.parse_watt(yaml_stream.read())
 
 aconf.load_all(fetcher.sorted())


### PR DESCRIPTION
- Fix a longstanding bug where the `namespace` and `source` were swapped for K8s `secrets` coming from `watt`. (!!!)
- Teach the `ResourceFetcher` how to validate things using `protobuf`s.
- Preserve namespace on input resources.
- Switch the `watch_hook` so that it uses the real `IR` class (with a short circuit in its initialization) rather than having so much duplicated logic for `FakeIR`.
- Explicitly call `python` to execute the `watch_hook`, rather than relying on `watch_hook.py` to be executable.
- Clean up some logging and typing errors.
- Pull in @rhs' change to mark `TestHUPGood2Alt` as a flake.