### PR TITLE
Track secrets in Host resources

### DIFF
--- a/python/ambassador/config/resourcefetcher.py
+++ b/python/ambassador/config/resourcefetcher.py
@@ -819,10 +819,14 @@ class ResourceFetcher:
         # This resource identifier is useful for log output since filenames can be duplicated (multiple subdirectories)
         resource_identifier = f'{resource_name}.{resource_namespace}'
 
-        tls_crt = data.get('tls.crt', None)
-        tls_key = data.get('tls.key', None)
+        found_any = False
 
-        if not tls_crt and not tls_key:
+        for key in [ 'tls.crt', 'tls.key', 'user.key' ]:
+            if data.get(key, None):
+                found_any = True
+                break
+
+        if not found_any:
             # Uh. WTFO?
             self.logger.debug(f'ignoring K8s Secret {resource_identifier} with no keys')
             return None
@@ -834,14 +838,12 @@ class ResourceFetcher:
             'ambassador_id': Config.ambassador_id,
             'kind': 'Secret',
             'name': resource_name,
-            'namespace': resource_namespace
+            'namespace': resource_namespace,
+            'secret_type': secret_type
         }
 
-        if tls_crt:
-            secret_info['tls_crt'] = tls_crt
-
-        if tls_key:
-            secret_info['tls_key'] = tls_key
+        for key, value in data.items():
+            secret_info[key.replace('.', '_')] = value
 
         return resource_identifier, [ secret_info ]
 

--- a/python/ambassador/ir/ir.py
+++ b/python/ambassador/ir/ir.py
@@ -35,7 +35,7 @@ from .irfilter import IRFilter
 from .ircluster import IRCluster
 from .irbasemappinggroup import IRBaseMappingGroup
 from .irbasemapping import IRBaseMapping
-from .irhttpmapping import IRHTTPMapping
+from .irhost import HostFactory
 from .irmappingfactory import MappingFactory
 from .irratelimit import IRRateLimit
 from .irtls import TLSModuleFactory, IRAmbassadorTLS
@@ -162,6 +162,9 @@ class IR:
 
         # Next, grab whatever information our aconf has about secrets...
         self.save_secret_info(aconf)
+
+        # ...then grab whatever we know about Hosts...
+        HostFactory.load_all(self, aconf)
 
         # ...and then it's on to default TLS stuff, both from the TLS module and from
         # any TLS contexts.

--- a/python/ambassador/ir/ir.py
+++ b/python/ambassador/ir/ir.py
@@ -371,7 +371,7 @@ class IR:
         if not secret_info:
             self.logger.error(f"Secret {ss_key} unknown")
 
-            ss = SavedSecret(secret_name, namespace, None, None, None)
+            ss = SavedSecret(secret_name, namespace, None, None, None, None)
         else:
             self.logger.info(f"resolve_secret {ss_key}: asking handler to cache")
 

--- a/python/ambassador/ir/ir.py
+++ b/python/ambassador/ir/ir.py
@@ -163,9 +163,6 @@ class IR:
         # Next, grab whatever information our aconf has about secrets...
         self.save_secret_info(aconf)
 
-        # ...then grab whatever we know about Hosts...
-        HostFactory.load_all(self, aconf)
-
         # ...and then it's on to default TLS stuff, both from the TLS module and from
         # any TLS contexts.
         #
@@ -175,6 +172,9 @@ class IR:
 
         TLSModuleFactory.load_all(self, aconf)
         TLSContextFactory.load_all(self, aconf)
+
+        # ...then grab whatever we know about Hosts...
+        HostFactory.load_all(self, aconf)
 
         # Now we can finalize the Ambassador module, to tidy up secrets et al. We do this
         # here so that secrets and TLS contexts are available.
@@ -339,8 +339,8 @@ class IR:
     def add_resolver(self, resolver: IRServiceResolver) -> None:
         self.resolvers[resolver.name] = resolver
 
-    # def has_tls_context(self, name: str) -> bool:
-    #     return bool(self.get_tls_context(name))
+    def has_tls_context(self, name: str) -> bool:
+        return bool(self.get_tls_context(name))
 
     def get_tls_context(self, name: str) -> Optional[IRTLSContext]:
         return self.tls_contexts.get(name, None)
@@ -376,7 +376,7 @@ class IR:
 
             ss = SavedSecret(secret_name, namespace, None, None, None, None)
         else:
