### PR TITLE
Bit of a hack for syncing sources with no DEV_KUBECONFIG

### DIFF
--- a/builder/builder.mk
+++ b/builder/builder.mk
@@ -42,9 +42,13 @@ endif
 sync: preflight
 	@$(foreach MODULE,$(MODULES),$(BUILDER) sync $(MODULE) $(SOURCE_$(MODULE)) &&) true
 	@test -n "$(DEV_KUBECONFIG)" || (printf "$${KUBECONFIG_ERR}\n"; exit 1)
-	@printf "$(CYN)==> $(GRN)Checking for test cluster$(END)\n"
-	@kubectl --kubeconfig $(DEV_KUBECONFIG) -n default get service kubernetes > /dev/null || (printf "$${KUBECTL_ERR}\n"; exit 1)
-	@cat $(DEV_KUBECONFIG) | docker exec -i $$($(BUILDER)) sh -c "cat > /buildroot/kubeconfig.yaml"
+	if [ "$(DEV_KUBECONFIG)" != '-skip-for-release-' ]; then \
+		printf "$(CYN)==> $(GRN)Checking for test cluster$(END)\n" ;\
+		kubectl --kubeconfig $(DEV_KUBECONFIG) -n default get service kubernetes > /dev/null || (printf "$${KUBECTL_ERR}\n"; exit 1) ;\
+		cat $(DEV_KUBECONFIG) | docker exec -i $$($(BUILDER)) sh -c "cat > /buildroot/kubeconfig.yaml" ;\
+	else \
+		printf "$(CYN)==> $(RED)Skipping test cluster checks$(END)\n" ;\
+	fi
 	@if [ -e ~/.docker/config.json ]; then \
 		cat ~/.docker/config.json | docker exec -i $$($(BUILDER)) sh -c "mkdir -p /home/dw/.docker && cat > /home/dw/.docker/config.json" ; \
 	fi


### PR DESCRIPTION
If `$DEV_KUBECONFIG` is `-skip-for-release-`, then `make sync` will run and just sync sources.

Hopefully this is a short-lived hack...