### PR TITLE
Allow plain to work in local mode, and for its children to be subsumed.

### DIFF
--- a/builder/builder.mk
+++ b/builder/builder.mk
@@ -100,7 +100,7 @@ pytest: test-ready
 	$(MAKE) pytest-only
 .PHONY: pytest
 
-pytest-only:
+pytest-only: sync
 	@printf "$(CYN)==> $(GRN)Running $(BLU)py$(GRN) tests$(END)\n"
 	docker exec \
 		-e AMBASSADOR_DOCKER_IMAGE=$(AMB_IMAGE) \
@@ -109,6 +109,7 @@ pytest-only:
 		-e KAT_IMAGE_PULL_POLICY=Always \
 		-e KAT_REQ_LIMIT \
 		-e KAT_RUN_MODE \
+		-e KAT_VERBOSE \
 		-e PYTEST_ARGS \
 		-it $(shell $(BUILDER)) /buildroot/builder.sh pytest-internal
 .PHONY: pytest-only

--- a/python/tests/abstract_tests.py
+++ b/python/tests/abstract_tests.py
@@ -425,6 +425,9 @@ class MappingTest(Test):
     options: Sequence['OptionTest']
     parent: AmbassadorTest
 
+    no_local_mode = True
+    skip_local_instead_of_xfail = "Plain (MappingTest)"
+
     def init(self, target: ServiceType, options=()) -> None:
         self.target = target
         self.options = list(options)
@@ -436,6 +439,9 @@ class OptionTest(Test):
     VALUES: ClassVar[Any] = None
     value: Any
     parent: Test
+
+    no_local_mode = True
+    skip_local_instead_of_xfail = "Plain (OptionTests)"
 
     @classmethod
     def variants(cls):

--- a/python/tests/gold/plain/snapshots/aconf.json
+++ b/python/tests/gold/plain/snapshots/aconf.json
@@ -5,13 +5,13 @@
                 "error": "Ambassador could not find core CRD definitions. Please visit https://www.getambassador.io/reference/core/crds/ for more information. You can continue using Ambassador via Kubernetes annotations, any configuration via CRDs will be ignored...",
                 "hostname": "plain",
                 "ok": false,
-                "version": "0.86.0-rc5-131-g4bcda0e6-dirty"
+                "version": "0.86.0-rc5-133-gd823f7de-dirty"
             },
             {
                 "error": "Ambassador could not find Resolver type CRD definitions. Please visit https://www.getambassador.io/reference/core/crds/ for more information. You can continue using Ambassador via Kubernetes annotations, any configuration via CRDs will be ignored...",
                 "hostname": "plain",
                 "ok": false,
-                "version": "0.86.0-rc5-131-g4bcda0e6-dirty"
+                "version": "0.86.0-rc5-133-gd823f7de-dirty"
             }
         ]
     },

--- a/python/tests/gold/plain/snapshots/snapshot.yaml
+++ b/python/tests/gold/plain/snapshots/snapshot.yaml
@@ -12,7 +12,7 @@
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"extensions/v1beta1\",\"kind\":\"Ingress\",\"metadata\":{\"annotations\":{\"getambassador.io/ambassador-id\":\"plain\",\"kubernetes.io/ingress.class\":\"ambassador\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"hostheadermappingingress-grpc\",\"namespace\":\"plain-namespace\"},\"spec\":{\"rules\":[{\"host\":\"inspector.external\",\"http\":{\"paths\":[{\"backend\":{\"serviceName\":\"plain-hostheadermappingingress-grpc-grpc\",\"servicePort\":80},\"path\":\"/HostHeaderMappingIngress-GRPC/\"}]}}]}}\n",
                         "kubernetes.io/ingress.class": "ambassador"
                     },
-                    "creationTimestamp": "2019-11-04T05:43:40Z",
+                    "creationTimestamp": "2019-11-04T07:58:50Z",
                     "generation": 1,
                     "labels": {
                         "kat-ambassador-id": "plain",
@@ -20,9 +20,9 @@
                     },
                     "name": "hostheadermappingingress-grpc",
                     "namespace": "plain-namespace",
-                    "resourceVersion": "12633",
+                    "resourceVersion": "16501",
                     "selfLink": "/apis/extensions/v1beta1/namespaces/plain-namespace/ingresses/hostheadermappingingress-grpc",