-            self.logger.info(f"resolve_secret {ss_key}: asking handler to cache")
+            self.logger.info(f"resolve_secret {ss_key}: found secret, asking handler to cache")
 
             # OK, we got a secret_info. Cache that using the secret handler.
             ss = self.secret_handler.cache_secret(resource, secret_info)

--- a/python/ambassador/ir/irhost.py
+++ b/python/ambassador/ir/irhost.py
@@ -1,0 +1,105 @@
+from typing import ClassVar, Dict, List, Optional, Tuple, TYPE_CHECKING
+
+import base64
+import os
+
+from ..utils import RichStatus, SavedSecret
+from ..config import Config, ACResource
+from .irresource import IRResource
+
+if TYPE_CHECKING:
+    from .ir import IR
+    from .irtls import IRAmbassadorTLS
+
+
+class IRHost(IRResource):
+    AllowedKeys = {
+        'acmeProvider',
+        'hostname',
+        'selector',
+        'tlsSecret',
+    }
+
+    def __init__(self, ir: 'IR', aconf: Config,
+                 rkey: str,      # REQUIRED
+                 name: str,      # REQUIRED
+                 location: str,  # REQUIRED
+                 namespace: Optional[str]=None,
+                 kind: str="IRHost",
+                 apiVersion: str="ambassador/v2",   # Not a typo! See below.
+                 **kwargs) -> None:
+
+        new_args = {
+            x: kwargs[x] for x in kwargs.keys()
+            if x in IRHost.AllowedKeys
+        }
+
+        super().__init__(
+            ir=ir, aconf=aconf, rkey=rkey, location=location,
+            kind=kind, name=name, namespace=namespace, apiVersion=apiVersion,
+            **new_args
+        )
+
+    def setup(self, ir: 'IR', aconf: Config) -> bool:
+        ir.logger.info(f"Host {self.name} setting up")
+
+        if self.get('tlsSecret', None):
+            tls_secret = self.tlsSecret
+            tls_name = tls_secret.get('name', None)
+
+            # ir.logger.info(f"Host {self.name} has TLS secret {tls_secret}")
+
+            if tls_name:
+                ir.logger.info(f"Host {self.name} has TLS secret name {tls_name}")
+
+            ss = self.resolve(ir, tls_name)
+
+            if not ss:
+                # Bzzt.
+                ir.logger.error(f"Host {self.name} has invalid TLS secret {tls_name}")
+                return False
+
+        if self.get('acmeProvider', None):
+            acme = self.acmeProvider
+            pkey_secret = acme.get('privateKeySecret', None)
+
+            # ir.logger.info(f"Host {self.name} has ACME provider {acme}")
+
+            if pkey_secret:
+                # ir.logger.info(f"Host {self.name} has ACME privateKeySecret {pkey_secret}")
+
+                pkey_name = pkey_secret.get('name', None)
+
+                if pkey_name:
+                    ir.logger.info(f"Host {self.name} has ACME private key name {pkey_name}")
+
+                    ss = self.resolve(ir, pkey_name)
+
+                    if not ss:
+                        # Bzzt.
+                        ir.logger.error(f"Host {self.name} has invalid private key secret {pkey_name}")
+                        return False
+
+        return True
+
+    def resolve(self, ir: 'IR', secret_name: str) -> SavedSecret:
+        # Try to use our namespace for secret resolution. If we somehow have no
+        # namespace, fall back to the Ambassador's namespace.
+        namespace = self.namespace or ir.ambassador_namespace
+
+        return ir.resolve_secret(self, secret_name, namespace)
+
+
+class HostFactory():
+    @classmethod
+    def load_all(cls, ir: 'IR', aconf: Config) -> None:
+        assert ir
+
+        hosts = aconf.get_config('hosts')
+
+        if hosts:
+            for config in hosts.values():
+                ir.logger.debug("creating host for %s" % repr(config.as_dict()))
+
+                host = IRHost(ir, aconf, **config)
+                ir.save_resource(host)

--- a/python/ambassador/ir/irtlscontext.py
+++ b/python/ambassador/ir/irtlscontext.py
@@ -1,10 +1,9 @@
-from typing import ClassVar, Dict, List, Optional, Tuple, TYPE_CHECKING
+from typing import ClassVar, List, Optional, TYPE_CHECKING
 
 import base64
