### PR TITLE
Edge Control: Refactor CLI and add batch mode

### DIFF
--- a/builder/builder.sh
+++ b/builder/builder.sh
@@ -34,7 +34,7 @@ builder_volume() { docker volume ls -q -f label=builder; }
 declare -a dsynced
 
 dsync() {
-    printf "${GRN}Synchronizing... $@${END}\n"
+    printf "${GRN}Synchronizing... $*${END}\n"
     IFS='|' read -ra dsynced <<<"$(rsync --info=name -aO -e 'docker exec -i' $@ 2> >(fgrep -v 'rsync: failed to set permissions on' >&2) | tr '\n' '|')"
 }
 

--- a/cmd/edgectl/aes_login.go
+++ b/cmd/edgectl/aes_login.go
@@ -58,6 +58,11 @@ func aesLogin(_ *cobra.Command, args []string) error {
 	var hostname string
 	if len(args) == 1 {
 		hostname = args[0]
+		// FIXME: validate that hostname by querying
+		// https://{{hostname}}/edge_stack/admin/api/ambassador_cluster_id and
+		// verifying that it returns the same UUID via direct access and via
+		// port-forward/teleproxy. This avoids leaking login credentials to the
+		// operator of a different website.
 	} else {
 		hostname, err = getHostname(restconfig)
 		if err != nil {
@@ -145,8 +150,6 @@ func getHostname(restconfig *rest.Config) (hostname string, err error) {
 			return
 		}
 	}
-	if hostname == "" {
-		err = fmt.Errorf("Did not find a valid Host in your cluster")
-	}
+	err = fmt.Errorf("Did not find a valid Host in your cluster. Use \"edgectl login HOSTNAME\"")
 	return
 }

--- a/cmd/edgectl/emitter.go
+++ b/cmd/edgectl/emitter.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 )
@@ -10,6 +11,8 @@ import (
 type Emitter struct {
 	w   io.Writer
 	err error
+	kv  bool
+	enc *json.Encoder
 }
 
 // NewEmitter returns a new Emitter to write to conn
@@ -17,10 +20,15 @@ func NewEmitter(w io.Writer) *Emitter {
 	return &Emitter{w: w}
 }
 
+func (out *Emitter) SetKV() {
+	out.kv = true
+	out.enc = json.NewEncoder(out.w)
+}
+
 // Printf formats according to a format specifier and writes to the
 // client. Errors are collected and returned by Err().
 func (out *Emitter) Printf(format string, a ...interface{}) {
-	if out.err == nil {
+	if out.err == nil && !out.kv {
 		_, out.err = fmt.Fprintf(out.w, format, a...)
 	}
 }
@@ -28,7 +36,7 @@ func (out *Emitter) Printf(format string, a ...interface{}) {
 // Print formats using the default formats for its operands and writes
 // to the client. Errors are collected and returned by Err().
 func (out *Emitter) Print(a ...interface{}) {
-	if out.err == nil {
+	if out.err == nil && !out.kv {
 		_, out.err = fmt.Fprint(out.w, a...)
 	}
 }
@@ -37,7 +45,7 @@ func (out *Emitter) Print(a ...interface{}) {
 // writes to the client, ending output with a newline. Errors are
 // collected and returned by Err().
 func (out *Emitter) Println(a ...interface{}) {
-	if out.err == nil {
+	if out.err == nil && !out.kv {
 		_, out.err = fmt.Fprintln(out.w, a...)
 	}
 }
@@ -47,6 +55,14 @@ func (out *Emitter) Println(a ...interface{}) {
 func (out *Emitter) SendExit(code int) {
 	if out.err == nil {
 		_, out.err = fmt.Fprintf(out.w, "%s%d", ExitPrefix, code)
+	}
+}
+
+// Send a key/value pair to the client if the Emitter is in key/value mode.
+// Errors are collected and returned by Err().
+func (out *Emitter) Send(key string, value interface{}) {
+	if out.err == nil && out.kv {
+		out.err = out.enc.Encode(map[string]interface{}{key: value})
 	}
 }
 

--- a/cmd/edgectl/intercept.go
+++ b/cmd/edgectl/intercept.go
@@ -110,7 +110,7 @@ func (d *Daemon) ListIntercepts(_ *supervisor.Process, out *Emitter) error {
 		out.Send(key, ii.Deployment)
 		for k, v := range ii.Patterns {
 			out.Printf("      - %s: %s\n", k, v)
-			out.Send(key+".pattern", []string{k, v})
+			out.Send(key+"."+k, v)
 		}
 		out.Printf("      and redirecting them to %s:%d\n", ii.TargetHost, ii.TargetPort)
 		out.Send(key+".host", ii.TargetHost)

--- a/cmd/edgectl/main.go
+++ b/cmd/edgectl/main.go
@@ -115,6 +115,7 @@ func getRootCommand(daemonIsRunning, runningAsDaemon bool) *cobra.Command {
 	daemonCmd := nilDaemon.getRootCommand(nil, nil, nil)
 	walkSubcommands(daemonCmd)
 	rootCmd.AddCommand(daemonCmd.Commands()...)
+	rootCmd.PersistentFlags().AddFlagSet(daemonCmd.PersistentFlags())
 
 	return rootCmd
 }

--- a/cmd/edgectl/main.go
+++ b/cmd/edgectl/main.go
@@ -47,16 +47,16 @@ func main() {
 		edgectl = executable
 	}
 
-	rootCmd := getRootCommand(false, false)
+	rootCmd := getRootCommand()
 	err := rootCmd.Execute()
 	if err != nil {
 		os.Exit(1)
 	}
 }
 
-func getRootCommand(daemonIsRunning, runningAsDaemon bool) *cobra.Command {
+func getRootCommand() *cobra.Command {
 	myName := "Edge Control"
-	if !(daemonIsRunning || runningAsDaemon) {
+	if !isServerRunning() {
 		myName = "Edge Control (daemon unavailable)"
 	}
 


### PR DESCRIPTION
- Refactor the CLI so that each command is defined once
- No longer guess intent if the command is missing
- Better error handling around intercept commands
- Add --batch so that output is somewhat machine-readable