-                    "uid": "0e5bb11a-fec6-11e9-8b1f-120e67b61000"
+                    "uid": "f023069f-fed8-11e9-9a8f-0e57b7345f92"
                 },
                 "spec": {
                     "rules": [
@@ -55,7 +55,7 @@
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"extensions/v1beta1\",\"kind\":\"Ingress\",\"metadata\":{\"annotations\":{\"getambassador.io/ambassador-id\":\"plain\",\"kubernetes.io/ingress.class\":\"ambassador\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"hostheadermappingingress-http\",\"namespace\":\"plain-namespace\"},\"spec\":{\"rules\":[{\"host\":\"inspector.external\",\"http\":{\"paths\":[{\"backend\":{\"serviceName\":\"plain-hostheadermappingingress-http-http\",\"servicePort\":80},\"path\":\"/HostHeaderMappingIngress-HTTP/\"}]}}]}}\n",
                         "kubernetes.io/ingress.class": "ambassador"
                     },
-                    "creationTimestamp": "2019-11-04T05:43:40Z",
+                    "creationTimestamp": "2019-11-04T07:58:50Z",
                     "generation": 1,
                     "labels": {
                         "kat-ambassador-id": "plain",
@@ -63,9 +63,9 @@
                     },
                     "name": "hostheadermappingingress-http",
                     "namespace": "plain-namespace",
-                    "resourceVersion": "12628",
+                    "resourceVersion": "16497",
                     "selfLink": "/apis/extensions/v1beta1/namespaces/plain-namespace/ingresses/hostheadermappingingress-http",
-                    "uid": "0e4533b4-fec6-11e9-8b1f-120e67b61000"
+                    "uid": "f0078f3b-fed8-11e9-9a8f-0e57b7345f92"
                 },
                 "spec": {
                     "rules": [
@@ -99,7 +99,7 @@
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"extensions/v1beta1\",\"kind\":\"Ingress\",\"metadata\":{\"annotations\":{\"getambassador.io/ambassador-id\":\"plain\",\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind:  Mapping\\nname:  SimpleIngressWithAnnotations-GRPC-nested\\nprefix: /SimpleIngressWithAnnotations-GRPC-nested/\\nservice: http://plain-simpleingresswithannotations-grpc-grpc.plain-namespace\\nambassador_id: plain\\n\",\"kubernetes.io/ingress.class\":\"ambassador\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"simpleingresswithannotations-grpc\",\"namespace\":\"plain-namespace\"},\"spec\":{\"rules\":[{\"http\":{\"paths\":[{\"backend\":{\"serviceName\":\"plain-simpleingresswithannotations-grpc-grpc\",\"servicePort\":80},\"path\":\"/SimpleIngressWithAnnotations-GRPC/\"}]}}]}}\n",
                         "kubernetes.io/ingress.class": "ambassador"
                     },
-                    "creationTimestamp": "2019-11-04T05:43:40Z",
+                    "creationTimestamp": "2019-11-04T07:58:50Z",
                     "generation": 1,
                     "labels": {
                         "kat-ambassador-id": "plain",
@@ -107,9 +107,9 @@
                     },
                     "name": "simpleingresswithannotations-grpc",
                     "namespace": "plain-namespace",
-                    "resourceVersion": "12622",
+                    "resourceVersion": "16492",
                     "selfLink": "/apis/extensions/v1beta1/namespaces/plain-namespace/ingresses/simpleingresswithannotations-grpc",
-                    "uid": "0e2df8ef-fec6-11e9-8b1f-120e67b61000"
+                    "uid": "efee098f-fed8-11e9-9a8f-0e57b7345f92"
                 },
                 "spec": {
                     "rules": [
@@ -142,7 +142,7 @@
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"extensions/v1beta1\",\"kind\":\"Ingress\",\"metadata\":{\"annotations\":{\"getambassador.io/ambassador-id\":\"plain\",\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind:  Mapping\\nname:  SimpleIngressWithAnnotations-HTTP-nested\\nprefix: /SimpleIngressWithAnnotations-HTTP-nested/\\nservice: http://plain-simpleingresswithannotations-http-http.plain-namespace\\nambassador_id: plain\\n\",\"kubernetes.io/ingress.class\":\"ambassador\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"simpleingresswithannotations-http\",\"namespace\":\"plain-namespace\"},\"spec\":{\"rules\":[{\"http\":{\"paths\":[{\"backend\":{\"serviceName\":\"plain-simpleingresswithannotations-http-http\",\"servicePort\":80},\"path\":\"/SimpleIngressWithAnnotations-HTTP/\"}]}}]}}\n",
                         "kubernetes.io/ingress.class": "ambassador"
                     },
-                    "creationTimestamp": "2019-11-04T05:43:40Z",
+                    "creationTimestamp": "2019-11-04T07:58:50Z",
                     "generation": 1,
                     "labels": {
                         "kat-ambassador-id": "plain",
@@ -150,9 +150,9 @@
                     },
                     "name": "simpleingresswithannotations-http",
                     "namespace": "plain-namespace",
-                    "resourceVersion": "12617",
+                    "resourceVersion": "16488",
                     "selfLink": "/apis/extensions/v1beta1/namespaces/plain-namespace/ingresses/simpleingresswithannotations-http",
-                    "uid": "0e16b1a1-fec6-11e9-8b1f-120e67b61000"
+                    "uid": "efd4018d-fed8-11e9-9a8f-0e57b7345f92"
                 },
                 "spec": {
                     "rules": [
@@ -184,7 +184,7 @@
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"extensions/v1beta1\",\"kind\":\"Ingress\",\"metadata\":{\"annotations\":{\"getambassador.io/ambassador-id\":\"plain\",\"kubernetes.io/ingress.class\":\"ambassador\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"simplemappingingress-grpc\",\"namespace\":\"plain-namespace\"},\"spec\":{\"rules\":[{\"http\":{\"paths\":[{\"backend\":{\"serviceName\":\"plain-simplemappingingress-grpc-grpc\",\"servicePort\":80},\"path\":\"/SimpleMappingIngress-GRPC/\"}]}}]}}\n",
                         "kubernetes.io/ingress.class": "ambassador"
                     },
-                    "creationTimestamp": "2019-11-04T05:43:40Z",
+                    "creationTimestamp": "2019-11-04T07:58:49Z",
                     "generation": 1,
                     "labels": {
                         "kat-ambassador-id": "plain",
@@ -192,9 +192,9 @@
                     },
                     "name": "simplemappingingress-grpc",
                     "namespace": "plain-namespace",
-                    "resourceVersion": "12613",
+                    "resourceVersion": "16484",
                     "selfLink": "/apis/extensions/v1beta1/namespaces/plain-namespace/ingresses/simplemappingingress-grpc",
-                    "uid": "0e007884-fec6-11e9-8b1f-120e67b61000"
+                    "uid": "efb9c31a-fed8-11e9-9a8f-0e57b7345f92"
                 },
                 "spec": {
                     "rules": [
@@ -226,7 +226,7 @@
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"extensions/v1beta1\",\"kind\":\"Ingress\",\"metadata\":{\"annotations\":{\"getambassador.io/ambassador-id\":\"plain\",\"kubernetes.io/ingress.class\":\"ambassador\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"simplemappingingress-http\",\"namespace\":\"plain-namespace\"},\"spec\":{\"rules\":[{\"http\":{\"paths\":[{\"backend\":{\"serviceName\":\"plain-simplemappingingress-http-http\",\"servicePort\":80},\"path\":\"/SimpleMappingIngress-HTTP/\"}]}}]}}\n",
                         "kubernetes.io/ingress.class": "ambassador"
                     },
-                    "creationTimestamp": "2019-11-04T05:43:40Z",
+                    "creationTimestamp": "2019-11-04T07:58:49Z",
                     "generation": 1,
                     "labels": {
                         "kat-ambassador-id": "plain",
@@ -234,9 +234,9 @@
                     },
                     "name": "simplemappingingress-http",
                     "namespace": "plain-namespace",
-                    "resourceVersion": "12607",
+                    "resourceVersion": "16479",
                     "selfLink": "/apis/extensions/v1beta1/namespaces/plain-namespace/ingresses/simplemappingingress-http",
-                    "uid": "0de9890a-fec6-11e9-8b1f-120e67b61000"
+                    "uid": "ef9f4634-fed8-11e9-9a8f-0e57b7345f92"
                 },
                 "spec": {
                     "rules": [
@@ -266,1188 +266,22 @@
                 "kind": "Service",
                 "metadata": {
                     "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: CanaryMapping-GRPC-10\nprefix: /CanaryMapping-GRPC-10/\nservice: http://plain-canarymapping-grpc-10-grpc.plain-namespace\nambassador_id: plain\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: CanaryMapping-GRPC-10\\nprefix: /CanaryMapping-GRPC-10/\\nservice: http://plain-canarymapping-grpc-10-grpc.plain-namespace\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-canarymapping-grpc-10-grpc\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8149},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8512}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2019-11-04T05:43:43Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-canarymapping-grpc-10-grpc",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "12726",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-canarymapping-grpc-10-grpc",
-                    "uid": "10173f69-fec6-11e9-8b1f-120e67b61000"
-                },
-                "spec": {
-                    "clusterIP": "10.107.180.151",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8149
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8512
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: CanaryMapping-HTTP-10-canary\nprefix: /CanaryMapping-HTTP-10/\nservice: http://plain-canarymapping-http-10-http-canary.plain-namespace\nweight: 10\nambassador_id: plain\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: CanaryMapping-HTTP-10-canary\\nprefix: /CanaryMapping-HTTP-10/\\nservice: http://plain-canarymapping-http-10-http-canary.plain-namespace\\nweight: 10\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-canarymapping-http-10-http-canary\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8142},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8505}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2019-11-04T05:43:43Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-canarymapping-http-10-http-canary",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "12696",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-canarymapping-http-10-http-canary",
-                    "uid": "0fa029d8-fec6-11e9-8b1f-120e67b61000"
-                },
-                "spec": {
-                    "clusterIP": "10.103.71.230",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8142
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8505
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: HostHeaderMapping-HTTP\nprefix: /HostHeaderMapping-HTTP/\nservice: http://plain-hostheadermapping-http-http.plain-namespace\nhost: inspector.external\nambassador_id: plain\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: HostHeaderMapping-HTTP\\nprefix: /HostHeaderMapping-HTTP/\\nservice: http://plain-hostheadermapping-http-http.plain-namespace\\nhost: inspector.external\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-hostheadermapping-http-http\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8128},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8491}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2019-11-04T05:43:41Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-hostheadermapping-http-http",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "12638",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-hostheadermapping-http-http",
-                    "uid": "0e732d1b-fec6-11e9-8b1f-120e67b61000"
-                },
-                "spec": {
-                    "clusterIP": "10.100.108.104",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8128
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8491
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: SimpleMapping-HTTP-AddRequestHeaders-foo-bar\nprefix: /SimpleMapping-HTTP-AddRequestHeaders-foo-bar/\nservice: http://plain-simplemapping-http-addrequestheaders-foo-bar-http.plain-namespace\nambassador_id: plain\nadd_request_headers: {\"foo\": \"bar\"}\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: SimpleMapping-HTTP-AddRequestHeaders-foo-bar\\nprefix: /SimpleMapping-HTTP-AddRequestHeaders-foo-bar/\\nservice: http://plain-simplemapping-http-addrequestheaders-foo-bar-http.plain-namespace\\nambassador_id: plain\\nadd_request_headers: {\\\"foo\\\": \\\"bar\\\"}\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-simplemapping-http-addrequestheaders-foo-bar-http\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8085},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8448}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2019-11-04T05:43:36Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-simplemapping-http-addrequestheaders-foo-bar-http",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "12460",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-simplemapping-http-addrequestheaders-foo-bar-http",
-                    "uid": "0bf0506b-fec6-11e9-8b1f-120e67b61000"
-                },
-                "spec": {
-                    "clusterIP": "10.96.101.23",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8085
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8448
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: SimpleMapping-HTTP-all\nprefix: /SimpleMapping-HTTP-all/\nservice: http://plain-simplemapping-http-all-http.plain-namespace\nambassador_id: plain\nadd_request_headers: {\"foo\": \"bar\"}\nadd_response_headers: {\"foo\": \"bar\"}\nuse_websocket: true\ncors: {origins: \"*\"}\ncase_sensitive: false\nauto_host_rewrite: true\nrewrite: /foo\nremove_response_headers: x-envoy-upstream-service-time\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: SimpleMapping-HTTP-all\\nprefix: /SimpleMapping-HTTP-all/\\nservice: http://plain-simplemapping-http-all-http.plain-namespace\\nambassador_id: plain\\nadd_request_headers: {\\\"foo\\\": \\\"bar\\\"}\\nadd_response_headers: {\\\"foo\\\": \\\"bar\\\"}\\nuse_websocket: true\\ncors: {origins: \\\"*\\\"}\\ncase_sensitive: false\\nauto_host_rewrite: true\\nrewrite: /foo\\nremove_response_headers: x-envoy-upstream-service-time\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-simplemapping-http-all-http\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8102},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8465}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2019-11-04T05:43:38Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-simplemapping-http-all-http",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "12533",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-simplemapping-http-all-http",
-                    "uid": "0ceb9890-fec6-11e9-8b1f-120e67b61000"
-                },
-                "spec": {
-                    "clusterIP": "10.104.132.154",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8102
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8465
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: AddReqHeadersMapping-HTTP\nprefix: /AddReqHeadersMapping-HTTP/\nservice: http://plain-addreqheadersmapping-http-http.plain-namespace\nadd_request_headers:\n  zoo:\n    append: False\n    value: Zoo\n  aoo:\n    append: True\n    value: aoo\n  boo:\n    value: boo\n  foo: Foo\nambassador_id: plain\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: AddReqHeadersMapping-HTTP\\nprefix: /AddReqHeadersMapping-HTTP/\\nservice: http://plain-addreqheadersmapping-http-http.plain-namespace\\nadd_request_headers:\\n  zoo:\\n    append: False\\n    value: Zoo\\n  aoo:\\n    append: True\\n    value: aoo\\n  boo:\\n    value: boo\\n  foo: Foo\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-addreqheadersmapping-http-http\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8175},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8538}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2019-11-04T05:43:48Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-addreqheadersmapping-http-http",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "12835",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-addreqheadersmapping-http-http",
-                    "uid": "1300a11c-fec6-11e9-8b1f-120e67b61000"
-                },
-                "spec": {
-                    "clusterIP": "10.101.61.198",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8175
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8538
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: CanaryMapping-GRPC-0\nprefix: /CanaryMapping-GRPC-0/\nservice: http://plain-canarymapping-grpc-0-grpc.plain-namespace\nambassador_id: plain\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: CanaryMapping-GRPC-0\\nprefix: /CanaryMapping-GRPC-0/\\nservice: http://plain-canarymapping-grpc-0-grpc.plain-namespace\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-canarymapping-grpc-0-grpc\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8147},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8510}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2019-11-04T05:43:43Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-canarymapping-grpc-0-grpc",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "12718",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-canarymapping-grpc-0-grpc",
-                    "uid": "0ff10a2a-fec6-11e9-8b1f-120e67b61000"
-                },
-                "spec": {
-                    "clusterIP": "10.106.109.226",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8147
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8510
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: CanaryMapping-HTTP-0-canary\nprefix: /CanaryMapping-HTTP-0/\nservice: http://plain-canarymapping-http-0-http-canary.plain-namespace\nweight: 0\nambassador_id: plain\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: CanaryMapping-HTTP-0-canary\\nprefix: /CanaryMapping-HTTP-0/\\nservice: http://plain-canarymapping-http-0-http-canary.plain-namespace\\nweight: 0\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-canarymapping-http-0-http-canary\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8140},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8503}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2019-11-04T05:43:42Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-canarymapping-http-0-http-canary",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "12689",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-canarymapping-http-0-http-canary",
-                    "uid": "0f79a27c-fec6-11e9-8b1f-120e67b61000"
-                },
-                "spec": {
-                    "clusterIP": "10.100.35.145",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8140
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8503
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: HeaderRoutingTest-HTTP-target1\nprefix: /HeaderRoutingTest-HTTP/\nservice: http://plain-headerroutingtest-http-http.plain-namespace\nambassador_id: plain\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: HeaderRoutingTest-HTTP-target1\\nprefix: /HeaderRoutingTest-HTTP/\\nservice: http://plain-headerroutingtest-http-http.plain-namespace\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-headerroutingtest-http-http\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8080},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8443}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2019-11-04T05:43:36Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-headerroutingtest-http-http",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "12440",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-headerroutingtest-http-http",
-                    "uid": "0ba3c9ec-fec6-11e9-8b1f-120e67b61000"
-                },
-                "spec": {
-                    "clusterIP": "10.111.135.203",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8080
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8443
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: SimpleMapping-GRPC-AddRequestHeaders-moo-arf\nprefix: /SimpleMapping-GRPC-AddRequestHeaders-moo-arf/\nservice: http://plain-simplemapping-grpc-addrequestheaders-moo-arf-grpc.plain-namespace\nambassador_id: plain\nadd_request_headers: {\"moo\": \"arf\"}\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: SimpleMapping-GRPC-AddRequestHeaders-moo-arf\\nprefix: /SimpleMapping-GRPC-AddRequestHeaders-moo-arf/\\nservice: http://plain-simplemapping-grpc-addrequestheaders-moo-arf-grpc.plain-namespace\\nambassador_id: plain\\nadd_request_headers: {\\\"moo\\\": \\\"arf\\\"}\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-simplemapping-grpc-addrequestheaders-moo-arf-grpc\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8105},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8468}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2019-11-04T05:43:38Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-simplemapping-grpc-addrequestheaders-moo-arf-grpc",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "12545",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-simplemapping-grpc-addrequestheaders-moo-arf-grpc",
-                    "uid": "0d13beca-fec6-11e9-8b1f-120e67b61000"
-                },
-                "spec": {
-                    "clusterIP": "10.100.50.85",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8105
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8468
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: SimpleMapping-GRPC-UseWebsocket\nprefix: /SimpleMapping-GRPC-UseWebsocket/\nservice: http://plain-simplemapping-grpc-usewebsocket-grpc.plain-namespace\nambassador_id: plain\nuse_websocket: true\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: SimpleMapping-GRPC-UseWebsocket\\nprefix: /SimpleMapping-GRPC-UseWebsocket/\\nservice: http://plain-simplemapping-grpc-usewebsocket-grpc.plain-namespace\\nambassador_id: plain\\nuse_websocket: true\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-simplemapping-grpc-usewebsocket-grpc\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8114},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8477}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2019-11-04T05:43:39Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-simplemapping-grpc-usewebsocket-grpc",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "12580",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-simplemapping-grpc-usewebsocket-grpc",
-                    "uid": "0d896f8a-fec6-11e9-8b1f-120e67b61000"
-                },
-                "spec": {
-                    "clusterIP": "10.105.188.15",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8114
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8477
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: WebSocketMapping-HTTP\nprefix: /WebSocketMapping-HTTP/\nservice: echo.websocket.org:80\nhost_rewrite: echo.websocket.org\nuse_websocket: true\nambassador_id: plain\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: WebSocketMapping-HTTP\\nprefix: /WebSocketMapping-HTTP/\\nservice: echo.websocket.org:80\\nhost_rewrite: echo.websocket.org\\nuse_websocket: true\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-websocketmapping-http-http\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8132},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8495}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2019-11-04T05:43:41Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-websocketmapping-http-http",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "12653",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-websocketmapping-http-http",
-                    "uid": "0ea48d58-fec6-11e9-8b1f-120e67b61000"
-                },
-                "spec": {
-                    "clusterIP": "10.110.85.182",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8132
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8495
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: SimpleMapping-HTTP-AddRequestHeaders-zoo-bar\nprefix: /SimpleMapping-HTTP-AddRequestHeaders-zoo-bar/\nservice: http://plain-simplemapping-http-addrequestheaders-zoo-bar-http.plain-namespace\nambassador_id: plain\nadd_request_headers: {\"zoo\": {\"append\": true, \"value\": \"bar\"}}\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: SimpleMapping-HTTP-AddRequestHeaders-zoo-bar\\nprefix: /SimpleMapping-HTTP-AddRequestHeaders-zoo-bar/\\nservice: http://plain-simplemapping-http-addrequestheaders-zoo-bar-http.plain-namespace\\nambassador_id: plain\\nadd_request_headers: {\\\"zoo\\\": {\\\"append\\\": true, \\\"value\\\": \\\"bar\\\"}}\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-simplemapping-http-addrequestheaders-zoo-bar-http\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8087},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8450}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2019-11-04T05:43:37Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-simplemapping-http-addrequestheaders-zoo-bar-http",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "12467",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-simplemapping-http-addrequestheaders-zoo-bar-http",
-                    "uid": "0c123dc8-fec6-11e9-8b1f-120e67b61000"
-                },
-                "spec": {
-                    "clusterIP": "10.105.49.115",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8087
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8450
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: SimpleMapping-HTTP-AddResponseHeaders-foo-bar\nprefix: /SimpleMapping-HTTP-AddResponseHeaders-foo-bar/\nservice: http://plain-simplemapping-http-addresponseheaders-foo-bar-http.plain-namespace\nambassador_id: plain\nadd_response_headers: {\"foo\": \"bar\"}\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: SimpleMapping-HTTP-AddResponseHeaders-foo-bar\\nprefix: /SimpleMapping-HTTP-AddResponseHeaders-foo-bar/\\nservice: http://plain-simplemapping-http-addresponseheaders-foo-bar-http.plain-namespace\\nambassador_id: plain\\nadd_response_headers: {\\\"foo\\\": \\\"bar\\\"}\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-simplemapping-http-addresponseheaders-foo-bar-http\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8090},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8453}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2019-11-04T05:43:37Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-simplemapping-http-addresponseheaders-foo-bar-http",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "12481",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-simplemapping-http-addresponseheaders-foo-bar-http",
-                    "uid": "0c42c58a-fec6-11e9-8b1f-120e67b61000"
-                },
-                "spec": {
-                    "clusterIP": "10.97.229.198",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8090
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8453
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: SimpleMapping-HTTP\nprefix: /SimpleMapping-HTTP/\nservice: http://plain-simplemapping-http-http.plain-namespace\nambassador_id: plain\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: SimpleMapping-HTTP\\nprefix: /SimpleMapping-HTTP/\\nservice: http://plain-simplemapping-http-http.plain-namespace\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-simplemapping-http-http\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8084},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8447}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2019-11-04T05:43:36Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-simplemapping-http-http",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "12456",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-simplemapping-http-http",
-                    "uid": "0be11355-fec6-11e9-8b1f-120e67b61000"
-                },
-                "spec": {
-                    "clusterIP": "10.108.161.90",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8084
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8447
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: CanaryDiffMapping-HTTP-0\nprefix: /CanaryDiffMapping-HTTP-0/\nservice: http://plain-canarydiffmapping-http-0-http.plain-namespace\nhost_rewrite: canary.1.example.com\nambassador_id: plain\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: CanaryDiffMapping-HTTP-0\\nprefix: /CanaryDiffMapping-HTTP-0/\\nservice: http://plain-canarydiffmapping-http-0-http.plain-namespace\\nhost_rewrite: canary.1.example.com\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-canarydiffmapping-http-0-http\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8155},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8518}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2019-11-04T05:43:44Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-canarydiffmapping-http-0-http",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "12747",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-canarydiffmapping-http-0-http",
-                    "uid": "107cdc29-fec6-11e9-8b1f-120e67b61000"
-                },
-                "spec": {
-                    "clusterIP": "10.104.8.233",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8155
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8518
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: SimpleMapping-GRPC-AddResponseHeaders-zoo-bar\nprefix: /SimpleMapping-GRPC-AddResponseHeaders-zoo-bar/\nservice: http://plain-simplemapping-grpc-addresponseheaders-zoo-bar-grpc.plain-namespace\nambassador_id: plain\nadd_response_headers: {\"zoo\": {\"append\": true, \"value\": \"bar\"}}\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: SimpleMapping-GRPC-AddResponseHeaders-zoo-bar\\nprefix: /SimpleMapping-GRPC-AddResponseHeaders-zoo-bar/\\nservice: http://plain-simplemapping-grpc-addresponseheaders-zoo-bar-grpc.plain-namespace\\nambassador_id: plain\\nadd_response_headers: {\\\"zoo\\\": {\\\"append\\\": true, \\\"value\\\": \\\"bar\\\"}}\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-simplemapping-grpc-addresponseheaders-zoo-bar-grpc\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8111},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8474}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2019-11-04T05:43:39Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-simplemapping-grpc-addresponseheaders-zoo-bar-grpc",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "12567",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-simplemapping-grpc-addresponseheaders-zoo-bar-grpc",
-                    "uid": "0d654c45-fec6-11e9-8b1f-120e67b61000"
-                },
-                "spec": {
-                    "clusterIP": "10.101.65.7",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8111
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8474
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: SimpleMapping-GRPC-CaseSensitive\nprefix: /SimpleMapping-GRPC-CaseSensitive/\nservice: http://plain-simplemapping-grpc-casesensitive-grpc.plain-namespace\nambassador_id: plain\ncase_sensitive: false\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: SimpleMapping-GRPC-CaseSensitive\\nprefix: /SimpleMapping-GRPC-CaseSensitive/\\nservice: http://plain-simplemapping-grpc-casesensitive-grpc.plain-namespace\\nambassador_id: plain\\ncase_sensitive: false\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-simplemapping-grpc-casesensitive-grpc\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8116},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8479}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2019-11-04T05:43:39Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-simplemapping-grpc-casesensitive-grpc",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "12587",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-simplemapping-grpc-casesensitive-grpc",
-                    "uid": "0da1d544-fec6-11e9-8b1f-120e67b61000"
-                },
-                "spec": {
-                    "clusterIP": "10.102.67.142",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8116
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8479
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: SimpleMapping-GRPC-RemoveResponseHeaders\nprefix: /SimpleMapping-GRPC-RemoveResponseHeaders/\nservice: http://plain-simplemapping-grpc-removeresponseheaders-grpc.plain-namespace\nambassador_id: plain\nremove_response_headers: x-envoy-upstream-service-time\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: SimpleMapping-GRPC-RemoveResponseHeaders\\nprefix: /SimpleMapping-GRPC-RemoveResponseHeaders/\\nservice: http://plain-simplemapping-grpc-removeresponseheaders-grpc.plain-namespace\\nambassador_id: plain\\nremove_response_headers: x-envoy-upstream-service-time\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-simplemapping-grpc-removeresponseheaders-grpc\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8120},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8483}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2019-11-04T05:43:40Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-simplemapping-grpc-removeresponseheaders-grpc",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "12601",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-simplemapping-grpc-removeresponseheaders-grpc",
-                    "uid": "0dd23fd5-fec6-11e9-8b1f-120e67b61000"
-                },
-                "spec": {
-                    "clusterIP": "10.105.225.157",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8120
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8483
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: CanaryMapping-HTTP-10\nprefix: /CanaryMapping-HTTP-10/\nservice: http://plain-canarymapping-http-10-http.plain-namespace\nambassador_id: plain\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: CanaryMapping-HTTP-10\\nprefix: /CanaryMapping-HTTP-10/\\nservice: http://plain-canarymapping-http-10-http.plain-namespace\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-canarymapping-http-10-http\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8141},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8504}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2019-11-04T05:43:42Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-canarymapping-http-10-http",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "12693",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-canarymapping-http-10-http",
-                    "uid": "0f88908d-fec6-11e9-8b1f-120e67b61000"
-                },
-                "spec": {
-                    "clusterIP": "10.108.14.91",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8141
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8504
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: SimpleMapping-GRPC\nprefix: /SimpleMapping-GRPC/\nservice: http://plain-simplemapping-grpc-grpc.plain-namespace\nambassador_id: plain\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: SimpleMapping-GRPC\\nprefix: /SimpleMapping-GRPC/\\nservice: http://plain-simplemapping-grpc-grpc.plain-namespace\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-simplemapping-grpc-grpc\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8103},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8466}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2019-11-04T05:43:38Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-simplemapping-grpc-grpc",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "12536",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-simplemapping-grpc-grpc",
-                    "uid": "0cf86860-fec6-11e9-8b1f-120e67b61000"
-                },
-                "spec": {
-                    "clusterIP": "10.107.248.6",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8103
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8466
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: TLSOrigination-GRPC-EXPLICIT\nprefix: /TLSOrigination-GRPC-EXPLICIT/\nservice: plain-tlsorigination-grpc-explicit-grpc.plain-namespace\ntls: true\nambassador_id: plain\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: TLSOrigination-GRPC-EXPLICIT\\nprefix: /TLSOrigination-GRPC-EXPLICIT/\\nservice: plain-tlsorigination-grpc-explicit-grpc.plain-namespace\\ntls: true\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-tlsorigination-grpc-explicit-grpc\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8137},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8500}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2019-11-04T05:43:42Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-tlsorigination-grpc-explicit-grpc",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "12677",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-tlsorigination-grpc-explicit-grpc",
-                    "uid": "0f4a48c1-fec6-11e9-8b1f-120e67b61000"
-                },
-                "spec": {
-                    "clusterIP": "10.102.234.187",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8137
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8500
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\",\"service\":\"plain-admin\"},\"name\":\"plain-admin\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"plain-admin\",\"port\":8877,\"targetPort\":8877}],\"selector\":{\"service\":\"plain\"},\"type\":\"NodePort\"}}\n"
-                    },
-                    "creationTimestamp": "2019-11-04T05:43:36Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest",
-                        "service": "plain-admin"
-                    },
-                    "name": "plain-admin",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "12433",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-admin",
-                    "uid": "0b88a427-fec6-11e9-8b1f-120e67b61000"
-                },
-                "spec": {
-                    "clusterIP": "10.101.62.208",
-                    "externalTrafficPolicy": "Cluster",
-                    "ports": [
-                        {
-                            "name": "plain-admin",
-                            "nodePort": 32626,
-                            "port": 8877,
-                            "protocol": "TCP",
-                            "targetPort": 8877
-                        }
-                    ],
-                    "selector": {
-                        "service": "plain"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "NodePort"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: CanaryDiffMapping-HTTP-50-canary\nprefix: /CanaryDiffMapping-HTTP-50/\nservice: http://plain-canarydiffmapping-http-50-http-canary.plain-namespace\nhost_rewrite: canary.2.example.com\nweight: 50\nambassador_id: plain\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: CanaryDiffMapping-HTTP-50-canary\\nprefix: /CanaryDiffMapping-HTTP-50/\\nservice: http://plain-canarydiffmapping-http-50-http-canary.plain-namespace\\nhost_rewrite: canary.2.example.com\\nweight: 50\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-canarydiffmapping-http-50-http-canary\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8160},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8523}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2019-11-04T05:43:45Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-canarydiffmapping-http-50-http-canary",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "12766",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-canarydiffmapping-http-50-http-canary",
-                    "uid": "10e1fc9e-fec6-11e9-8b1f-120e67b61000"
-                },
-                "spec": {
-                    "clusterIP": "10.102.212.104",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8160
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8523
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: InvalidPortMapping-GRPC\nprefix: /InvalidPortMapping-GRPC/\nservice: http://plain-invalidportmapping-grpc-grpc.plain-namespace:80.invalid\nambassador_id: plain\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: InvalidPortMapping-GRPC\\nprefix: /InvalidPortMapping-GRPC/\\nservice: http://plain-invalidportmapping-grpc-grpc.plain-namespace:80.invalid\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-invalidportmapping-grpc-grpc\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8131},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8494}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2019-11-04T05:43:41Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-invalidportmapping-grpc-grpc",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "12650",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-invalidportmapping-grpc-grpc",
-                    "uid": "0e979e39-fec6-11e9-8b1f-120e67b61000"
-                },
-                "spec": {
-                    "clusterIP": "10.104.234.154",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8131
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8494
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: SimpleMapping-GRPC-AddRequestHeaders-foo-bar\nprefix: /SimpleMapping-GRPC-AddRequestHeaders-foo-bar/\nservice: http://plain-simplemapping-grpc-addrequestheaders-foo-bar-grpc.plain-namespace\nambassador_id: plain\nadd_request_headers: {\"foo\": \"bar\"}\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: SimpleMapping-GRPC-AddRequestHeaders-foo-bar\\nprefix: /SimpleMapping-GRPC-AddRequestHeaders-foo-bar/\\nservice: http://plain-simplemapping-grpc-addrequestheaders-foo-bar-grpc.plain-namespace\\nambassador_id: plain\\nadd_request_headers: {\\\"foo\\\": \\\"bar\\\"}\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-simplemapping-grpc-addrequestheaders-foo-bar-grpc\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8104},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8467}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2019-11-04T05:43:38Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-simplemapping-grpc-addrequestheaders-foo-bar-grpc",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "12540",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-simplemapping-grpc-addrequestheaders-foo-bar-grpc",
-                    "uid": "0d05e2a5-fec6-11e9-8b1f-120e67b61000"
-                },
-                "spec": {
-                    "clusterIP": "10.104.216.231",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8104
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8467
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
                         "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: SimpleMapping-GRPC-AddRequestHeaders-xoo-dwe\nprefix: /SimpleMapping-GRPC-AddRequestHeaders-xoo-dwe/\nservice: http://plain-simplemapping-grpc-addrequestheaders-xoo-dwe-grpc.plain-namespace\nambassador_id: plain\nadd_request_headers: {\"xoo\": {\"append\": false, \"value\": \"dwe\"}}\n",
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: SimpleMapping-GRPC-AddRequestHeaders-xoo-dwe\\nprefix: /SimpleMapping-GRPC-AddRequestHeaders-xoo-dwe/\\nservice: http://plain-simplemapping-grpc-addrequestheaders-xoo-dwe-grpc.plain-namespace\\nambassador_id: plain\\nadd_request_headers: {\\\"xoo\\\": {\\\"append\\\": false, \\\"value\\\": \\\"dwe\\\"}}\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-simplemapping-grpc-addrequestheaders-xoo-dwe-grpc\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8107},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8470}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
                     },
-                    "creationTimestamp": "2019-11-04T05:43:39Z",
+                    "creationTimestamp": "2019-11-04T07:58:48Z",
                     "labels": {
                         "kat-ambassador-id": "plain",
                         "scope": "AmbassadorTest"
                     },
                     "name": "plain-simplemapping-grpc-addrequestheaders-xoo-dwe-grpc",
                     "namespace": "plain-namespace",
-                    "resourceVersion": "12552",
+                    "resourceVersion": "16435",
                     "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-simplemapping-grpc-addrequestheaders-xoo-dwe-grpc",
-                    "uid": "0d3557a2-fec6-11e9-8b1f-120e67b61000"
+                    "uid": "eecfaf58-fed8-11e9-9a8f-0e57b7345f92"
                 },
                 "spec": {
-                    "clusterIP": "10.110.8.102",
+                    "clusterIP": "10.96.181.210",
                     "ports": [
                         {
                             "name": "http",
@@ -1477,697 +311,22 @@
                 "kind": "Service",
                 "metadata": {
                     "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: SimpleMapping-GRPC-CORS\nprefix: /SimpleMapping-GRPC-CORS/\nservice: http://plain-simplemapping-grpc-cors-grpc.plain-namespace\nambassador_id: plain\ncors: {origins: \"*\"}\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: SimpleMapping-GRPC-CORS\\nprefix: /SimpleMapping-GRPC-CORS/\\nservice: http://plain-simplemapping-grpc-cors-grpc.plain-namespace\\nambassador_id: plain\\ncors: {origins: \\\"*\\\"}\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-simplemapping-grpc-cors-grpc\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8115},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8478}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2019-11-04T05:43:39Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-simplemapping-grpc-cors-grpc",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "12583",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-simplemapping-grpc-cors-grpc",
-                    "uid": "0d96393a-fec6-11e9-8b1f-120e67b61000"
-                },
-                "spec": {
-                    "clusterIP": "10.105.235.166",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8115
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8478
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: TLSOrigination-HTTP-IMPLICIT\nprefix: /TLSOrigination-HTTP-IMPLICIT/\nservice: https://plain-tlsorigination-http-implicit-http.plain-namespace\nambassador_id: plain\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: TLSOrigination-HTTP-IMPLICIT\\nprefix: /TLSOrigination-HTTP-IMPLICIT/\\nservice: https://plain-tlsorigination-http-implicit-http.plain-namespace\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-tlsorigination-http-implicit-http\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8134},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8497}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2019-11-04T05:43:42Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-tlsorigination-http-implicit-http",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "12665",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-tlsorigination-http-implicit-http",
-                    "uid": "0f0c2ea8-fec6-11e9-8b1f-120e67b61000"
-                },
-                "spec": {
-                    "clusterIP": "10.111.164.20",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8134
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8497
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: CanaryDiffMapping-HTTP-50\nprefix: /CanaryDiffMapping-HTTP-50/\nservice: http://plain-canarydiffmapping-http-50-http.plain-namespace\nhost_rewrite: canary.1.example.com\nambassador_id: plain\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: CanaryDiffMapping-HTTP-50\\nprefix: /CanaryDiffMapping-HTTP-50/\\nservice: http://plain-canarydiffmapping-http-50-http.plain-namespace\\nhost_rewrite: canary.1.example.com\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-canarydiffmapping-http-50-http\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8159},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8522}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2019-11-04T05:43:45Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-canarydiffmapping-http-50-http",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "12762",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-canarydiffmapping-http-50-http",
-                    "uid": "10d33991-fec6-11e9-8b1f-120e67b61000"
-                },
-                "spec": {
-                    "clusterIP": "10.108.202.183",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8159
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8522
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: CanaryMapping-HTTP-100-canary\nprefix: /CanaryMapping-HTTP-100/\nservice: http://plain-canarymapping-http-100-http-canary.plain-namespace\nweight: 100\nambassador_id: plain\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: CanaryMapping-HTTP-100-canary\\nprefix: /CanaryMapping-HTTP-100/\\nservice: http://plain-canarymapping-http-100-http-canary.plain-namespace\\nweight: 100\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-canarymapping-http-100-http-canary\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8146},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8509}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2019-11-04T05:43:43Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-canarymapping-http-100-http-canary",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "12713",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-canarymapping-http-100-http-canary",
-                    "uid": "0fe039f4-fec6-11e9-8b1f-120e67b61000"
-                },
-                "spec": {
-                    "clusterIP": "10.101.114.237",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8146
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8509
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: HeaderRoutingTest-GRPC-target2\nprefix: /HeaderRoutingTest-GRPC/\nservice: http://plain-headerroutingtest-grpc-grpc-target2.plain-namespace\nheaders:\n  X-Route: target2\nambassador_id: plain\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: HeaderRoutingTest-GRPC-target2\\nprefix: /HeaderRoutingTest-GRPC/\\nservice: http://plain-headerroutingtest-grpc-grpc-target2.plain-namespace\\nheaders:\\n  X-Route: target2\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-headerroutingtest-grpc-grpc-target2\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8083},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8446}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2019-11-04T05:43:36Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-headerroutingtest-grpc-grpc-target2",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "12451",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-headerroutingtest-grpc-grpc-target2",
-                    "uid": "0bd0c10e-fec6-11e9-8b1f-120e67b61000"
-                },
-                "spec": {
-                    "clusterIP": "10.108.49.1",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8083
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8446
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: HostHeaderMapping-GRPC\nprefix: /HostHeaderMapping-GRPC/\nservice: http://plain-hostheadermapping-grpc-grpc.plain-namespace\nhost: inspector.external\nambassador_id: plain\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: HostHeaderMapping-GRPC\\nprefix: /HostHeaderMapping-GRPC/\\nservice: http://plain-hostheadermapping-grpc-grpc.plain-namespace\\nhost: inspector.external\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-hostheadermapping-grpc-grpc\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8129},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8492}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2019-11-04T05:43:41Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-hostheadermapping-grpc-grpc",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "12643",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-hostheadermapping-grpc-grpc",
-                    "uid": "0e7f4afd-fec6-11e9-8b1f-120e67b61000"
-                },
-                "spec": {
-                    "clusterIP": "10.101.216.23",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8129
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8492
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: SimpleMapping-HTTP-AddRequestHeaders-xoo-dwe\nprefix: /SimpleMapping-HTTP-AddRequestHeaders-xoo-dwe/\nservice: http://plain-simplemapping-http-addrequestheaders-xoo-dwe-http.plain-namespace\nambassador_id: plain\nadd_request_headers: {\"xoo\": {\"append\": false, \"value\": \"dwe\"}}\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: SimpleMapping-HTTP-AddRequestHeaders-xoo-dwe\\nprefix: /SimpleMapping-HTTP-AddRequestHeaders-xoo-dwe/\\nservice: http://plain-simplemapping-http-addrequestheaders-xoo-dwe-http.plain-namespace\\nambassador_id: plain\\nadd_request_headers: {\\\"xoo\\\": {\\\"append\\\": false, \\\"value\\\": \\\"dwe\\\"}}\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-simplemapping-http-addrequestheaders-xoo-dwe-http\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8088},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8451}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2019-11-04T05:43:37Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-simplemapping-http-addrequestheaders-xoo-dwe-http",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "12472",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-simplemapping-http-addrequestheaders-xoo-dwe-http",
-                    "uid": "0c201420-fec6-11e9-8b1f-120e67b61000"
-                },
-                "spec": {
-                    "clusterIP": "10.101.223.179",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8088
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8451
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: AddRespHeadersMapping-GRPC\nprefix: /AddRespHeadersMapping-GRPC/\nservice: http://httpbin.org\nadd_response_headers:\n  koo:\n    append: False\n    value: KooK\n  zoo:\n    append: True\n    value: ZooZ\n  test:\n    value: boo\n  foo: Foo\nambassador_id: plain\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: AddRespHeadersMapping-GRPC\\nprefix: /AddRespHeadersMapping-GRPC/\\nservice: http://httpbin.org\\nadd_response_headers:\\n  koo:\\n    append: False\\n    value: KooK\\n  zoo:\\n    append: True\\n    value: ZooZ\\n  test:\\n    value: boo\\n  foo: Foo\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-addrespheadersmapping-grpc-grpc\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8172},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8535}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2019-11-04T05:43:48Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-addrespheadersmapping-grpc-grpc",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "12822",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-addrespheadersmapping-grpc-grpc",
-                    "uid": "12a31e32-fec6-11e9-8b1f-120e67b61000"
-                },
-                "spec": {
-                    "clusterIP": "10.107.92.76",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8172
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8535
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: CanaryDiffMapping-GRPC-0\nprefix: /CanaryDiffMapping-GRPC-0/\nservice: http://plain-canarydiffmapping-grpc-0-grpc.plain-namespace\nhost_rewrite: canary.1.example.com\nambassador_id: plain\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: CanaryDiffMapping-GRPC-0\\nprefix: /CanaryDiffMapping-GRPC-0/\\nservice: http://plain-canarydiffmapping-grpc-0-grpc.plain-namespace\\nhost_rewrite: canary.1.example.com\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-canarydiffmapping-grpc-0-grpc\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8163},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8526}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2019-11-04T05:43:45Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-canarydiffmapping-grpc-0-grpc",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "12779",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-canarydiffmapping-grpc-0-grpc",
-                    "uid": "11283907-fec6-11e9-8b1f-120e67b61000"
-                },
-                "spec": {
-                    "clusterIP": "10.99.180.131",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8163
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8526
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: HostRedirectMapping\nprefix: /HostRedirectMapping/\nservice: foobar.com\nhost_redirect: true\nambassador_id: plain\n---\napiVersion: ambassador/v0\nkind: Mapping\nname: HostRedirectMapping-2\nprefix: /HostRedirectMapping-2/\ncase_sensitive: false\nservice: foobar.com\nhost_redirect: true\nambassador_id: plain\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: HostRedirectMapping\\nprefix: /HostRedirectMapping/\\nservice: foobar.com\\nhost_redirect: true\\nambassador_id: plain\\n---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: HostRedirectMapping-2\\nprefix: /HostRedirectMapping-2/\\ncase_sensitive: false\\nservice: foobar.com\\nhost_redirect: true\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-hostredirectmapping-http\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8138},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8501}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2019-11-04T05:43:42Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-hostredirectmapping-http",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "12681",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-hostredirectmapping-http",
-                    "uid": "0f5ad00e-fec6-11e9-8b1f-120e67b61000"
-                },
-                "spec": {
-                    "clusterIP": "10.110.145.103",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8138
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8501
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: WebSocketMapping-GRPC\nprefix: /WebSocketMapping-GRPC/\nservice: echo.websocket.org:80\nhost_rewrite: echo.websocket.org\nuse_websocket: true\nambassador_id: plain\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: WebSocketMapping-GRPC\\nprefix: /WebSocketMapping-GRPC/\\nservice: echo.websocket.org:80\\nhost_rewrite: echo.websocket.org\\nuse_websocket: true\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-websocketmapping-grpc-grpc\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8133},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8496}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2019-11-04T05:43:41Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-websocketmapping-grpc-grpc",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "12660",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-websocketmapping-grpc-grpc",
-                    "uid": "0ec307cd-fec6-11e9-8b1f-120e67b61000"
-                },
-                "spec": {
-                    "clusterIP": "10.105.185.224",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8133
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8496
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: CanaryDiffMapping-GRPC-0-canary\nprefix: /CanaryDiffMapping-GRPC-0/\nservice: http://plain-canarydiffmapping-grpc-0-grpc-canary.plain-namespace\nhost_rewrite: canary.2.example.com\nweight: 0\nambassador_id: plain\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: CanaryDiffMapping-GRPC-0-canary\\nprefix: /CanaryDiffMapping-GRPC-0/\\nservice: http://plain-canarydiffmapping-grpc-0-grpc-canary.plain-namespace\\nhost_rewrite: canary.2.example.com\\nweight: 0\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-canarydiffmapping-grpc-0-grpc-canary\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8164},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8527}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2019-11-04T05:43:45Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-canarydiffmapping-grpc-0-grpc-canary",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "12783",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-canarydiffmapping-grpc-0-grpc-canary",
-                    "uid": "11458a1d-fec6-11e9-8b1f-120e67b61000"
-                },
-                "spec": {
-                    "clusterIP": "10.97.25.4",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8164
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8527
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: CanaryDiffMapping-GRPC-50\nprefix: /CanaryDiffMapping-GRPC-50/\nservice: http://plain-canarydiffmapping-grpc-50-grpc.plain-namespace\nhost_rewrite: canary.1.example.com\nambassador_id: plain\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: CanaryDiffMapping-GRPC-50\\nprefix: /CanaryDiffMapping-GRPC-50/\\nservice: http://plain-canarydiffmapping-grpc-50-grpc.plain-namespace\\nhost_rewrite: canary.1.example.com\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-canarydiffmapping-grpc-50-grpc\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8167},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8530}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2019-11-04T05:43:46Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-canarydiffmapping-grpc-50-grpc",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "12796",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-canarydiffmapping-grpc-50-grpc",
-                    "uid": "11b0dd95-fec6-11e9-8b1f-120e67b61000"
-                },
-                "spec": {
-                    "clusterIP": "10.102.127.143",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8167
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8530
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: CanaryDiffMapping-HTTP-100-canary\nprefix: /CanaryDiffMapping-HTTP-100/\nservice: http://plain-canarydiffmapping-http-100-http-canary.plain-namespace\nhost_rewrite: canary.2.example.com\nweight: 100\nambassador_id: plain\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: CanaryDiffMapping-HTTP-100-canary\\nprefix: /CanaryDiffMapping-HTTP-100/\\nservice: http://plain-canarydiffmapping-http-100-http-canary.plain-namespace\\nhost_rewrite: canary.2.example.com\\nweight: 100\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-canarydiffmapping-http-100-http-canary\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8162},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8525}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2019-11-04T05:43:45Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-canarydiffmapping-http-100-http-canary",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "12773",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-canarydiffmapping-http-100-http-canary",
-                    "uid": "1108695a-fec6-11e9-8b1f-120e67b61000"
-                },
-                "spec": {
-                    "clusterIP": "10.100.240.88",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8162
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8525
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: CanaryMapping-GRPC-0-canary\nprefix: /CanaryMapping-GRPC-0/\nservice: http://plain-canarymapping-grpc-0-grpc-canary.plain-namespace\nweight: 0\nambassador_id: plain\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: CanaryMapping-GRPC-0-canary\\nprefix: /CanaryMapping-GRPC-0/\\nservice: http://plain-canarymapping-grpc-0-grpc-canary.plain-namespace\\nweight: 0\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-canarymapping-grpc-0-grpc-canary\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8148},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8511}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2019-11-04T05:43:43Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-canarymapping-grpc-0-grpc-canary",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "12721",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-canarymapping-grpc-0-grpc-canary",
-                    "uid": "100281ff-fec6-11e9-8b1f-120e67b61000"
-                },
-                "spec": {
-                    "clusterIP": "10.102.36.193",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8148
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8511
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
                         "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: SimpleMapping-GRPC-Rewrite-foo\nprefix: /SimpleMapping-GRPC-Rewrite-foo/\nservice: http://plain-simplemapping-grpc-rewrite-foo-grpc.plain-namespace\nambassador_id: plain\nrewrite: foo\n",
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: SimpleMapping-GRPC-Rewrite-foo\\nprefix: /SimpleMapping-GRPC-Rewrite-foo/\\nservice: http://plain-simplemapping-grpc-rewrite-foo-grpc.plain-namespace\\nambassador_id: plain\\nrewrite: foo\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-simplemapping-grpc-rewrite-foo-grpc\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8119},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8482}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
                     },