-import os
 
-from ..utils import RichStatus, SavedSecret
-from ..config import ACResource
+from ..utils import SavedSecret
+from ..config import Config
 from .irresource import IRResource
 
 if TYPE_CHECKING:
@@ -13,14 +12,28 @@ if TYPE_CHECKING:
 
 
 class IRTLSContext(IRResource):
-    CertKeys: ClassVar = [
+    CertKeys: ClassVar = {
         'secret',
         'cert_chain_file',
         'private_key_file',
 
         'ca_secret',
         'cacert_chain_file'
-    ]
+    }
+
+    AllowedKeys: ClassVar = {
+        '_ambassador_enabled',
+        '_legacy',
+        "alpn_protocols",
+        "cert_required",
+        "cipher_suites",
+        "ecdh_curves",
+        "hosts",
+        "max_tls_version",
+        "min_tls_version",
+        "redirect_cleartext_from",
+        "secret_namespacing",
+    }
 
     name: str
     hosts: Optional[List[str]]
@@ -34,102 +47,77 @@ class IRTLSContext(IRResource):
     secret_namespacing: Optional[bool]
     secret_info: dict
 
-    def __init__(self, ir: 'IR', config,
-                 rkey: str="ir.tlscontext",
+    _ambassador_enabled: bool
+    _legacy: bool
+
+    def __init__(self, ir: 'IR', aconf: Config,
+                 rkey: str,      # REQUIRED
+                 name: str,      # REQUIRED
+                 location: str,  # REQUIRED
+                 namespace: Optional[str]=None,
                  kind: str="IRTLSContext",
-                 name: str="tlscontext",
+                 apiVersion: str = "ambassador/v1",
                  **kwargs) -> None:
 
+        new_args = {
+            x: kwargs[x] for x in kwargs.keys()
+            if x in IRTLSContext.AllowedKeys.union(IRTLSContext.CertKeys)
+        }
+
         super().__init__(
-            ir=ir, aconf=config, rkey=rkey, kind=kind, name=name
+            ir=ir, aconf=aconf, rkey=rkey, location=location,
+            kind=kind, name=name, namespace=namespace, apiVersion=apiVersion,
+            **new_args
         )
 
-    def setup(self, ir: 'IR', config) -> bool:
-        # ir.logger.debug("IRTLSContext incoming config: %s" % config.as_json())
+    def setup(self, ir: 'IR', aconf: Config) -> bool:
+        if not self.get('_ambassador_enabled', False):
+            spec_count = 0
+            errors = 0
 
-        if config.get('_ambassador_enabled', False):
-            # Null context.
-            self['_ambassador_enabled'] = True
-        elif not self.validate(config):
-            return False
+            if self.get('secret', None):
+                spec_count += 1
 
-        self.sourced_by(config)
-        self.referenced_by(config)
+            if self.get('cert_chain_file', None):
+                spec_count += 1
 
-        self.name = config.get('name')
-        self.hosts = config.get('hosts')
-        self.alpn_protocols = config.get('alpn_protocols')
-        self.cert_required = config.get('cert_required')
-        self.min_tls_version = config.get('min_tls_version')
-        self.max_tls_version = config.get('max_tls_version')
-        self.cipher_suites = config.get('cipher_suites')
-        self.ecdh_curves = config.get('ecdh_curves')
-        self.secret_namespacing = config.get('secret_namespacing', None)
+                if not self.get('private_key_file', None):
+                    err_msg = f"TLSContext {self.name}: 'cert_chain_file' requires 'private_key_file' as well"
+
+                    self.post_error(err_msg)
+                    errors += 1
+
+            if spec_count == 2:
+                err_msg = f"TLSContext {self.name}: exactly one of 'secret' and 'cert_chain_file' must be present"
+
+                self.post_error(err_msg)
+                errors += 1
+
+            if errors:
+                return False
+
+        # self.sourced_by(config)
+        # self.referenced_by(config)
 
         # Assume that we have no redirect_cleartext_from...
-        self.redirect_cleartext_from = None
+        rcf = self.get('redirect_cleartext_from', None)
 
-        # Then override if actually an int.
-        rcf = config.get('redirect_cleartext_from')
         if rcf is not None:
             try:
                 self.redirect_cleartext_from = int(rcf)
             except ValueError:
-                self.post_error("redirect_cleartext_from must give a port number rather than '%s'" % rcf)
+                err_msg = f"TLSContext {self.name}: redirect_cleartext_from must be a port number rather than '{rcf}'"
+                self.post_error(err_msg)
                 self.redirect_cleartext_from = None
 
-        # Finally, set up our secret_info.
+        # Finally, move cert keys into secret_info.
         self.secret_info = {}
 
         for key in IRTLSContext.CertKeys:
-            if key in config:
-                self.secret_info[key] = config[key]
+            if key in self:
+                self.secret_info[key] = self.pop(key)
 
-        # ir.logger.debug("IRTLSContext at setup: %s" % self.as_json())
-        #
-        # rc = False
-        #
-        # if self.get('_ambassador_enabled', False):
-        #     ir.logger.debug("IRTLSContext skipping resolution of null context")
-        #     rc = True
-        # else:
-        #     if self.resolve():
-        #         rc = True
-
-        rc = True
-
-        ir.logger.debug("IRTLSContext setup done (returning %s): %s" % (rc, self.as_json()))
-
-        return rc
-
-    def validate(self, config) -> bool:
-        if 'name' not in config:
-            self.post_error(RichStatus.fromError("`name` field is required in a TLSContext resource", module=config))
-            return False
-
-        spec_count = 0
-        errors = 0
-
-        if config.get('secret', None):
-            spec_count += 1
-
-        if config.get('cert_chain_file', None):
-            spec_count += 1
-
-            if not config.get('private_key_file', None):
-                err_msg = "TLSContext %s: 'cert_chain_file' requires 'private_key_file' as well" % config.name
-
-                self.post_error(RichStatus.fromError(err_msg, module=config))
-                errors += 1
-
-        if spec_count == 2:
-            err_msg = "TLSContext %s: exactly one of 'secret' and 'cert_chain_file' must be present" % config.name
-
-            self.post_error(RichStatus.fromError(err_msg, module=config))
-            errors += 1
-
-        if errors:
-            return False
+        ir.logger.info(f"IRTLSContext setup good: {self.as_json()}")
 
         return True
 
@@ -245,7 +233,7 @@ class IRTLSContext(IRResource):
                 if not fc(path):
                     self.post_error("TLSContext %s found no %s '%s'" % (self.name, key, path))
                     errors += 1
-            elif key != 'cacert_chain_file' and self.hosts:
+            elif key != 'cacert_chain_file' and self.get('hosts', None):
                 self.post_error("TLSContext %s is missing %s" % (self.name, key))
                 errors += 1
 
@@ -255,20 +243,16 @@ class IRTLSContext(IRResource):
         return True
 
     @classmethod
-    def from_config(cls, ir: 'IR', rkey: str, location: str, *,
-                    kind="synthesized-TLS-context", name: str, **kwargs) -> 'IRTLSContext':
-        ctx_config = ACResource(rkey, location, kind=kind, name=name, **kwargs)
-
-        return cls(ir, ctx_config)
-
-    @classmethod
     def null_context(cls, ir: 'IR') -> 'IRTLSContext':
         ctx = ir.get_tls_context("no-cert-upstream")
 
         if not ctx:
-            ctx = IRTLSContext.from_config(ir, "ir.no-cert-upstream", "ir.no-cert-upstream",
-                                           kind="null-TLS-context", name="no-cert-upstream",
-                                           _ambassador_enabled=True)
+            ctx = IRTLSContext(ir, ir.aconf,
+                               rkey="ir.no-cert-upstream",
+                               name="no-cert-upstream",
+                               location="ir.no-cert-upstream",
+                               kind="null-TLS-context",
+                               _ambassador_enabled=True)
 
             ir.save_tls_context(ctx)
 
@@ -331,9 +315,33 @@ class IRTLSContext(IRResource):
                     # Assume they want the 'ambassador-cacert' secret.
                     new_args['secret'] = 'ambassador-cacert'
 
-        # Remember that this is a legacy context.
-        new_args['_legacy'] = True
+        ctx = IRTLSContext(ir, ir.aconf,
+                           rkey=rkey,
+                           name=name,
+                           location=location,
+                           kind="synthesized-TLS-context",
+                           _legacy=True,
+                           **new_args)
 
-        return IRTLSContext.from_config(ir, rkey, location,
-                                        kind="synthesized-TLS-context",
-                                        name=name, **new_args)
+        return ctx
+
+
+class TLSContextFactory:
+    @classmethod
+    def load_all(cls, ir: 'IR', aconf: Config) -> None:
+        assert ir
+
+        # Save TLS contexts from the aconf into the IR. Note that the contexts in the aconf
+        # are just ACResources; they need to be turned into IRTLSContexts.
+        tls_contexts = aconf.get_config('tls_contexts')
+
+        if tls_contexts is not None:
+            for config in tls_contexts.values():
+                ctx = IRTLSContext(ir, aconf, **config)
+
+                if ctx.is_active():
+                    ctx.referenced_by(config)
+                    ctx.sourced_by(config)
+
+                    ir.save_tls_context(ctx)
+

--- a/python/ambassador/ir/irtlscontext.py
+++ b/python/ambassador/ir/irtlscontext.py
@@ -122,9 +122,8 @@ class IRTLSContext(IRResource):
         return True
 
     def resolve_secret(self, secret_name: str) -> SavedSecret:
-        # Start by figuring out a namespace to look in. Assume that we're
-        # in the Ambassador's namespace...
-        namespace = self.ir.ambassador_namespace
+        # Assume that we need to look in whichever namespace the TLSContext itself is in...
+        namespace = self.namespace
 
         # You can't just always allow '.' in a secret name to span namespaces, or you end up with
         # https://github.com/datawire/ambassador/issues/1255, which is particularly problematic

--- a/python/ambassador/utils.py
+++ b/python/ambassador/utils.py
@@ -243,10 +243,12 @@ class PeriodicTrigger(threading.Thread):
 
 
 class SecretInfo:
-    def __init__(self, name: str, namespace: str,
-                 tls_crt: Optional[str], tls_key: Optional[str]=None, decode_b64=True) -> None:
+    def __init__(self, name: str, namespace: str, secret_type: str,
+                 tls_crt: Optional[str], tls_key: Optional[str]=None, user_key: Optional[str]=None,
+                 decode_b64=True) -> None:
         self.name = name
         self.namespace = namespace
+        self.secret_type = secret_type
 
         if decode_b64:
             if tls_crt and not tls_crt.startswith('-----BEGIN'):
@@ -255,8 +257,12 @@ class SecretInfo:
             if tls_key and not tls_key.startswith('-----BEGIN'):
                 tls_key = self.decode(tls_key)
 
+            if user_key and not user_key.startswith('-----BEGIN'):
+                user_key = self.decode(user_key)
+
         self.tls_crt = tls_crt
         self.tls_key = tls_key
+        self.user_key = user_key
 
     @staticmethod
     def decode(b64_pem: str) -> Optional[str]:
@@ -292,8 +298,10 @@ class SecretInfo:
         return {
             'name': self.name,
             'namespace': self.namespace,
+            'secret_type': self.secret_type,
             'tls_crt': self.fingerprint(self.tls_crt),
-            'tls_key': self.fingerprint(self.tls_key)
+            'tls_key': self.fingerprint(self.tls_key),
+            'user_key': self.fingerprint(self.user_key)
         }
 
     @classmethod
@@ -301,39 +309,58 @@ class SecretInfo:
         return SecretInfo(
             aconf_object.name,
             aconf_object.namespace,
+            aconf_object.secret_type,
             aconf_object.tls_crt,
-            aconf_object.get('tls_key', None)
+            aconf_object.get('tls_key', None),
+            aconf_object.get('user_key', None)
         )
 
     @classmethod
     def from_dict(cls, resource: 'IRResource',
                   secret_name: str, namespace: str, source: str,
-                  cert_data: Optional[Dict[str, Any]]) -> Optional['SecretInfo']:
+                  cert_data: Optional[Dict[str, Any]], secret_type="kubernetes.io/tls") -> Optional['SecretInfo']:
+
+        tls_crt = None
+        tls_key = None
+        user_key = None
+
         if not cert_data:
             resource.ir.logger.error(f"{resource.kind} {resource.name}: found no certificate in {source}?")
             return None
 
