### PR TITLE
Drop the builder cache for CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ env:
   global:
     - DEV_REGISTRY=quay.io/datawire-dev
     - RELEASE_REGISTRY=quay.io/datawire-dev
-    - DBUILD_ARGS="--cache-from ${DEV_REGISTRY}/builder:latest"
+    # - DBUILD_ARGS="--cache-from ${DEV_REGISTRY}/builder:latest"
 
     # Set from the repository settings:
     #- DOCKER_BUILD_USERNAME=[secure] (optional)
@@ -58,4 +58,4 @@ script:
 after_script:
   # release the kubernaut claim
   - ./releng/travis-cleanup.sh
-  - docker tag builder:latest ${DEV_REGISTRY}/builder:latest && docker push ${DEV_REGISTRY}/builder:latest
+  # - docker tag builder:latest ${DEV_REGISTRY}/builder:latest && docker push ${DEV_REGISTRY}/builder:latest


### PR DESCRIPTION
We were running with a single shared Docker cache for the builder image in CI. Turns out that it doesn't seem to speed things up much, but man can it slow things down when you change the Dockerfile! So this just turns it off.