### PR TITLE
Edge Control: Support context/namespace for `edgectl connect`

### DIFF
--- a/cmd/edgectl/cli.go
+++ b/cmd/edgectl/cli.go
@@ -61,16 +61,27 @@ func (d *Daemon) getRootCommand(p *supervisor.Process, out *Emitter, data *Clien
 			return out.Err()
 		},
 	})
-	rootCmd.AddCommand(&cobra.Command{
-		Use:   "connect [-- additional kubectl arguments...]",
+	connectCmd := &cobra.Command{
+		Use:   "connect [flags] [-- additional kubectl arguments...]",
 		Short: "Connect to a cluster",
-		RunE: func(_ *cobra.Command, args []string) error {
-			if err := d.Connect(p, out, data.RAI, args); err != nil {
+		RunE: func(cmd *cobra.Command, args []string) error {
+			context, _ := cmd.Flags().GetString("context")
+			namespace, _ := cmd.Flags().GetString("namespace")
+			if err := d.Connect(p, out, data.RAI, context, namespace, args); err != nil {
 				return err
 			}
 			return out.Err()
 		},
-	})
+	}
+	_ = connectCmd.Flags().StringP(
+		"context", "c", "",
+		"The Kubernetes context to use. Defaults to the current kubectl context.",
+	)
+	_ = connectCmd.Flags().StringP(
+		"namespace", "n", "",
+		"The Kubernetes namespace to use. Defaults to kubectl's default for the context.",
+	)
+	rootCmd.AddCommand(connectCmd)
 	rootCmd.AddCommand(&cobra.Command{
 		Use:   "disconnect",
 		Short: "Disconnect from the connected cluster",

--- a/cmd/edgectl/cluster.go
+++ b/cmd/edgectl/cluster.go
@@ -19,7 +19,10 @@ import (
 )
 
 // Connect the daemon to a cluster
-func (d *Daemon) Connect(p *supervisor.Process, out *Emitter, rai *RunAsInfo, kargs []string) error {
+func (d *Daemon) Connect(
+	p *supervisor.Process, out *Emitter, rai *RunAsInfo,
+	context, namespace string, kargs []string,
+) error {
 	// Sanity checks
 	if d.cluster != nil {
 		out.Println("Already connected")
@@ -39,7 +42,7 @@ func (d *Daemon) Connect(p *supervisor.Process, out *Emitter, rai *RunAsInfo, ka
 
 	out.Println("Connecting...")
 	out.Send("connect", "Connecting...")
-	cluster, err := TrackKCluster(p, rai, kargs)
+	cluster, err := TrackKCluster(p, rai, context, namespace, kargs)
 	if err != nil {
 		out.Println(err.Error())
 		out.Send("failed", err.Error())
@@ -51,7 +54,7 @@ func (d *Daemon) Connect(p *supervisor.Process, out *Emitter, rai *RunAsInfo, ka
 	bridge, err := CheckedRetryingCommand(
 		p,
 		"bridge",
-		[]string{edgectl, "teleproxy", "bridge", "", "default"},
+		[]string{edgectl, "teleproxy", "bridge", cluster.context, cluster.namespace},
 		rai,
 		checkBridge,
 		15*time.Second,

--- a/cmd/edgectl/cluster.go
+++ b/cmd/edgectl/cluster.go
@@ -51,7 +51,7 @@ func (d *Daemon) Connect(p *supervisor.Process, out *Emitter, rai *RunAsInfo, ka
 	bridge, err := CheckedRetryingCommand(
 		p,
 		"bridge",
-		[]string{edgectl, "teleproxy", "bridge"},
+		[]string{edgectl, "teleproxy", "bridge", "", "default"},
 		rai,
 		checkBridge,
 		15*time.Second,

--- a/cmd/edgectl/main.go
+++ b/cmd/edgectl/main.go
@@ -78,20 +78,30 @@ func getRootCommand() *cobra.Command {
 			return RunAsDaemon()
 		},
 	})
-	rootCmd.AddCommand(&cobra.Command{
-		Use:       "teleproxy",
-		Short:     "Impersonate Teleproxy (for internal use)",
-		Args:      cobra.ExactValidArgs(1),
-		ValidArgs: []string{"intercept", "bridge"},
-		Hidden:    true,
-		RunE: func(_ *cobra.Command, args []string) error {
-			if args[0] == "intercept" {
-				return RunAsTeleproxyIntercept()
-			} else {
-				return RunAsTeleproxyBridge()
-			}
+	teleproxyCmd := &cobra.Command{
+		Use:    "teleproxy",
+		Short:  "Impersonate Teleproxy (for internal use)",
+		Hidden: true,
+	}
+	teleproxyCmd.AddCommand(&cobra.Command{
+		Use:    "intercept",
+		Short:  "Impersonate Teleproxy Intercept (for internal use)",
+		Args:   cobra.NoArgs,
+		Hidden: true,
+		RunE: func(_ *cobra.Command, _ []string) error {
+			return RunAsTeleproxyIntercept()
 		},
 	})
+	teleproxyCmd.AddCommand(&cobra.Command{
+		Use:    "bridge",
+		Short:  "Impersonate Teleproxy Bridge (for internal use)",
+		Args:   cobra.ExactArgs(2),
+		Hidden: true,
+		RunE: func(_ *cobra.Command, args []string) error {
+			return RunAsTeleproxyBridge(args[0], args[1])
+		},
+	})
+	rootCmd.AddCommand(teleproxyCmd)
 
 	// Client commands. These are never sent to the daemon.
 

--- a/cmd/edgectl/main.go
+++ b/cmd/edgectl/main.go
@@ -14,7 +14,7 @@ import (
 // Version is inserted at build using --ldflags -X
 // But we don't really build that way any longer.
 // So include a fallback version number that's not useless.
-var Version = "0.8.0"
+var Version = "0.8.1"
 
 const socketName = "/var/run/edgectl.socket"
 const logfile = "/tmp/edgectl.log"

--- a/cmd/edgectl/teleproxy.go
+++ b/cmd/edgectl/teleproxy.go
@@ -20,7 +20,11 @@ func RunAsTeleproxyIntercept() error {
 
 // RunAsTeleproxyBridge is the main function when executing as
 // teleproxy bridge
-func RunAsTeleproxyBridge() error {
-	tele := &teleproxy.Teleproxy{Mode: "bridge"}
+func RunAsTeleproxyBridge(context, namespace string) error {
+	tele := &teleproxy.Teleproxy{
+		Mode:      "bridge",
+		Context:   context,
+		Namespace: namespace,
+	}
 	return teleproxy.RunTeleproxy(tele, displayVersion)
 }


### PR DESCRIPTION
Correct handling of context and namespace is necessary for Telepresence. 