-        # OK, we have something to work with. Hopefully.
-        cert = cert_data.get('tls.crt', None)
+        if secret_type == 'kubernetes.io/tls':
+            # OK, we have something to work with. Hopefully.
+            tls_crt = cert_data.get('tls.crt', None)
 
-        if not cert:
-            # Having no public half is definitely an error. Having no private half given a public half
-            # might be OK, though -- that's up to our caller to decide.
-            resource.ir.logger.error(f"{resource.kind} {resource.name}: found data but no certificate in {source}?")
-            return None
+            if not tls_crt:
+                # Having no public half is definitely an error. Having no private half given a public half
+                # might be OK, though -- that's up to our caller to decide.
+                resource.ir.logger.error(f"{resource.kind} {resource.name}: found data but no certificate in {source}?")
+                return None
 
-        key = cert_data.get('tls.key', None)
+            tls_key = cert_data.get('tls.key', None)
+        elif secret_type == 'Opaque':
+            user_key = cert_data.get('user.key', None)
 
-        return SecretInfo(secret_name, namespace, cert, key)
+            if not user_key:
+                # The opaque keys we support must have user.key, but will likely have nothing else.
+                resource.ir.logger.error(f"{resource.kind} {resource.name}: found data but no user.key in {source}?")
+                return None
+
+            cert = None
+
+        return SecretInfo(secret_name, namespace, secret_type, tls_crt=tls_crt, tls_key=tls_key, user_key=user_key)
 
 
 class SavedSecret:
     def __init__(self, secret_name: str, namespace: str,
-                 cert_path: Optional[str], key_path: Optional[str], cert_data: Optional[Dict]) -> None:
+                 cert_path: Optional[str], key_path: Optional[str], user_path: Optional[str],
+                 cert_data: Optional[Dict]) -> None:
         self.secret_name = secret_name
         self.namespace = namespace
         self.cert_path = cert_path
         self.key_path = key_path
