### PR TITLE
Keep watching for changes to secrets that we successfully loaded

### DIFF
--- a/python/ambassador/ir/ir.py
+++ b/python/ambassador/ir/ir.py
@@ -357,6 +357,7 @@ class IR:
         if ss:
             # Done. Return it.
             self.logger.info(f"resolve_secret {ss_key}: using cached SavedSecret")
+            self.secret_handler.still_needed(resource, secret_name, namespace)
             return ss
 
         # OK, do we have a secret_info for it??
@@ -366,6 +367,7 @@ class IR:
 
         if secret_info:
             self.logger.info(f"resolve_secret {ss_key}: found secret_info")
+            self.secret_handler.still_needed(resource, secret_name, namespace)
         else:
             # No secret_info, so ask the secret_handler to find us one.
             self.logger.info(f"resolve_secret {ss_key}: no secret_info, asking handler to load")

--- a/python/ambassador/utils.py
+++ b/python/ambassador/utils.py
@@ -400,6 +400,13 @@ class SecretHandler:
 
         return None
 
+    def still_needed(self, resource: 'IRResource', secret_name: str, namespace: str) -> None:
+        # This is the fallback no-op still_needed implementation, which honestly most things in
+        # the IR can use -- probably the watch_hook is all that'll need to override this.
+
+        self.logger.debug("SecretHandler (%s %s): secret %s in namespace %s is still needed" %
+                          (resource.kind, resource.name, secret_name, namespace))
+
     def cache_secret(self, resource: 'IRResource', secret_info: SecretInfo) -> SavedSecret:
         name = secret_info.name
         namespace = secret_info.namespace


### PR DESCRIPTION
If the `watch_hook` hands back a watch for a given element in one cycle, then doesn't include it in the next cycle, `watt` stops watching for that element, so we won't notice changes. This isn't unreasonable on `watt`'s end, but `watch_hook` wasn't on the same page -- it would stop asking for `Secret`s to be watched once they were loaded. Oops.