-                    "creationTimestamp": "2019-11-04T05:43:39Z",
+                    "creationTimestamp": "2019-11-04T07:58:49Z",
                     "labels": {
                         "kat-ambassador-id": "plain",
                         "scope": "AmbassadorTest"
                     },
                     "name": "plain-simplemapping-grpc-rewrite-foo-grpc",
                     "namespace": "plain-namespace",
-                    "resourceVersion": "12598",
+                    "resourceVersion": "16471",
                     "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-simplemapping-grpc-rewrite-foo-grpc",
-                    "uid": "0dc591fc-fec6-11e9-8b1f-120e67b61000"
+                    "uid": "ef76e786-fed8-11e9-9a8f-0e57b7345f92"
                 },
                 "spec": {
-                    "clusterIP": "10.109.245.70",
+                    "clusterIP": "10.107.114.157",
                     "ports": [
                         {
                             "name": "http",
@@ -2197,1476 +356,34 @@
                 "kind": "Service",
                 "metadata": {
                     "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: SimpleMapping-HTTP-AddResponseHeaders-moo-arf\nprefix: /SimpleMapping-HTTP-AddResponseHeaders-moo-arf/\nservice: http://plain-simplemapping-http-addresponseheaders-moo-arf-http.plain-namespace\nambassador_id: plain\nadd_response_headers: {\"moo\": \"arf\"}\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: SimpleMapping-HTTP-AddResponseHeaders-moo-arf\\nprefix: /SimpleMapping-HTTP-AddResponseHeaders-moo-arf/\\nservice: http://plain-simplemapping-http-addresponseheaders-moo-arf-http.plain-namespace\\nambassador_id: plain\\nadd_response_headers: {\\\"moo\\\": \\\"arf\\\"}\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-simplemapping-http-addresponseheaders-moo-arf-http\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8091},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8454}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: CanaryMapping-GRPC-0-canary\nprefix: /CanaryMapping-GRPC-0/\nservice: http://plain-canarymapping-grpc-0-grpc-canary.plain-namespace\nweight: 0\nambassador_id: plain\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: CanaryMapping-GRPC-0-canary\\nprefix: /CanaryMapping-GRPC-0/\\nservice: http://plain-canarymapping-grpc-0-grpc-canary.plain-namespace\\nweight: 0\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-canarymapping-grpc-0-grpc-canary\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8148},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8511}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
                     },
-                    "creationTimestamp": "2019-11-04T05:43:37Z",
+                    "creationTimestamp": "2019-11-04T07:58:52Z",
                     "labels": {
                         "kat-ambassador-id": "plain",
                         "scope": "AmbassadorTest"
                     },
-                    "name": "plain-simplemapping-http-addresponseheaders-moo-arf-http",
+                    "name": "plain-canarymapping-grpc-0-grpc-canary",
                     "namespace": "plain-namespace",
-                    "resourceVersion": "12485",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-simplemapping-http-addresponseheaders-moo-arf-http",
-                    "uid": "0c4f1336-fec6-11e9-8b1f-120e67b61000"
+                    "resourceVersion": "16569",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-canarymapping-grpc-0-grpc-canary",
+                    "uid": "f164cd75-fed8-11e9-9a8f-0e57b7345f92"
                 },
                 "spec": {
-                    "clusterIP": "10.97.224.143",
+                    "clusterIP": "10.105.156.98",
                     "ports": [
                         {
                             "name": "http",
                             "port": 80,
                             "protocol": "TCP",
-                            "targetPort": 8091
+                            "targetPort": 8148
                         },
                         {
                             "name": "https",
                             "port": 443,
                             "protocol": "TCP",
-                            "targetPort": 8454
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: SimpleMapping-HTTP-AutoHostRewrite\nprefix: /SimpleMapping-HTTP-AutoHostRewrite/\nservice: http://plain-simplemapping-http-autohostrewrite-http.plain-namespace\nambassador_id: plain\nauto_host_rewrite: true\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: SimpleMapping-HTTP-AutoHostRewrite\\nprefix: /SimpleMapping-HTTP-AutoHostRewrite/\\nservice: http://plain-simplemapping-http-autohostrewrite-http.plain-namespace\\nambassador_id: plain\\nauto_host_rewrite: true\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-simplemapping-http-autohostrewrite-http\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8098},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8461}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2019-11-04T05:43:38Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-simplemapping-http-autohostrewrite-http",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "12516",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-simplemapping-http-autohostrewrite-http",
-                    "uid": "0cb1e0c4-fec6-11e9-8b1f-120e67b61000"
-                },
-                "spec": {
-                    "clusterIP": "10.107.145.66",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8098
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8461
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: SimpleMapping-HTTP-RemoveResponseHeaders\nprefix: /SimpleMapping-HTTP-RemoveResponseHeaders/\nservice: http://plain-simplemapping-http-removeresponseheaders-http.plain-namespace\nambassador_id: plain\nremove_response_headers: x-envoy-upstream-service-time\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: SimpleMapping-HTTP-RemoveResponseHeaders\\nprefix: /SimpleMapping-HTTP-RemoveResponseHeaders/\\nservice: http://plain-simplemapping-http-removeresponseheaders-http.plain-namespace\\nambassador_id: plain\\nremove_response_headers: x-envoy-upstream-service-time\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-simplemapping-http-removeresponseheaders-http\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8101},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8464}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2019-11-04T05:43:38Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-simplemapping-http-removeresponseheaders-http",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "12528",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-simplemapping-http-removeresponseheaders-http",
-                    "uid": "0cde097a-fec6-11e9-8b1f-120e67b61000"
-                },
-                "spec": {
-                    "clusterIP": "10.100.186.248",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8101
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8464
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: CanaryDiffMapping-GRPC-10\nprefix: /CanaryDiffMapping-GRPC-10/\nservice: http://plain-canarydiffmapping-grpc-10-grpc.plain-namespace\nhost_rewrite: canary.1.example.com\nambassador_id: plain\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: CanaryDiffMapping-GRPC-10\\nprefix: /CanaryDiffMapping-GRPC-10/\\nservice: http://plain-canarydiffmapping-grpc-10-grpc.plain-namespace\\nhost_rewrite: canary.1.example.com\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-canarydiffmapping-grpc-10-grpc\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8165},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8528}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2019-11-04T05:43:46Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-canarydiffmapping-grpc-10-grpc",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "12787",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-canarydiffmapping-grpc-10-grpc",
-                    "uid": "11692dd2-fec6-11e9-8b1f-120e67b61000"
-                },
-                "spec": {
-                    "clusterIP": "10.108.199.211",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8165
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8528
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: CanaryDiffMapping-GRPC-10-canary\nprefix: /CanaryDiffMapping-GRPC-10/\nservice: http://plain-canarydiffmapping-grpc-10-grpc-canary.plain-namespace\nhost_rewrite: canary.2.example.com\nweight: 10\nambassador_id: plain\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: CanaryDiffMapping-GRPC-10-canary\\nprefix: /CanaryDiffMapping-GRPC-10/\\nservice: http://plain-canarydiffmapping-grpc-10-grpc-canary.plain-namespace\\nhost_rewrite: canary.2.example.com\\nweight: 10\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-canarydiffmapping-grpc-10-grpc-canary\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8166},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8529}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2019-11-04T05:43:46Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-canarydiffmapping-grpc-10-grpc-canary",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "12792",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-canarydiffmapping-grpc-10-grpc-canary",
-                    "uid": "11a0f6d4-fec6-11e9-8b1f-120e67b61000"
-                },
-                "spec": {
-                    "clusterIP": "10.111.16.81",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8166
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8529
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: CanaryDiffMapping-GRPC-100-canary\nprefix: /CanaryDiffMapping-GRPC-100/\nservice: http://plain-canarydiffmapping-grpc-100-grpc-canary.plain-namespace\nhost_rewrite: canary.2.example.com\nweight: 100\nambassador_id: plain\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: CanaryDiffMapping-GRPC-100-canary\\nprefix: /CanaryDiffMapping-GRPC-100/\\nservice: http://plain-canarydiffmapping-grpc-100-grpc-canary.plain-namespace\\nhost_rewrite: canary.2.example.com\\nweight: 100\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-canarydiffmapping-grpc-100-grpc-canary\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8170},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8533}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2019-11-04T05:43:47Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-canarydiffmapping-grpc-100-grpc-canary",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "12809",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-canarydiffmapping-grpc-100-grpc-canary",
-                    "uid": "121e5f04-fec6-11e9-8b1f-120e67b61000"
-                },
-                "spec": {
-                    "clusterIP": "10.103.179.243",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8170
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8533
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: CanaryDiffMapping-GRPC-50-canary\nprefix: /CanaryDiffMapping-GRPC-50/\nservice: http://plain-canarydiffmapping-grpc-50-grpc-canary.plain-namespace\nhost_rewrite: canary.2.example.com\nweight: 50\nambassador_id: plain\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: CanaryDiffMapping-GRPC-50-canary\\nprefix: /CanaryDiffMapping-GRPC-50/\\nservice: http://plain-canarydiffmapping-grpc-50-grpc-canary.plain-namespace\\nhost_rewrite: canary.2.example.com\\nweight: 50\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-canarydiffmapping-grpc-50-grpc-canary\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8168},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8531}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2019-11-04T05:43:46Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-canarydiffmapping-grpc-50-grpc-canary",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "12799",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-canarydiffmapping-grpc-50-grpc-canary",
-                    "uid": "11c97b25-fec6-11e9-8b1f-120e67b61000"
-                },
-                "spec": {
-                    "clusterIP": "10.102.161.212",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8168
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8531
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: CanaryMapping-HTTP-100\nprefix: /CanaryMapping-HTTP-100/\nservice: http://plain-canarymapping-http-100-http.plain-namespace\nambassador_id: plain\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: CanaryMapping-HTTP-100\\nprefix: /CanaryMapping-HTTP-100/\\nservice: http://plain-canarymapping-http-100-http.plain-namespace\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-canarymapping-http-100-http\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8145},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8508}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2019-11-04T05:43:43Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-canarymapping-http-100-http",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "12708",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-canarymapping-http-100-http",
-                    "uid": "0fcfea84-fec6-11e9-8b1f-120e67b61000"
-                },
-                "spec": {
-                    "clusterIP": "10.111.45.243",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8145
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8508
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: HeaderRoutingTest-GRPC-target1\nprefix: /HeaderRoutingTest-GRPC/\nservice: http://plain-headerroutingtest-grpc-grpc.plain-namespace\nambassador_id: plain\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: HeaderRoutingTest-GRPC-target1\\nprefix: /HeaderRoutingTest-GRPC/\\nservice: http://plain-headerroutingtest-grpc-grpc.plain-namespace\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-headerroutingtest-grpc-grpc\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8082},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8445}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2019-11-04T05:43:36Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-headerroutingtest-grpc-grpc",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "12448",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-headerroutingtest-grpc-grpc",
-                    "uid": "0bbf6455-fec6-11e9-8b1f-120e67b61000"
-                },
-                "spec": {
-                    "clusterIP": "10.109.33.108",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8082
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8445
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: CanaryDiffMapping-GRPC-100\nprefix: /CanaryDiffMapping-GRPC-100/\nservice: http://plain-canarydiffmapping-grpc-100-grpc.plain-namespace\nhost_rewrite: canary.1.example.com\nambassador_id: plain\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: CanaryDiffMapping-GRPC-100\\nprefix: /CanaryDiffMapping-GRPC-100/\\nservice: http://plain-canarydiffmapping-grpc-100-grpc.plain-namespace\\nhost_rewrite: canary.1.example.com\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-canarydiffmapping-grpc-100-grpc\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8169},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8532}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2019-11-04T05:43:46Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-canarydiffmapping-grpc-100-grpc",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "12804",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-canarydiffmapping-grpc-100-grpc",
-                    "uid": "11eb5db0-fec6-11e9-8b1f-120e67b61000"
-                },
-                "spec": {
-                    "clusterIP": "10.105.252.72",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8169
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8532
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: CanaryMapping-HTTP-50\nprefix: /CanaryMapping-HTTP-50/\nservice: http://plain-canarymapping-http-50-http.plain-namespace\nambassador_id: plain\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: CanaryMapping-HTTP-50\\nprefix: /CanaryMapping-HTTP-50/\\nservice: http://plain-canarymapping-http-50-http.plain-namespace\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-canarymapping-http-50-http\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8143},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8506}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2019-11-04T05:43:43Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-canarymapping-http-50-http",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "12701",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-canarymapping-http-50-http",
-                    "uid": "0fb0ca2d-fec6-11e9-8b1f-120e67b61000"
-                },
-                "spec": {
-                    "clusterIP": "10.102.75.155",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8143
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8506
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: RemoveReqHeadersMapping-HTTP\nprefix: /RemoveReqHeadersMapping-HTTP/\nservice: http://httpbin.org\nremove_request_headers:\n- zoo\n- aoo\nambassador_id: plain\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: RemoveReqHeadersMapping-HTTP\\nprefix: /RemoveReqHeadersMapping-HTTP/\\nservice: http://httpbin.org\\nremove_request_headers:\\n- zoo\\n- aoo\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-removereqheadersmapping-http-http\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8173},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8536}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2019-11-04T05:43:48Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-removereqheadersmapping-http-http",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "12827",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-removereqheadersmapping-http-http",
-                    "uid": "12da6d37-fec6-11e9-8b1f-120e67b61000"
-                },
-                "spec": {
-                    "clusterIP": "10.103.83.88",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8173
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8536
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: SimpleMapping-HTTP-AddRequestHeaders-aoo-tyu\nprefix: /SimpleMapping-HTTP-AddRequestHeaders-aoo-tyu/\nservice: http://plain-simplemapping-http-addrequestheaders-aoo-tyu-http.plain-namespace\nambassador_id: plain\nadd_request_headers: {\"aoo\": {\"value\": \"tyu\"}}\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: SimpleMapping-HTTP-AddRequestHeaders-aoo-tyu\\nprefix: /SimpleMapping-HTTP-AddRequestHeaders-aoo-tyu/\\nservice: http://plain-simplemapping-http-addrequestheaders-aoo-tyu-http.plain-namespace\\nambassador_id: plain\\nadd_request_headers: {\\\"aoo\\\": {\\\"value\\\": \\\"tyu\\\"}}\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-simplemapping-http-addrequestheaders-aoo-tyu-http\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8089},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8452}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2019-11-04T05:43:37Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-simplemapping-http-addrequestheaders-aoo-tyu-http",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "12476",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-simplemapping-http-addrequestheaders-aoo-tyu-http",
-                    "uid": "0c2fd313-fec6-11e9-8b1f-120e67b61000"
-                },
-                "spec": {
-                    "clusterIP": "10.104.140.92",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8089
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8452
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: SimpleMapping-HTTP-AddResponseHeaders-zoo-bar\nprefix: /SimpleMapping-HTTP-AddResponseHeaders-zoo-bar/\nservice: http://plain-simplemapping-http-addresponseheaders-zoo-bar-http.plain-namespace\nambassador_id: plain\nadd_response_headers: {\"zoo\": {\"append\": true, \"value\": \"bar\"}}\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: SimpleMapping-HTTP-AddResponseHeaders-zoo-bar\\nprefix: /SimpleMapping-HTTP-AddResponseHeaders-zoo-bar/\\nservice: http://plain-simplemapping-http-addresponseheaders-zoo-bar-http.plain-namespace\\nambassador_id: plain\\nadd_response_headers: {\\\"zoo\\\": {\\\"append\\\": true, \\\"value\\\": \\\"bar\\\"}}\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-simplemapping-http-addresponseheaders-zoo-bar-http\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8092},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8455}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2019-11-04T05:43:37Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-simplemapping-http-addresponseheaders-zoo-bar-http",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "12490",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-simplemapping-http-addresponseheaders-zoo-bar-http",
-                    "uid": "0c5dcb09-fec6-11e9-8b1f-120e67b61000"
-                },
-                "spec": {
-                    "clusterIP": "10.108.67.42",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8092
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8455
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: SimpleMapping-HTTP-Rewrite-SLASH-foo\nprefix: /SimpleMapping-HTTP-Rewrite-SLASH-foo/\nservice: http://plain-simplemapping-http-rewrite-slash-foo-http.plain-namespace\nambassador_id: plain\nrewrite: /foo\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: SimpleMapping-HTTP-Rewrite-SLASH-foo\\nprefix: /SimpleMapping-HTTP-Rewrite-SLASH-foo/\\nservice: http://plain-simplemapping-http-rewrite-slash-foo-http.plain-namespace\\nambassador_id: plain\\nrewrite: /foo\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-simplemapping-http-rewrite-slash-foo-http\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8099},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8462}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2019-11-04T05:43:38Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-simplemapping-http-rewrite-slash-foo-http",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "12520",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-simplemapping-http-rewrite-slash-foo-http",
-                    "uid": "0cc035fc-fec6-11e9-8b1f-120e67b61000"
-                },
-                "spec": {
-                    "clusterIP": "10.107.162.125",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8099
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8462
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: TLSOrigination-HTTP-EXPLICIT\nprefix: /TLSOrigination-HTTP-EXPLICIT/\nservice: plain-tlsorigination-http-explicit-http.plain-namespace\ntls: true\nambassador_id: plain\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: TLSOrigination-HTTP-EXPLICIT\\nprefix: /TLSOrigination-HTTP-EXPLICIT/\\nservice: plain-tlsorigination-http-explicit-http.plain-namespace\\ntls: true\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-tlsorigination-http-explicit-http\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8135},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8498}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2019-11-04T05:43:42Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-tlsorigination-http-explicit-http",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "12669",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-tlsorigination-http-explicit-http",
-                    "uid": "0f19f8ca-fec6-11e9-8b1f-120e67b61000"
-                },
-                "spec": {
-                    "clusterIP": "10.108.31.171",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8135
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8498
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"app.kubernetes.io/component\":\"ambassador-service\",\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8080},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8443}],\"selector\":{\"service\":\"plain\"},\"type\":\"NodePort\"}}\n"
-                    },
-                    "creationTimestamp": "2019-11-04T05:43:36Z",
-                    "labels": {
-                        "app.kubernetes.io/component": "ambassador-service",
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "12427",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain",
-                    "uid": "0b76befa-fec6-11e9-8b1f-120e67b61000"
-                },
-                "spec": {
-                    "clusterIP": "10.104.75.246",
-                    "externalTrafficPolicy": "Cluster",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "nodePort": 30521,
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8080
-                        },
-                        {
-                            "name": "https",
-                            "nodePort": 30263,
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8443
-                        }
-                    ],
-                    "selector": {
-                        "service": "plain"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "NodePort"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: HeaderRoutingTest-HTTP-target2\nprefix: /HeaderRoutingTest-HTTP/\nservice: http://plain-headerroutingtest-http-http-target2.plain-namespace\nheaders:\n  X-Route: target2\nambassador_id: plain\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: HeaderRoutingTest-HTTP-target2\\nprefix: /HeaderRoutingTest-HTTP/\\nservice: http://plain-headerroutingtest-http-http-target2.plain-namespace\\nheaders:\\n  X-Route: target2\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-headerroutingtest-http-http-target2\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8081},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8444}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2019-11-04T05:43:36Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-headerroutingtest-http-http-target2",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "12443",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-headerroutingtest-http-http-target2",
-                    "uid": "0bb00a64-fec6-11e9-8b1f-120e67b61000"
-                },
-                "spec": {
-                    "clusterIP": "10.104.42.169",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8081
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8444
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: RemoveReqHeadersMapping-GRPC\nprefix: /RemoveReqHeadersMapping-GRPC/\nservice: http://httpbin.org\nremove_request_headers:\n- zoo\n- aoo\nambassador_id: plain\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: RemoveReqHeadersMapping-GRPC\\nprefix: /RemoveReqHeadersMapping-GRPC/\\nservice: http://httpbin.org\\nremove_request_headers:\\n- zoo\\n- aoo\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-removereqheadersmapping-grpc-grpc\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8174},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8537}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2019-11-04T05:43:48Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-removereqheadersmapping-grpc-grpc",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "12831",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-removereqheadersmapping-grpc-grpc",
-                    "uid": "12f09503-fec6-11e9-8b1f-120e67b61000"
-                },
-                "spec": {
-                    "clusterIP": "10.99.213.239",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8174
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8537
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: SimpleMapping-GRPC-AddRequestHeaders-aoo-tyu\nprefix: /SimpleMapping-GRPC-AddRequestHeaders-aoo-tyu/\nservice: http://plain-simplemapping-grpc-addrequestheaders-aoo-tyu-grpc.plain-namespace\nambassador_id: plain\nadd_request_headers: {\"aoo\": {\"value\": \"tyu\"}}\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: SimpleMapping-GRPC-AddRequestHeaders-aoo-tyu\\nprefix: /SimpleMapping-GRPC-AddRequestHeaders-aoo-tyu/\\nservice: http://plain-simplemapping-grpc-addrequestheaders-aoo-tyu-grpc.plain-namespace\\nambassador_id: plain\\nadd_request_headers: {\\\"aoo\\\": {\\\"value\\\": \\\"tyu\\\"}}\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-simplemapping-grpc-addrequestheaders-aoo-tyu-grpc\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8108},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8471}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2019-11-04T05:43:39Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-simplemapping-grpc-addrequestheaders-aoo-tyu-grpc",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "12555",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-simplemapping-grpc-addrequestheaders-aoo-tyu-grpc",
-                    "uid": "0d40e30c-fec6-11e9-8b1f-120e67b61000"
-                },
-                "spec": {
-                    "clusterIP": "10.110.166.82",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8108
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8471
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: SimpleMapping-GRPC-AddResponseHeaders-xoo-dwe\nprefix: /SimpleMapping-GRPC-AddResponseHeaders-xoo-dwe/\nservice: http://plain-simplemapping-grpc-addresponseheaders-xoo-dwe-grpc.plain-namespace\nambassador_id: plain\nadd_response_headers: {\"xoo\": {\"append\": false, \"value\": \"dwe\"}}\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: SimpleMapping-GRPC-AddResponseHeaders-xoo-dwe\\nprefix: /SimpleMapping-GRPC-AddResponseHeaders-xoo-dwe/\\nservice: http://plain-simplemapping-grpc-addresponseheaders-xoo-dwe-grpc.plain-namespace\\nambassador_id: plain\\nadd_response_headers: {\\\"xoo\\\": {\\\"append\\\": false, \\\"value\\\": \\\"dwe\\\"}}\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-simplemapping-grpc-addresponseheaders-xoo-dwe-grpc\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8112},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8475}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2019-11-04T05:43:39Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-simplemapping-grpc-addresponseheaders-xoo-dwe-grpc",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "12570",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-simplemapping-grpc-addresponseheaders-xoo-dwe-grpc",
-                    "uid": "0d712599-fec6-11e9-8b1f-120e67b61000"
-                },
-                "spec": {
-                    "clusterIP": "10.106.91.124",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8112
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8475
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: SimpleMapping-HTTP-AddRequestHeaders-moo-arf\nprefix: /SimpleMapping-HTTP-AddRequestHeaders-moo-arf/\nservice: http://plain-simplemapping-http-addrequestheaders-moo-arf-http.plain-namespace\nambassador_id: plain\nadd_request_headers: {\"moo\": \"arf\"}\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: SimpleMapping-HTTP-AddRequestHeaders-moo-arf\\nprefix: /SimpleMapping-HTTP-AddRequestHeaders-moo-arf/\\nservice: http://plain-simplemapping-http-addrequestheaders-moo-arf-http.plain-namespace\\nambassador_id: plain\\nadd_request_headers: {\\\"moo\\\": \\\"arf\\\"}\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-simplemapping-http-addrequestheaders-moo-arf-http\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8086},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8449}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2019-11-04T05:43:36Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-simplemapping-http-addrequestheaders-moo-arf-http",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "12464",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-simplemapping-http-addrequestheaders-moo-arf-http",
-                    "uid": "0c02aaaa-fec6-11e9-8b1f-120e67b61000"
-                },
-                "spec": {
-                    "clusterIP": "10.105.79.221",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8086
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8449
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: AddRespHeadersMapping-HTTP\nprefix: /AddRespHeadersMapping-HTTP/\nservice: http://httpbin.org\nadd_response_headers:\n  koo:\n    append: False\n    value: KooK\n  zoo:\n    append: True\n    value: ZooZ\n  test:\n    value: boo\n  foo: Foo\nambassador_id: plain\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: AddRespHeadersMapping-HTTP\\nprefix: /AddRespHeadersMapping-HTTP/\\nservice: http://httpbin.org\\nadd_response_headers:\\n  koo:\\n    append: False\\n    value: KooK\\n  zoo:\\n    append: True\\n    value: ZooZ\\n  test:\\n    value: boo\\n  foo: Foo\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-addrespheadersmapping-http-http\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8171},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8534}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2019-11-04T05:43:47Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-addrespheadersmapping-http-http",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "12814",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-addrespheadersmapping-http-http",
-                    "uid": "12466b74-fec6-11e9-8b1f-120e67b61000"
-                },
-                "spec": {
-                    "clusterIP": "10.100.171.121",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8171
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8534
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: CanaryDiffMapping-HTTP-10\nprefix: /CanaryDiffMapping-HTTP-10/\nservice: http://plain-canarydiffmapping-http-10-http.plain-namespace\nhost_rewrite: canary.1.example.com\nambassador_id: plain\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: CanaryDiffMapping-HTTP-10\\nprefix: /CanaryDiffMapping-HTTP-10/\\nservice: http://plain-canarydiffmapping-http-10-http.plain-namespace\\nhost_rewrite: canary.1.example.com\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-canarydiffmapping-http-10-http\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8157},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8520}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2019-11-04T05:43:44Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-canarydiffmapping-http-10-http",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "12755",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-canarydiffmapping-http-10-http",
-                    "uid": "10a87a33-fec6-11e9-8b1f-120e67b61000"
-                },
-                "spec": {
-                    "clusterIP": "10.107.194.12",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8157
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8520
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: CanaryDiffMapping-HTTP-10-canary\nprefix: /CanaryDiffMapping-HTTP-10/\nservice: http://plain-canarydiffmapping-http-10-http-canary.plain-namespace\nhost_rewrite: canary.2.example.com\nweight: 10\nambassador_id: plain\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: CanaryDiffMapping-HTTP-10-canary\\nprefix: /CanaryDiffMapping-HTTP-10/\\nservice: http://plain-canarydiffmapping-http-10-http-canary.plain-namespace\\nhost_rewrite: canary.2.example.com\\nweight: 10\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-canarydiffmapping-http-10-http-canary\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8158},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8521}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2019-11-04T05:43:44Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-canarydiffmapping-http-10-http-canary",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "12759",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-canarydiffmapping-http-10-http-canary",
-                    "uid": "10c19419-fec6-11e9-8b1f-120e67b61000"
-                },
-                "spec": {
-                    "clusterIP": "10.104.165.57",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8158
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8521
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: CanaryMapping-GRPC-50\nprefix: /CanaryMapping-GRPC-50/\nservice: http://plain-canarymapping-grpc-50-grpc.plain-namespace\nambassador_id: plain\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: CanaryMapping-GRPC-50\\nprefix: /CanaryMapping-GRPC-50/\\nservice: http://plain-canarymapping-grpc-50-grpc.plain-namespace\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-canarymapping-grpc-50-grpc\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8151},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8514}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2019-11-04T05:43:44Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-canarymapping-grpc-50-grpc",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "12733",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-canarymapping-grpc-50-grpc",
-                    "uid": "103cad1e-fec6-11e9-8b1f-120e67b61000"
-                },
-                "spec": {
-                    "clusterIP": "10.100.200.164",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8151
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8514
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: CanaryMapping-HTTP-50-canary\nprefix: /CanaryMapping-HTTP-50/\nservice: http://plain-canarymapping-http-50-http-canary.plain-namespace\nweight: 50\nambassador_id: plain\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: CanaryMapping-HTTP-50-canary\\nprefix: /CanaryMapping-HTTP-50/\\nservice: http://plain-canarymapping-http-50-http-canary.plain-namespace\\nweight: 50\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-canarymapping-http-50-http-canary\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8144},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8507}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2019-11-04T05:43:43Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-canarymapping-http-50-http-canary",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "12704",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-canarymapping-http-50-http-canary",
-                    "uid": "0fbf79b6-fec6-11e9-8b1f-120e67b61000"
-                },
-                "spec": {
-                    "clusterIP": "10.102.80.25",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8144
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8507
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-simpleingresswithannotations-grpc-grpc\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8125},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8488}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2019-11-04T05:43:40Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-simpleingresswithannotations-grpc-grpc",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "12625",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-simpleingresswithannotations-grpc-grpc",
-                    "uid": "0e39c68b-fec6-11e9-8b1f-120e67b61000"
-                },
-                "spec": {
-                    "clusterIP": "10.106.220.218",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8125
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8488
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: SimpleMapping-GRPC-all\nprefix: /SimpleMapping-GRPC-all/\nservice: http://plain-simplemapping-grpc-all-grpc.plain-namespace\nambassador_id: plain\nadd_request_headers: {\"foo\": \"bar\"}\nadd_response_headers: {\"foo\": \"bar\"}\nuse_websocket: true\ncors: {origins: \"*\"}\ncase_sensitive: false\nauto_host_rewrite: true\nrewrite: /foo\nremove_response_headers: x-envoy-upstream-service-time\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: SimpleMapping-GRPC-all\\nprefix: /SimpleMapping-GRPC-all/\\nservice: http://plain-simplemapping-grpc-all-grpc.plain-namespace\\nambassador_id: plain\\nadd_request_headers: {\\\"foo\\\": \\\"bar\\\"}\\nadd_response_headers: {\\\"foo\\\": \\\"bar\\\"}\\nuse_websocket: true\\ncors: {origins: \\\"*\\\"}\\ncase_sensitive: false\\nauto_host_rewrite: true\\nrewrite: /foo\\nremove_response_headers: x-envoy-upstream-service-time\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-simplemapping-grpc-all-grpc\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8121},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8484}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2019-11-04T05:43:40Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-simplemapping-grpc-all-grpc",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "12605",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-simplemapping-grpc-all-grpc",
-                    "uid": "0dde891f-fec6-11e9-8b1f-120e67b61000"
-                },
-                "spec": {
-                    "clusterIP": "10.108.222.195",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8121
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8484
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: SimpleMapping-HTTP-AddResponseHeaders-aoo-tyu\nprefix: /SimpleMapping-HTTP-AddResponseHeaders-aoo-tyu/\nservice: http://plain-simplemapping-http-addresponseheaders-aoo-tyu-http.plain-namespace\nambassador_id: plain\nadd_response_headers: {\"aoo\": {\"value\": \"tyu\"}}\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: SimpleMapping-HTTP-AddResponseHeaders-aoo-tyu\\nprefix: /SimpleMapping-HTTP-AddResponseHeaders-aoo-tyu/\\nservice: http://plain-simplemapping-http-addresponseheaders-aoo-tyu-http.plain-namespace\\nambassador_id: plain\\nadd_response_headers: {\\\"aoo\\\": {\\\"value\\\": \\\"tyu\\\"}}\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-simplemapping-http-addresponseheaders-aoo-tyu-http\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8094},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8457}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2019-11-04T05:43:37Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-simplemapping-http-addresponseheaders-aoo-tyu-http",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "12497",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-simplemapping-http-addresponseheaders-aoo-tyu-http",
-                    "uid": "0c792a86-fec6-11e9-8b1f-120e67b61000"
-                },
-                "spec": {
-                    "clusterIP": "10.103.157.68",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8094
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8457
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: SimpleMapping-HTTP-CORS\nprefix: /SimpleMapping-HTTP-CORS/\nservice: http://plain-simplemapping-http-cors-http.plain-namespace\nambassador_id: plain\ncors: {origins: \"*\"}\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: SimpleMapping-HTTP-CORS\\nprefix: /SimpleMapping-HTTP-CORS/\\nservice: http://plain-simplemapping-http-cors-http.plain-namespace\\nambassador_id: plain\\ncors: {origins: \\\"*\\\"}\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-simplemapping-http-cors-http\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8096},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8459}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2019-11-04T05:43:37Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-simplemapping-http-cors-http",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "12505",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-simplemapping-http-cors-http",
-                    "uid": "0c9775da-fec6-11e9-8b1f-120e67b61000"
-                },
-                "spec": {
-                    "clusterIP": "10.103.183.163",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8096
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8459
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: SimpleMapping-HTTP-Rewrite-foo\nprefix: /SimpleMapping-HTTP-Rewrite-foo/\nservice: http://plain-simplemapping-http-rewrite-foo-http.plain-namespace\nambassador_id: plain\nrewrite: foo\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: SimpleMapping-HTTP-Rewrite-foo\\nprefix: /SimpleMapping-HTTP-Rewrite-foo/\\nservice: http://plain-simplemapping-http-rewrite-foo-http.plain-namespace\\nambassador_id: plain\\nrewrite: foo\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-simplemapping-http-rewrite-foo-http\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8100},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8463}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2019-11-04T05:43:38Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-simplemapping-http-rewrite-foo-http",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "12525",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-simplemapping-http-rewrite-foo-http",
-                    "uid": "0cce9887-fec6-11e9-8b1f-120e67b61000"
-                },
-                "spec": {
-                    "clusterIP": "10.108.61.47",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8100
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8463
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: TLSOrigination-GRPC-IMPLICIT\nprefix: /TLSOrigination-GRPC-IMPLICIT/\nservice: https://plain-tlsorigination-grpc-implicit-grpc.plain-namespace\nambassador_id: plain\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: TLSOrigination-GRPC-IMPLICIT\\nprefix: /TLSOrigination-GRPC-IMPLICIT/\\nservice: https://plain-tlsorigination-grpc-implicit-grpc.plain-namespace\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-tlsorigination-grpc-implicit-grpc\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8136},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8499}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2019-11-04T05:43:42Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-tlsorigination-grpc-implicit-grpc",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "12672",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-tlsorigination-grpc-implicit-grpc",
-                    "uid": "0f27c36d-fec6-11e9-8b1f-120e67b61000"
-                },
-                "spec": {
-                    "clusterIP": "10.101.5.199",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8136
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8499
+                            "targetPort": 8511
                         }
                     ],
                     "selector": {
@@ -3687,19 +404,19 @@
                         "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: CanaryMapping-GRPC-10-canary\nprefix: /CanaryMapping-GRPC-10/\nservice: http://plain-canarymapping-grpc-10-grpc-canary.plain-namespace\nweight: 10\nambassador_id: plain\n",
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: CanaryMapping-GRPC-10-canary\\nprefix: /CanaryMapping-GRPC-10/\\nservice: http://plain-canarymapping-grpc-10-grpc-canary.plain-namespace\\nweight: 10\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-canarymapping-grpc-10-grpc-canary\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8150},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8513}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
                     },