+        self.user_path = user_path
         self.cert_data = cert_data
 
     @property
@@ -341,11 +368,11 @@ class SavedSecret:
         return "secret %s in namespace %s" % (self.secret_name, self.namespace)
 
     def __bool__(self) -> bool:
-        return bool(bool(self.cert_path) and (self.cert_data is not None))
+        return bool((bool(self.cert_path) or bool(self.user_path)) and (self.cert_data is not None))
 
     def __str__(self) -> str:
-        return "<SavedSecret %s.%s -- cert_path %s, key_path %s, cert_data %s>" % (
-                  self.secret_name, self.namespace, self.cert_path, self.key_path,
+        return "<SavedSecret %s.%s -- cert_path %s, key_path %s, user_path %s, cert_data %s>" % (
+                  self.secret_name, self.namespace, self.cert_path, self.key_path, self.user_path,
                   "present" if self.cert_data else "absent"
                 )
 
@@ -376,20 +403,22 @@ class SecretHandler:
     def cache_secret(self, resource: 'IRResource', secret_info: SecretInfo) -> SavedSecret:
         name = secret_info.name
         namespace = secret_info.namespace
-        cert = secret_info.tls_crt
-        key = secret_info.tls_key
+        tls_crt = secret_info.tls_crt
+        tls_key = secret_info.tls_key
+        user_key = secret_info.user_key
 
-        cert_path = None
-        key_path = None
+        tls_crt_path = None
+        tls_key_path = None
+        user_key_path = None
         cert_data = None
 
         h = hashlib.new('sha1')
 
-        if cert:
-            h.update(cert.encode('utf-8'))
-
-            if key:
-                h.update(key.encode('utf-8'))
+        # Don't save if it has neither a tls_crt or a user_key.
+        if tls_crt or user_key:
+            for el in [tls_crt, tls_key, user_key]:
+                if el:
+                    h.update(el.encode('utf-8'))
 
             hd = h.hexdigest().upper()
 
@@ -400,19 +429,25 @@ class SecretHandler:
             except FileExistsError:
                 pass
 
-            cert_path = os.path.join(secret_dir, f'{hd}.crt')
-            open(cert_path, "w").write(cert)
+            if tls_crt:
+                tls_crt_path = os.path.join(secret_dir, f'{hd}.crt')
+                open(tls_crt_path, "w").write(tls_crt)
 
-            if key:
-                key_path = os.path.join(secret_dir, f'{hd}.key')
-                open(key_path, "w").write(key)
+            if tls_key:
+                tls_key_path = os.path.join(secret_dir, f'{hd}.key')
+                open(tls_key_path, "w").write(tls_key)
+
+            if user_key:
+                user_key_path = os.path.join(secret_dir, f'{hd}.user')
+                open(user_key_path, "w").write(user_key)
 
             cert_data = {
-                'tls_crt': cert,
-                'tls_key': key
+                'tls_crt': tls_crt,
+                'tls_key': tls_key,
+                'user_key': user_key,
             }
 
-        return SavedSecret(name, namespace, cert_path, key_path, cert_data)
+        return SavedSecret(name, namespace, tls_crt_path, tls_key_path, user_key_path, cert_data)
 
     # secret_info_from_k8s takes a K8s Secret and returns a SecretInfo (or None if something
     # is wrong).
@@ -435,6 +470,7 @@ class SecretHandler:
             # Nothing in the serialization, we're done.
             return None
 
+        secret_type = None
         cert_data = None
         ocount = 0
         errors = 0
@@ -457,6 +493,8 @@ class SecretHandler:
                 errors += 1
                 continue
 
+            secret_type = metadata.get('type', 'kubernetes.io/tls')
+
             if 'data' in obj:
                 if cert_data:
                     self.logger.error("%s %s: found multiple Secrets in %s?" %
@@ -470,7 +508,8 @@ class SecretHandler:
             # Bzzt.
             return None
 
-        return SecretInfo.from_dict(resource, secret_name, namespace, source, cert_data=cert_data)
+        return SecretInfo.from_dict(resource, secret_name, namespace, source,
+                                    cert_data=cert_data, secret_type=secret_type)
 
 
 class NullSecretHandler(SecretHandler):
@@ -498,7 +537,8 @@ class NullSecretHandler(SecretHandler):
         self.logger.debug("NullSecretHandler (%s %s): load secret %s in namespace %s" %
                           (resource.kind, resource.name, secret_name, namespace))
 
-        return SecretInfo(secret_name, namespace, "fake-tls-crt", "fake-tls-key")
+        return SecretInfo(secret_name, namespace, "fake-secret", "fake-tls-crt", "fake-tls-key", "fake-user-key",
+                          decode_b64=False)
 
 
 class FSSecretHandler(SecretHandler):
@@ -541,9 +581,11 @@ class FSSecretHandler(SecretHandler):
         version = obj.get('apiVersion', None)
         kind = obj.get('kind', None)
 
-        if version.startswith('ambassador') and (kind == 'Secret'):
+        if (kind == 'Secret') and (version.startswith('ambassador') or version.startswith('getambassador.io')):
             # It's an Ambassador Secret. It should have a public key and maybe a private key.
-            return SecretInfo.from_dict(resource, secret_name, namespace, source, obj)
+            secret_type = obj.get('type', 'kubernetes.io/tls')
+            return SecretInfo.from_dict(resource, secret_name, namespace, source,
+                                        cert_data=obj, secret_type=secret_type)
 
         # Didn't look like an Ambassador object. Try K8s.
         return self.secret_info_from_k8s(resource, secret_name, namespace, source, serialization)

--- a/python/tests/t_tls.py
+++ b/python/tests/t_tls.py
@@ -545,7 +545,7 @@ min_tls_version: v1.0
 max_tls_version: v1.3
 redirect_cleartext_from: 8080
 """)
-        # Ambassador should return and error for this configuration.
+        # Ambassador should return an error for this configuration.
         yield self, self.format("""
 ---
 apiVersion: ambassador/v1
@@ -555,7 +555,7 @@ hosts:
 - tls-context-host-1
 redirect_cleartext_from: 8080
 """)
-      # Ambassador should return and error for this configuration.
+      # Ambassador should return an error for this configuration.
         yield self, self.format("""
 ---
 apiVersion: ambassador/v1
@@ -631,14 +631,14 @@ redirect_cleartext_from: 8081
                     insecure=True,
                     sni=True)
 
-        # 7 - explicit Host header 2 wins, we'll get the SNI cert for this overlapping path
+        # 8 - explicit Host header 2 wins, we'll get the SNI cert for this overlapping path
         yield Query(self.url(self.name + "/"),
                     headers={"Host": "tls-context-host-2"},
                     expected=200,
                     insecure=True,
                     sni=True)
 
-        # 8 - Redirect cleartext from actually redirects.
+        # 9 - Redirect cleartext from actually redirects.
         yield Query(self.url("tls-context-same/", scheme="http"),
                     headers={"Host": "tls-context-host-1"},
                     expected=301,

--- a/python/watch_hook.py
+++ b/python/watch_hook.py
@@ -68,7 +68,8 @@ class SecretRecorder(SecretHandler):
         secret_key = ( secret_name, namespace )
 
         if secret_key not in self.needed:
-            self.needed[secret_key] = SecretInfo(secret_name, namespace, '-crt-', '-key-', decode_b64=False)
+            self.needed[secret_key] = SecretInfo(secret_name, namespace, 'needed-secret', '-crt-', '-key-',
+                                                 decode_b64=False)
 
         return self.needed[secret_key]
 
@@ -76,9 +77,9 @@ class SecretRecorder(SecretHandler):
     def cache_secret(self, resource: 'IRResource', secret_info: SecretInfo):
         self.logger.debug("SecretRecorder (%s %s): skipping cache step for secret %s in namespace %s" %
                           (resource.kind, resource.name, secret_info.name, secret_info.namespace))
-        
-        return SavedSecret(secret_info.name, secret_info.namespace, '-crt-path-', '-key-path-',
-                           { 'tls_crt': '-crt-', 'tls_key': '-key-' })
+                          
+        return SavedSecret(secret_info.name, secret_info.namespace, '-crt-path-', '-key-path-', '-user-path-',
+                           { 'tls.crt': '-crt-', 'tls.key': '-key-', 'user.key': '-user-' })
 
 
 # XXX Sooooo there's some ugly stuff here.

--- a/python/watch_hook.py
+++ b/python/watch_hook.py
@@ -44,6 +44,7 @@ from ambassador import Config, IR
 from ambassador.config.resourcefetcher import ResourceFetcher
 from ambassador.ir.irserviceresolver import IRServiceResolverFactory
 from ambassador.ir.irtls import TLSModuleFactory, IRAmbassadorTLS
+from ambassador.ir.irhost import HostFactory
 from ambassador.ir.irambassador import IRAmbassador
 from ambassador.utils import SecretInfo, SavedSecret, SecretHandler
 

--- a/python/watch_hook.py
+++ b/python/watch_hook.py
@@ -60,9 +60,11 @@ class SecretRecorder(SecretHandler):
         self.needed: Dict[Tuple[str, str], SecretInfo] = {}
 
     # Record what was requested, and always return True.
-    def load_secret(self, context: 'IRTLSContext',
+    def load_secret(self, resource: 'IRResource',
                     secret_name: str, namespace: str) -> Optional[SecretInfo]:
-        self.logger.info(f"SecretRecorder: Trying to load secret {secret_name} in namespace {namespace} from TLSContext {context}")
+        self.logger.debug("SecretRecorder (%s %s): load secret %s in namespace %s" %
+                          (resource.kind, resource.name, secret_name, namespace))
+
         secret_key = ( secret_name, namespace )
 
         if secret_key not in self.needed:
@@ -71,7 +73,10 @@ class SecretRecorder(SecretHandler):
         return self.needed[secret_key]
 
     # Never cache anything.
-    def cache_secret(self, context: 'IRTLSContext', secret_info: SecretInfo):
+    def cache_secret(self, resource: 'IRResource', secret_info: SecretInfo):
+        self.logger.debug("SecretRecorder (%s %s): skipping cache step for secret %s in namespace %s" %
+                          (resource.kind, resource.name, secret_info.name, secret_info.namespace))
+        
         return SavedSecret(secret_info.name, secret_info.namespace, '-crt-path-', '-key-path-',
                            { 'tls_crt': '-crt-', 'tls_key': '-key-' })
 


### PR DESCRIPTION
(Note that this is over `flynn/dev/watcher-and-namespaces`! Both will need to be merged into `shared/edgy`.)

This may be simplest to review commit-by-commit.

- Fix `IRTLSContext` so that it has a `Factory` and accepts keyword arguments like basically everything else.
- Make secret resolution work with an `IRResource` as a base, not only an `IRTLSContext`.
- Allow secret resolution to manage `user.key` secrets as well as TLS secrets.
- Link up `Host` CRDs, and generate `TLSContext`s from them.
- Mark the `TestHUPGood2Alt` Go test as a flake (this is also in `flynn/dev/watcher-and-namespaces` for the moment).