### PR TITLE
Fix a typo when managing nonzero precedences.

### DIFF
--- a/python/ambassador/diagnostics/diagnostics.py
+++ b/python/ambassador/diagnostics/diagnostics.py
@@ -281,7 +281,8 @@ class DiagResult:
             'method': method,
             'headers': headers,
             'clusters': [ x.default_missing() for x in route_clusters ],
-            'host': host if host else '*'
+            'host': host if host else '*',
+            'precedence': group['precedence']
         }
 
         self.routes.append(route_info)

--- a/python/ambassador/ir/irhttpmappinggroup.py
+++ b/python/ambassador/ir/irhttpmappinggroup.py
@@ -177,7 +177,7 @@ class IRHTTPMappingGroup (IRBaseMappingGroup):
             self.mappings.append(mapping)
 
             if mapping.route_weight > self.group_weight:
-                self.group_weight = mapping.group_weight
+                self.group_weight = mapping.route_weight
 
         self.referenced_by(mapping)
 

--- a/python/ambassador/ir/irmappingfactory.py
+++ b/python/ambassador/ir/irmappingfactory.py
@@ -30,30 +30,6 @@ class MappingFactory:
         cls.load_config(ir, aconf, "mappings", IRHTTPMapping)
         cls.load_config(ir, aconf, "tcpmappings", IRTCPMapping)
 
-        # If the wizard is allowed, take over the root prefix.
-        if ir.wizard_allowed:
-            ir.logger.info(f"WIZARD ALLOWED: adding firstboot mapping")
-
-            ir.add_mapping(aconf,
-                           IRHTTPMapping(ir, aconf, rkey='--internal--', location='--internal--',
-                                         name=unique_mapping_name(aconf, 'firstboot-mapping'),
-                                         apiVersion='getambassador.io/v1',
-                                         prefix='/',
-                                         rewrite='/firstboot/',
-                                         service='127.0.0.1:8500'))
-
-        if ir.edge_stack_allowed:
-            # Whether the wizard is allowed or not, add the mapping for ACME challenges.
-            ir.logger.info(f"MappingFactory: adding ACME challenge mapping")
-
-            ir.add_mapping(aconf,
-                           IRHTTPMapping(ir, aconf, rkey='--internal--', location='--internal--',
-                                         name=unique_mapping_name(aconf, 'acme-mapping'),
-                                         apiVersion='getambassador.io/v1',
-                                         prefix='/.well-known/acme-challenge/',
-                                         rewrite='/.well-known/acme-challenge/',
-                                         service='127.0.0.1:8500'))
-
     @classmethod
     def load_config(cls, ir: 'IR', aconf: Config, config_name: str, mapping_class: Type[IRBaseMapping]) -> None:
         config_info = aconf.get_config(config_name)

--- a/python/templates/overview.html
+++ b/python/templates/overview.html
@@ -230,6 +230,10 @@ limitations under the License
                               {{ hdr['name'] }}: {{ hdr['value'] }}
                             {% endfor %}
                           {% endif %}
+                          {% if route['precedence'] != 0 %}
+                            <br/>
+                            precedence {{ route.precedence }}
+                          {% endif %}
                           </code>
                         </a>
                       </td>


### PR DESCRIPTION
- Fix a crash that's been lingering for quite awhile around nonzero precedences
- Show nonzero precedences in the diag UI
- Don't synthesize firstboot or ACME-challenge mappings for edge stack -- that's what `init-config` is for