-                    "creationTimestamp": "2019-11-04T05:43:43Z",
+                    "creationTimestamp": "2019-11-04T07:58:52Z",
                     "labels": {
                         "kat-ambassador-id": "plain",
                         "scope": "AmbassadorTest"
                     },
                     "name": "plain-canarymapping-grpc-10-grpc-canary",
                     "namespace": "plain-namespace",
-                    "resourceVersion": "12730",
+                    "resourceVersion": "16575",
                     "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-canarymapping-grpc-10-grpc-canary",
-                    "uid": "10296010-fec6-11e9-8b1f-120e67b61000"
+                    "uid": "f183a0e1-fed8-11e9-9a8f-0e57b7345f92"
                 },
                 "spec": {
-                    "clusterIP": "10.108.133.72",
+                    "clusterIP": "10.111.145.130",
                     "ports": [
                         {
                             "name": "http",
@@ -3729,333 +446,22 @@
                 "kind": "Service",
                 "metadata": {
                     "annotations": {
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-hostheadermappingingress-grpc-grpc\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8127},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8490}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2019-11-04T05:43:41Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-hostheadermappingingress-grpc-grpc",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "12635",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-hostheadermappingingress-grpc-grpc",
-                    "uid": "0e66f987-fec6-11e9-8b1f-120e67b61000"
-                },
-                "spec": {
-                    "clusterIP": "10.99.10.155",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8127
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8490
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-hostheadermappingingress-http-http\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8126},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8489}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2019-11-04T05:43:40Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-hostheadermappingingress-http-http",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "12630",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-hostheadermappingingress-http-http",
-                    "uid": "0e50c269-fec6-11e9-8b1f-120e67b61000"
-                },
-                "spec": {
-                    "clusterIP": "10.106.243.4",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8126
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8489
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-simpleingresswithannotations-http-http\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8124},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8487}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2019-11-04T05:43:40Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-simpleingresswithannotations-http-http",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "12620",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-simpleingresswithannotations-http-http",
-                    "uid": "0e21f977-fec6-11e9-8b1f-120e67b61000"
-                },
-                "spec": {
-                    "clusterIP": "10.98.181.154",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8124
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8487
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: SimpleMapping-GRPC-AddResponseHeaders-foo-bar\nprefix: /SimpleMapping-GRPC-AddResponseHeaders-foo-bar/\nservice: http://plain-simplemapping-grpc-addresponseheaders-foo-bar-grpc.plain-namespace\nambassador_id: plain\nadd_response_headers: {\"foo\": \"bar\"}\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: SimpleMapping-GRPC-AddResponseHeaders-foo-bar\\nprefix: /SimpleMapping-GRPC-AddResponseHeaders-foo-bar/\\nservice: http://plain-simplemapping-grpc-addresponseheaders-foo-bar-grpc.plain-namespace\\nambassador_id: plain\\nadd_response_headers: {\\\"foo\\\": \\\"bar\\\"}\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-simplemapping-grpc-addresponseheaders-foo-bar-grpc\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8109},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8472}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2019-11-04T05:43:39Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-simplemapping-grpc-addresponseheaders-foo-bar-grpc",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "12560",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-simplemapping-grpc-addresponseheaders-foo-bar-grpc",
-                    "uid": "0d4cd596-fec6-11e9-8b1f-120e67b61000"
-                },
-                "spec": {
-                    "clusterIP": "10.101.171.104",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8109
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8472
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: SimpleMapping-HTTP-AddResponseHeaders-xoo-dwe\nprefix: /SimpleMapping-HTTP-AddResponseHeaders-xoo-dwe/\nservice: http://plain-simplemapping-http-addresponseheaders-xoo-dwe-http.plain-namespace\nambassador_id: plain\nadd_response_headers: {\"xoo\": {\"append\": false, \"value\": \"dwe\"}}\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: SimpleMapping-HTTP-AddResponseHeaders-xoo-dwe\\nprefix: /SimpleMapping-HTTP-AddResponseHeaders-xoo-dwe/\\nservice: http://plain-simplemapping-http-addresponseheaders-xoo-dwe-http.plain-namespace\\nambassador_id: plain\\nadd_response_headers: {\\\"xoo\\\": {\\\"append\\\": false, \\\"value\\\": \\\"dwe\\\"}}\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-simplemapping-http-addresponseheaders-xoo-dwe-http\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8093},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8456}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2019-11-04T05:43:37Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-simplemapping-http-addresponseheaders-xoo-dwe-http",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "12493",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-simplemapping-http-addresponseheaders-xoo-dwe-http",
-                    "uid": "0c6ba5da-fec6-11e9-8b1f-120e67b61000"
-                },
-                "spec": {
-                    "clusterIP": "10.96.52.157",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8093
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8456
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-simplemappingingress-http-http\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8122},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8485}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2019-11-04T05:43:40Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-simplemappingingress-http-http",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "12609",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-simplemappingingress-http-http",
-                    "uid": "0df58640-fec6-11e9-8b1f-120e67b61000"
-                },
-                "spec": {
-                    "clusterIP": "10.97.176.217",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8122
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8485
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: AddReqHeadersMapping-GRPC\nprefix: /AddReqHeadersMapping-GRPC/\nservice: http://plain-addreqheadersmapping-grpc-grpc.plain-namespace\nadd_request_headers:\n  zoo:\n    append: False\n    value: Zoo\n  aoo:\n    append: True\n    value: aoo\n  boo:\n    value: boo\n  foo: Foo\nambassador_id: plain\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: AddReqHeadersMapping-GRPC\\nprefix: /AddReqHeadersMapping-GRPC/\\nservice: http://plain-addreqheadersmapping-grpc-grpc.plain-namespace\\nadd_request_headers:\\n  zoo:\\n    append: False\\n    value: Zoo\\n  aoo:\\n    append: True\\n    value: aoo\\n  boo:\\n    value: boo\\n  foo: Foo\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-addreqheadersmapping-grpc-grpc\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8176},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8539}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2019-11-04T05:43:48Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-addreqheadersmapping-grpc-grpc",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "12838",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-addreqheadersmapping-grpc-grpc",
-                    "uid": "130cf80a-fec6-11e9-8b1f-120e67b61000"
-                },
-                "spec": {
-                    "clusterIP": "10.110.137.204",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8176
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8539
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
                         "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: CanaryMapping-GRPC-100\nprefix: /CanaryMapping-GRPC-100/\nservice: http://plain-canarymapping-grpc-100-grpc.plain-namespace\nambassador_id: plain\n",
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: CanaryMapping-GRPC-100\\nprefix: /CanaryMapping-GRPC-100/\\nservice: http://plain-canarymapping-grpc-100-grpc.plain-namespace\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-canarymapping-grpc-100-grpc\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8153},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8516}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
                     },
-                    "creationTimestamp": "2019-11-04T05:43:44Z",
+                    "creationTimestamp": "2019-11-04T07:58:53Z",
                     "labels": {
                         "kat-ambassador-id": "plain",
                         "scope": "AmbassadorTest"
                     },
                     "name": "plain-canarymapping-grpc-100-grpc",
                     "namespace": "plain-namespace",
-                    "resourceVersion": "12740",
+                    "resourceVersion": "16584",
                     "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-canarymapping-grpc-100-grpc",
-                    "uid": "105ae608-fec6-11e9-8b1f-120e67b61000"
+                    "uid": "f1abbed3-fed8-11e9-9a8f-0e57b7345f92"
                 },
                 "spec": {
-                    "clusterIP": "10.104.163.170",
+                    "clusterIP": "10.108.216.120",
                     "ports": [
                         {
                             "name": "http",
@@ -4088,19 +494,19 @@
                         "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: CanaryMapping-GRPC-100-canary\nprefix: /CanaryMapping-GRPC-100/\nservice: http://plain-canarymapping-grpc-100-grpc-canary.plain-namespace\nweight: 100\nambassador_id: plain\n",
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: CanaryMapping-GRPC-100-canary\\nprefix: /CanaryMapping-GRPC-100/\\nservice: http://plain-canarymapping-grpc-100-grpc-canary.plain-namespace\\nweight: 100\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-canarymapping-grpc-100-grpc-canary\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8154},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8517}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
                     },
-                    "creationTimestamp": "2019-11-04T05:43:44Z",
+                    "creationTimestamp": "2019-11-04T07:58:53Z",
                     "labels": {
                         "kat-ambassador-id": "plain",
                         "scope": "AmbassadorTest"
                     },
                     "name": "plain-canarymapping-grpc-100-grpc-canary",
                     "namespace": "plain-namespace",
-                    "resourceVersion": "12744",
+                    "resourceVersion": "16587",
                     "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-canarymapping-grpc-100-grpc-canary",
-                    "uid": "106beb37-fec6-11e9-8b1f-120e67b61000"
+                    "uid": "f1b8af72-fed8-11e9-9a8f-0e57b7345f92"
                 },
                 "spec": {
-                    "clusterIP": "10.110.56.203",
+                    "clusterIP": "10.98.131.62",
                     "ports": [
                         {
                             "name": "http",
@@ -4130,34 +536,34 @@
                 "kind": "Service",
                 "metadata": {
                     "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: CanaryMapping-GRPC-50-canary\nprefix: /CanaryMapping-GRPC-50/\nservice: http://plain-canarymapping-grpc-50-grpc-canary.plain-namespace\nweight: 50\nambassador_id: plain\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: CanaryMapping-GRPC-50-canary\\nprefix: /CanaryMapping-GRPC-50/\\nservice: http://plain-canarymapping-grpc-50-grpc-canary.plain-namespace\\nweight: 50\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-canarymapping-grpc-50-grpc-canary\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8152},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8515}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: TLSOrigination-GRPC-EXPLICIT\nprefix: /TLSOrigination-GRPC-EXPLICIT/\nservice: plain-tlsorigination-grpc-explicit-grpc.plain-namespace\ntls: true\nambassador_id: plain\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: TLSOrigination-GRPC-EXPLICIT\\nprefix: /TLSOrigination-GRPC-EXPLICIT/\\nservice: plain-tlsorigination-grpc-explicit-grpc.plain-namespace\\ntls: true\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-tlsorigination-grpc-explicit-grpc\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8137},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8500}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
                     },
-                    "creationTimestamp": "2019-11-04T05:43:44Z",
+                    "creationTimestamp": "2019-11-04T07:58:51Z",
                     "labels": {
                         "kat-ambassador-id": "plain",
                         "scope": "AmbassadorTest"
                     },
-                    "name": "plain-canarymapping-grpc-50-grpc-canary",
+                    "name": "plain-tlsorigination-grpc-explicit-grpc",
                     "namespace": "plain-namespace",
-                    "resourceVersion": "12737",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-canarymapping-grpc-50-grpc-canary",
-                    "uid": "104b6426-fec6-11e9-8b1f-120e67b61000"
+                    "resourceVersion": "16534",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-tlsorigination-grpc-explicit-grpc",
+                    "uid": "f0c7aa37-fed8-11e9-9a8f-0e57b7345f92"
                 },
                 "spec": {
-                    "clusterIP": "10.96.225.102",
+                    "clusterIP": "10.106.18.246",
                     "ports": [
                         {
                             "name": "http",
                             "port": 80,
                             "protocol": "TCP",
-                            "targetPort": 8152
+                            "targetPort": 8137
                         },
                         {
                             "name": "https",
                             "port": 443,
                             "protocol": "TCP",
-                            "targetPort": 8515
+                            "targetPort": 8500
                         }
                     ],
                     "selector": {
@@ -4175,41 +581,44 @@
                 "kind": "Service",
                 "metadata": {
                     "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: CanaryMapping-HTTP-0\nprefix: /CanaryMapping-HTTP-0/\nservice: http://plain-canarymapping-http-0-http.plain-namespace\nambassador_id: plain\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: CanaryMapping-HTTP-0\\nprefix: /CanaryMapping-HTTP-0/\\nservice: http://plain-canarymapping-http-0-http.plain-namespace\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-canarymapping-http-0-http\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8139},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8502}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"app.kubernetes.io/component\":\"ambassador-service\",\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8080},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8443}],\"selector\":{\"service\":\"plain\"},\"type\":\"NodePort\"}}\n"
                     },
-                    "creationTimestamp": "2019-11-04T05:43:42Z",
+                    "creationTimestamp": "2019-11-04T07:58:45Z",
                     "labels": {
+                        "app.kubernetes.io/component": "ambassador-service",
                         "kat-ambassador-id": "plain",
                         "scope": "AmbassadorTest"
                     },
-                    "name": "plain-canarymapping-http-0-http",
+                    "name": "plain",
                     "namespace": "plain-namespace",
-                    "resourceVersion": "12684",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-canarymapping-http-0-http",
-                    "uid": "0f6802af-fec6-11e9-8b1f-120e67b61000"
+                    "resourceVersion": "16334",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain",
+                    "uid": "ed2b94c6-fed8-11e9-9a8f-0e57b7345f92"
                 },
                 "spec": {
-                    "clusterIP": "10.97.175.251",
+                    "clusterIP": "10.97.171.218",
+                    "externalTrafficPolicy": "Cluster",
                     "ports": [
                         {
                             "name": "http",
+                            "nodePort": 32229,
                             "port": 80,
                             "protocol": "TCP",
-                            "targetPort": 8139
+                            "targetPort": 8080
                         },
                         {
                             "name": "https",
+                            "nodePort": 31608,
                             "port": 443,
                             "protocol": "TCP",
-                            "targetPort": 8502
+                            "targetPort": 8443
                         }
                     ],
                     "selector": {
-                        "backend": "superpod-plain-namespace"
+                        "service": "plain"
                     },
                     "sessionAffinity": "None",
-                    "type": "ClusterIP"
+                    "type": "NodePort"
                 },
                 "status": {
                     "loadBalancer": {}
@@ -4220,349 +629,34 @@
                 "kind": "Service",
                 "metadata": {
                     "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: SimpleMapping-GRPC-AddRequestHeaders-zoo-bar\nprefix: /SimpleMapping-GRPC-AddRequestHeaders-zoo-bar/\nservice: http://plain-simplemapping-grpc-addrequestheaders-zoo-bar-grpc.plain-namespace\nambassador_id: plain\nadd_request_headers: {\"zoo\": {\"append\": true, \"value\": \"bar\"}}\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: SimpleMapping-GRPC-AddRequestHeaders-zoo-bar\\nprefix: /SimpleMapping-GRPC-AddRequestHeaders-zoo-bar/\\nservice: http://plain-simplemapping-grpc-addrequestheaders-zoo-bar-grpc.plain-namespace\\nambassador_id: plain\\nadd_request_headers: {\\\"zoo\\\": {\\\"append\\\": true, \\\"value\\\": \\\"bar\\\"}}\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-simplemapping-grpc-addrequestheaders-zoo-bar-grpc\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8106},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8469}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: AddReqHeadersMapping-GRPC\nprefix: /AddReqHeadersMapping-GRPC/\nservice: http://plain-addreqheadersmapping-grpc-grpc.plain-namespace\nadd_request_headers:\n  zoo:\n    append: False\n    value: Zoo\n  aoo:\n    append: True\n    value: aoo\n  boo:\n    value: boo\n  foo: Foo\nambassador_id: plain\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: AddReqHeadersMapping-GRPC\\nprefix: /AddReqHeadersMapping-GRPC/\\nservice: http://plain-addreqheadersmapping-grpc-grpc.plain-namespace\\nadd_request_headers:\\n  zoo:\\n    append: False\\n    value: Zoo\\n  aoo:\\n    append: True\\n    value: aoo\\n  boo:\\n    value: boo\\n  foo: Foo\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-addreqheadersmapping-grpc-grpc\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8176},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8539}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
                     },
-                    "creationTimestamp": "2019-11-04T05:43:38Z",
+                    "creationTimestamp": "2019-11-04T07:58:55Z",
                     "labels": {
                         "kat-ambassador-id": "plain",
                         "scope": "AmbassadorTest"
                     },
-                    "name": "plain-simplemapping-grpc-addrequestheaders-zoo-bar-grpc",
+                    "name": "plain-addreqheadersmapping-grpc-grpc",
                     "namespace": "plain-namespace",
-                    "resourceVersion": "12548",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-simplemapping-grpc-addrequestheaders-zoo-bar-grpc",
-                    "uid": "0d210aca-fec6-11e9-8b1f-120e67b61000"
+                    "resourceVersion": "16656",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-addreqheadersmapping-grpc-grpc",
+                    "uid": "f2e71ade-fed8-11e9-9a8f-0e57b7345f92"
                 },
                 "spec": {
-                    "clusterIP": "10.100.65.255",
+                    "clusterIP": "10.101.33.181",
                     "ports": [
                         {
                             "name": "http",
                             "port": 80,
                             "protocol": "TCP",
-                            "targetPort": 8106
+                            "targetPort": 8176
                         },
                         {
                             "name": "https",
                             "port": 443,
                             "protocol": "TCP",
-                            "targetPort": 8469
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: SimpleMapping-GRPC-AddResponseHeaders-aoo-tyu\nprefix: /SimpleMapping-GRPC-AddResponseHeaders-aoo-tyu/\nservice: http://plain-simplemapping-grpc-addresponseheaders-aoo-tyu-grpc.plain-namespace\nambassador_id: plain\nadd_response_headers: {\"aoo\": {\"value\": \"tyu\"}}\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: SimpleMapping-GRPC-AddResponseHeaders-aoo-tyu\\nprefix: /SimpleMapping-GRPC-AddResponseHeaders-aoo-tyu/\\nservice: http://plain-simplemapping-grpc-addresponseheaders-aoo-tyu-grpc.plain-namespace\\nambassador_id: plain\\nadd_response_headers: {\\\"aoo\\\": {\\\"value\\\": \\\"tyu\\\"}}\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-simplemapping-grpc-addresponseheaders-aoo-tyu-grpc\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8113},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8476}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2019-11-04T05:43:39Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-simplemapping-grpc-addresponseheaders-aoo-tyu-grpc",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "12575",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-simplemapping-grpc-addresponseheaders-aoo-tyu-grpc",
-                    "uid": "0d7ccff0-fec6-11e9-8b1f-120e67b61000"
-                },
-                "spec": {
-                    "clusterIP": "10.111.33.179",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8113
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8476
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: SimpleMapping-GRPC-AutoHostRewrite\nprefix: /SimpleMapping-GRPC-AutoHostRewrite/\nservice: http://plain-simplemapping-grpc-autohostrewrite-grpc.plain-namespace\nambassador_id: plain\nauto_host_rewrite: true\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: SimpleMapping-GRPC-AutoHostRewrite\\nprefix: /SimpleMapping-GRPC-AutoHostRewrite/\\nservice: http://plain-simplemapping-grpc-autohostrewrite-grpc.plain-namespace\\nambassador_id: plain\\nauto_host_rewrite: true\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-simplemapping-grpc-autohostrewrite-grpc\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8117},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8480}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2019-11-04T05:43:39Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-simplemapping-grpc-autohostrewrite-grpc",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "12590",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-simplemapping-grpc-autohostrewrite-grpc",
-                    "uid": "0dae732d-fec6-11e9-8b1f-120e67b61000"
-                },
-                "spec": {
-                    "clusterIP": "10.97.103.51",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8117
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8480
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: SimpleMapping-GRPC-Rewrite-SLASH-foo\nprefix: /SimpleMapping-GRPC-Rewrite-SLASH-foo/\nservice: http://plain-simplemapping-grpc-rewrite-slash-foo-grpc.plain-namespace\nambassador_id: plain\nrewrite: /foo\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: SimpleMapping-GRPC-Rewrite-SLASH-foo\\nprefix: /SimpleMapping-GRPC-Rewrite-SLASH-foo/\\nservice: http://plain-simplemapping-grpc-rewrite-slash-foo-grpc.plain-namespace\\nambassador_id: plain\\nrewrite: /foo\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-simplemapping-grpc-rewrite-slash-foo-grpc\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8118},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8481}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2019-11-04T05:43:39Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-simplemapping-grpc-rewrite-slash-foo-grpc",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "12593",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-simplemapping-grpc-rewrite-slash-foo-grpc",
-                    "uid": "0dba1e92-fec6-11e9-8b1f-120e67b61000"
-                },
-                "spec": {
-                    "clusterIP": "10.111.186.76",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8118
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8481
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: SimpleMapping-HTTP-CaseSensitive\nprefix: /SimpleMapping-HTTP-CaseSensitive/\nservice: http://plain-simplemapping-http-casesensitive-http.plain-namespace\nambassador_id: plain\ncase_sensitive: false\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: SimpleMapping-HTTP-CaseSensitive\\nprefix: /SimpleMapping-HTTP-CaseSensitive/\\nservice: http://plain-simplemapping-http-casesensitive-http.plain-namespace\\nambassador_id: plain\\ncase_sensitive: false\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-simplemapping-http-casesensitive-http\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8097},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8460}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2019-11-04T05:43:38Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-simplemapping-http-casesensitive-http",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "12510",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-simplemapping-http-casesensitive-http",
-                    "uid": "0ca51f90-fec6-11e9-8b1f-120e67b61000"
-                },
-                "spec": {
-                    "clusterIP": "10.104.230.200",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8097
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8460
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: CanaryDiffMapping-HTTP-0-canary\nprefix: /CanaryDiffMapping-HTTP-0/\nservice: http://plain-canarydiffmapping-http-0-http-canary.plain-namespace\nhost_rewrite: canary.2.example.com\nweight: 0\nambassador_id: plain\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: CanaryDiffMapping-HTTP-0-canary\\nprefix: /CanaryDiffMapping-HTTP-0/\\nservice: http://plain-canarydiffmapping-http-0-http-canary.plain-namespace\\nhost_rewrite: canary.2.example.com\\nweight: 0\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-canarydiffmapping-http-0-http-canary\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8156},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8519}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2019-11-04T05:43:44Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-canarydiffmapping-http-0-http-canary",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "12751",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-canarydiffmapping-http-0-http-canary",
-                    "uid": "109646e9-fec6-11e9-8b1f-120e67b61000"
-                },
-                "spec": {
-                    "clusterIP": "10.107.202.13",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8156
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8519
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: CanaryDiffMapping-HTTP-100\nprefix: /CanaryDiffMapping-HTTP-100/\nservice: http://plain-canarydiffmapping-http-100-http.plain-namespace\nhost_rewrite: canary.1.example.com\nambassador_id: plain\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: CanaryDiffMapping-HTTP-100\\nprefix: /CanaryDiffMapping-HTTP-100/\\nservice: http://plain-canarydiffmapping-http-100-http.plain-namespace\\nhost_rewrite: canary.1.example.com\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-canarydiffmapping-http-100-http\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8161},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8524}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2019-11-04T05:43:45Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-canarydiffmapping-http-100-http",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "12769",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-canarydiffmapping-http-100-http",
-                    "uid": "10f0f105-fec6-11e9-8b1f-120e67b61000"
-                },
-                "spec": {
-                    "clusterIP": "10.108.79.118",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8161
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8524
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: InvalidPortMapping-HTTP\nprefix: /InvalidPortMapping-HTTP/\nservice: http://plain-invalidportmapping-http-http.plain-namespace:80.invalid\nambassador_id: plain\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: InvalidPortMapping-HTTP\\nprefix: /InvalidPortMapping-HTTP/\\nservice: http://plain-invalidportmapping-http-http.plain-namespace:80.invalid\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-invalidportmapping-http-http\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8130},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8493}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2019-11-04T05:43:41Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-invalidportmapping-http-http",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "12646",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-invalidportmapping-http-http",
-                    "uid": "0e8b7742-fec6-11e9-8b1f-120e67b61000"
-                },
-                "spec": {
-                    "clusterIP": "10.111.229.11",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8130
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8493
+                            "targetPort": 8539
                         }
                     ],
                     "selector": {
@@ -4583,19 +677,19 @@
                         "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: SimpleMapping-GRPC-AddResponseHeaders-moo-arf\nprefix: /SimpleMapping-GRPC-AddResponseHeaders-moo-arf/\nservice: http://plain-simplemapping-grpc-addresponseheaders-moo-arf-grpc.plain-namespace\nambassador_id: plain\nadd_response_headers: {\"moo\": \"arf\"}\n",
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: SimpleMapping-GRPC-AddResponseHeaders-moo-arf\\nprefix: /SimpleMapping-GRPC-AddResponseHeaders-moo-arf/\\nservice: http://plain-simplemapping-grpc-addresponseheaders-moo-arf-grpc.plain-namespace\\nambassador_id: plain\\nadd_response_headers: {\\\"moo\\\": \\\"arf\\\"}\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-simplemapping-grpc-addresponseheaders-moo-arf-grpc\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8110},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8473}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
                     },
-                    "creationTimestamp": "2019-11-04T05:43:39Z",
+                    "creationTimestamp": "2019-11-04T07:58:48Z",
                     "labels": {
                         "kat-ambassador-id": "plain",
                         "scope": "AmbassadorTest"
                     },
                     "name": "plain-simplemapping-grpc-addresponseheaders-moo-arf-grpc",
                     "namespace": "plain-namespace",
-                    "resourceVersion": "12563",
+                    "resourceVersion": "16444",
                     "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-simplemapping-grpc-addresponseheaders-moo-arf-grpc",
-                    "uid": "0d584527-fec6-11e9-8b1f-120e67b61000"
+                    "uid": "eef859ef-fed8-11e9-9a8f-0e57b7345f92"
                 },
                 "spec": {
-                    "clusterIP": "10.106.239.209",
+                    "clusterIP": "10.102.250.127",
                     "ports": [
                         {
                             "name": "http",
@@ -4625,22 +719,1412 @@
                 "kind": "Service",
                 "metadata": {
                     "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: SimpleMapping-HTTP-Rewrite-SLASH-foo\nprefix: /SimpleMapping-HTTP-Rewrite-SLASH-foo/\nservice: http://plain-simplemapping-http-rewrite-slash-foo-http.plain-namespace\nambassador_id: plain\nrewrite: /foo\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: SimpleMapping-HTTP-Rewrite-SLASH-foo\\nprefix: /SimpleMapping-HTTP-Rewrite-SLASH-foo/\\nservice: http://plain-simplemapping-http-rewrite-slash-foo-http.plain-namespace\\nambassador_id: plain\\nrewrite: /foo\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-simplemapping-http-rewrite-slash-foo-http\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8099},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8462}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2019-11-04T07:58:47Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-simplemapping-http-rewrite-slash-foo-http",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "16409",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-simplemapping-http-rewrite-slash-foo-http",
+                    "uid": "ee52181f-fed8-11e9-9a8f-0e57b7345f92"
+                },
+                "spec": {
+                    "clusterIP": "10.108.9.215",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8099
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8462
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: CanaryDiffMapping-HTTP-10\nprefix: /CanaryDiffMapping-HTTP-10/\nservice: http://plain-canarydiffmapping-http-10-http.plain-namespace\nhost_rewrite: canary.1.example.com\nambassador_id: plain\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: CanaryDiffMapping-HTTP-10\\nprefix: /CanaryDiffMapping-HTTP-10/\\nservice: http://plain-canarydiffmapping-http-10-http.plain-namespace\\nhost_rewrite: canary.1.example.com\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-canarydiffmapping-http-10-http\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8157},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8520}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2019-11-04T07:58:53Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-canarydiffmapping-http-10-http",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "16596",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-canarydiffmapping-http-10-http",
+                    "uid": "f1e0f1c6-fed8-11e9-9a8f-0e57b7345f92"
+                },
+                "spec": {
+                    "clusterIP": "10.110.37.208",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8157
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8520
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: CanaryMapping-HTTP-50-canary\nprefix: /CanaryMapping-HTTP-50/\nservice: http://plain-canarymapping-http-50-http-canary.plain-namespace\nweight: 50\nambassador_id: plain\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: CanaryMapping-HTTP-50-canary\\nprefix: /CanaryMapping-HTTP-50/\\nservice: http://plain-canarymapping-http-50-http-canary.plain-namespace\\nweight: 50\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-canarymapping-http-50-http-canary\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8144},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8507}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2019-11-04T07:58:52Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-canarymapping-http-50-http-canary",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "16556",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-canarymapping-http-50-http-canary",
+                    "uid": "f12cd666-fed8-11e9-9a8f-0e57b7345f92"
+                },
+                "spec": {
+                    "clusterIP": "10.110.64.154",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8144
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8507
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: SimpleMapping-HTTP-AddResponseHeaders-foo-bar\nprefix: /SimpleMapping-HTTP-AddResponseHeaders-foo-bar/\nservice: http://plain-simplemapping-http-addresponseheaders-foo-bar-http.plain-namespace\nambassador_id: plain\nadd_response_headers: {\"foo\": \"bar\"}\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: SimpleMapping-HTTP-AddResponseHeaders-foo-bar\\nprefix: /SimpleMapping-HTTP-AddResponseHeaders-foo-bar/\\nservice: http://plain-simplemapping-http-addresponseheaders-foo-bar-http.plain-namespace\\nambassador_id: plain\\nadd_response_headers: {\\\"foo\\\": \\\"bar\\\"}\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-simplemapping-http-addresponseheaders-foo-bar-http\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8090},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8453}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2019-11-04T07:58:46Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-simplemapping-http-addresponseheaders-foo-bar-http",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "16380",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-simplemapping-http-addresponseheaders-foo-bar-http",
+                    "uid": "edd3f570-fed8-11e9-9a8f-0e57b7345f92"
+                },
+                "spec": {
+                    "clusterIP": "10.107.35.142",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8090
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8453
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: InvalidPortMapping-HTTP\nprefix: /InvalidPortMapping-HTTP/\nservice: http://plain-invalidportmapping-http-http.plain-namespace:80.invalid\nambassador_id: plain\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: InvalidPortMapping-HTTP\\nprefix: /InvalidPortMapping-HTTP/\\nservice: http://plain-invalidportmapping-http-http.plain-namespace:80.invalid\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-invalidportmapping-http-http\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8130},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8493}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2019-11-04T07:58:51Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-invalidportmapping-http-http",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "16512",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-invalidportmapping-http-http",
+                    "uid": "f064751d-fed8-11e9-9a8f-0e57b7345f92"
+                },
+                "spec": {
+                    "clusterIP": "10.103.147.193",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8130
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8493
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: SimpleMapping-GRPC-Rewrite-SLASH-foo\nprefix: /SimpleMapping-GRPC-Rewrite-SLASH-foo/\nservice: http://plain-simplemapping-grpc-rewrite-slash-foo-grpc.plain-namespace\nambassador_id: plain\nrewrite: /foo\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: SimpleMapping-GRPC-Rewrite-SLASH-foo\\nprefix: /SimpleMapping-GRPC-Rewrite-SLASH-foo/\\nservice: http://plain-simplemapping-grpc-rewrite-slash-foo-grpc.plain-namespace\\nambassador_id: plain\\nrewrite: /foo\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-simplemapping-grpc-rewrite-slash-foo-grpc\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8118},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8481}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2019-11-04T07:58:49Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-simplemapping-grpc-rewrite-slash-foo-grpc",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "16468",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-simplemapping-grpc-rewrite-slash-foo-grpc",
+                    "uid": "ef68167e-fed8-11e9-9a8f-0e57b7345f92"
+                },
+                "spec": {
+                    "clusterIP": "10.100.3.72",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8118
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8481
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: SimpleMapping-HTTP-AddRequestHeaders-moo-arf\nprefix: /SimpleMapping-HTTP-AddRequestHeaders-moo-arf/\nservice: http://plain-simplemapping-http-addrequestheaders-moo-arf-http.plain-namespace\nambassador_id: plain\nadd_request_headers: {\"moo\": \"arf\"}\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: SimpleMapping-HTTP-AddRequestHeaders-moo-arf\\nprefix: /SimpleMapping-HTTP-AddRequestHeaders-moo-arf/\\nservice: http://plain-simplemapping-http-addrequestheaders-moo-arf-http.plain-namespace\\nambassador_id: plain\\nadd_request_headers: {\\\"moo\\\": \\\"arf\\\"}\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-simplemapping-http-addrequestheaders-moo-arf-http\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8086},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8449}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2019-11-04T07:58:46Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-simplemapping-http-addrequestheaders-moo-arf-http",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "16368",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-simplemapping-http-addrequestheaders-moo-arf-http",
+                    "uid": "ed9d02ac-fed8-11e9-9a8f-0e57b7345f92"
+                },
+                "spec": {
+                    "clusterIP": "10.103.92.219",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8086
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8449
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\",\"service\":\"plain-admin\"},\"name\":\"plain-admin\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"plain-admin\",\"port\":8877,\"targetPort\":8877}],\"selector\":{\"service\":\"plain\"},\"type\":\"NodePort\"}}\n"
+                    },
+                    "creationTimestamp": "2019-11-04T07:58:45Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest",
+                        "service": "plain-admin"
+                    },
+                    "name": "plain-admin",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "16338",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-admin",
+                    "uid": "ed383e8f-fed8-11e9-9a8f-0e57b7345f92"
+                },
+                "spec": {
+                    "clusterIP": "10.111.4.138",
+                    "externalTrafficPolicy": "Cluster",
+                    "ports": [
+                        {
+                            "name": "plain-admin",
+                            "nodePort": 31528,
+                            "port": 8877,
+                            "protocol": "TCP",
+                            "targetPort": 8877
+                        }
+                    ],
+                    "selector": {
+                        "service": "plain"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "NodePort"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: CanaryDiffMapping-GRPC-50\nprefix: /CanaryDiffMapping-GRPC-50/\nservice: http://plain-canarydiffmapping-grpc-50-grpc.plain-namespace\nhost_rewrite: canary.1.example.com\nambassador_id: plain\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: CanaryDiffMapping-GRPC-50\\nprefix: /CanaryDiffMapping-GRPC-50/\\nservice: http://plain-canarydiffmapping-grpc-50-grpc.plain-namespace\\nhost_rewrite: canary.1.example.com\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-canarydiffmapping-grpc-50-grpc\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8167},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8530}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2019-11-04T07:58:54Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-canarydiffmapping-grpc-50-grpc",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "16628",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-canarydiffmapping-grpc-50-grpc",
+                    "uid": "f2663bf2-fed8-11e9-9a8f-0e57b7345f92"
+                },
+                "spec": {
+                    "clusterIP": "10.98.223.50",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8167
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8530
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: CanaryMapping-HTTP-50\nprefix: /CanaryMapping-HTTP-50/\nservice: http://plain-canarymapping-http-50-http.plain-namespace\nambassador_id: plain\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: CanaryMapping-HTTP-50\\nprefix: /CanaryMapping-HTTP-50/\\nservice: http://plain-canarymapping-http-50-http.plain-namespace\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-canarymapping-http-50-http\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8143},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8506}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2019-11-04T07:58:52Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-canarymapping-http-50-http",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "16553",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-canarymapping-http-50-http",
+                    "uid": "f11dc335-fed8-11e9-9a8f-0e57b7345f92"
+                },
+                "spec": {
+                    "clusterIP": "10.107.14.102",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8143
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8506
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: InvalidPortMapping-GRPC\nprefix: /InvalidPortMapping-GRPC/\nservice: http://plain-invalidportmapping-grpc-grpc.plain-namespace:80.invalid\nambassador_id: plain\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: InvalidPortMapping-GRPC\\nprefix: /InvalidPortMapping-GRPC/\\nservice: http://plain-invalidportmapping-grpc-grpc.plain-namespace:80.invalid\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-invalidportmapping-grpc-grpc\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8131},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8494}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2019-11-04T07:58:51Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-invalidportmapping-grpc-grpc",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "16515",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-invalidportmapping-grpc-grpc",
+                    "uid": "f0729726-fed8-11e9-9a8f-0e57b7345f92"
+                },
+                "spec": {
+                    "clusterIP": "10.109.52.220",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8131
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8494
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: SimpleMapping-GRPC-AddRequestHeaders-moo-arf\nprefix: /SimpleMapping-GRPC-AddRequestHeaders-moo-arf/\nservice: http://plain-simplemapping-grpc-addrequestheaders-moo-arf-grpc.plain-namespace\nambassador_id: plain\nadd_request_headers: {\"moo\": \"arf\"}\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: SimpleMapping-GRPC-AddRequestHeaders-moo-arf\\nprefix: /SimpleMapping-GRPC-AddRequestHeaders-moo-arf/\\nservice: http://plain-simplemapping-grpc-addrequestheaders-moo-arf-grpc.plain-namespace\\nambassador_id: plain\\nadd_request_headers: {\\\"moo\\\": \\\"arf\\\"}\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-simplemapping-grpc-addrequestheaders-moo-arf-grpc\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8105},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8468}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2019-11-04T07:58:48Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-simplemapping-grpc-addrequestheaders-moo-arf-grpc",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "16428",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-simplemapping-grpc-addrequestheaders-moo-arf-grpc",
+                    "uid": "eeadb284-fed8-11e9-9a8f-0e57b7345f92"
+                },
+                "spec": {
+                    "clusterIP": "10.105.80.112",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8105
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8468
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: SimpleMapping-HTTP-AddRequestHeaders-foo-bar\nprefix: /SimpleMapping-HTTP-AddRequestHeaders-foo-bar/\nservice: http://plain-simplemapping-http-addrequestheaders-foo-bar-http.plain-namespace\nambassador_id: plain\nadd_request_headers: {\"foo\": \"bar\"}\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: SimpleMapping-HTTP-AddRequestHeaders-foo-bar\\nprefix: /SimpleMapping-HTTP-AddRequestHeaders-foo-bar/\\nservice: http://plain-simplemapping-http-addrequestheaders-foo-bar-http.plain-namespace\\nambassador_id: plain\\nadd_request_headers: {\\\"foo\\\": \\\"bar\\\"}\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-simplemapping-http-addrequestheaders-foo-bar-http\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8085},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8448}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2019-11-04T07:58:46Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-simplemapping-http-addrequestheaders-foo-bar-http",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "16364",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-simplemapping-http-addrequestheaders-foo-bar-http",
+                    "uid": "ed9064b0-fed8-11e9-9a8f-0e57b7345f92"
+                },
+                "spec": {
+                    "clusterIP": "10.97.215.173",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8085
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8448
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: SimpleMapping-HTTP-AddResponseHeaders-xoo-dwe\nprefix: /SimpleMapping-HTTP-AddResponseHeaders-xoo-dwe/\nservice: http://plain-simplemapping-http-addresponseheaders-xoo-dwe-http.plain-namespace\nambassador_id: plain\nadd_response_headers: {\"xoo\": {\"append\": false, \"value\": \"dwe\"}}\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: SimpleMapping-HTTP-AddResponseHeaders-xoo-dwe\\nprefix: /SimpleMapping-HTTP-AddResponseHeaders-xoo-dwe/\\nservice: http://plain-simplemapping-http-addresponseheaders-xoo-dwe-http.plain-namespace\\nambassador_id: plain\\nadd_response_headers: {\\\"xoo\\\": {\\\"append\\\": false, \\\"value\\\": \\\"dwe\\\"}}\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-simplemapping-http-addresponseheaders-xoo-dwe-http\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8093},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8456}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2019-11-04T07:58:47Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-simplemapping-http-addresponseheaders-xoo-dwe-http",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "16389",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-simplemapping-http-addresponseheaders-xoo-dwe-http",
+                    "uid": "edfbbfed-fed8-11e9-9a8f-0e57b7345f92"
+                },
+                "spec": {
+                    "clusterIP": "10.107.7.225",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8093
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8456
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: SimpleMapping-HTTP-AutoHostRewrite\nprefix: /SimpleMapping-HTTP-AutoHostRewrite/\nservice: http://plain-simplemapping-http-autohostrewrite-http.plain-namespace\nambassador_id: plain\nauto_host_rewrite: true\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: SimpleMapping-HTTP-AutoHostRewrite\\nprefix: /SimpleMapping-HTTP-AutoHostRewrite/\\nservice: http://plain-simplemapping-http-autohostrewrite-http.plain-namespace\\nambassador_id: plain\\nauto_host_rewrite: true\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-simplemapping-http-autohostrewrite-http\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8098},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8461}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2019-11-04T07:58:47Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-simplemapping-http-autohostrewrite-http",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "16406",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-simplemapping-http-autohostrewrite-http",
+                    "uid": "ee41d31c-fed8-11e9-9a8f-0e57b7345f92"
+                },
+                "spec": {
+                    "clusterIP": "10.96.202.160",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8098
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8461
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: CanaryDiffMapping-GRPC-10-canary\nprefix: /CanaryDiffMapping-GRPC-10/\nservice: http://plain-canarydiffmapping-grpc-10-grpc-canary.plain-namespace\nhost_rewrite: canary.2.example.com\nweight: 10\nambassador_id: plain\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: CanaryDiffMapping-GRPC-10-canary\\nprefix: /CanaryDiffMapping-GRPC-10/\\nservice: http://plain-canarydiffmapping-grpc-10-grpc-canary.plain-namespace\\nhost_rewrite: canary.2.example.com\\nweight: 10\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-canarydiffmapping-grpc-10-grpc-canary\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8166},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8529}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2019-11-04T07:58:54Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-canarydiffmapping-grpc-10-grpc-canary",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "16624",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-canarydiffmapping-grpc-10-grpc-canary",
+                    "uid": "f2581762-fed8-11e9-9a8f-0e57b7345f92"
+                },
+                "spec": {
+                    "clusterIP": "10.107.116.7",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8166
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8529
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: CanaryDiffMapping-HTTP-100\nprefix: /CanaryDiffMapping-HTTP-100/\nservice: http://plain-canarydiffmapping-http-100-http.plain-namespace\nhost_rewrite: canary.1.example.com\nambassador_id: plain\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: CanaryDiffMapping-HTTP-100\\nprefix: /CanaryDiffMapping-HTTP-100/\\nservice: http://plain-canarydiffmapping-http-100-http.plain-namespace\\nhost_rewrite: canary.1.example.com\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-canarydiffmapping-http-100-http\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8161},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8524}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2019-11-04T07:58:53Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-canarydiffmapping-http-100-http",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "16609",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-canarydiffmapping-http-100-http",
+                    "uid": "f2145724-fed8-11e9-9a8f-0e57b7345f92"
+                },
+                "spec": {
+                    "clusterIP": "10.100.162.157",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8161
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8524
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: CanaryMapping-HTTP-100\nprefix: /CanaryMapping-HTTP-100/\nservice: http://plain-canarymapping-http-100-http.plain-namespace\nambassador_id: plain\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: CanaryMapping-HTTP-100\\nprefix: /CanaryMapping-HTTP-100/\\nservice: http://plain-canarymapping-http-100-http.plain-namespace\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-canarymapping-http-100-http\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8145},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8508}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2019-11-04T07:58:52Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-canarymapping-http-100-http",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "16560",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-canarymapping-http-100-http",
+                    "uid": "f13bd1ef-fed8-11e9-9a8f-0e57b7345f92"
+                },
+                "spec": {
+                    "clusterIP": "10.100.102.83",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8145
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8508
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: SimpleMapping-GRPC-AddRequestHeaders-foo-bar\nprefix: /SimpleMapping-GRPC-AddRequestHeaders-foo-bar/\nservice: http://plain-simplemapping-grpc-addrequestheaders-foo-bar-grpc.plain-namespace\nambassador_id: plain\nadd_request_headers: {\"foo\": \"bar\"}\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: SimpleMapping-GRPC-AddRequestHeaders-foo-bar\\nprefix: /SimpleMapping-GRPC-AddRequestHeaders-foo-bar/\\nservice: http://plain-simplemapping-grpc-addrequestheaders-foo-bar-grpc.plain-namespace\\nambassador_id: plain\\nadd_request_headers: {\\\"foo\\\": \\\"bar\\\"}\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-simplemapping-grpc-addrequestheaders-foo-bar-grpc\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8104},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8467}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2019-11-04T07:58:48Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-simplemapping-grpc-addrequestheaders-foo-bar-grpc",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "16425",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-simplemapping-grpc-addrequestheaders-foo-bar-grpc",
+                    "uid": "ee9d3889-fed8-11e9-9a8f-0e57b7345f92"
+                },
+                "spec": {
+                    "clusterIP": "10.110.151.14",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8104
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8467
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: TLSOrigination-HTTP-IMPLICIT\nprefix: /TLSOrigination-HTTP-IMPLICIT/\nservice: https://plain-tlsorigination-http-implicit-http.plain-namespace\nambassador_id: plain\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: TLSOrigination-HTTP-IMPLICIT\\nprefix: /TLSOrigination-HTTP-IMPLICIT/\\nservice: https://plain-tlsorigination-http-implicit-http.plain-namespace\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-tlsorigination-http-implicit-http\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8134},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8497}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2019-11-04T07:58:51Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-tlsorigination-http-implicit-http",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "16524",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-tlsorigination-http-implicit-http",
+                    "uid": "f09d0406-fed8-11e9-9a8f-0e57b7345f92"
+                },
+                "spec": {
+                    "clusterIP": "10.105.170.120",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8134
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8497
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: CanaryMapping-GRPC-50\nprefix: /CanaryMapping-GRPC-50/\nservice: http://plain-canarymapping-grpc-50-grpc.plain-namespace\nambassador_id: plain\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: CanaryMapping-GRPC-50\\nprefix: /CanaryMapping-GRPC-50/\\nservice: http://plain-canarymapping-grpc-50-grpc.plain-namespace\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-canarymapping-grpc-50-grpc\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8151},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8514}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2019-11-04T07:58:53Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-canarymapping-grpc-50-grpc",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "16578",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-canarymapping-grpc-50-grpc",
+                    "uid": "f190deea-fed8-11e9-9a8f-0e57b7345f92"
+                },
+                "spec": {
+                    "clusterIP": "10.102.243.189",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8151
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8514
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: CanaryMapping-HTTP-0-canary\nprefix: /CanaryMapping-HTTP-0/\nservice: http://plain-canarymapping-http-0-http-canary.plain-namespace\nweight: 0\nambassador_id: plain\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: CanaryMapping-HTTP-0-canary\\nprefix: /CanaryMapping-HTTP-0/\\nservice: http://plain-canarymapping-http-0-http-canary.plain-namespace\\nweight: 0\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-canarymapping-http-0-http-canary\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8140},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8503}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2019-11-04T07:58:52Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-canarymapping-http-0-http-canary",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "16544",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-canarymapping-http-0-http-canary",
+                    "uid": "f0f2c730-fed8-11e9-9a8f-0e57b7345f92"
+                },
+                "spec": {
+                    "clusterIP": "10.107.254.14",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8140
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8503
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: CanaryMapping-HTTP-100-canary\nprefix: /CanaryMapping-HTTP-100/\nservice: http://plain-canarymapping-http-100-http-canary.plain-namespace\nweight: 100\nambassador_id: plain\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: CanaryMapping-HTTP-100-canary\\nprefix: /CanaryMapping-HTTP-100/\\nservice: http://plain-canarymapping-http-100-http-canary.plain-namespace\\nweight: 100\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-canarymapping-http-100-http-canary\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8146},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8509}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2019-11-04T07:58:52Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-canarymapping-http-100-http-canary",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "16563",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-canarymapping-http-100-http-canary",
+                    "uid": "f148aded-fed8-11e9-9a8f-0e57b7345f92"
+                },
+                "spec": {
+                    "clusterIP": "10.97.245.106",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8146
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8509
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: SimpleMapping-GRPC-AddRequestHeaders-zoo-bar\nprefix: /SimpleMapping-GRPC-AddRequestHeaders-zoo-bar/\nservice: http://plain-simplemapping-grpc-addrequestheaders-zoo-bar-grpc.plain-namespace\nambassador_id: plain\nadd_request_headers: {\"zoo\": {\"append\": true, \"value\": \"bar\"}}\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: SimpleMapping-GRPC-AddRequestHeaders-zoo-bar\\nprefix: /SimpleMapping-GRPC-AddRequestHeaders-zoo-bar/\\nservice: http://plain-simplemapping-grpc-addrequestheaders-zoo-bar-grpc.plain-namespace\\nambassador_id: plain\\nadd_request_headers: {\\\"zoo\\\": {\\\"append\\\": true, \\\"value\\\": \\\"bar\\\"}}\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-simplemapping-grpc-addrequestheaders-zoo-bar-grpc\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8106},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8469}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2019-11-04T07:58:48Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-simplemapping-grpc-addrequestheaders-zoo-bar-grpc",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "16431",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-simplemapping-grpc-addrequestheaders-zoo-bar-grpc",
+                    "uid": "eec03eeb-fed8-11e9-9a8f-0e57b7345f92"
+                },
+                "spec": {
+                    "clusterIP": "10.107.255.188",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8106
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8469
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: AddRespHeadersMapping-HTTP\nprefix: /AddRespHeadersMapping-HTTP/\nservice: http://httpbin.org\nadd_response_headers:\n  koo:\n    append: False\n    value: KooK\n  zoo:\n    append: True\n    value: ZooZ\n  test:\n    value: boo\n  foo: Foo\nambassador_id: plain\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: AddRespHeadersMapping-HTTP\\nprefix: /AddRespHeadersMapping-HTTP/\\nservice: http://httpbin.org\\nadd_response_headers:\\n  koo:\\n    append: False\\n    value: KooK\\n  zoo:\\n    append: True\\n    value: ZooZ\\n  test:\\n    value: boo\\n  foo: Foo\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-addrespheadersmapping-http-http\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8171},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8534}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2019-11-04T07:58:54Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-addrespheadersmapping-http-http",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "16640",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-addrespheadersmapping-http-http",
+                    "uid": "f29cbfd8-fed8-11e9-9a8f-0e57b7345f92"
+                },
+                "spec": {
+                    "clusterIP": "10.111.106.98",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8171
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8534
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: CanaryDiffMapping-HTTP-0-canary\nprefix: /CanaryDiffMapping-HTTP-0/\nservice: http://plain-canarydiffmapping-http-0-http-canary.plain-namespace\nhost_rewrite: canary.2.example.com\nweight: 0\nambassador_id: plain\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: CanaryDiffMapping-HTTP-0-canary\\nprefix: /CanaryDiffMapping-HTTP-0/\\nservice: http://plain-canarydiffmapping-http-0-http-canary.plain-namespace\\nhost_rewrite: canary.2.example.com\\nweight: 0\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-canarydiffmapping-http-0-http-canary\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8156},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8519}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2019-11-04T07:58:53Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-canarydiffmapping-http-0-http-canary",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "16593",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-canarydiffmapping-http-0-http-canary",
+                    "uid": "f1d3fefe-fed8-11e9-9a8f-0e57b7345f92"
+                },
+                "spec": {
+                    "clusterIP": "10.111.215.169",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8156
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8519
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: CanaryMapping-GRPC-0\nprefix: /CanaryMapping-GRPC-0/\nservice: http://plain-canarymapping-grpc-0-grpc.plain-namespace\nambassador_id: plain\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: CanaryMapping-GRPC-0\\nprefix: /CanaryMapping-GRPC-0/\\nservice: http://plain-canarymapping-grpc-0-grpc.plain-namespace\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-canarymapping-grpc-0-grpc\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8147},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8510}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2019-11-04T07:58:52Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-canarymapping-grpc-0-grpc",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "16566",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-canarymapping-grpc-0-grpc",
+                    "uid": "f1569abe-fed8-11e9-9a8f-0e57b7345f92"
+                },
+                "spec": {
+                    "clusterIP": "10.108.124.240",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8147
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8510
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: CanaryMapping-GRPC-10\nprefix: /CanaryMapping-GRPC-10/\nservice: http://plain-canarymapping-grpc-10-grpc.plain-namespace\nambassador_id: plain\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: CanaryMapping-GRPC-10\\nprefix: /CanaryMapping-GRPC-10/\\nservice: http://plain-canarymapping-grpc-10-grpc.plain-namespace\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-canarymapping-grpc-10-grpc\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8149},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8512}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2019-11-04T07:58:52Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-canarymapping-grpc-10-grpc",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "16572",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-canarymapping-grpc-10-grpc",
+                    "uid": "f172da48-fed8-11e9-9a8f-0e57b7345f92"
+                },
+                "spec": {
+                    "clusterIP": "10.101.237.177",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8149
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8512
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: SimpleMapping-HTTP-AddResponseHeaders-aoo-tyu\nprefix: /SimpleMapping-HTTP-AddResponseHeaders-aoo-tyu/\nservice: http://plain-simplemapping-http-addresponseheaders-aoo-tyu-http.plain-namespace\nambassador_id: plain\nadd_response_headers: {\"aoo\": {\"value\": \"tyu\"}}\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: SimpleMapping-HTTP-AddResponseHeaders-aoo-tyu\\nprefix: /SimpleMapping-HTTP-AddResponseHeaders-aoo-tyu/\\nservice: http://plain-simplemapping-http-addresponseheaders-aoo-tyu-http.plain-namespace\\nambassador_id: plain\\nadd_response_headers: {\\\"aoo\\\": {\\\"value\\\": \\\"tyu\\\"}}\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-simplemapping-http-addresponseheaders-aoo-tyu-http\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8094},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8457}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2019-11-04T07:58:47Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-simplemapping-http-addresponseheaders-aoo-tyu-http",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "16394",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-simplemapping-http-addresponseheaders-aoo-tyu-http",
+                    "uid": "ee0b21b8-fed8-11e9-9a8f-0e57b7345f92"
+                },
+                "spec": {
+                    "clusterIP": "10.101.103.90",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8094
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8457
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: CanaryDiffMapping-GRPC-100-canary\nprefix: /CanaryDiffMapping-GRPC-100/\nservice: http://plain-canarydiffmapping-grpc-100-grpc-canary.plain-namespace\nhost_rewrite: canary.2.example.com\nweight: 100\nambassador_id: plain\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: CanaryDiffMapping-GRPC-100-canary\\nprefix: /CanaryDiffMapping-GRPC-100/\\nservice: http://plain-canarydiffmapping-grpc-100-grpc-canary.plain-namespace\\nhost_rewrite: canary.2.example.com\\nweight: 100\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-canarydiffmapping-grpc-100-grpc-canary\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8170},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8533}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2019-11-04T07:58:54Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-canarydiffmapping-grpc-100-grpc-canary",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "16637",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-canarydiffmapping-grpc-100-grpc-canary",
+                    "uid": "f28ea353-fed8-11e9-9a8f-0e57b7345f92"
+                },
+                "spec": {
+                    "clusterIP": "10.100.68.100",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8170
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8533
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-simpleingresswithannotations-grpc-grpc\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8125},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8488}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2019-11-04T07:58:50Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-simpleingresswithannotations-grpc-grpc",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "16494",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-simpleingresswithannotations-grpc-grpc",
+                    "uid": "effaa178-fed8-11e9-9a8f-0e57b7345f92"
+                },
+                "spec": {
+                    "clusterIP": "10.96.34.239",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8125
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8488
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
                         "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: SimpleMapping-HTTP-UseWebsocket\nprefix: /SimpleMapping-HTTP-UseWebsocket/\nservice: http://plain-simplemapping-http-usewebsocket-http.plain-namespace\nambassador_id: plain\nuse_websocket: true\n",
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: SimpleMapping-HTTP-UseWebsocket\\nprefix: /SimpleMapping-HTTP-UseWebsocket/\\nservice: http://plain-simplemapping-http-usewebsocket-http.plain-namespace\\nambassador_id: plain\\nuse_websocket: true\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-simplemapping-http-usewebsocket-http\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8095},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8458}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
                     },
-                    "creationTimestamp": "2019-11-04T05:43:37Z",
+                    "creationTimestamp": "2019-11-04T07:58:47Z",
                     "labels": {
                         "kat-ambassador-id": "plain",
                         "scope": "AmbassadorTest"
                     },
                     "name": "plain-simplemapping-http-usewebsocket-http",
                     "namespace": "plain-namespace",
-                    "resourceVersion": "12500",
+                    "resourceVersion": "16397",
                     "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-simplemapping-http-usewebsocket-http",
-                    "uid": "0c88f599-fec6-11e9-8b1f-120e67b61000"
+                    "uid": "ee190c5c-fed8-11e9-9a8f-0e57b7345f92"
                 },
                 "spec": {
-                    "clusterIP": "10.107.246.147",
+                    "clusterIP": "10.105.39.145",
                     "ports": [
                         {
                             "name": "http",
@@ -4670,21 +2154,1280 @@
                 "kind": "Service",
                 "metadata": {
                     "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: HostRedirectMapping\nprefix: /HostRedirectMapping/\nservice: foobar.com\nhost_redirect: true\nambassador_id: plain\n---\napiVersion: ambassador/v0\nkind: Mapping\nname: HostRedirectMapping-2\nprefix: /HostRedirectMapping-2/\ncase_sensitive: false\nservice: foobar.com\nhost_redirect: true\nambassador_id: plain\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: HostRedirectMapping\\nprefix: /HostRedirectMapping/\\nservice: foobar.com\\nhost_redirect: true\\nambassador_id: plain\\n---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: HostRedirectMapping-2\\nprefix: /HostRedirectMapping-2/\\ncase_sensitive: false\\nservice: foobar.com\\nhost_redirect: true\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-hostredirectmapping-http\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8138},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8501}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2019-11-04T07:58:51Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-hostredirectmapping-http",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "16537",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-hostredirectmapping-http",
+                    "uid": "f0d614ce-fed8-11e9-9a8f-0e57b7345f92"
+                },
+                "spec": {
+                    "clusterIP": "10.111.243.122",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8138
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8501
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: SimpleMapping-GRPC-CaseSensitive\nprefix: /SimpleMapping-GRPC-CaseSensitive/\nservice: http://plain-simplemapping-grpc-casesensitive-grpc.plain-namespace\nambassador_id: plain\ncase_sensitive: false\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: SimpleMapping-GRPC-CaseSensitive\\nprefix: /SimpleMapping-GRPC-CaseSensitive/\\nservice: http://plain-simplemapping-grpc-casesensitive-grpc.plain-namespace\\nambassador_id: plain\\ncase_sensitive: false\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-simplemapping-grpc-casesensitive-grpc\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8116},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8479}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2019-11-04T07:58:49Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-simplemapping-grpc-casesensitive-grpc",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "16462",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-simplemapping-grpc-casesensitive-grpc",
+                    "uid": "ef4bc567-fed8-11e9-9a8f-0e57b7345f92"
+                },
+                "spec": {
+                    "clusterIP": "10.97.7.146",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8116
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8479
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: SimpleMapping-GRPC\nprefix: /SimpleMapping-GRPC/\nservice: http://plain-simplemapping-grpc-grpc.plain-namespace\nambassador_id: plain\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: SimpleMapping-GRPC\\nprefix: /SimpleMapping-GRPC/\\nservice: http://plain-simplemapping-grpc-grpc.plain-namespace\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-simplemapping-grpc-grpc\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8103},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8466}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2019-11-04T07:58:48Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-simplemapping-grpc-grpc",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "16422",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-simplemapping-grpc-grpc",
+                    "uid": "ee8f211e-fed8-11e9-9a8f-0e57b7345f92"
+                },
+                "spec": {
+                    "clusterIP": "10.96.41.78",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8103
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8466
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: SimpleMapping-HTTP\nprefix: /SimpleMapping-HTTP/\nservice: http://plain-simplemapping-http-http.plain-namespace\nambassador_id: plain\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: SimpleMapping-HTTP\\nprefix: /SimpleMapping-HTTP/\\nservice: http://plain-simplemapping-http-http.plain-namespace\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-simplemapping-http-http\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8084},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8447}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2019-11-04T07:58:46Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-simplemapping-http-http",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "16361",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-simplemapping-http-http",
+                    "uid": "ed841fa6-fed8-11e9-9a8f-0e57b7345f92"
+                },
+                "spec": {
+                    "clusterIP": "10.105.30.11",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8084
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8447
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: CanaryDiffMapping-GRPC-50-canary\nprefix: /CanaryDiffMapping-GRPC-50/\nservice: http://plain-canarydiffmapping-grpc-50-grpc-canary.plain-namespace\nhost_rewrite: canary.2.example.com\nweight: 50\nambassador_id: plain\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: CanaryDiffMapping-GRPC-50-canary\\nprefix: /CanaryDiffMapping-GRPC-50/\\nservice: http://plain-canarydiffmapping-grpc-50-grpc-canary.plain-namespace\\nhost_rewrite: canary.2.example.com\\nweight: 50\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-canarydiffmapping-grpc-50-grpc-canary\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8168},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8531}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2019-11-04T07:58:54Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-canarydiffmapping-grpc-50-grpc-canary",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "16631",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-canarydiffmapping-grpc-50-grpc-canary",
+                    "uid": "f273f0bc-fed8-11e9-9a8f-0e57b7345f92"
+                },
+                "spec": {
+                    "clusterIP": "10.97.183.197",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8168
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8531
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: CanaryDiffMapping-HTTP-50\nprefix: /CanaryDiffMapping-HTTP-50/\nservice: http://plain-canarydiffmapping-http-50-http.plain-namespace\nhost_rewrite: canary.1.example.com\nambassador_id: plain\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: CanaryDiffMapping-HTTP-50\\nprefix: /CanaryDiffMapping-HTTP-50/\\nservice: http://plain-canarydiffmapping-http-50-http.plain-namespace\\nhost_rewrite: canary.1.example.com\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-canarydiffmapping-http-50-http\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8159},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8522}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2019-11-04T07:58:53Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-canarydiffmapping-http-50-http",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "16602",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-canarydiffmapping-http-50-http",
+                    "uid": "f1faae36-fed8-11e9-9a8f-0e57b7345f92"
+                },
+                "spec": {
+                    "clusterIP": "10.104.21.171",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8159
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8522
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: HeaderRoutingTest-GRPC-target2\nprefix: /HeaderRoutingTest-GRPC/\nservice: http://plain-headerroutingtest-grpc-grpc-target2.plain-namespace\nheaders:\n  X-Route: target2\nambassador_id: plain\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: HeaderRoutingTest-GRPC-target2\\nprefix: /HeaderRoutingTest-GRPC/\\nservice: http://plain-headerroutingtest-grpc-grpc-target2.plain-namespace\\nheaders:\\n  X-Route: target2\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-headerroutingtest-grpc-grpc-target2\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8083},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8446}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2019-11-04T07:58:46Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-headerroutingtest-grpc-grpc-target2",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "16358",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-headerroutingtest-grpc-grpc-target2",
+                    "uid": "ed75be6e-fed8-11e9-9a8f-0e57b7345f92"
+                },
+                "spec": {
+                    "clusterIP": "10.110.136.206",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8083
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8446
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-hostheadermappingingress-grpc-grpc\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8127},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8490}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2019-11-04T07:58:50Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-hostheadermappingingress-grpc-grpc",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "16503",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-hostheadermappingingress-grpc-grpc",
+                    "uid": "f0311913-fed8-11e9-9a8f-0e57b7345f92"
+                },
+                "spec": {
+                    "clusterIP": "10.99.167.245",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8127
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8490
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: SimpleMapping-HTTP-Rewrite-foo\nprefix: /SimpleMapping-HTTP-Rewrite-foo/\nservice: http://plain-simplemapping-http-rewrite-foo-http.plain-namespace\nambassador_id: plain\nrewrite: foo\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: SimpleMapping-HTTP-Rewrite-foo\\nprefix: /SimpleMapping-HTTP-Rewrite-foo/\\nservice: http://plain-simplemapping-http-rewrite-foo-http.plain-namespace\\nambassador_id: plain\\nrewrite: foo\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-simplemapping-http-rewrite-foo-http\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8100},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8463}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2019-11-04T07:58:47Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-simplemapping-http-rewrite-foo-http",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "16412",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-simplemapping-http-rewrite-foo-http",
+                    "uid": "ee6355d7-fed8-11e9-9a8f-0e57b7345f92"
+                },
+                "spec": {
+                    "clusterIP": "10.104.89.212",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8100
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8463
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: HeaderRoutingTest-HTTP-target2\nprefix: /HeaderRoutingTest-HTTP/\nservice: http://plain-headerroutingtest-http-http-target2.plain-namespace\nheaders:\n  X-Route: target2\nambassador_id: plain\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: HeaderRoutingTest-HTTP-target2\\nprefix: /HeaderRoutingTest-HTTP/\\nservice: http://plain-headerroutingtest-http-http-target2.plain-namespace\\nheaders:\\n  X-Route: target2\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-headerroutingtest-http-http-target2\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8081},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8444}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2019-11-04T07:58:46Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-headerroutingtest-http-http-target2",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "16349",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-headerroutingtest-http-http-target2",
+                    "uid": "ed5c8b09-fed8-11e9-9a8f-0e57b7345f92"
+                },
+                "spec": {
+                    "clusterIP": "10.106.72.217",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8081
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8444
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: SimpleMapping-GRPC-AutoHostRewrite\nprefix: /SimpleMapping-GRPC-AutoHostRewrite/\nservice: http://plain-simplemapping-grpc-autohostrewrite-grpc.plain-namespace\nambassador_id: plain\nauto_host_rewrite: true\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: SimpleMapping-GRPC-AutoHostRewrite\\nprefix: /SimpleMapping-GRPC-AutoHostRewrite/\\nservice: http://plain-simplemapping-grpc-autohostrewrite-grpc.plain-namespace\\nambassador_id: plain\\nauto_host_rewrite: true\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-simplemapping-grpc-autohostrewrite-grpc\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8117},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8480}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2019-11-04T07:58:49Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-simplemapping-grpc-autohostrewrite-grpc",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "16465",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-simplemapping-grpc-autohostrewrite-grpc",
+                    "uid": "ef585aee-fed8-11e9-9a8f-0e57b7345f92"
+                },
+                "spec": {
+                    "clusterIP": "10.109.56.240",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8117
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8480
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: SimpleMapping-GRPC-RemoveResponseHeaders\nprefix: /SimpleMapping-GRPC-RemoveResponseHeaders/\nservice: http://plain-simplemapping-grpc-removeresponseheaders-grpc.plain-namespace\nambassador_id: plain\nremove_response_headers: x-envoy-upstream-service-time\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: SimpleMapping-GRPC-RemoveResponseHeaders\\nprefix: /SimpleMapping-GRPC-RemoveResponseHeaders/\\nservice: http://plain-simplemapping-grpc-removeresponseheaders-grpc.plain-namespace\\nambassador_id: plain\\nremove_response_headers: x-envoy-upstream-service-time\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-simplemapping-grpc-removeresponseheaders-grpc\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8120},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8483}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2019-11-04T07:58:49Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-simplemapping-grpc-removeresponseheaders-grpc",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "16474",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-simplemapping-grpc-removeresponseheaders-grpc",
+                    "uid": "ef8508bf-fed8-11e9-9a8f-0e57b7345f92"
+                },
+                "spec": {
+                    "clusterIP": "10.107.188.53",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8120
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8483
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: SimpleMapping-GRPC-UseWebsocket\nprefix: /SimpleMapping-GRPC-UseWebsocket/\nservice: http://plain-simplemapping-grpc-usewebsocket-grpc.plain-namespace\nambassador_id: plain\nuse_websocket: true\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: SimpleMapping-GRPC-UseWebsocket\\nprefix: /SimpleMapping-GRPC-UseWebsocket/\\nservice: http://plain-simplemapping-grpc-usewebsocket-grpc.plain-namespace\\nambassador_id: plain\\nuse_websocket: true\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-simplemapping-grpc-usewebsocket-grpc\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8114},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8477}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2019-11-04T07:58:49Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-simplemapping-grpc-usewebsocket-grpc",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "16456",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-simplemapping-grpc-usewebsocket-grpc",
+                    "uid": "ef2e3332-fed8-11e9-9a8f-0e57b7345f92"
+                },
+                "spec": {
+                    "clusterIP": "10.110.188.148",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8114
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8477
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: WebSocketMapping-HTTP\nprefix: /WebSocketMapping-HTTP/\nservice: echo.websocket.org:80\nhost_rewrite: echo.websocket.org\nuse_websocket: true\nambassador_id: plain\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: WebSocketMapping-HTTP\\nprefix: /WebSocketMapping-HTTP/\\nservice: echo.websocket.org:80\\nhost_rewrite: echo.websocket.org\\nuse_websocket: true\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-websocketmapping-http-http\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8132},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8495}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2019-11-04T07:58:51Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-websocketmapping-http-http",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "16518",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-websocketmapping-http-http",
+                    "uid": "f081a44c-fed8-11e9-9a8f-0e57b7345f92"
+                },
+                "spec": {
+                    "clusterIP": "10.105.177.246",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8132
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8495
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: CanaryDiffMapping-GRPC-0-canary\nprefix: /CanaryDiffMapping-GRPC-0/\nservice: http://plain-canarydiffmapping-grpc-0-grpc-canary.plain-namespace\nhost_rewrite: canary.2.example.com\nweight: 0\nambassador_id: plain\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: CanaryDiffMapping-GRPC-0-canary\\nprefix: /CanaryDiffMapping-GRPC-0/\\nservice: http://plain-canarydiffmapping-grpc-0-grpc-canary.plain-namespace\\nhost_rewrite: canary.2.example.com\\nweight: 0\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-canarydiffmapping-grpc-0-grpc-canary\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8164},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8527}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2019-11-04T07:58:54Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-canarydiffmapping-grpc-0-grpc-canary",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "16618",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-canarydiffmapping-grpc-0-grpc-canary",
+                    "uid": "f23e079e-fed8-11e9-9a8f-0e57b7345f92"
+                },
+                "spec": {
+                    "clusterIP": "10.106.40.167",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8164
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8527
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: CanaryDiffMapping-HTTP-100-canary\nprefix: /CanaryDiffMapping-HTTP-100/\nservice: http://plain-canarydiffmapping-http-100-http-canary.plain-namespace\nhost_rewrite: canary.2.example.com\nweight: 100\nambassador_id: plain\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: CanaryDiffMapping-HTTP-100-canary\\nprefix: /CanaryDiffMapping-HTTP-100/\\nservice: http://plain-canarydiffmapping-http-100-http-canary.plain-namespace\\nhost_rewrite: canary.2.example.com\\nweight: 100\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-canarydiffmapping-http-100-http-canary\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8162},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8525}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2019-11-04T07:58:54Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-canarydiffmapping-http-100-http-canary",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "16612",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-canarydiffmapping-http-100-http-canary",
+                    "uid": "f222b299-fed8-11e9-9a8f-0e57b7345f92"
+                },
+                "spec": {
+                    "clusterIP": "10.107.23.255",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8162
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8525
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: SimpleMapping-GRPC-AddResponseHeaders-aoo-tyu\nprefix: /SimpleMapping-GRPC-AddResponseHeaders-aoo-tyu/\nservice: http://plain-simplemapping-grpc-addresponseheaders-aoo-tyu-grpc.plain-namespace\nambassador_id: plain\nadd_response_headers: {\"aoo\": {\"value\": \"tyu\"}}\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: SimpleMapping-GRPC-AddResponseHeaders-aoo-tyu\\nprefix: /SimpleMapping-GRPC-AddResponseHeaders-aoo-tyu/\\nservice: http://plain-simplemapping-grpc-addresponseheaders-aoo-tyu-grpc.plain-namespace\\nambassador_id: plain\\nadd_response_headers: {\\\"aoo\\\": {\\\"value\\\": \\\"tyu\\\"}}\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-simplemapping-grpc-addresponseheaders-aoo-tyu-grpc\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8113},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8476}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2019-11-04T07:58:48Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-simplemapping-grpc-addresponseheaders-aoo-tyu-grpc",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "16453",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-simplemapping-grpc-addresponseheaders-aoo-tyu-grpc",
+                    "uid": "ef213ce9-fed8-11e9-9a8f-0e57b7345f92"
+                },
+                "spec": {
+                    "clusterIP": "10.97.54.43",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8113
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8476
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: SimpleMapping-GRPC-AddResponseHeaders-xoo-dwe\nprefix: /SimpleMapping-GRPC-AddResponseHeaders-xoo-dwe/\nservice: http://plain-simplemapping-grpc-addresponseheaders-xoo-dwe-grpc.plain-namespace\nambassador_id: plain\nadd_response_headers: {\"xoo\": {\"append\": false, \"value\": \"dwe\"}}\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: SimpleMapping-GRPC-AddResponseHeaders-xoo-dwe\\nprefix: /SimpleMapping-GRPC-AddResponseHeaders-xoo-dwe/\\nservice: http://plain-simplemapping-grpc-addresponseheaders-xoo-dwe-grpc.plain-namespace\\nambassador_id: plain\\nadd_response_headers: {\\\"xoo\\\": {\\\"append\\\": false, \\\"value\\\": \\\"dwe\\\"}}\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-simplemapping-grpc-addresponseheaders-xoo-dwe-grpc\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8112},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8475}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2019-11-04T07:58:48Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-simplemapping-grpc-addresponseheaders-xoo-dwe-grpc",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "16450",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-simplemapping-grpc-addresponseheaders-xoo-dwe-grpc",
+                    "uid": "ef129cd7-fed8-11e9-9a8f-0e57b7345f92"
+                },
+                "spec": {
+                    "clusterIP": "10.100.151.110",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8112
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8475
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: HeaderRoutingTest-HTTP-target1\nprefix: /HeaderRoutingTest-HTTP/\nservice: http://plain-headerroutingtest-http-http.plain-namespace\nambassador_id: plain\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: HeaderRoutingTest-HTTP-target1\\nprefix: /HeaderRoutingTest-HTTP/\\nservice: http://plain-headerroutingtest-http-http.plain-namespace\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-headerroutingtest-http-http\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8080},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8443}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2019-11-04T07:58:45Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-headerroutingtest-http-http",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "16346",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-headerroutingtest-http-http",
+                    "uid": "ed504571-fed8-11e9-9a8f-0e57b7345f92"
+                },
+                "spec": {
+                    "clusterIP": "10.109.249.183",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8080
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8443
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: RemoveReqHeadersMapping-GRPC\nprefix: /RemoveReqHeadersMapping-GRPC/\nservice: http://httpbin.org\nremove_request_headers:\n- zoo\n- aoo\nambassador_id: plain\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: RemoveReqHeadersMapping-GRPC\\nprefix: /RemoveReqHeadersMapping-GRPC/\\nservice: http://httpbin.org\\nremove_request_headers:\\n- zoo\\n- aoo\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-removereqheadersmapping-grpc-grpc\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8174},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8537}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2019-11-04T07:58:55Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-removereqheadersmapping-grpc-grpc",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "16649",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-removereqheadersmapping-grpc-grpc",
+                    "uid": "f2c8e222-fed8-11e9-9a8f-0e57b7345f92"
+                },
+                "spec": {
+                    "clusterIP": "10.97.60.174",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8174
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8537
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: SimpleMapping-HTTP-CaseSensitive\nprefix: /SimpleMapping-HTTP-CaseSensitive/\nservice: http://plain-simplemapping-http-casesensitive-http.plain-namespace\nambassador_id: plain\ncase_sensitive: false\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: SimpleMapping-HTTP-CaseSensitive\\nprefix: /SimpleMapping-HTTP-CaseSensitive/\\nservice: http://plain-simplemapping-http-casesensitive-http.plain-namespace\\nambassador_id: plain\\ncase_sensitive: false\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-simplemapping-http-casesensitive-http\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8097},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8460}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2019-11-04T07:58:47Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-simplemapping-http-casesensitive-http",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "16403",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-simplemapping-http-casesensitive-http",
+                    "uid": "ee333806-fed8-11e9-9a8f-0e57b7345f92"
+                },
+                "spec": {
+                    "clusterIP": "10.98.195.25",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8097
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8460
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: TLSOrigination-HTTP-EXPLICIT\nprefix: /TLSOrigination-HTTP-EXPLICIT/\nservice: plain-tlsorigination-http-explicit-http.plain-namespace\ntls: true\nambassador_id: plain\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: TLSOrigination-HTTP-EXPLICIT\\nprefix: /TLSOrigination-HTTP-EXPLICIT/\\nservice: plain-tlsorigination-http-explicit-http.plain-namespace\\ntls: true\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-tlsorigination-http-explicit-http\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8135},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8498}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2019-11-04T07:58:51Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-tlsorigination-http-explicit-http",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "16527",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-tlsorigination-http-explicit-http",
+                    "uid": "f0abe16b-fed8-11e9-9a8f-0e57b7345f92"
+                },
+                "spec": {
+                    "clusterIP": "10.98.200.219",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8135
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8498
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: AddReqHeadersMapping-HTTP\nprefix: /AddReqHeadersMapping-HTTP/\nservice: http://plain-addreqheadersmapping-http-http.plain-namespace\nadd_request_headers:\n  zoo:\n    append: False\n    value: Zoo\n  aoo:\n    append: True\n    value: aoo\n  boo:\n    value: boo\n  foo: Foo\nambassador_id: plain\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: AddReqHeadersMapping-HTTP\\nprefix: /AddReqHeadersMapping-HTTP/\\nservice: http://plain-addreqheadersmapping-http-http.plain-namespace\\nadd_request_headers:\\n  zoo:\\n    append: False\\n    value: Zoo\\n  aoo:\\n    append: True\\n    value: aoo\\n  boo:\\n    value: boo\\n  foo: Foo\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-addreqheadersmapping-http-http\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8175},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8538}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2019-11-04T07:58:55Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-addreqheadersmapping-http-http",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "16652",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-addreqheadersmapping-http-http",
+                    "uid": "f2d691b4-fed8-11e9-9a8f-0e57b7345f92"
+                },
+                "spec": {
+                    "clusterIP": "10.98.65.212",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8175
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8538
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: CanaryDiffMapping-HTTP-0\nprefix: /CanaryDiffMapping-HTTP-0/\nservice: http://plain-canarydiffmapping-http-0-http.plain-namespace\nhost_rewrite: canary.1.example.com\nambassador_id: plain\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: CanaryDiffMapping-HTTP-0\\nprefix: /CanaryDiffMapping-HTTP-0/\\nservice: http://plain-canarydiffmapping-http-0-http.plain-namespace\\nhost_rewrite: canary.1.example.com\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-canarydiffmapping-http-0-http\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8155},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8518}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2019-11-04T07:58:53Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-canarydiffmapping-http-0-http",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "16590",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-canarydiffmapping-http-0-http",
+                    "uid": "f1c5a095-fed8-11e9-9a8f-0e57b7345f92"
+                },
+                "spec": {
+                    "clusterIP": "10.97.139.100",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8155
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8518
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: CanaryDiffMapping-HTTP-10-canary\nprefix: /CanaryDiffMapping-HTTP-10/\nservice: http://plain-canarydiffmapping-http-10-http-canary.plain-namespace\nhost_rewrite: canary.2.example.com\nweight: 10\nambassador_id: plain\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: CanaryDiffMapping-HTTP-10-canary\\nprefix: /CanaryDiffMapping-HTTP-10/\\nservice: http://plain-canarydiffmapping-http-10-http-canary.plain-namespace\\nhost_rewrite: canary.2.example.com\\nweight: 10\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-canarydiffmapping-http-10-http-canary\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8158},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8521}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2019-11-04T07:58:53Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-canarydiffmapping-http-10-http-canary",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "16599",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-canarydiffmapping-http-10-http-canary",
+                    "uid": "f1ee5ba1-fed8-11e9-9a8f-0e57b7345f92"
+                },
+                "spec": {
+                    "clusterIP": "10.107.47.107",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8158
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8521
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: HeaderRoutingTest-GRPC-target1\nprefix: /HeaderRoutingTest-GRPC/\nservice: http://plain-headerroutingtest-grpc-grpc.plain-namespace\nambassador_id: plain\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: HeaderRoutingTest-GRPC-target1\\nprefix: /HeaderRoutingTest-GRPC/\\nservice: http://plain-headerroutingtest-grpc-grpc.plain-namespace\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-headerroutingtest-grpc-grpc\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8082},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8445}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2019-11-04T07:58:46Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-headerroutingtest-grpc-grpc",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "16355",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-headerroutingtest-grpc-grpc",
+                    "uid": "ed692929-fed8-11e9-9a8f-0e57b7345f92"
+                },
+                "spec": {
+                    "clusterIP": "10.109.97.234",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8082
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8445
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: WebSocketMapping-GRPC\nprefix: /WebSocketMapping-GRPC/\nservice: echo.websocket.org:80\nhost_rewrite: echo.websocket.org\nuse_websocket: true\nambassador_id: plain\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: WebSocketMapping-GRPC\\nprefix: /WebSocketMapping-GRPC/\\nservice: echo.websocket.org:80\\nhost_rewrite: echo.websocket.org\\nuse_websocket: true\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-websocketmapping-grpc-grpc\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8133},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8496}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2019-11-04T07:58:51Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-websocketmapping-grpc-grpc",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "16521",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-websocketmapping-grpc-grpc",
+                    "uid": "f08e3905-fed8-11e9-9a8f-0e57b7345f92"
+                },
+                "spec": {
+                    "clusterIP": "10.99.174.173",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8133
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8496
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: SimpleMapping-HTTP-CORS\nprefix: /SimpleMapping-HTTP-CORS/\nservice: http://plain-simplemapping-http-cors-http.plain-namespace\nambassador_id: plain\ncors: {origins: \"*\"}\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: SimpleMapping-HTTP-CORS\\nprefix: /SimpleMapping-HTTP-CORS/\\nservice: http://plain-simplemapping-http-cors-http.plain-namespace\\nambassador_id: plain\\ncors: {origins: \\\"*\\\"}\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-simplemapping-http-cors-http\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8096},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8459}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2019-11-04T07:58:47Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-simplemapping-http-cors-http",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "16400",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-simplemapping-http-cors-http",
+                    "uid": "ee25e920-fed8-11e9-9a8f-0e57b7345f92"
+                },
+                "spec": {
+                    "clusterIP": "10.108.132.230",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8096
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8459
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-simplemappingingress-grpc-grpc\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8123},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8486}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
                     },
-                    "creationTimestamp": "2019-11-04T05:43:40Z",
+                    "creationTimestamp": "2019-11-04T07:58:50Z",
                     "labels": {
                         "kat-ambassador-id": "plain",
                         "scope": "AmbassadorTest"
                     },
                     "name": "plain-simplemappingingress-grpc-grpc",
                     "namespace": "plain-namespace",
-                    "resourceVersion": "12615",
+                    "resourceVersion": "16486",
                     "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-simplemappingingress-grpc-grpc",
-                    "uid": "0e0c11f4-fec6-11e9-8b1f-120e67b61000"
+                    "uid": "efc855c6-fed8-11e9-9a8f-0e57b7345f92"
                 },
                 "spec": {
-                    "clusterIP": "10.107.133.40",
+                    "clusterIP": "10.109.31.64",
                     "ports": [
                         {
                             "name": "http",
@@ -4697,6 +3440,1263 @@
                             "port": 443,
                             "protocol": "TCP",
                             "targetPort": 8486
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: CanaryMapping-GRPC-50-canary\nprefix: /CanaryMapping-GRPC-50/\nservice: http://plain-canarymapping-grpc-50-grpc-canary.plain-namespace\nweight: 50\nambassador_id: plain\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: CanaryMapping-GRPC-50-canary\\nprefix: /CanaryMapping-GRPC-50/\\nservice: http://plain-canarymapping-grpc-50-grpc-canary.plain-namespace\\nweight: 50\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-canarymapping-grpc-50-grpc-canary\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8152},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8515}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2019-11-04T07:58:53Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-canarymapping-grpc-50-grpc-canary",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "16581",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-canarymapping-grpc-50-grpc-canary",
+                    "uid": "f19d9302-fed8-11e9-9a8f-0e57b7345f92"
+                },
+                "spec": {
+                    "clusterIP": "10.107.64.180",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8152
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8515
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: CanaryMapping-HTTP-10-canary\nprefix: /CanaryMapping-HTTP-10/\nservice: http://plain-canarymapping-http-10-http-canary.plain-namespace\nweight: 10\nambassador_id: plain\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: CanaryMapping-HTTP-10-canary\\nprefix: /CanaryMapping-HTTP-10/\\nservice: http://plain-canarymapping-http-10-http-canary.plain-namespace\\nweight: 10\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-canarymapping-http-10-http-canary\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8142},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8505}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2019-11-04T07:58:52Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-canarymapping-http-10-http-canary",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "16550",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-canarymapping-http-10-http-canary",
+                    "uid": "f10fde22-fed8-11e9-9a8f-0e57b7345f92"
+                },
+                "spec": {
+                    "clusterIP": "10.97.252.89",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8142
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8505
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: SimpleMapping-GRPC-CORS\nprefix: /SimpleMapping-GRPC-CORS/\nservice: http://plain-simplemapping-grpc-cors-grpc.plain-namespace\nambassador_id: plain\ncors: {origins: \"*\"}\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: SimpleMapping-GRPC-CORS\\nprefix: /SimpleMapping-GRPC-CORS/\\nservice: http://plain-simplemapping-grpc-cors-grpc.plain-namespace\\nambassador_id: plain\\ncors: {origins: \\\"*\\\"}\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-simplemapping-grpc-cors-grpc\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8115},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8478}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2019-11-04T07:58:49Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-simplemapping-grpc-cors-grpc",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "16459",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-simplemapping-grpc-cors-grpc",
+                    "uid": "ef3cce34-fed8-11e9-9a8f-0e57b7345f92"
+                },
+                "spec": {
+                    "clusterIP": "10.104.6.144",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8115
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8478
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: SimpleMapping-HTTP-AddRequestHeaders-zoo-bar\nprefix: /SimpleMapping-HTTP-AddRequestHeaders-zoo-bar/\nservice: http://plain-simplemapping-http-addrequestheaders-zoo-bar-http.plain-namespace\nambassador_id: plain\nadd_request_headers: {\"zoo\": {\"append\": true, \"value\": \"bar\"}}\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: SimpleMapping-HTTP-AddRequestHeaders-zoo-bar\\nprefix: /SimpleMapping-HTTP-AddRequestHeaders-zoo-bar/\\nservice: http://plain-simplemapping-http-addrequestheaders-zoo-bar-http.plain-namespace\\nambassador_id: plain\\nadd_request_headers: {\\\"zoo\\\": {\\\"append\\\": true, \\\"value\\\": \\\"bar\\\"}}\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-simplemapping-http-addrequestheaders-zoo-bar-http\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8087},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8450}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2019-11-04T07:58:46Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-simplemapping-http-addrequestheaders-zoo-bar-http",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "16371",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-simplemapping-http-addrequestheaders-zoo-bar-http",
+                    "uid": "eda9fd4b-fed8-11e9-9a8f-0e57b7345f92"
+                },
+                "spec": {
+                    "clusterIP": "10.101.252.10",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8087
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8450
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: CanaryMapping-HTTP-0\nprefix: /CanaryMapping-HTTP-0/\nservice: http://plain-canarymapping-http-0-http.plain-namespace\nambassador_id: plain\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: CanaryMapping-HTTP-0\\nprefix: /CanaryMapping-HTTP-0/\\nservice: http://plain-canarymapping-http-0-http.plain-namespace\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-canarymapping-http-0-http\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8139},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8502}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2019-11-04T07:58:51Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-canarymapping-http-0-http",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "16541",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-canarymapping-http-0-http",
+                    "uid": "f0e5b5b4-fed8-11e9-9a8f-0e57b7345f92"
+                },
+                "spec": {
+                    "clusterIP": "10.106.17.229",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8139
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8502
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: HostHeaderMapping-HTTP\nprefix: /HostHeaderMapping-HTTP/\nservice: http://plain-hostheadermapping-http-http.plain-namespace\nhost: inspector.external\nambassador_id: plain\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: HostHeaderMapping-HTTP\\nprefix: /HostHeaderMapping-HTTP/\\nservice: http://plain-hostheadermapping-http-http.plain-namespace\\nhost: inspector.external\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-hostheadermapping-http-http\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8128},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8491}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2019-11-04T07:58:50Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-hostheadermapping-http-http",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "16506",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-hostheadermapping-http-http",
+                    "uid": "f0402fb9-fed8-11e9-9a8f-0e57b7345f92"
+                },
+                "spec": {
+                    "clusterIP": "10.100.91.125",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8128
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8491
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: SimpleMapping-GRPC-AddResponseHeaders-zoo-bar\nprefix: /SimpleMapping-GRPC-AddResponseHeaders-zoo-bar/\nservice: http://plain-simplemapping-grpc-addresponseheaders-zoo-bar-grpc.plain-namespace\nambassador_id: plain\nadd_response_headers: {\"zoo\": {\"append\": true, \"value\": \"bar\"}}\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: SimpleMapping-GRPC-AddResponseHeaders-zoo-bar\\nprefix: /SimpleMapping-GRPC-AddResponseHeaders-zoo-bar/\\nservice: http://plain-simplemapping-grpc-addresponseheaders-zoo-bar-grpc.plain-namespace\\nambassador_id: plain\\nadd_response_headers: {\\\"zoo\\\": {\\\"append\\\": true, \\\"value\\\": \\\"bar\\\"}}\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-simplemapping-grpc-addresponseheaders-zoo-bar-grpc\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8111},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8474}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2019-11-04T07:58:48Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-simplemapping-grpc-addresponseheaders-zoo-bar-grpc",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "16447",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-simplemapping-grpc-addresponseheaders-zoo-bar-grpc",
+                    "uid": "ef0591f9-fed8-11e9-9a8f-0e57b7345f92"
+                },
+                "spec": {
+                    "clusterIP": "10.102.241.11",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8111
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8474
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: SimpleMapping-HTTP-AddResponseHeaders-moo-arf\nprefix: /SimpleMapping-HTTP-AddResponseHeaders-moo-arf/\nservice: http://plain-simplemapping-http-addresponseheaders-moo-arf-http.plain-namespace\nambassador_id: plain\nadd_response_headers: {\"moo\": \"arf\"}\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: SimpleMapping-HTTP-AddResponseHeaders-moo-arf\\nprefix: /SimpleMapping-HTTP-AddResponseHeaders-moo-arf/\\nservice: http://plain-simplemapping-http-addresponseheaders-moo-arf-http.plain-namespace\\nambassador_id: plain\\nadd_response_headers: {\\\"moo\\\": \\\"arf\\\"}\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-simplemapping-http-addresponseheaders-moo-arf-http\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8091},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8454}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2019-11-04T07:58:46Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-simplemapping-http-addresponseheaders-moo-arf-http",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "16383",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-simplemapping-http-addresponseheaders-moo-arf-http",
+                    "uid": "ede07017-fed8-11e9-9a8f-0e57b7345f92"
+                },
+                "spec": {
+                    "clusterIP": "10.111.95.163",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8091
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8454
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: SimpleMapping-GRPC-all\nprefix: /SimpleMapping-GRPC-all/\nservice: http://plain-simplemapping-grpc-all-grpc.plain-namespace\nambassador_id: plain\nadd_request_headers: {\"foo\": \"bar\"}\nadd_response_headers: {\"foo\": \"bar\"}\nuse_websocket: true\ncors: {origins: \"*\"}\ncase_sensitive: false\nauto_host_rewrite: true\nrewrite: /foo\nremove_response_headers: x-envoy-upstream-service-time\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: SimpleMapping-GRPC-all\\nprefix: /SimpleMapping-GRPC-all/\\nservice: http://plain-simplemapping-grpc-all-grpc.plain-namespace\\nambassador_id: plain\\nadd_request_headers: {\\\"foo\\\": \\\"bar\\\"}\\nadd_response_headers: {\\\"foo\\\": \\\"bar\\\"}\\nuse_websocket: true\\ncors: {origins: \\\"*\\\"}\\ncase_sensitive: false\\nauto_host_rewrite: true\\nrewrite: /foo\\nremove_response_headers: x-envoy-upstream-service-time\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-simplemapping-grpc-all-grpc\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8121},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8484}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2019-11-04T07:58:49Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-simplemapping-grpc-all-grpc",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "16477",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-simplemapping-grpc-all-grpc",
+                    "uid": "ef935d05-fed8-11e9-9a8f-0e57b7345f92"
+                },
+                "spec": {
+                    "clusterIP": "10.100.123.114",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8121
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8484
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: SimpleMapping-HTTP-all\nprefix: /SimpleMapping-HTTP-all/\nservice: http://plain-simplemapping-http-all-http.plain-namespace\nambassador_id: plain\nadd_request_headers: {\"foo\": \"bar\"}\nadd_response_headers: {\"foo\": \"bar\"}\nuse_websocket: true\ncors: {origins: \"*\"}\ncase_sensitive: false\nauto_host_rewrite: true\nrewrite: /foo\nremove_response_headers: x-envoy-upstream-service-time\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: SimpleMapping-HTTP-all\\nprefix: /SimpleMapping-HTTP-all/\\nservice: http://plain-simplemapping-http-all-http.plain-namespace\\nambassador_id: plain\\nadd_request_headers: {\\\"foo\\\": \\\"bar\\\"}\\nadd_response_headers: {\\\"foo\\\": \\\"bar\\\"}\\nuse_websocket: true\\ncors: {origins: \\\"*\\\"}\\ncase_sensitive: false\\nauto_host_rewrite: true\\nrewrite: /foo\\nremove_response_headers: x-envoy-upstream-service-time\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-simplemapping-http-all-http\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8102},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8465}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2019-11-04T07:58:47Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-simplemapping-http-all-http",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "16419",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-simplemapping-http-all-http",
+                    "uid": "ee810f9f-fed8-11e9-9a8f-0e57b7345f92"
+                },
+                "spec": {
+                    "clusterIP": "10.100.33.124",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8102
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8465
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: AddRespHeadersMapping-GRPC\nprefix: /AddRespHeadersMapping-GRPC/\nservice: http://httpbin.org\nadd_response_headers:\n  koo:\n    append: False\n    value: KooK\n  zoo:\n    append: True\n    value: ZooZ\n  test:\n    value: boo\n  foo: Foo\nambassador_id: plain\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: AddRespHeadersMapping-GRPC\\nprefix: /AddRespHeadersMapping-GRPC/\\nservice: http://httpbin.org\\nadd_response_headers:\\n  koo:\\n    append: False\\n    value: KooK\\n  zoo:\\n    append: True\\n    value: ZooZ\\n  test:\\n    value: boo\\n  foo: Foo\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-addrespheadersmapping-grpc-grpc\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8172},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8535}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2019-11-04T07:58:54Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-addrespheadersmapping-grpc-grpc",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "16643",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-addrespheadersmapping-grpc-grpc",
+                    "uid": "f2ad8bb3-fed8-11e9-9a8f-0e57b7345f92"
+                },
+                "spec": {
+                    "clusterIP": "10.107.174.53",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8172
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8535
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: CanaryDiffMapping-GRPC-10\nprefix: /CanaryDiffMapping-GRPC-10/\nservice: http://plain-canarydiffmapping-grpc-10-grpc.plain-namespace\nhost_rewrite: canary.1.example.com\nambassador_id: plain\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: CanaryDiffMapping-GRPC-10\\nprefix: /CanaryDiffMapping-GRPC-10/\\nservice: http://plain-canarydiffmapping-grpc-10-grpc.plain-namespace\\nhost_rewrite: canary.1.example.com\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-canarydiffmapping-grpc-10-grpc\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8165},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8528}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2019-11-04T07:58:54Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-canarydiffmapping-grpc-10-grpc",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "16621",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-canarydiffmapping-grpc-10-grpc",
+                    "uid": "f24a9a39-fed8-11e9-9a8f-0e57b7345f92"
+                },
+                "spec": {
+                    "clusterIP": "10.97.181.214",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8165
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8528
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: SimpleMapping-GRPC-AddRequestHeaders-aoo-tyu\nprefix: /SimpleMapping-GRPC-AddRequestHeaders-aoo-tyu/\nservice: http://plain-simplemapping-grpc-addrequestheaders-aoo-tyu-grpc.plain-namespace\nambassador_id: plain\nadd_request_headers: {\"aoo\": {\"value\": \"tyu\"}}\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: SimpleMapping-GRPC-AddRequestHeaders-aoo-tyu\\nprefix: /SimpleMapping-GRPC-AddRequestHeaders-aoo-tyu/\\nservice: http://plain-simplemapping-grpc-addrequestheaders-aoo-tyu-grpc.plain-namespace\\nambassador_id: plain\\nadd_request_headers: {\\\"aoo\\\": {\\\"value\\\": \\\"tyu\\\"}}\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-simplemapping-grpc-addrequestheaders-aoo-tyu-grpc\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8108},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8471}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2019-11-04T07:58:48Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-simplemapping-grpc-addrequestheaders-aoo-tyu-grpc",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "16438",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-simplemapping-grpc-addrequestheaders-aoo-tyu-grpc",
+                    "uid": "eedd9a14-fed8-11e9-9a8f-0e57b7345f92"
+                },
+                "spec": {
+                    "clusterIP": "10.107.237.126",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8108
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8471
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: SimpleMapping-GRPC-AddResponseHeaders-foo-bar\nprefix: /SimpleMapping-GRPC-AddResponseHeaders-foo-bar/\nservice: http://plain-simplemapping-grpc-addresponseheaders-foo-bar-grpc.plain-namespace\nambassador_id: plain\nadd_response_headers: {\"foo\": \"bar\"}\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: SimpleMapping-GRPC-AddResponseHeaders-foo-bar\\nprefix: /SimpleMapping-GRPC-AddResponseHeaders-foo-bar/\\nservice: http://plain-simplemapping-grpc-addresponseheaders-foo-bar-grpc.plain-namespace\\nambassador_id: plain\\nadd_response_headers: {\\\"foo\\\": \\\"bar\\\"}\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-simplemapping-grpc-addresponseheaders-foo-bar-grpc\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8109},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8472}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2019-11-04T07:58:48Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-simplemapping-grpc-addresponseheaders-foo-bar-grpc",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "16441",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-simplemapping-grpc-addresponseheaders-foo-bar-grpc",
+                    "uid": "eeeab96e-fed8-11e9-9a8f-0e57b7345f92"
+                },
+                "spec": {
+                    "clusterIP": "10.104.84.3",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8109
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8472
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: RemoveReqHeadersMapping-HTTP\nprefix: /RemoveReqHeadersMapping-HTTP/\nservice: http://httpbin.org\nremove_request_headers:\n- zoo\n- aoo\nambassador_id: plain\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: RemoveReqHeadersMapping-HTTP\\nprefix: /RemoveReqHeadersMapping-HTTP/\\nservice: http://httpbin.org\\nremove_request_headers:\\n- zoo\\n- aoo\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-removereqheadersmapping-http-http\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8173},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8536}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2019-11-04T07:58:55Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-removereqheadersmapping-http-http",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "16646",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-removereqheadersmapping-http-http",
+                    "uid": "f2bad498-fed8-11e9-9a8f-0e57b7345f92"
+                },
+                "spec": {
+                    "clusterIP": "10.97.49.9",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8173
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8536
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: SimpleMapping-HTTP-AddRequestHeaders-aoo-tyu\nprefix: /SimpleMapping-HTTP-AddRequestHeaders-aoo-tyu/\nservice: http://plain-simplemapping-http-addrequestheaders-aoo-tyu-http.plain-namespace\nambassador_id: plain\nadd_request_headers: {\"aoo\": {\"value\": \"tyu\"}}\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: SimpleMapping-HTTP-AddRequestHeaders-aoo-tyu\\nprefix: /SimpleMapping-HTTP-AddRequestHeaders-aoo-tyu/\\nservice: http://plain-simplemapping-http-addrequestheaders-aoo-tyu-http.plain-namespace\\nambassador_id: plain\\nadd_request_headers: {\\\"aoo\\\": {\\\"value\\\": \\\"tyu\\\"}}\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-simplemapping-http-addrequestheaders-aoo-tyu-http\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8089},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8452}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2019-11-04T07:58:46Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-simplemapping-http-addrequestheaders-aoo-tyu-http",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "16377",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-simplemapping-http-addrequestheaders-aoo-tyu-http",
+                    "uid": "edc6ec90-fed8-11e9-9a8f-0e57b7345f92"
+                },
+                "spec": {
+                    "clusterIP": "10.102.190.36",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8089
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8452
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: SimpleMapping-HTTP-AddRequestHeaders-xoo-dwe\nprefix: /SimpleMapping-HTTP-AddRequestHeaders-xoo-dwe/\nservice: http://plain-simplemapping-http-addrequestheaders-xoo-dwe-http.plain-namespace\nambassador_id: plain\nadd_request_headers: {\"xoo\": {\"append\": false, \"value\": \"dwe\"}}\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: SimpleMapping-HTTP-AddRequestHeaders-xoo-dwe\\nprefix: /SimpleMapping-HTTP-AddRequestHeaders-xoo-dwe/\\nservice: http://plain-simplemapping-http-addrequestheaders-xoo-dwe-http.plain-namespace\\nambassador_id: plain\\nadd_request_headers: {\\\"xoo\\\": {\\\"append\\\": false, \\\"value\\\": \\\"dwe\\\"}}\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-simplemapping-http-addrequestheaders-xoo-dwe-http\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8088},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8451}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2019-11-04T07:58:46Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-simplemapping-http-addrequestheaders-xoo-dwe-http",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "16374",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-simplemapping-http-addrequestheaders-xoo-dwe-http",
+                    "uid": "edb7da42-fed8-11e9-9a8f-0e57b7345f92"
+                },
+                "spec": {
+                    "clusterIP": "10.96.78.40",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8088
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8451
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: SimpleMapping-HTTP-RemoveResponseHeaders\nprefix: /SimpleMapping-HTTP-RemoveResponseHeaders/\nservice: http://plain-simplemapping-http-removeresponseheaders-http.plain-namespace\nambassador_id: plain\nremove_response_headers: x-envoy-upstream-service-time\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: SimpleMapping-HTTP-RemoveResponseHeaders\\nprefix: /SimpleMapping-HTTP-RemoveResponseHeaders/\\nservice: http://plain-simplemapping-http-removeresponseheaders-http.plain-namespace\\nambassador_id: plain\\nremove_response_headers: x-envoy-upstream-service-time\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-simplemapping-http-removeresponseheaders-http\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8101},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8464}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2019-11-04T07:58:47Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-simplemapping-http-removeresponseheaders-http",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "16415",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-simplemapping-http-removeresponseheaders-http",
+                    "uid": "ee719134-fed8-11e9-9a8f-0e57b7345f92"
+                },
+                "spec": {
+                    "clusterIP": "10.109.53.214",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8101
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8464
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: CanaryDiffMapping-GRPC-0\nprefix: /CanaryDiffMapping-GRPC-0/\nservice: http://plain-canarydiffmapping-grpc-0-grpc.plain-namespace\nhost_rewrite: canary.1.example.com\nambassador_id: plain\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: CanaryDiffMapping-GRPC-0\\nprefix: /CanaryDiffMapping-GRPC-0/\\nservice: http://plain-canarydiffmapping-grpc-0-grpc.plain-namespace\\nhost_rewrite: canary.1.example.com\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-canarydiffmapping-grpc-0-grpc\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8163},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8526}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2019-11-04T07:58:54Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-canarydiffmapping-grpc-0-grpc",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "16615",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-canarydiffmapping-grpc-0-grpc",
+                    "uid": "f22fbc31-fed8-11e9-9a8f-0e57b7345f92"
+                },
+                "spec": {
+                    "clusterIP": "10.109.123.214",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8163
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8526
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: CanaryDiffMapping-GRPC-100\nprefix: /CanaryDiffMapping-GRPC-100/\nservice: http://plain-canarydiffmapping-grpc-100-grpc.plain-namespace\nhost_rewrite: canary.1.example.com\nambassador_id: plain\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: CanaryDiffMapping-GRPC-100\\nprefix: /CanaryDiffMapping-GRPC-100/\\nservice: http://plain-canarydiffmapping-grpc-100-grpc.plain-namespace\\nhost_rewrite: canary.1.example.com\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-canarydiffmapping-grpc-100-grpc\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8169},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8532}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2019-11-04T07:58:54Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-canarydiffmapping-grpc-100-grpc",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "16634",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-canarydiffmapping-grpc-100-grpc",
+                    "uid": "f282e13e-fed8-11e9-9a8f-0e57b7345f92"
+                },
+                "spec": {
+                    "clusterIP": "10.111.202.37",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8169
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8532
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: CanaryMapping-HTTP-10\nprefix: /CanaryMapping-HTTP-10/\nservice: http://plain-canarymapping-http-10-http.plain-namespace\nambassador_id: plain\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: CanaryMapping-HTTP-10\\nprefix: /CanaryMapping-HTTP-10/\\nservice: http://plain-canarymapping-http-10-http.plain-namespace\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-canarymapping-http-10-http\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8141},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8504}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2019-11-04T07:58:52Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-canarymapping-http-10-http",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "16547",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-canarymapping-http-10-http",
+                    "uid": "f1018804-fed8-11e9-9a8f-0e57b7345f92"
+                },
+                "spec": {
+                    "clusterIP": "10.102.190.155",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8141
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8504
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-hostheadermappingingress-http-http\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8126},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8489}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2019-11-04T07:58:50Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-hostheadermappingingress-http-http",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "16499",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-hostheadermappingingress-http-http",
+                    "uid": "f014f00b-fed8-11e9-9a8f-0e57b7345f92"
+                },
+                "spec": {
+                    "clusterIP": "10.106.189.158",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8126
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8489
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: TLSOrigination-GRPC-IMPLICIT\nprefix: /TLSOrigination-GRPC-IMPLICIT/\nservice: https://plain-tlsorigination-grpc-implicit-grpc.plain-namespace\nambassador_id: plain\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: TLSOrigination-GRPC-IMPLICIT\\nprefix: /TLSOrigination-GRPC-IMPLICIT/\\nservice: https://plain-tlsorigination-grpc-implicit-grpc.plain-namespace\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-tlsorigination-grpc-implicit-grpc\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8136},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8499}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2019-11-04T07:58:51Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-tlsorigination-grpc-implicit-grpc",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "16531",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-tlsorigination-grpc-implicit-grpc",
+                    "uid": "f0ba4b8e-fed8-11e9-9a8f-0e57b7345f92"
+                },
+                "spec": {
+                    "clusterIP": "10.106.166.234",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8136
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8499
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-simplemappingingress-http-http\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8122},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8485}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2019-11-04T07:58:49Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-simplemappingingress-http-http",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "16482",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-simplemappingingress-http-http",
+                    "uid": "efae3aee-fed8-11e9-9a8f-0e57b7345f92"
+                },
+                "spec": {
+                    "clusterIP": "10.101.105.125",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8122
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8485
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: CanaryDiffMapping-HTTP-50-canary\nprefix: /CanaryDiffMapping-HTTP-50/\nservice: http://plain-canarydiffmapping-http-50-http-canary.plain-namespace\nhost_rewrite: canary.2.example.com\nweight: 50\nambassador_id: plain\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: CanaryDiffMapping-HTTP-50-canary\\nprefix: /CanaryDiffMapping-HTTP-50/\\nservice: http://plain-canarydiffmapping-http-50-http-canary.plain-namespace\\nhost_rewrite: canary.2.example.com\\nweight: 50\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-canarydiffmapping-http-50-http-canary\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8160},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8523}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2019-11-04T07:58:53Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-canarydiffmapping-http-50-http-canary",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "16605",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-canarydiffmapping-http-50-http-canary",
+                    "uid": "f2077467-fed8-11e9-9a8f-0e57b7345f92"
+                },
+                "spec": {
+                    "clusterIP": "10.103.17.115",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8160
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8523
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: HostHeaderMapping-GRPC\nprefix: /HostHeaderMapping-GRPC/\nservice: http://plain-hostheadermapping-grpc-grpc.plain-namespace\nhost: inspector.external\nambassador_id: plain\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: HostHeaderMapping-GRPC\\nprefix: /HostHeaderMapping-GRPC/\\nservice: http://plain-hostheadermapping-grpc-grpc.plain-namespace\\nhost: inspector.external\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-hostheadermapping-grpc-grpc\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8129},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8492}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2019-11-04T07:58:50Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-hostheadermapping-grpc-grpc",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "16509",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-hostheadermapping-grpc-grpc",
+                    "uid": "f052be07-fed8-11e9-9a8f-0e57b7345f92"
+                },
+                "spec": {
+                    "clusterIP": "10.105.102.190",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8129
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8492
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-simpleingresswithannotations-http-http\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8124},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8487}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2019-11-04T07:58:50Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-simpleingresswithannotations-http-http",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "16490",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-simpleingresswithannotations-http-http",
+                    "uid": "efe153e5-fed8-11e9-9a8f-0e57b7345f92"
+                },
+                "spec": {
+                    "clusterIP": "10.101.192.149",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8124
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8487
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: SimpleMapping-HTTP-AddResponseHeaders-zoo-bar\nprefix: /SimpleMapping-HTTP-AddResponseHeaders-zoo-bar/\nservice: http://plain-simplemapping-http-addresponseheaders-zoo-bar-http.plain-namespace\nambassador_id: plain\nadd_response_headers: {\"zoo\": {\"append\": true, \"value\": \"bar\"}}\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: SimpleMapping-HTTP-AddResponseHeaders-zoo-bar\\nprefix: /SimpleMapping-HTTP-AddResponseHeaders-zoo-bar/\\nservice: http://plain-simplemapping-http-addresponseheaders-zoo-bar-http.plain-namespace\\nambassador_id: plain\\nadd_response_headers: {\\\"zoo\\\": {\\\"append\\\": true, \\\"value\\\": \\\"bar\\\"}}\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-simplemapping-http-addresponseheaders-zoo-bar-http\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8092},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8455}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2019-11-04T07:58:46Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-simplemapping-http-addresponseheaders-zoo-bar-http",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "16386",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-simplemapping-http-addresponseheaders-zoo-bar-http",
+                    "uid": "edecc017-fed8-11e9-9a8f-0e57b7345f92"
+                },
+                "spec": {
+                    "clusterIP": "10.105.170.157",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8092
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8455
                         }
                     ],
                     "selector": {

--- a/python/tests/t_plain.py
+++ b/python/tests/t_plain.py
@@ -12,8 +12,6 @@ class Plain(AmbassadorTest):
     single_namespace = True
     namespace = "plain-namespace"
 
-    no_local_mode = True
-
     @classmethod
     def variants(cls):
         yield cls(variants(MappingTest))


### PR DESCRIPTION
Mostly this was recognizing that `-s ingresses` is supposed to match resources of `Kind` `Ingress`, too. 

Since the `Plain` test actually does an enormous amount of work across its `MappingTest`s and `OptionTest`s, letting it be cacheable is an important step in speeding things up.
