### PR TITLE
Move CORS filter in front of RateLimit filter. Fixes #2030.

### DIFF
--- a/python/ambassador/ir/ir.py
+++ b/python/ambassador/ir/ir.py
@@ -219,20 +219,20 @@ class IR:
         IRLogServiceFactory.load_all(self, aconf)
 
         # After the Ambassador and TLS modules are done, we need to set up the
-        # filter chains, which requires checking in on the auth, and
-        # ratelimit configuration. Note that order of the filters matter.
+        # filter chains. Note that order of the filters matters. Start with auth,
+        # since it needs to be able to override everything...
         self.save_filter(IRAuth(self, aconf))
-
-        # ...note that ratelimit is a filter too...
-        if self.ratelimit:
-            self.save_filter(self.ratelimit, already_saved=True)
 
         # ...then deal with the non-configurable cors filter...
         self.save_filter(IRFilter(ir=self, aconf=aconf,
                                   rkey="ir.cors", kind="ir.cors", name="cors",
                                   config={}))
 
-        # ...and the marginally-configurable router filter.
+        # ...then the ratelimit filter...
+        if self.ratelimit:
+            self.save_filter(self.ratelimit, already_saved=True)
+
+        # ...and, finally, the barely-configurable router filter.
         router_config = {}
 
         if self.tracing:

--- a/python/kat/harness.py
+++ b/python/kat/harness.py
@@ -1045,7 +1045,7 @@ class Runner:
         self.done = False
         self.skip_nonlocal_tests = False
         self.ids_to_strip: Dict[str, bool] = {}
-        self.names_to_strip: Dict[str, bool] = {}
+        self.names_to_ignore: Dict[str, bool] = {}
 
         @pytest.mark.parametrize("t", self.tests, ids=self.ids)
         def test(request, capsys, t):

--- a/python/tests/gold/ratelimitv0test/snapshots/aconf.json
+++ b/python/tests/gold/ratelimitv0test/snapshots/aconf.json
@@ -11,7 +11,7 @@
     "_sources": {
         "--diagnostics--": {
             "_referenced_by": {},
-            "apiVersion": "ambassador/v0",
+            "apiVersion": "getambassador.io/v0",
             "description": "The '--diagnostics--' source marks objects created by Ambassador to assist with diagnostic output.",
             "kind": "Diagnostics",
             "location": "--diagnostics--",
@@ -19,11 +19,11 @@
             "namespace": null,
             "rkey": "--diagnostics--",
             "serialization": null,
-            "version": "ambassador/v0"
+            "version": "getambassador.io/v0"
         },
         "--internal--": {
             "_referenced_by": {},
-            "apiVersion": "ambassador/v0",
+            "apiVersion": "getambassador.io/v0",
             "description": "The '--internal--' source marks objects created by Ambassador's internal logic.",
             "kind": "Internal",
             "location": "--internal--",
@@ -31,62 +31,84 @@
             "namespace": null,
             "rkey": "--internal--",
             "serialization": null,
-            "version": "ambassador/v0"
+            "version": "getambassador.io/v0"
         },
         "k8s-rate-limit-v0-default": {
             "_referenced_by": {},
             "ambassador_id": "ratelimitv0test",
-            "apiVersion": "ambassador/v1",
+            "apiVersion": "getambassador.io/v2",
             "endpoints": {},
             "kind": "Service",
             "location": "k8s-rate-limit-v0-default",
+            "metadata_labels": {
+                "kat-ambassador-id": "ratelimitv0test",
+                "scope": "AmbassadorTest"
+            },
             "name": "rate-limit-v0",
             "namespace": "default",
             "rkey": "k8s-rate-limit-v0-default",
-            "serialization": "ambassador_id: ratelimitv0test\napiVersion: ambassador/v1\nendpoints: {}\nkind: Service\nname: rate-limit-v0\nnamespace: default\n"
+            "serialization": "ambassador_id: ratelimitv0test\napiVersion: getambassador.io/v2\nendpoints: {}\nkind: Service\nmetadata_labels:\n  kat-ambassador-id: ratelimitv0test\n  scope: AmbassadorTest\nname: rate-limit-v0\nnamespace: default\n"
         },
         "k8s-ratelimitv0test-admin-default": {
             "_referenced_by": {},
             "ambassador_id": "ratelimitv0test",
-            "apiVersion": "ambassador/v1",
+            "apiVersion": "getambassador.io/v2",
             "endpoints": {},
             "kind": "Service",
             "location": "k8s-ratelimitv0test-admin-default",
+            "metadata_labels": {
+                "kat-ambassador-id": "ratelimitv0test",
+                "scope": "AmbassadorTest",
+                "service": "ratelimitv0test-admin"
+            },
             "name": "ratelimitv0test-admin",
             "namespace": "default",
             "rkey": "k8s-ratelimitv0test-admin-default",
-            "serialization": "ambassador_id: ratelimitv0test\napiVersion: ambassador/v1\nendpoints: {}\nkind: Service\nname: ratelimitv0test-admin\nnamespace: default\n"
+            "serialization": "ambassador_id: ratelimitv0test\napiVersion: getambassador.io/v2\nendpoints: {}\nkind: Service\nmetadata_labels:\n  kat-ambassador-id: ratelimitv0test\n  scope: AmbassadorTest\n  service: ratelimitv0test-admin\nname: ratelimitv0test-admin\nnamespace: default\n"
         },
         "k8s-ratelimitv0test-default": {
             "_referenced_by": {},
             "ambassador_id": "ratelimitv0test",
-            "apiVersion": "ambassador/v1",
+            "apiVersion": "getambassador.io/v2",
             "endpoints": {},
             "kind": "Service",
             "location": "k8s-ratelimitv0test-default",
+            "metadata_labels": {
+                "app.kubernetes.io/component": "ambassador-service",
+                "kat-ambassador-id": "ratelimitv0test",
+                "scope": "AmbassadorTest"
+            },
             "name": "ratelimitv0test",
             "namespace": "default",
             "rkey": "k8s-ratelimitv0test-default",
-            "serialization": "ambassador_id: ratelimitv0test\napiVersion: ambassador/v1\nendpoints: {}\nkind: Service\nname: ratelimitv0test\nnamespace: default\n"
+            "serialization": "ambassador_id: ratelimitv0test\napiVersion: getambassador.io/v2\nendpoints: {}\nkind: Service\nmetadata_labels:\n  app.kubernetes.io/component: ambassador-service\n  kat-ambassador-id: ratelimitv0test\n  scope: AmbassadorTest\nname: ratelimitv0test\nnamespace: default\n"
         },
         "k8s-ratelimitv0test-http-default": {
             "_referenced_by": {},
             "ambassador_id": "ratelimitv0test",
-            "apiVersion": "ambassador/v1",
+            "apiVersion": "getambassador.io/v2",
             "endpoints": {},
             "kind": "Service",
             "location": "k8s-ratelimitv0test-http-default",
+            "metadata_labels": {
+                "kat-ambassador-id": "ratelimitv0test",
+                "scope": "AmbassadorTest"
+            },
             "name": "ratelimitv0test-http",
             "namespace": "default",
             "rkey": "k8s-ratelimitv0test-http-default",
-            "serialization": "ambassador_id: ratelimitv0test\napiVersion: ambassador/v1\nendpoints: {}\nkind: Service\nname: ratelimitv0test-http\nnamespace: default\n"
+            "serialization": "ambassador_id: ratelimitv0test\napiVersion: getambassador.io/v2\nendpoints: {}\nkind: Service\nmetadata_labels:\n  kat-ambassador-id: ratelimitv0test\n  scope: AmbassadorTest\nname: ratelimitv0test-http\nnamespace: default\n"
         },
         "ratelimitv0test-http.default.1": {
             "_referenced_by": {},
             "ambassador_id": "ratelimitv0test",
-            "apiVersion": "ambassador/v0",
+            "apiVersion": "getambassador.io/v0",
             "kind": "Mapping",
             "location": "ratelimitv0test-http.default.1",
+            "metadata_labels": {
+                "kat-ambassador-id": "ratelimitv0test",
+                "scope": "AmbassadorTest"
+            },
             "name": "ratelimit_target_mapping",
             "namespace": "default",
             "prefix": "/target/",
@@ -99,13 +121,13 @@
                 }
             ],
             "rkey": "ratelimitv0test-http.default.1",
-            "serialization": "ambassador_id: ratelimitv0test\napiVersion: ambassador/v0\nkind: Mapping\nname: ratelimit_target_mapping\nprefix: /target/\nrate_limits:\n- descriptor: A test case\n  headers:\n  - x-ambassador-test-allow\nservice: ratelimitv0test-http\n",
+            "serialization": "ambassador_id: ratelimitv0test\napiVersion: ambassador/v0\nkind: Mapping\nmetadata_labels:\n  kat-ambassador-id: ratelimitv0test\n  scope: AmbassadorTest\nname: ratelimit_target_mapping\nprefix: /target/\nrate_limits:\n- descriptor: A test case\n  headers:\n  - x-ambassador-test-allow\nservice: ratelimitv0test-http\n",
             "service": "ratelimitv0test-http"
         },
         "ratelimitv0test-http.default.2": {
             "_referenced_by": {},
             "ambassador_id": "ratelimitv0test",
-            "apiVersion": "ambassador/v1",
+            "apiVersion": "getambassador.io/v1",
             "kind": "Mapping",
             "labels": {
                 "ambassador": [
@@ -138,23 +160,32 @@
                 ]
             },
             "location": "ratelimitv0test-http.default.2",
+            "metadata_labels": {
+                "kat-ambassador-id": "ratelimitv0test",
+                "scope": "AmbassadorTest"
+            },
             "name": "ratelimit_label_mapping",
             "namespace": "default",
             "prefix": "/labels/",
             "rkey": "ratelimitv0test-http.default.2",
-            "serialization": "ambassador_id: ratelimitv0test\napiVersion: ambassador/v1\nkind: Mapping\nlabels:\n  ambassador:\n  - host_and_user:\n    - custom-label:\n        header: :authority\n        omit_if_not_present: true\n    - user:\n        header: x-user\n        omit_if_not_present: true\n  - omg_header:\n    - custom-label:\n        default: OMFG!\n        header: x-omg\nname: ratelimit_label_mapping\nprefix: /labels/\nservice: ratelimitv0test-http\n",
+            "serialization": "ambassador_id: ratelimitv0test\napiVersion: ambassador/v1\nkind: Mapping\nlabels:\n  ambassador:\n  - host_and_user:\n    - custom-label:\n        header: :authority\n        omit_if_not_present: true\n    - user:\n        header: x-user\n        omit_if_not_present: true\n  - omg_header:\n    - custom-label:\n        default: OMFG!\n        header: x-omg\nmetadata_labels:\n  kat-ambassador-id: ratelimitv0test\n  scope: AmbassadorTest\nname: ratelimit_label_mapping\nprefix: /labels/\nservice: ratelimitv0test-http\n",
             "service": "ratelimitv0test-http"
         },
         "ratelimitv0test.default.1": {
             "_referenced_by": {},
             "ambassador_id": "ratelimitv0test",
-            "apiVersion": "ambassador/v0",
+            "apiVersion": "getambassador.io/v0",
             "kind": "RateLimitService",
             "location": "ratelimitv0test.default.1",
+            "metadata_labels": {
+                "app.kubernetes.io/component": "ambassador-service",
+                "kat-ambassador-id": "ratelimitv0test",
+                "scope": "AmbassadorTest"
+            },
             "name": "ratelimit-v0",
             "namespace": "default",
             "rkey": "ratelimitv0test.default.1",
-            "serialization": "ambassador_id: ratelimitv0test\napiVersion: ambassador/v0\nkind: RateLimitService\nname: ratelimit-v0\nservice: rate-limit-v0:5000\ntimeout_ms: 500\n",
+            "serialization": "ambassador_id: ratelimitv0test\napiVersion: ambassador/v0\nkind: RateLimitService\nmetadata_labels:\n  app.kubernetes.io/component: ambassador-service\n  kat-ambassador-id: ratelimitv0test\n  scope: AmbassadorTest\nname: ratelimit-v0\nservice: rate-limit-v0:5000\ntimeout_ms: 500\n",
             "service": "rate-limit-v0:5000",
             "timeout_ms": 500
         }
@@ -162,7 +193,7 @@
     "mappings": {
         "ratelimit_label_mapping": {
             "ambassador_id": "ratelimitv0test",
-            "apiVersion": "ambassador/v1",
+            "apiVersion": "getambassador.io/v1",
             "kind": "Mapping",
             "labels": {
                 "ambassador": [
@@ -194,6 +225,10 @@
                     }
                 ]
             },
+            "metadata_labels": {
+                "kat-ambassador-id": "ratelimitv0test",
+                "scope": "AmbassadorTest"
+            },
             "name": "ratelimit_label_mapping",
             "namespace": "default",
             "prefix": "/labels/",
@@ -201,8 +236,12 @@
         },
         "ratelimit_target_mapping": {
             "ambassador_id": "ratelimitv0test",
-            "apiVersion": "ambassador/v0",
+            "apiVersion": "getambassador.io/v0",
             "kind": "Mapping",
+            "metadata_labels": {
+                "kat-ambassador-id": "ratelimitv0test",
+                "scope": "AmbassadorTest"
+            },
             "name": "ratelimit_target_mapping",
             "namespace": "default",
             "prefix": "/target/",
@@ -220,8 +259,13 @@
     "ratelimit_configs": {
         "ratelimit-v0": {
             "ambassador_id": "ratelimitv0test",
-            "apiVersion": "ambassador/v0",
+            "apiVersion": "getambassador.io/v0",
             "kind": "RateLimitService",
+            "metadata_labels": {
+                "app.kubernetes.io/component": "ambassador-service",
+                "kat-ambassador-id": "ratelimitv0test",
+                "scope": "AmbassadorTest"
+            },
             "name": "ratelimit-v0",
             "namespace": "default",
             "service": "rate-limit-v0:5000",
@@ -231,33 +275,51 @@
     "service": {
         "k8s-rate-limit-v0-default": {
             "ambassador_id": "ratelimitv0test",
-            "apiVersion": "ambassador/v1",
+            "apiVersion": "getambassador.io/v2",
             "endpoints": {},
             "kind": "Service",
+            "metadata_labels": {
+                "kat-ambassador-id": "ratelimitv0test",
+                "scope": "AmbassadorTest"
+            },
             "name": "rate-limit-v0",
             "namespace": "default"
         },
         "k8s-ratelimitv0test-admin-default": {
             "ambassador_id": "ratelimitv0test",
-            "apiVersion": "ambassador/v1",
+            "apiVersion": "getambassador.io/v2",
             "endpoints": {},
             "kind": "Service",
+            "metadata_labels": {
+                "kat-ambassador-id": "ratelimitv0test",
+                "scope": "AmbassadorTest",
+                "service": "ratelimitv0test-admin"
+            },
             "name": "ratelimitv0test-admin",
             "namespace": "default"
         },
         "k8s-ratelimitv0test-default": {
             "ambassador_id": "ratelimitv0test",
-            "apiVersion": "ambassador/v1",
+            "apiVersion": "getambassador.io/v2",
             "endpoints": {},
             "kind": "Service",
+            "metadata_labels": {
+                "app.kubernetes.io/component": "ambassador-service",
+                "kat-ambassador-id": "ratelimitv0test",
+                "scope": "AmbassadorTest"
+            },
             "name": "ratelimitv0test",
             "namespace": "default"
         },
         "k8s-ratelimitv0test-http-default": {
             "ambassador_id": "ratelimitv0test",
-            "apiVersion": "ambassador/v1",
+            "apiVersion": "getambassador.io/v2",
             "endpoints": {},
             "kind": "Service",
+            "metadata_labels": {
+                "kat-ambassador-id": "ratelimitv0test",
+                "scope": "AmbassadorTest"
+            },
             "name": "ratelimitv0test-http",
             "namespace": "default"
         }

--- a/python/tests/gold/ratelimitv0test/snapshots/econf.json
+++ b/python/tests/gold/ratelimitv0test/snapshots/econf.json
@@ -109,6 +109,9 @@
                                     ],
                                     "http_filters": [
                                         {
+                                            "name": "envoy.cors"
+                                        },
+                                        {
                                             "config": {
                                                 "domain": "ambassador",
                                                 "rate_limit_service": {
@@ -122,9 +125,6 @@
                                                 "timeout": "0.500s"
                                             },
                                             "name": "envoy.rate_limit"
-                                        },
-                                        {
-                                            "name": "envoy.cors"
                                         },
                                         {
                                             "name": "envoy.router"

--- a/python/tests/gold/ratelimitv0test/snapshots/ir.json
+++ b/python/tests/gold/ratelimitv0test/snapshots/ir.json
@@ -149,6 +149,16 @@
         {
             "_active": true,
             "_errored": false,
+            "_rkey": "ir.cors",
+            "config": {},
+            "kind": "ir.cors",
+            "location": "--internal--",
+            "name": "cors",
+            "namespace": "default"
+        },
+        {
+            "_active": true,
+            "_errored": false,
             "_referenced_by": [
                 "ratelimitv0test.default.1"
             ],
@@ -236,16 +246,6 @@
         {
             "_active": true,
             "_errored": false,
-            "_rkey": "ir.cors",
-            "config": {},
-            "kind": "ir.cors",
-            "location": "--internal--",
-            "name": "cors",
-            "namespace": "default"
-        },
-        {
-            "_active": true,
-            "_errored": false,
             "_rkey": "ir.router",
             "config": {},
             "kind": "ir.router",
@@ -318,7 +318,7 @@
                     },
                     "group_id": "b4db12f5b638f1750062dd4220911c4f6f44fc57",
                     "headers": [],
-                    "kind": "IRMapping",
+                    "kind": "IRHTTPMapping",
                     "location": "--internal--",
                     "name": "internal_readiness_probe_mapping",
                     "namespace": "default",
@@ -407,7 +407,7 @@
                     },
                     "group_id": "7df546235997704c909d473af2cbcb5e606d20de",
                     "headers": [],
-                    "kind": "IRMapping",
+                    "kind": "IRHTTPMapping",
                     "location": "--internal--",
                     "name": "internal_liveness_probe_mapping",
                     "namespace": "default",
@@ -496,7 +496,7 @@
                     },
                     "group_id": "8de18501d2044fe30db225289b318d5fda913b64",
                     "headers": [],
-                    "kind": "IRMapping",
+                    "kind": "IRHTTPMapping",
                     "location": "--internal--",
                     "name": "internal_diagnostics_probe_mapping",
                     "namespace": "default",
@@ -625,6 +625,10 @@
                         ]
                     },
                     "location": "ratelimitv0test-http.default.1",
+                    "metadata_labels": {
+                        "kat-ambassador-id": "ratelimitv0test",
+                        "scope": "AmbassadorTest"
+                    },
                     "name": "ratelimit_target_mapping",
                     "namespace": "default",
                     "precedence": 0,
@@ -638,17 +642,21 @@
                         "/target/",
                         "GET"
                     ],
-                    "serialization": "ambassador_id: ratelimitv0test\napiVersion: ambassador/v0\nkind: Mapping\nname: ratelimit_target_mapping\nprefix: /target/\nrate_limits:\n- descriptor: A test case\n  headers:\n  - x-ambassador-test-allow\nservice: ratelimitv0test-http\n",
+                    "serialization": "ambassador_id: ratelimitv0test\napiVersion: ambassador/v0\nkind: Mapping\nmetadata_labels:\n  kat-ambassador-id: ratelimitv0test\n  scope: AmbassadorTest\nname: ratelimit_target_mapping\nprefix: /target/\nrate_limits:\n- descriptor: A test case\n  headers:\n  - x-ambassador-test-allow\nservice: ratelimitv0test-http\n",
                     "service": "ratelimitv0test-http",
                     "weight": 100
                 }
             ],
+            "metadata_labels": {
+                "kat-ambassador-id": "ratelimitv0test",
+                "scope": "AmbassadorTest"
+            },
             "name": "GROUP: ratelimit_target_mapping",
             "namespace": "default",
             "precedence": 0,
             "prefix": "/target/",
             "rewrite": "/",
-            "serialization": "ambassador_id: ratelimitv0test\napiVersion: ambassador/v0\nkind: Mapping\nname: ratelimit_target_mapping\nprefix: /target/\nrate_limits:\n- descriptor: A test case\n  headers:\n  - x-ambassador-test-allow\nservice: ratelimitv0test-http\n"
+            "serialization": "ambassador_id: ratelimitv0test\napiVersion: ambassador/v0\nkind: Mapping\nmetadata_labels:\n  kat-ambassador-id: ratelimitv0test\n  scope: AmbassadorTest\nname: ratelimit_target_mapping\nprefix: /target/\nrate_limits:\n- descriptor: A test case\n  headers:\n  - x-ambassador-test-allow\nservice: ratelimitv0test-http\n"
         },
         {
             "_active": true,
@@ -772,6 +780,10 @@
                         ]
                     },
                     "location": "ratelimitv0test-http.default.2",
+                    "metadata_labels": {
+                        "kat-ambassador-id": "ratelimitv0test",
+                        "scope": "AmbassadorTest"
+                    },
                     "name": "ratelimit_label_mapping",
                     "namespace": "default",
                     "precedence": 0,
@@ -785,17 +797,21 @@
                         "/labels/",
                         "GET"
                     ],
-                    "serialization": "ambassador_id: ratelimitv0test\napiVersion: ambassador/v1\nkind: Mapping\nlabels:\n  ambassador:\n  - host_and_user:\n    - custom-label:\n        header: :authority\n        omit_if_not_present: true\n    - user:\n        header: x-user\n        omit_if_not_present: true\n  - omg_header:\n    - custom-label:\n        default: OMFG!\n        header: x-omg\nname: ratelimit_label_mapping\nprefix: /labels/\nservice: ratelimitv0test-http\n",
+                    "serialization": "ambassador_id: ratelimitv0test\napiVersion: ambassador/v1\nkind: Mapping\nlabels:\n  ambassador:\n  - host_and_user:\n    - custom-label:\n        header: :authority\n        omit_if_not_present: true\n    - user:\n        header: x-user\n        omit_if_not_present: true\n  - omg_header:\n    - custom-label:\n        default: OMFG!\n        header: x-omg\nmetadata_labels:\n  kat-ambassador-id: ratelimitv0test\n  scope: AmbassadorTest\nname: ratelimit_label_mapping\nprefix: /labels/\nservice: ratelimitv0test-http\n",
                     "service": "ratelimitv0test-http",
                     "weight": 100
                 }
             ],
+            "metadata_labels": {
+                "kat-ambassador-id": "ratelimitv0test",
+                "scope": "AmbassadorTest"
+            },
             "name": "GROUP: ratelimit_label_mapping",
             "namespace": "default",
             "precedence": 0,
             "prefix": "/labels/",
             "rewrite": "/",
-            "serialization": "ambassador_id: ratelimitv0test\napiVersion: ambassador/v1\nkind: Mapping\nlabels:\n  ambassador:\n  - host_and_user:\n    - custom-label:\n        header: :authority\n        omit_if_not_present: true\n    - user:\n        header: x-user\n        omit_if_not_present: true\n  - omg_header:\n    - custom-label:\n        default: OMFG!\n        header: x-omg\nname: ratelimit_label_mapping\nprefix: /labels/\nservice: ratelimitv0test-http\n"
+            "serialization": "ambassador_id: ratelimitv0test\napiVersion: ambassador/v1\nkind: Mapping\nlabels:\n  ambassador:\n  - host_and_user:\n    - custom-label:\n        header: :authority\n        omit_if_not_present: true\n    - user:\n        header: x-user\n        omit_if_not_present: true\n  - omg_header:\n    - custom-label:\n        default: OMFG!\n        header: x-omg\nmetadata_labels:\n  kat-ambassador-id: ratelimitv0test\n  scope: AmbassadorTest\nname: ratelimit_label_mapping\nprefix: /labels/\nservice: ratelimitv0test-http\n"
         }
     ],
     "grpc_services": {
@@ -948,50 +964,68 @@
         "k8s-rate-limit-v0-default": {
             "_referenced_by": {},
             "ambassador_id": "ratelimitv0test",
-            "apiVersion": "ambassador/v1",
+            "apiVersion": "getambassador.io/v2",
             "endpoints": {},
             "kind": "Service",
             "location": "k8s-rate-limit-v0-default",
+            "metadata_labels": {
+                "kat-ambassador-id": "ratelimitv0test",
+                "scope": "AmbassadorTest"
+            },
             "name": "rate-limit-v0",
             "namespace": "default",
             "rkey": "k8s-rate-limit-v0-default",
-            "serialization": "ambassador_id: ratelimitv0test\napiVersion: ambassador/v1\nendpoints: {}\nkind: Service\nname: rate-limit-v0\nnamespace: default\n"
+            "serialization": "ambassador_id: ratelimitv0test\napiVersion: getambassador.io/v2\nendpoints: {}\nkind: Service\nmetadata_labels:\n  kat-ambassador-id: ratelimitv0test\n  scope: AmbassadorTest\nname: rate-limit-v0\nnamespace: default\n"
         },
         "k8s-ratelimitv0test-admin-default": {
             "_referenced_by": {},
             "ambassador_id": "ratelimitv0test",
-            "apiVersion": "ambassador/v1",
+            "apiVersion": "getambassador.io/v2",
             "endpoints": {},
             "kind": "Service",
             "location": "k8s-ratelimitv0test-admin-default",
+            "metadata_labels": {
+                "kat-ambassador-id": "ratelimitv0test",
+                "scope": "AmbassadorTest",
+                "service": "ratelimitv0test-admin"
+            },
             "name": "ratelimitv0test-admin",
             "namespace": "default",
             "rkey": "k8s-ratelimitv0test-admin-default",
-            "serialization": "ambassador_id: ratelimitv0test\napiVersion: ambassador/v1\nendpoints: {}\nkind: Service\nname: ratelimitv0test-admin\nnamespace: default\n"
+            "serialization": "ambassador_id: ratelimitv0test\napiVersion: getambassador.io/v2\nendpoints: {}\nkind: Service\nmetadata_labels:\n  kat-ambassador-id: ratelimitv0test\n  scope: AmbassadorTest\n  service: ratelimitv0test-admin\nname: ratelimitv0test-admin\nnamespace: default\n"
         },
         "k8s-ratelimitv0test-default": {
             "_referenced_by": {},
             "ambassador_id": "ratelimitv0test",
-            "apiVersion": "ambassador/v1",
+            "apiVersion": "getambassador.io/v2",
             "endpoints": {},
             "kind": "Service",
             "location": "k8s-ratelimitv0test-default",
+            "metadata_labels": {
+                "app.kubernetes.io/component": "ambassador-service",
+                "kat-ambassador-id": "ratelimitv0test",
+                "scope": "AmbassadorTest"
+            },
             "name": "ratelimitv0test",
             "namespace": "default",
             "rkey": "k8s-ratelimitv0test-default",
-            "serialization": "ambassador_id: ratelimitv0test\napiVersion: ambassador/v1\nendpoints: {}\nkind: Service\nname: ratelimitv0test\nnamespace: default\n"
+            "serialization": "ambassador_id: ratelimitv0test\napiVersion: getambassador.io/v2\nendpoints: {}\nkind: Service\nmetadata_labels:\n  app.kubernetes.io/component: ambassador-service\n  kat-ambassador-id: ratelimitv0test\n  scope: AmbassadorTest\nname: ratelimitv0test\nnamespace: default\n"
         },
         "k8s-ratelimitv0test-http-default": {
             "_referenced_by": {},
             "ambassador_id": "ratelimitv0test",
-            "apiVersion": "ambassador/v1",
+            "apiVersion": "getambassador.io/v2",
             "endpoints": {},
             "kind": "Service",
             "location": "k8s-ratelimitv0test-http-default",
+            "metadata_labels": {
+                "kat-ambassador-id": "ratelimitv0test",
+                "scope": "AmbassadorTest"
+            },
             "name": "ratelimitv0test-http",
             "namespace": "default",
             "rkey": "k8s-ratelimitv0test-http-default",
-            "serialization": "ambassador_id: ratelimitv0test\napiVersion: ambassador/v1\nendpoints: {}\nkind: Service\nname: ratelimitv0test-http\nnamespace: default\n"
+            "serialization": "ambassador_id: ratelimitv0test\napiVersion: getambassador.io/v2\nendpoints: {}\nkind: Service\nmetadata_labels:\n  kat-ambassador-id: ratelimitv0test\n  scope: AmbassadorTest\nname: ratelimitv0test-http\nnamespace: default\n"
         }
     },
     "tls_contexts": []

--- a/python/tests/gold/ratelimitv0test/snapshots/snapshot.yaml
+++ b/python/tests/gold/ratelimitv0test/snapshots/snapshot.yaml
@@ -20,21 +20,66 @@
                 "kind": "Service",
                 "metadata": {
                     "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: ratelimit_target_mapping\nprefix: /target/\nservice: ratelimitv0test-http\nrate_limits:\n- descriptor: A test case\n  headers:\n  - \"x-ambassador-test-allow\"\nambassador_id: ratelimitv0test\n---\napiVersion: ambassador/v1\nkind: Mapping\nname: ratelimit_label_mapping\nprefix: /labels/\nservice: ratelimitv0test-http\nlabels:\n  ambassador:\n  - host_and_user:\n    - custom-label:\n        header: \":authority\"\n        omit_if_not_present: true\n    - user:\n        header: \"x-user\"\n        omit_if_not_present: true\n  - omg_header:\n    - custom-label:\n        header: \"x-omg\"\n        default: \"OMFG!\"\nambassador_id: ratelimitv0test\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: ratelimit_target_mapping\\nprefix: /target/\\nservice: ratelimitv0test-http\\nrate_limits:\\n- descriptor: A test case\\n  headers:\\n  - \\\"x-ambassador-test-allow\\\"\\nambassador_id: ratelimitv0test\\n---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: ratelimit_label_mapping\\nprefix: /labels/\\nservice: ratelimitv0test-http\\nlabels:\\n  ambassador:\\n  - host_and_user:\\n    - custom-label:\\n        header: \\\":authority\\\"\\n        omit_if_not_present: true\\n    - user:\\n        header: \\\"x-user\\\"\\n        omit_if_not_present: true\\n  - omg_header:\\n    - custom-label:\\n        header: \\\"x-omg\\\"\\n        default: \\\"OMFG!\\\"\\nambassador_id: ratelimitv0test\\n\"},\"labels\":{\"kat-ambassador-id\":\"ratelimitv0test\",\"scope\":\"AmbassadorTest\"},\"name\":\"ratelimitv0test-http\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8080},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8443}],\"selector\":{\"backend\":\"superpod-default\"}}}\n"
+                    },
+                    "creationTimestamp": "2019-11-13T20:38:21Z",
+                    "labels": {
+                        "kat-ambassador-id": "ratelimitv0test",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "ratelimitv0test-http",
+                    "namespace": "default",
+                    "resourceVersion": "103383",
+                    "selfLink": "/api/v1/namespaces/default/services/ratelimitv0test-http",
+                    "uid": "8879e366-0655-11ea-8a6b-063c64bfaacb"
+                },
+                "spec": {
+                    "clusterIP": "10.103.103.176",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8080
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8443
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-default"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"ratelimitv0test\",\"scope\":\"AmbassadorTest\"},\"name\":\"rate-limit-v0\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"grpc\",\"port\":5000,\"targetPort\":\"grpc\"}],\"selector\":{\"app\":\"rate-limit-v0\"},\"type\":\"ClusterIP\"}}\n"
                     },
-                    "creationTimestamp": "2019-11-04T05:43:49Z",
+                    "creationTimestamp": "2019-11-13T20:38:21Z",
                     "labels": {
                         "kat-ambassador-id": "ratelimitv0test",
                         "scope": "AmbassadorTest"
                     },
                     "name": "rate-limit-v0",
                     "namespace": "default",
-                    "resourceVersion": "12861",
+                    "resourceVersion": "103364",
                     "selfLink": "/api/v1/namespaces/default/services/rate-limit-v0",
-                    "uid": "1350682a-fec6-11e9-8b1f-120e67b61000"
+                    "uid": "8857e406-0655-11ea-8a6b-063c64bfaacb"
                 },
                 "spec": {
-                    "clusterIP": "10.107.195.141",
+                    "clusterIP": "10.109.237.226",
                     "ports": [
                         {
                             "name": "grpc",
@@ -61,7 +106,7 @@
                         "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: RateLimitService\nname: ratelimit-v0\nservice: rate-limit-v0:5000\ntimeout_ms: 500\nambassador_id: ratelimitv0test\n",
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: RateLimitService\\nname: ratelimit-v0\\nservice: rate-limit-v0:5000\\ntimeout_ms: 500\\nambassador_id: ratelimitv0test\\n\"},\"labels\":{\"app.kubernetes.io/component\":\"ambassador-service\",\"kat-ambassador-id\":\"ratelimitv0test\",\"scope\":\"AmbassadorTest\"},\"name\":\"ratelimitv0test\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8080},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8443}],\"selector\":{\"service\":\"ratelimitv0test\"},\"type\":\"NodePort\"}}\n"
                     },
-                    "creationTimestamp": "2019-11-04T05:43:49Z",
+                    "creationTimestamp": "2019-11-13T20:38:21Z",
                     "labels": {
                         "app.kubernetes.io/component": "ambassador-service",
                         "kat-ambassador-id": "ratelimitv0test",
@@ -69,24 +114,24 @@
                     },
                     "name": "ratelimitv0test",
                     "namespace": "default",
-                    "resourceVersion": "12850",
+                    "resourceVersion": "103353",
                     "selfLink": "/api/v1/namespaces/default/services/ratelimitv0test",
-                    "uid": "133219e6-fec6-11e9-8b1f-120e67b61000"
+                    "uid": "88426139-0655-11ea-8a6b-063c64bfaacb"
                 },
                 "spec": {
-                    "clusterIP": "10.101.82.232",
+                    "clusterIP": "10.103.180.75",
                     "externalTrafficPolicy": "Cluster",
                     "ports": [
                         {
                             "name": "http",
-                            "nodePort": 31270,
+                            "nodePort": 32453,
                             "port": 80,
                             "protocol": "TCP",
                             "targetPort": 8080
                         },
                         {
                             "name": "https",
-                            "nodePort": 32260,
+                            "nodePort": 30571,
                             "port": 443,
                             "protocol": "TCP",
                             "targetPort": 8443
@@ -109,7 +154,7 @@
                     "annotations": {
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"ratelimitv0test\",\"scope\":\"AmbassadorTest\",\"service\":\"ratelimitv0test-admin\"},\"name\":\"ratelimitv0test-admin\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"ratelimitv0test-admin\",\"port\":8877,\"targetPort\":8877}],\"selector\":{\"service\":\"ratelimitv0test\"},\"type\":\"NodePort\"}}\n"
                     },
-                    "creationTimestamp": "2019-11-04T05:43:49Z",
+                    "creationTimestamp": "2019-11-13T20:38:21Z",
                     "labels": {
                         "kat-ambassador-id": "ratelimitv0test",
                         "scope": "AmbassadorTest",
@@ -117,17 +162,17 @@
                     },
                     "name": "ratelimitv0test-admin",
                     "namespace": "default",
-                    "resourceVersion": "12855",
+                    "resourceVersion": "103357",
                     "selfLink": "/api/v1/namespaces/default/services/ratelimitv0test-admin",
-                    "uid": "133c6894-fec6-11e9-8b1f-120e67b61000"
+                    "uid": "884af818-0655-11ea-8a6b-063c64bfaacb"
                 },
                 "spec": {
-                    "clusterIP": "10.98.112.18",
+                    "clusterIP": "10.111.75.241",
                     "externalTrafficPolicy": "Cluster",
                     "ports": [
                         {
                             "name": "ratelimitv0test-admin",
-                            "nodePort": 31355,
+                            "nodePort": 32533,
                             "port": 8877,
                             "protocol": "TCP",
                             "targetPort": 8877
@@ -138,51 +183,6 @@
                     },
                     "sessionAffinity": "None",
                     "type": "NodePort"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: ratelimit_target_mapping\nprefix: /target/\nservice: ratelimitv0test-http\nrate_limits:\n- descriptor: A test case\n  headers:\n  - \"x-ambassador-test-allow\"\nambassador_id: ratelimitv0test\n---\napiVersion: ambassador/v1\nkind: Mapping\nname: ratelimit_label_mapping\nprefix: /labels/\nservice: ratelimitv0test-http\nlabels:\n  ambassador:\n  - host_and_user:\n    - custom-label:\n        header: \":authority\"\n        omit_if_not_present: true\n    - user:\n        header: \"x-user\"\n        omit_if_not_present: true\n  - omg_header:\n    - custom-label:\n        header: \"x-omg\"\n        default: \"OMFG!\"\nambassador_id: ratelimitv0test\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: ratelimit_target_mapping\\nprefix: /target/\\nservice: ratelimitv0test-http\\nrate_limits:\\n- descriptor: A test case\\n  headers:\\n  - \\\"x-ambassador-test-allow\\\"\\nambassador_id: ratelimitv0test\\n---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: ratelimit_label_mapping\\nprefix: /labels/\\nservice: ratelimitv0test-http\\nlabels:\\n  ambassador:\\n  - host_and_user:\\n    - custom-label:\\n        header: \\\":authority\\\"\\n        omit_if_not_present: true\\n    - user:\\n        header: \\\"x-user\\\"\\n        omit_if_not_present: true\\n  - omg_header:\\n    - custom-label:\\n        header: \\\"x-omg\\\"\\n        default: \\\"OMFG!\\\"\\nambassador_id: ratelimitv0test\\n\"},\"labels\":{\"kat-ambassador-id\":\"ratelimitv0test\",\"scope\":\"AmbassadorTest\"},\"name\":\"ratelimitv0test-http\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8108},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8471}],\"selector\":{\"backend\":\"superpod-default\"}}}\n"
-                    },
-                    "creationTimestamp": "2019-11-04T05:43:49Z",
-                    "labels": {
-                        "kat-ambassador-id": "ratelimitv0test",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "ratelimitv0test-http",
-                    "namespace": "default",
-                    "resourceVersion": "12874",
-                    "selfLink": "/api/v1/namespaces/default/services/ratelimitv0test-http",
-                    "uid": "136d5c61-fec6-11e9-8b1f-120e67b61000"
-                },
-                "spec": {
-                    "clusterIP": "10.111.209.82",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8108
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8471
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-default"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
                 },
                 "status": {
                     "loadBalancer": {}

--- a/python/tests/gold/ratelimitv1test/snapshots/aconf.json
+++ b/python/tests/gold/ratelimitv1test/snapshots/aconf.json
@@ -4,7 +4,7 @@
     "_sources": {
         "--diagnostics--": {
             "_referenced_by": {},
-            "apiVersion": "ambassador/v0",
+            "apiVersion": "getambassador.io/v0",
             "description": "The '--diagnostics--' source marks objects created by Ambassador to assist with diagnostic output.",
             "kind": "Diagnostics",
             "location": "--diagnostics--",
@@ -12,11 +12,11 @@
             "namespace": null,
             "rkey": "--diagnostics--",
             "serialization": null,
-            "version": "ambassador/v0"
+            "version": "getambassador.io/v0"
         },
         "--internal--": {
             "_referenced_by": {},
-            "apiVersion": "ambassador/v0",
+            "apiVersion": "getambassador.io/v0",
             "description": "The '--internal--' source marks objects created by Ambassador's internal logic.",
             "kind": "Internal",
             "location": "--internal--",
@@ -24,60 +24,78 @@
             "namespace": null,
             "rkey": "--internal--",
             "serialization": null,
-            "version": "ambassador/v0"
+            "version": "getambassador.io/v0"
         },
         "k8s-rate-limit-v1-default": {
             "_referenced_by": {},
             "ambassador_id": "ratelimitv1test",
-            "apiVersion": "ambassador/v1",
+            "apiVersion": "getambassador.io/v2",
             "endpoints": {},
             "kind": "Service",
             "location": "k8s-rate-limit-v1-default",
+            "metadata_labels": {
+                "kat-ambassador-id": "ratelimitv1test",
+                "scope": "AmbassadorTest"
+            },
             "name": "rate-limit-v1",
             "namespace": "default",
             "rkey": "k8s-rate-limit-v1-default",
-            "serialization": "ambassador_id: ratelimitv1test\napiVersion: ambassador/v1\nendpoints: {}\nkind: Service\nname: rate-limit-v1\nnamespace: default\n"
+            "serialization": "ambassador_id: ratelimitv1test\napiVersion: getambassador.io/v2\nendpoints: {}\nkind: Service\nmetadata_labels:\n  kat-ambassador-id: ratelimitv1test\n  scope: AmbassadorTest\nname: rate-limit-v1\nnamespace: default\n"
         },
         "k8s-ratelimitv1test-admin-default": {
             "_referenced_by": {},
             "ambassador_id": "ratelimitv1test",
-            "apiVersion": "ambassador/v1",
+            "apiVersion": "getambassador.io/v2",
             "endpoints": {},
             "kind": "Service",
             "location": "k8s-ratelimitv1test-admin-default",
+            "metadata_labels": {
+                "kat-ambassador-id": "ratelimitv1test",
+                "scope": "AmbassadorTest",
+                "service": "ratelimitv1test-admin"
+            },
             "name": "ratelimitv1test-admin",
             "namespace": "default",
             "rkey": "k8s-ratelimitv1test-admin-default",
-            "serialization": "ambassador_id: ratelimitv1test\napiVersion: ambassador/v1\nendpoints: {}\nkind: Service\nname: ratelimitv1test-admin\nnamespace: default\n"
+            "serialization": "ambassador_id: ratelimitv1test\napiVersion: getambassador.io/v2\nendpoints: {}\nkind: Service\nmetadata_labels:\n  kat-ambassador-id: ratelimitv1test\n  scope: AmbassadorTest\n  service: ratelimitv1test-admin\nname: ratelimitv1test-admin\nnamespace: default\n"
         },
         "k8s-ratelimitv1test-default": {
             "_referenced_by": {},
             "ambassador_id": "ratelimitv1test",
-            "apiVersion": "ambassador/v1",
+            "apiVersion": "getambassador.io/v2",
             "endpoints": {},
             "kind": "Service",
             "location": "k8s-ratelimitv1test-default",
+            "metadata_labels": {
+                "app.kubernetes.io/component": "ambassador-service",
+                "kat-ambassador-id": "ratelimitv1test",
+                "scope": "AmbassadorTest"
+            },
             "name": "ratelimitv1test",
             "namespace": "default",
             "rkey": "k8s-ratelimitv1test-default",
-            "serialization": "ambassador_id: ratelimitv1test\napiVersion: ambassador/v1\nendpoints: {}\nkind: Service\nname: ratelimitv1test\nnamespace: default\n"
+            "serialization": "ambassador_id: ratelimitv1test\napiVersion: getambassador.io/v2\nendpoints: {}\nkind: Service\nmetadata_labels:\n  app.kubernetes.io/component: ambassador-service\n  kat-ambassador-id: ratelimitv1test\n  scope: AmbassadorTest\nname: ratelimitv1test\nnamespace: default\n"
         },
         "k8s-ratelimitv1test-http-default": {
             "_referenced_by": {},
             "ambassador_id": "ratelimitv1test",
-            "apiVersion": "ambassador/v1",
+            "apiVersion": "getambassador.io/v2",
             "endpoints": {},
             "kind": "Service",
             "location": "k8s-ratelimitv1test-http-default",
+            "metadata_labels": {
+                "kat-ambassador-id": "ratelimitv1test",
+                "scope": "AmbassadorTest"
+            },
             "name": "ratelimitv1test-http",
             "namespace": "default",
             "rkey": "k8s-ratelimitv1test-http-default",
-            "serialization": "ambassador_id: ratelimitv1test\napiVersion: ambassador/v1\nendpoints: {}\nkind: Service\nname: ratelimitv1test-http\nnamespace: default\n"
+            "serialization": "ambassador_id: ratelimitv1test\napiVersion: getambassador.io/v2\nendpoints: {}\nkind: Service\nmetadata_labels:\n  kat-ambassador-id: ratelimitv1test\n  scope: AmbassadorTest\nname: ratelimitv1test-http\nnamespace: default\n"
         },
         "ratelimitv1test-http.default.1": {
             "_referenced_by": {},
             "ambassador_id": "ratelimitv1test",
-            "apiVersion": "ambassador/v1",
+            "apiVersion": "getambassador.io/v1",
             "kind": "Mapping",
             "labels": {
                 "ambassador": [
@@ -94,23 +112,32 @@
                 ]
             },
             "location": "ratelimitv1test-http.default.1",
+            "metadata_labels": {
+                "kat-ambassador-id": "ratelimitv1test",
+                "scope": "AmbassadorTest"
+            },
             "name": "ratelimit_target_mapping",
             "namespace": "default",
             "prefix": "/target/",
             "rkey": "ratelimitv1test-http.default.1",
-            "serialization": "ambassador_id: ratelimitv1test\napiVersion: ambassador/v1\nkind: Mapping\nlabels:\n  ambassador:\n  - request_label_group:\n    - x-ambassador-test-allow:\n        header: x-ambassador-test-allow\n        omit_if_not_present: true\nname: ratelimit_target_mapping\nprefix: /target/\nservice: ratelimitv1test-http\n",
+            "serialization": "ambassador_id: ratelimitv1test\napiVersion: ambassador/v1\nkind: Mapping\nlabels:\n  ambassador:\n  - request_label_group:\n    - x-ambassador-test-allow:\n        header: x-ambassador-test-allow\n        omit_if_not_present: true\nmetadata_labels:\n  kat-ambassador-id: ratelimitv1test\n  scope: AmbassadorTest\nname: ratelimit_target_mapping\nprefix: /target/\nservice: ratelimitv1test-http\n",
             "service": "ratelimitv1test-http"
         },
         "ratelimitv1test.default.1": {
             "_referenced_by": {},
             "ambassador_id": "ratelimitv1test",
-            "apiVersion": "ambassador/v1",
+            "apiVersion": "getambassador.io/v1",
             "kind": "RateLimitService",
             "location": "ratelimitv1test.default.1",
+            "metadata_labels": {
+                "app.kubernetes.io/component": "ambassador-service",
+                "kat-ambassador-id": "ratelimitv1test",
+                "scope": "AmbassadorTest"
+            },
             "name": "ratelimit-v1",
             "namespace": "default",
             "rkey": "ratelimitv1test.default.1",
-            "serialization": "ambassador_id: ratelimitv1test\napiVersion: ambassador/v1\nkind: RateLimitService\nname: ratelimit-v1\nservice: rate-limit-v1:5000\ntimeout_ms: 500\n",
+            "serialization": "ambassador_id: ratelimitv1test\napiVersion: ambassador/v1\nkind: RateLimitService\nmetadata_labels:\n  app.kubernetes.io/component: ambassador-service\n  kat-ambassador-id: ratelimitv1test\n  scope: AmbassadorTest\nname: ratelimit-v1\nservice: rate-limit-v1:5000\ntimeout_ms: 500\n",
             "service": "rate-limit-v1:5000",
             "timeout_ms": 500
         }
@@ -118,7 +145,7 @@
     "mappings": {
         "ratelimit_target_mapping": {
             "ambassador_id": "ratelimitv1test",
-            "apiVersion": "ambassador/v1",
+            "apiVersion": "getambassador.io/v1",
             "kind": "Mapping",
             "labels": {
                 "ambassador": [
@@ -134,6 +161,10 @@
                     }
                 ]
             },
+            "metadata_labels": {
+                "kat-ambassador-id": "ratelimitv1test",
+                "scope": "AmbassadorTest"
+            },
             "name": "ratelimit_target_mapping",
             "namespace": "default",
             "prefix": "/target/",
@@ -143,8 +174,13 @@
     "ratelimit_configs": {
         "ratelimit-v1": {
             "ambassador_id": "ratelimitv1test",
-            "apiVersion": "ambassador/v1",
+            "apiVersion": "getambassador.io/v1",
             "kind": "RateLimitService",
+            "metadata_labels": {
+                "app.kubernetes.io/component": "ambassador-service",
+                "kat-ambassador-id": "ratelimitv1test",
+                "scope": "AmbassadorTest"
+            },
             "name": "ratelimit-v1",
             "namespace": "default",
             "service": "rate-limit-v1:5000",
@@ -154,33 +190,51 @@
     "service": {
         "k8s-rate-limit-v1-default": {
             "ambassador_id": "ratelimitv1test",
-            "apiVersion": "ambassador/v1",
+            "apiVersion": "getambassador.io/v2",
             "endpoints": {},
             "kind": "Service",
+            "metadata_labels": {
+                "kat-ambassador-id": "ratelimitv1test",
+                "scope": "AmbassadorTest"
+            },
             "name": "rate-limit-v1",
             "namespace": "default"
         },
         "k8s-ratelimitv1test-admin-default": {
             "ambassador_id": "ratelimitv1test",
-            "apiVersion": "ambassador/v1",
+            "apiVersion": "getambassador.io/v2",
             "endpoints": {},
             "kind": "Service",
+            "metadata_labels": {
+                "kat-ambassador-id": "ratelimitv1test",
+                "scope": "AmbassadorTest",
+                "service": "ratelimitv1test-admin"
+            },
             "name": "ratelimitv1test-admin",
             "namespace": "default"
         },
         "k8s-ratelimitv1test-default": {
             "ambassador_id": "ratelimitv1test",
-            "apiVersion": "ambassador/v1",
+            "apiVersion": "getambassador.io/v2",
             "endpoints": {},
             "kind": "Service",
+            "metadata_labels": {
+                "app.kubernetes.io/component": "ambassador-service",
+                "kat-ambassador-id": "ratelimitv1test",
+                "scope": "AmbassadorTest"
+            },
             "name": "ratelimitv1test",
             "namespace": "default"
         },
         "k8s-ratelimitv1test-http-default": {
             "ambassador_id": "ratelimitv1test",
-            "apiVersion": "ambassador/v1",
+            "apiVersion": "getambassador.io/v2",
             "endpoints": {},
             "kind": "Service",
+            "metadata_labels": {
+                "kat-ambassador-id": "ratelimitv1test",
+                "scope": "AmbassadorTest"
+            },
             "name": "ratelimitv1test-http",
             "namespace": "default"
         }

--- a/python/tests/gold/ratelimitv1test/snapshots/econf.json
+++ b/python/tests/gold/ratelimitv1test/snapshots/econf.json
@@ -109,6 +109,9 @@
                                     ],
                                     "http_filters": [
                                         {
+                                            "name": "envoy.cors"
+                                        },
+                                        {
                                             "config": {
                                                 "domain": "ambassador",
                                                 "rate_limit_service": {
@@ -122,9 +125,6 @@
                                                 "timeout": "0.500s"
                                             },
                                             "name": "envoy.rate_limit"
-                                        },
-                                        {
-                                            "name": "envoy.cors"
                                         },
                                         {
                                             "name": "envoy.router"

--- a/python/tests/gold/ratelimitv1test/snapshots/ir.json
+++ b/python/tests/gold/ratelimitv1test/snapshots/ir.json
@@ -148,6 +148,16 @@
         {
             "_active": true,
             "_errored": false,
+            "_rkey": "ir.cors",
+            "config": {},
+            "kind": "ir.cors",
+            "location": "--internal--",
+            "name": "cors",
+            "namespace": "default"
+        },
+        {
+            "_active": true,
+            "_errored": false,
             "_referenced_by": [
                 "ratelimitv1test.default.1"
             ],
@@ -235,16 +245,6 @@
         {
             "_active": true,
             "_errored": false,
-            "_rkey": "ir.cors",
-            "config": {},
-            "kind": "ir.cors",
-            "location": "--internal--",
-            "name": "cors",
-            "namespace": "default"
-        },
-        {
-            "_active": true,
-            "_errored": false,
             "_rkey": "ir.router",
             "config": {},
             "kind": "ir.router",
@@ -317,7 +317,7 @@
                     },
                     "group_id": "b4db12f5b638f1750062dd4220911c4f6f44fc57",
                     "headers": [],
-                    "kind": "IRMapping",
+                    "kind": "IRHTTPMapping",
                     "location": "--internal--",
                     "name": "internal_readiness_probe_mapping",
                     "namespace": "default",
@@ -406,7 +406,7 @@
                     },
                     "group_id": "7df546235997704c909d473af2cbcb5e606d20de",
                     "headers": [],
-                    "kind": "IRMapping",
+                    "kind": "IRHTTPMapping",
                     "location": "--internal--",
                     "name": "internal_liveness_probe_mapping",
                     "namespace": "default",
@@ -495,7 +495,7 @@
                     },
                     "group_id": "8de18501d2044fe30db225289b318d5fda913b64",
                     "headers": [],
-                    "kind": "IRMapping",
+                    "kind": "IRHTTPMapping",
                     "location": "--internal--",
                     "name": "internal_diagnostics_probe_mapping",
                     "namespace": "default",
@@ -611,6 +611,10 @@
                         ]
                     },
                     "location": "ratelimitv1test-http.default.1",
+                    "metadata_labels": {
+                        "kat-ambassador-id": "ratelimitv1test",
+                        "scope": "AmbassadorTest"
+                    },
                     "name": "ratelimit_target_mapping",
                     "namespace": "default",
                     "precedence": 0,
@@ -624,17 +628,21 @@
                         "/target/",
                         "GET"
                     ],
-                    "serialization": "ambassador_id: ratelimitv1test\napiVersion: ambassador/v1\nkind: Mapping\nlabels:\n  ambassador:\n  - request_label_group:\n    - x-ambassador-test-allow:\n        header: x-ambassador-test-allow\n        omit_if_not_present: true\nname: ratelimit_target_mapping\nprefix: /target/\nservice: ratelimitv1test-http\n",
+                    "serialization": "ambassador_id: ratelimitv1test\napiVersion: ambassador/v1\nkind: Mapping\nlabels:\n  ambassador:\n  - request_label_group:\n    - x-ambassador-test-allow:\n        header: x-ambassador-test-allow\n        omit_if_not_present: true\nmetadata_labels:\n  kat-ambassador-id: ratelimitv1test\n  scope: AmbassadorTest\nname: ratelimit_target_mapping\nprefix: /target/\nservice: ratelimitv1test-http\n",
                     "service": "ratelimitv1test-http",
                     "weight": 100
                 }
             ],
+            "metadata_labels": {
+                "kat-ambassador-id": "ratelimitv1test",
+                "scope": "AmbassadorTest"
+            },
             "name": "GROUP: ratelimit_target_mapping",
             "namespace": "default",
             "precedence": 0,
             "prefix": "/target/",
             "rewrite": "/",
-            "serialization": "ambassador_id: ratelimitv1test\napiVersion: ambassador/v1\nkind: Mapping\nlabels:\n  ambassador:\n  - request_label_group:\n    - x-ambassador-test-allow:\n        header: x-ambassador-test-allow\n        omit_if_not_present: true\nname: ratelimit_target_mapping\nprefix: /target/\nservice: ratelimitv1test-http\n"
+            "serialization": "ambassador_id: ratelimitv1test\napiVersion: ambassador/v1\nkind: Mapping\nlabels:\n  ambassador:\n  - request_label_group:\n    - x-ambassador-test-allow:\n        header: x-ambassador-test-allow\n        omit_if_not_present: true\nmetadata_labels:\n  kat-ambassador-id: ratelimitv1test\n  scope: AmbassadorTest\nname: ratelimit_target_mapping\nprefix: /target/\nservice: ratelimitv1test-http\n"
         }
     ],
     "grpc_services": {
@@ -787,50 +795,68 @@
         "k8s-rate-limit-v1-default": {
             "_referenced_by": {},
             "ambassador_id": "ratelimitv1test",
-            "apiVersion": "ambassador/v1",
+            "apiVersion": "getambassador.io/v2",
             "endpoints": {},
             "kind": "Service",
             "location": "k8s-rate-limit-v1-default",
+            "metadata_labels": {
+                "kat-ambassador-id": "ratelimitv1test",
+                "scope": "AmbassadorTest"
+            },
             "name": "rate-limit-v1",
             "namespace": "default",
             "rkey": "k8s-rate-limit-v1-default",
-            "serialization": "ambassador_id: ratelimitv1test\napiVersion: ambassador/v1\nendpoints: {}\nkind: Service\nname: rate-limit-v1\nnamespace: default\n"
+            "serialization": "ambassador_id: ratelimitv1test\napiVersion: getambassador.io/v2\nendpoints: {}\nkind: Service\nmetadata_labels:\n  kat-ambassador-id: ratelimitv1test\n  scope: AmbassadorTest\nname: rate-limit-v1\nnamespace: default\n"
         },
         "k8s-ratelimitv1test-admin-default": {
             "_referenced_by": {},
             "ambassador_id": "ratelimitv1test",
-            "apiVersion": "ambassador/v1",
+            "apiVersion": "getambassador.io/v2",
             "endpoints": {},
             "kind": "Service",
             "location": "k8s-ratelimitv1test-admin-default",
+            "metadata_labels": {
+                "kat-ambassador-id": "ratelimitv1test",
+                "scope": "AmbassadorTest",
+                "service": "ratelimitv1test-admin"
+            },
             "name": "ratelimitv1test-admin",
             "namespace": "default",
             "rkey": "k8s-ratelimitv1test-admin-default",
-            "serialization": "ambassador_id: ratelimitv1test\napiVersion: ambassador/v1\nendpoints: {}\nkind: Service\nname: ratelimitv1test-admin\nnamespace: default\n"
+            "serialization": "ambassador_id: ratelimitv1test\napiVersion: getambassador.io/v2\nendpoints: {}\nkind: Service\nmetadata_labels:\n  kat-ambassador-id: ratelimitv1test\n  scope: AmbassadorTest\n  service: ratelimitv1test-admin\nname: ratelimitv1test-admin\nnamespace: default\n"
         },
         "k8s-ratelimitv1test-default": {
             "_referenced_by": {},
             "ambassador_id": "ratelimitv1test",
-            "apiVersion": "ambassador/v1",
+            "apiVersion": "getambassador.io/v2",
             "endpoints": {},
             "kind": "Service",
             "location": "k8s-ratelimitv1test-default",
+            "metadata_labels": {
+                "app.kubernetes.io/component": "ambassador-service",
+                "kat-ambassador-id": "ratelimitv1test",
+                "scope": "AmbassadorTest"
+            },
             "name": "ratelimitv1test",
             "namespace": "default",
             "rkey": "k8s-ratelimitv1test-default",
-            "serialization": "ambassador_id: ratelimitv1test\napiVersion: ambassador/v1\nendpoints: {}\nkind: Service\nname: ratelimitv1test\nnamespace: default\n"
+            "serialization": "ambassador_id: ratelimitv1test\napiVersion: getambassador.io/v2\nendpoints: {}\nkind: Service\nmetadata_labels:\n  app.kubernetes.io/component: ambassador-service\n  kat-ambassador-id: ratelimitv1test\n  scope: AmbassadorTest\nname: ratelimitv1test\nnamespace: default\n"
         },
         "k8s-ratelimitv1test-http-default": {
             "_referenced_by": {},
             "ambassador_id": "ratelimitv1test",
-            "apiVersion": "ambassador/v1",
+            "apiVersion": "getambassador.io/v2",
             "endpoints": {},
             "kind": "Service",
             "location": "k8s-ratelimitv1test-http-default",
+            "metadata_labels": {
+                "kat-ambassador-id": "ratelimitv1test",
+                "scope": "AmbassadorTest"
+            },
             "name": "ratelimitv1test-http",
             "namespace": "default",
             "rkey": "k8s-ratelimitv1test-http-default",
-            "serialization": "ambassador_id: ratelimitv1test\napiVersion: ambassador/v1\nendpoints: {}\nkind: Service\nname: ratelimitv1test-http\nnamespace: default\n"
+            "serialization": "ambassador_id: ratelimitv1test\napiVersion: getambassador.io/v2\nendpoints: {}\nkind: Service\nmetadata_labels:\n  kat-ambassador-id: ratelimitv1test\n  scope: AmbassadorTest\nname: ratelimitv1test-http\nnamespace: default\n"
         }
     },
     "tls_contexts": []

--- a/python/tests/gold/ratelimitv1test/snapshots/snapshot.yaml
+++ b/python/tests/gold/ratelimitv1test/snapshots/snapshot.yaml
@@ -22,19 +22,19 @@
                     "annotations": {
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"ratelimitv1test\",\"scope\":\"AmbassadorTest\"},\"name\":\"rate-limit-v1\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"grpc\",\"port\":5000,\"targetPort\":\"grpc\"}],\"selector\":{\"app\":\"rate-limit-v1\"},\"type\":\"ClusterIP\"}}\n"
                     },
-                    "creationTimestamp": "2019-11-04T05:43:51Z",
+                    "creationTimestamp": "2019-11-13T20:38:22Z",
                     "labels": {
                         "kat-ambassador-id": "ratelimitv1test",
                         "scope": "AmbassadorTest"
                     },
                     "name": "rate-limit-v1",
                     "namespace": "default",
-                    "resourceVersion": "12909",
+                    "resourceVersion": "103407",
                     "selfLink": "/api/v1/namespaces/default/services/rate-limit-v1",
-                    "uid": "1498bbd9-fec6-11e9-8b1f-120e67b61000"
+                    "uid": "88e3c4dc-0655-11ea-8a6b-063c64bfaacb"
                 },
                 "spec": {
-                    "clusterIP": "10.111.69.72",
+                    "clusterIP": "10.97.108.205",
                     "ports": [
                         {
                             "name": "grpc",
@@ -61,7 +61,7 @@
                         "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: RateLimitService\nname: ratelimit-v1\nservice: rate-limit-v1:5000\ntimeout_ms: 500\nambassador_id: ratelimitv1test\n",
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: RateLimitService\\nname: ratelimit-v1\\nservice: rate-limit-v1:5000\\ntimeout_ms: 500\\nambassador_id: ratelimitv1test\\n\"},\"labels\":{\"app.kubernetes.io/component\":\"ambassador-service\",\"kat-ambassador-id\":\"ratelimitv1test\",\"scope\":\"AmbassadorTest\"},\"name\":\"ratelimitv1test\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8080},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8443}],\"selector\":{\"service\":\"ratelimitv1test\"},\"type\":\"NodePort\"}}\n"
                     },
-                    "creationTimestamp": "2019-11-04T05:43:50Z",
+                    "creationTimestamp": "2019-11-13T20:38:22Z",
                     "labels": {
                         "app.kubernetes.io/component": "ambassador-service",
                         "kat-ambassador-id": "ratelimitv1test",
@@ -69,24 +69,24 @@
                     },
                     "name": "ratelimitv1test",
                     "namespace": "default",
-                    "resourceVersion": "12894",
+                    "resourceVersion": "103396",
                     "selfLink": "/api/v1/namespaces/default/services/ratelimitv1test",
-                    "uid": "13daeb13-fec6-11e9-8b1f-120e67b61000"
+                    "uid": "889e35db-0655-11ea-8a6b-063c64bfaacb"
                 },
                 "spec": {
-                    "clusterIP": "10.96.34.222",
+                    "clusterIP": "10.106.205.57",
                     "externalTrafficPolicy": "Cluster",
                     "ports": [
                         {
                             "name": "http",
-                            "nodePort": 31155,
+                            "nodePort": 30203,
                             "port": 80,
                             "protocol": "TCP",
                             "targetPort": 8080
                         },
                         {
                             "name": "https",
-                            "nodePort": 31394,
+                            "nodePort": 31046,
                             "port": 443,
                             "protocol": "TCP",
                             "targetPort": 8443
@@ -109,7 +109,7 @@
                     "annotations": {
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"ratelimitv1test\",\"scope\":\"AmbassadorTest\",\"service\":\"ratelimitv1test-admin\"},\"name\":\"ratelimitv1test-admin\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"ratelimitv1test-admin\",\"port\":8877,\"targetPort\":8877}],\"selector\":{\"service\":\"ratelimitv1test\"},\"type\":\"NodePort\"}}\n"
                     },
-                    "creationTimestamp": "2019-11-04T05:43:50Z",
+                    "creationTimestamp": "2019-11-13T20:38:22Z",
                     "labels": {
                         "kat-ambassador-id": "ratelimitv1test",
                         "scope": "AmbassadorTest",
@@ -117,17 +117,17 @@
                     },
                     "name": "ratelimitv1test-admin",
                     "namespace": "default",
-                    "resourceVersion": "12901",
+                    "resourceVersion": "103400",
                     "selfLink": "/api/v1/namespaces/default/services/ratelimitv1test-admin",
-                    "uid": "143b7f44-fec6-11e9-8b1f-120e67b61000"
+                    "uid": "88a996d9-0655-11ea-8a6b-063c64bfaacb"
                 },
                 "spec": {
-                    "clusterIP": "10.99.243.152",
+                    "clusterIP": "10.109.137.168",
                     "externalTrafficPolicy": "Cluster",
                     "ports": [
                         {
                             "name": "ratelimitv1test-admin",
-                            "nodePort": 32678,
+                            "nodePort": 30544,
                             "port": 8877,
                             "protocol": "TCP",
                             "targetPort": 8877
@@ -149,33 +149,33 @@
                 "metadata": {
                     "annotations": {
                         "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: ratelimit_target_mapping\nprefix: /target/\nservice: ratelimitv1test-http\nlabels:\n  ambassador:\n  - request_label_group:\n    - x-ambassador-test-allow:\n        header: \"x-ambassador-test-allow\"\n        omit_if_not_present: true\nambassador_id: ratelimitv1test\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: ratelimit_target_mapping\\nprefix: /target/\\nservice: ratelimitv1test-http\\nlabels:\\n  ambassador:\\n  - request_label_group:\\n    - x-ambassador-test-allow:\\n        header: \\\"x-ambassador-test-allow\\\"\\n        omit_if_not_present: true\\nambassador_id: ratelimitv1test\\n\"},\"labels\":{\"kat-ambassador-id\":\"ratelimitv1test\",\"scope\":\"AmbassadorTest\"},\"name\":\"ratelimitv1test-http\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8109},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8472}],\"selector\":{\"backend\":\"superpod-default\"}}}\n"
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: ratelimit_target_mapping\\nprefix: /target/\\nservice: ratelimitv1test-http\\nlabels:\\n  ambassador:\\n  - request_label_group:\\n    - x-ambassador-test-allow:\\n        header: \\\"x-ambassador-test-allow\\\"\\n        omit_if_not_present: true\\nambassador_id: ratelimitv1test\\n\"},\"labels\":{\"kat-ambassador-id\":\"ratelimitv1test\",\"scope\":\"AmbassadorTest\"},\"name\":\"ratelimitv1test-http\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8081},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8444}],\"selector\":{\"backend\":\"superpod-default\"}}}\n"
                     },
-                    "creationTimestamp": "2019-11-04T05:43:51Z",
+                    "creationTimestamp": "2019-11-13T20:38:22Z",
                     "labels": {
                         "kat-ambassador-id": "ratelimitv1test",
                         "scope": "AmbassadorTest"
                     },
                     "name": "ratelimitv1test-http",
                     "namespace": "default",
-                    "resourceVersion": "12927",
+                    "resourceVersion": "103423",
                     "selfLink": "/api/v1/namespaces/default/services/ratelimitv1test-http",
-                    "uid": "14cbd850-fec6-11e9-8b1f-120e67b61000"
+                    "uid": "88f7b3b4-0655-11ea-8a6b-063c64bfaacb"
                 },
                 "spec": {
-                    "clusterIP": "10.111.49.87",
+                    "clusterIP": "10.99.113.232",
                     "ports": [
                         {
                             "name": "http",
                             "port": 80,
                             "protocol": "TCP",
-                            "targetPort": 8109
+                            "targetPort": 8081
                         },
                         {
                             "name": "https",
                             "port": 443,
                             "protocol": "TCP",
-                            "targetPort": 8472
+                            "targetPort": 8444
                         }
                     ],
                     "selector": {

--- a/python/tests/gold/ratelimitv1withtlstest/snapshots/aconf.json
+++ b/python/tests/gold/ratelimitv1withtlstest/snapshots/aconf.json
@@ -4,7 +4,7 @@
     "_sources": {
         "--diagnostics--": {
             "_referenced_by": {},
-            "apiVersion": "ambassador/v0",
+            "apiVersion": "getambassador.io/v0",
             "description": "The '--diagnostics--' source marks objects created by Ambassador to assist with diagnostic output.",
             "kind": "Diagnostics",
             "location": "--diagnostics--",
@@ -12,11 +12,11 @@
             "namespace": null,
             "rkey": "--diagnostics--",
             "serialization": null,
-            "version": "ambassador/v0"
+            "version": "getambassador.io/v0"
         },
         "--internal--": {
             "_referenced_by": {},
-            "apiVersion": "ambassador/v0",
+            "apiVersion": "getambassador.io/v0",
             "description": "The '--internal--' source marks objects created by Ambassador's internal logic.",
             "kind": "Internal",
             "location": "--internal--",
@@ -24,67 +24,89 @@
             "namespace": null,
             "rkey": "--internal--",
             "serialization": null,
-            "version": "ambassador/v0"
+            "version": "getambassador.io/v0"
         },
         "k8s-rate-limit-tls-default": {
             "_referenced_by": {},
             "ambassador_id": "ratelimitv1withtlstest",
-            "apiVersion": "ambassador/v1",
+            "apiVersion": "getambassador.io/v2",
             "endpoints": {},
             "kind": "Service",
             "location": "k8s-rate-limit-tls-default",
+            "metadata_labels": {
+                "kat-ambassador-id": "ratelimitv1withtlstest",
+                "scope": "AmbassadorTest"
+            },
             "name": "rate-limit-tls",
             "namespace": "default",
             "rkey": "k8s-rate-limit-tls-default",
-            "serialization": "ambassador_id: ratelimitv1withtlstest\napiVersion: ambassador/v1\nendpoints: {}\nkind: Service\nname: rate-limit-tls\nnamespace: default\n"
+            "serialization": "ambassador_id: ratelimitv1withtlstest\napiVersion: getambassador.io/v2\nendpoints: {}\nkind: Service\nmetadata_labels:\n  kat-ambassador-id: ratelimitv1withtlstest\n  scope: AmbassadorTest\nname: rate-limit-tls\nnamespace: default\n"
         },
         "k8s-ratelimitv1withtlstest-admin-default": {
             "_referenced_by": {},
             "ambassador_id": "ratelimitv1withtlstest",
-            "apiVersion": "ambassador/v1",
+            "apiVersion": "getambassador.io/v2",
             "endpoints": {},
             "kind": "Service",
             "location": "k8s-ratelimitv1withtlstest-admin-default",
+            "metadata_labels": {
+                "kat-ambassador-id": "ratelimitv1withtlstest",
+                "scope": "AmbassadorTest",
+                "service": "ratelimitv1withtlstest-admin"
+            },
             "name": "ratelimitv1withtlstest-admin",
             "namespace": "default",
             "rkey": "k8s-ratelimitv1withtlstest-admin-default",
-            "serialization": "ambassador_id: ratelimitv1withtlstest\napiVersion: ambassador/v1\nendpoints: {}\nkind: Service\nname: ratelimitv1withtlstest-admin\nnamespace: default\n"
+            "serialization": "ambassador_id: ratelimitv1withtlstest\napiVersion: getambassador.io/v2\nendpoints: {}\nkind: Service\nmetadata_labels:\n  kat-ambassador-id: ratelimitv1withtlstest\n  scope: AmbassadorTest\n  service: ratelimitv1withtlstest-admin\nname: ratelimitv1withtlstest-admin\nnamespace: default\n"
         },
         "k8s-ratelimitv1withtlstest-default": {
             "_referenced_by": {},
             "ambassador_id": "ratelimitv1withtlstest",
-            "apiVersion": "ambassador/v1",
+            "apiVersion": "getambassador.io/v2",
             "endpoints": {},
             "kind": "Service",
             "location": "k8s-ratelimitv1withtlstest-default",
+            "metadata_labels": {
+                "app.kubernetes.io/component": "ambassador-service",
+                "kat-ambassador-id": "ratelimitv1withtlstest",
+                "scope": "AmbassadorTest"
+            },
             "name": "ratelimitv1withtlstest",
             "namespace": "default",
             "rkey": "k8s-ratelimitv1withtlstest-default",
-            "serialization": "ambassador_id: ratelimitv1withtlstest\napiVersion: ambassador/v1\nendpoints: {}\nkind: Service\nname: ratelimitv1withtlstest\nnamespace: default\n"
+            "serialization": "ambassador_id: ratelimitv1withtlstest\napiVersion: getambassador.io/v2\nendpoints: {}\nkind: Service\nmetadata_labels:\n  app.kubernetes.io/component: ambassador-service\n  kat-ambassador-id: ratelimitv1withtlstest\n  scope: AmbassadorTest\nname: ratelimitv1withtlstest\nnamespace: default\n"
         },
         "k8s-ratelimitv1withtlstest-http-default": {
             "_referenced_by": {},
             "ambassador_id": "ratelimitv1withtlstest",
-            "apiVersion": "ambassador/v1",
+            "apiVersion": "getambassador.io/v2",
             "endpoints": {},
             "kind": "Service",
             "location": "k8s-ratelimitv1withtlstest-http-default",
+            "metadata_labels": {
+                "kat-ambassador-id": "ratelimitv1withtlstest",
+                "scope": "AmbassadorTest"
+            },
             "name": "ratelimitv1withtlstest-http",
             "namespace": "default",
             "rkey": "k8s-ratelimitv1withtlstest-http-default",
-            "serialization": "ambassador_id: ratelimitv1withtlstest\napiVersion: ambassador/v1\nendpoints: {}\nkind: Service\nname: ratelimitv1withtlstest-http\nnamespace: default\n"
+            "serialization": "ambassador_id: ratelimitv1withtlstest\napiVersion: getambassador.io/v2\nendpoints: {}\nkind: Service\nmetadata_labels:\n  kat-ambassador-id: ratelimitv1withtlstest\n  scope: AmbassadorTest\nname: ratelimitv1withtlstest-http\nnamespace: default\n"
         },
         "ratelimit-tls-secret.default.1": {
             "_referenced_by": {},
             "ambassador_id": "ratelimitv1withtlstest",
-            "apiVersion": "ambassador/v1",
+            "apiVersion": "getambassador.io/v2",
             "kind": "Secret",
             "location": "ratelimit-tls-secret.default.1",
+            "metadata_labels": {
+                "kat-ambassador-id": "ratelimitv1withtlstest",
+                "scope": "AmbassadorTest"
+            },
             "name": "ratelimit-tls-secret",
             "namespace": "default",
             "rkey": "ratelimit-tls-secret.default.1",
             "secret_type": "kubernetes.io/tls",
-            "serialization": "ambassador_id: ratelimitv1withtlstest\napiVersion: ambassador/v1\nkind: Secret\nname: ratelimit-tls-secret\nnamespace: default\nsecret_type: kubernetes.io/tls\ntls_crt: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURDakNDQWZJQ0NRRGdYUjZ3V1Z6Wk9EQU5CZ2txaGtpRzl3MEJBUVVGQURCSE1SNHdIQVlEVlFRRERCVnkKWVhSbGJHbHRhWFF1WkdGMFlYZHBjbVV1YVc4eEpUQWpCZ2txaGtpRzl3MEJDUUVXRm1odmMzUnRZWE4wWlhKQQpaR0YwWVhkcGNtVXVhVzh3SGhjTk1Ua3dPVEU1TVRnek16QXlXaGNOTWpFd09ERTVNVGd6TXpBeVdqQkhNUjR3CkhBWURWUVFEREJWeVlYUmxiR2x0YVhRdVpHRjBZWGRwY21VdWFXOHhKVEFqQmdrcWhraUc5dzBCQ1FFV0ZtaHYKYzNSdFlYTjBaWEpBWkdGMFlYZHBjbVV1YVc4d2dnRWlNQTBHQ1NxR1NJYjNEUUVCQVFVQUE0SUJEd0F3Z2dFSwpBb0lCQVFDeWw5VkJtVjVCcFYxOHZzclNqUktyZGlEVnZZS0dxNlZVaGFTRTlZSWNRODhiSTFaeHlhUE9zUVlRCmMycmY4Q0RKdUp4M1hoUjUzMENwN3pQNmVSMjNwMkZBOSsxSWs5SHZhWUx0WDRtQTJOdjh4V1kxaEhua1BURnMKVFRwazBMREdYYjVZWnh2QkczNTNKL3NFKzFrSUUxenpKZldpQUpUMzZzMk5PRzRVQWhoVmFPS2p1K3grYXJwbQoyZnNhTldKTTFEMS9CUXVVN1Vid0p0QmIyZFo2WUtUNHE4M2doQWgybDhad1hQcFdJQmtpWGpNNXJ0WkQ3QmN4CkRxdFNtVE1ZejVjZWNwbmhiNEw4Z3hFVUJyWlRxQ3g4RVkvcDArY05mN2hScmFWbTd6Q3BaRDhvSUtLS0IvUDQKM1dHZHRHNlpHS0VFSmtXNjB5QWtxRmI3czNWdEFnTUJBQUV3RFFZSktvWklodmNOQVFFRkJRQURnZ0VCQUFJUwp2Znh1K3dQcUxicVRZV1NLTUt6S3JmNUxxWlpBZFpZZXNIR0oxNmFyVmt6eGhzcElGRGZpblZ1UmI1eERxWVVSCnFta0U1K0dCNDh5UGoxaUQvdXdPOEI0ckFnNW1Pekw1MEpUMDVQT1dyc0hjK1loLzAvUXpGNmlqNHlVNWZ6dloKRHpJdFBiNE5qWTMxUE44WkJMYTFGSHk5d2JGSzdyS2lWK2MxTzd0UHVjQTVUWnoxS0h5VUVYaWxHdmNoczB4OApzazRJR2xrVTNoSDFVWHBzTmw0NTI4VjR0L3dXOTdiYmhFeHYvYnBwR3RLbjRKei9hYkNScjA3Q3kzUytjUzc5CnlQNTZiQVZxa1R2TTVkUkhiNG9zOGYzNUJuQTdPci9YRTQ2K2VRMXNVY21IVG5OUWdFVkpWZGVwR3V4Sk5pNFMKejJ0WHhHSStTdTFlUnlQcVNGWT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=\ntls_key: LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0tCk1JSUV2UUlCQURBTkJna3Foa2lHOXcwQkFRRUZBQVNDQktjd2dnU2pBZ0VBQW9JQkFRQ3lsOVZCbVY1QnBWMTgKdnNyU2pSS3JkaURWdllLR3E2VlVoYVNFOVlJY1E4OGJJMVp4eWFQT3NRWVFjMnJmOENESnVKeDNYaFI1MzBDcAo3elA2ZVIyM3AyRkE5KzFJazlIdmFZTHRYNG1BMk52OHhXWTFoSG5rUFRGc1RUcGswTERHWGI1WVp4dkJHMzUzCkovc0UrMWtJRTF6ekpmV2lBSlQzNnMyTk9HNFVBaGhWYU9LanUreCthcnBtMmZzYU5XSk0xRDEvQlF1VTdVYncKSnRCYjJkWjZZS1Q0cTgzZ2hBaDJsOFp3WFBwV0lCa2lYak01cnRaRDdCY3hEcXRTbVRNWXo1Y2VjcG5oYjRMOApneEVVQnJaVHFDeDhFWS9wMCtjTmY3aFJyYVZtN3pDcFpEOG9JS0tLQi9QNDNXR2R0RzZaR0tFRUprVzYweUFrCnFGYjdzM1Z0QWdNQkFBRUNnZ0VBS3hvNzdOWWdDb1hubHpqUTZKb0ZuSDRwRkl6bFdLMUtmS2k0ZVNKcm9YaTQKSGx1Yi9HQm0rWFo5K1RCeDVkUWxoYW5aa1hHU1RZdVZKcTVGaERrQTlCY2dnTGFWZlFPNEVpa0w0VkJDZG1kZwpTSlEzdzhqU1JrU0NqaG5oY3YxdS9LRVpWR3FtSnlnRWtLdUVpTUpFelk4bXlzUXBrVXpFcDBUekVSZENjZTljClNKT2Q2V2dGYUdzN3ZmTEpMajBmTk1SYytwcjFORnBmcTk0R2lyZFVyQUIvOHhlL2lpT3hnZXJoM1JPR0I4Z1MKZWpMeTZmZEhZK0Y1d2cyREtFMjVjeHcrdWFUeEo4MElucktWYTdhVjlqeGl1L0YvWW42a0FGT201cUFaTEdJUQo3bDVDY0dMWCtKdS96UGNpSEJRRWx2R2dSTGdZTCtxWHNPYStyZ3VvZ1FLQmdRRFpVU25xQUdvd2Zma3h1QTB2CnVxc042M3NaMHFVVUMraDB1aGZCanV1ZGxEZU8rM2U5WC9ncW1vTHFnYmpLbUNxcHZ0eFRKT2RZbWlkTG42QysKU3ZIMkw5V3RBNzVFMDB1bDdWb0VEOWs5S1c5aEU4M1ZoM0hJcnowQ3RtLzAvMEtJaVlXb2VkaWw2YktlTndUSApXci9MdlI5M2F2dHo2NUkwVWFBVjVyMjhqUUtCZ1FEU1loS2R1YzB1YUQ2VW45NW0yTmZJelRaNWxaNmZZdFFyCkZHbzByWWlTelZCRlZrNnR3akI5dmhtdmtjZjBNU21wQ1NPUUZGcjJ3Zk9UZGtBTnlxTWxwNXdHK3ZpRi9LeGMKcXNMQ1RROGhwNmFnazMzRE9MVEl2OXpKdkhnU2NsWW9pOTZqNk9Zc28rWUtITkxmTU1jVWw3dThqYmZ3YWx2dwp4Tno3WkdRVVlRS0JnSFdsZWRKamJSbFphVWxnUVV0QWZBL3FGbGR4Y01xOGM1aVZrZnpJT1lleVVLMklOMWQvCkYrTkFpSFVaeXdkcWYxWXJyQzBhd2w5MS9LWDFBZGxpeTBDaXZzT09UamdHUjJMSmJyemFNNW5uejVNM1hHd24KaWhMQnczNnZjMGFuMWNZQzVTZkM1dVZTOGM2ekxGUWNMYzdIVUx5ZVh3aHZWRlFjaUZTeStLNlZBb0dBUkFObQpwMDBBOHliS1RId2VoenRGRDJxZ1dOQXc5ckFaalUvTlFmaHo5Wm1nZ0xuMU42RlcwZC9hSi9OR0pFQ2Npa1FsCkZoZ3VqQ1dKbkR1WFc1NE4va2RnWHJWV0VPTHR5Z3QrYVJoR2N3ZmpDM2lES05DMVNVMFZrTFo0VHVaZHlqL2wKbXpIWTc4ZVF2K1l2bWU0SC9qVkxnUnFEdzVwdTNMaVlCRUdoUlNFQ2dZRUExdmNGWmsxOXVLS0JSWDhFRlgzbQphTlk2QWVhWTVJV2xVbDFJbEpHUHBFNnBnejh1aVRYNU9paG5KbGh4NDIzdjBIRU1QV0ZxNXQzcCtJdGRKZ24zCnlTQ0RNcXhyZUo4cytCS3BqeUcwVHFjN0pkbkpUcm1NN1FUMCtVUXExYmlBOENiU0FvMWVybHJpcEZ1blVMblEKSXp3SURyM1VzN0ROQkxNZmlOaDZuVWs9Ci0tLS0tRU5EIFBSSVZBVEUgS0VZLS0tLS0K\n",
+            "serialization": "ambassador_id: ratelimitv1withtlstest\napiVersion: getambassador.io/v2\nkind: Secret\nmetadata_labels:\n  kat-ambassador-id: ratelimitv1withtlstest\n  scope: AmbassadorTest\nname: ratelimit-tls-secret\nnamespace: default\nsecret_type: kubernetes.io/tls\ntls_crt: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURDakNDQWZJQ0NRRGdYUjZ3V1Z6Wk9EQU5CZ2txaGtpRzl3MEJBUVVGQURCSE1SNHdIQVlEVlFRRERCVnkKWVhSbGJHbHRhWFF1WkdGMFlYZHBjbVV1YVc4eEpUQWpCZ2txaGtpRzl3MEJDUUVXRm1odmMzUnRZWE4wWlhKQQpaR0YwWVhkcGNtVXVhVzh3SGhjTk1Ua3dPVEU1TVRnek16QXlXaGNOTWpFd09ERTVNVGd6TXpBeVdqQkhNUjR3CkhBWURWUVFEREJWeVlYUmxiR2x0YVhRdVpHRjBZWGRwY21VdWFXOHhKVEFqQmdrcWhraUc5dzBCQ1FFV0ZtaHYKYzNSdFlYTjBaWEpBWkdGMFlYZHBjbVV1YVc4d2dnRWlNQTBHQ1NxR1NJYjNEUUVCQVFVQUE0SUJEd0F3Z2dFSwpBb0lCQVFDeWw5VkJtVjVCcFYxOHZzclNqUktyZGlEVnZZS0dxNlZVaGFTRTlZSWNRODhiSTFaeHlhUE9zUVlRCmMycmY4Q0RKdUp4M1hoUjUzMENwN3pQNmVSMjNwMkZBOSsxSWs5SHZhWUx0WDRtQTJOdjh4V1kxaEhua1BURnMKVFRwazBMREdYYjVZWnh2QkczNTNKL3NFKzFrSUUxenpKZldpQUpUMzZzMk5PRzRVQWhoVmFPS2p1K3grYXJwbQoyZnNhTldKTTFEMS9CUXVVN1Vid0p0QmIyZFo2WUtUNHE4M2doQWgybDhad1hQcFdJQmtpWGpNNXJ0WkQ3QmN4CkRxdFNtVE1ZejVjZWNwbmhiNEw4Z3hFVUJyWlRxQ3g4RVkvcDArY05mN2hScmFWbTd6Q3BaRDhvSUtLS0IvUDQKM1dHZHRHNlpHS0VFSmtXNjB5QWtxRmI3czNWdEFnTUJBQUV3RFFZSktvWklodmNOQVFFRkJRQURnZ0VCQUFJUwp2Znh1K3dQcUxicVRZV1NLTUt6S3JmNUxxWlpBZFpZZXNIR0oxNmFyVmt6eGhzcElGRGZpblZ1UmI1eERxWVVSCnFta0U1K0dCNDh5UGoxaUQvdXdPOEI0ckFnNW1Pekw1MEpUMDVQT1dyc0hjK1loLzAvUXpGNmlqNHlVNWZ6dloKRHpJdFBiNE5qWTMxUE44WkJMYTFGSHk5d2JGSzdyS2lWK2MxTzd0UHVjQTVUWnoxS0h5VUVYaWxHdmNoczB4OApzazRJR2xrVTNoSDFVWHBzTmw0NTI4VjR0L3dXOTdiYmhFeHYvYnBwR3RLbjRKei9hYkNScjA3Q3kzUytjUzc5CnlQNTZiQVZxa1R2TTVkUkhiNG9zOGYzNUJuQTdPci9YRTQ2K2VRMXNVY21IVG5OUWdFVkpWZGVwR3V4Sk5pNFMKejJ0WHhHSStTdTFlUnlQcVNGWT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=\ntls_key: LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0tCk1JSUV2UUlCQURBTkJna3Foa2lHOXcwQkFRRUZBQVNDQktjd2dnU2pBZ0VBQW9JQkFRQ3lsOVZCbVY1QnBWMTgKdnNyU2pSS3JkaURWdllLR3E2VlVoYVNFOVlJY1E4OGJJMVp4eWFQT3NRWVFjMnJmOENESnVKeDNYaFI1MzBDcAo3elA2ZVIyM3AyRkE5KzFJazlIdmFZTHRYNG1BMk52OHhXWTFoSG5rUFRGc1RUcGswTERHWGI1WVp4dkJHMzUzCkovc0UrMWtJRTF6ekpmV2lBSlQzNnMyTk9HNFVBaGhWYU9LanUreCthcnBtMmZzYU5XSk0xRDEvQlF1VTdVYncKSnRCYjJkWjZZS1Q0cTgzZ2hBaDJsOFp3WFBwV0lCa2lYak01cnRaRDdCY3hEcXRTbVRNWXo1Y2VjcG5oYjRMOApneEVVQnJaVHFDeDhFWS9wMCtjTmY3aFJyYVZtN3pDcFpEOG9JS0tLQi9QNDNXR2R0RzZaR0tFRUprVzYweUFrCnFGYjdzM1Z0QWdNQkFBRUNnZ0VBS3hvNzdOWWdDb1hubHpqUTZKb0ZuSDRwRkl6bFdLMUtmS2k0ZVNKcm9YaTQKSGx1Yi9HQm0rWFo5K1RCeDVkUWxoYW5aa1hHU1RZdVZKcTVGaERrQTlCY2dnTGFWZlFPNEVpa0w0VkJDZG1kZwpTSlEzdzhqU1JrU0NqaG5oY3YxdS9LRVpWR3FtSnlnRWtLdUVpTUpFelk4bXlzUXBrVXpFcDBUekVSZENjZTljClNKT2Q2V2dGYUdzN3ZmTEpMajBmTk1SYytwcjFORnBmcTk0R2lyZFVyQUIvOHhlL2lpT3hnZXJoM1JPR0I4Z1MKZWpMeTZmZEhZK0Y1d2cyREtFMjVjeHcrdWFUeEo4MElucktWYTdhVjlqeGl1L0YvWW42a0FGT201cUFaTEdJUQo3bDVDY0dMWCtKdS96UGNpSEJRRWx2R2dSTGdZTCtxWHNPYStyZ3VvZ1FLQmdRRFpVU25xQUdvd2Zma3h1QTB2CnVxc042M3NaMHFVVUMraDB1aGZCanV1ZGxEZU8rM2U5WC9ncW1vTHFnYmpLbUNxcHZ0eFRKT2RZbWlkTG42QysKU3ZIMkw5V3RBNzVFMDB1bDdWb0VEOWs5S1c5aEU4M1ZoM0hJcnowQ3RtLzAvMEtJaVlXb2VkaWw2YktlTndUSApXci9MdlI5M2F2dHo2NUkwVWFBVjVyMjhqUUtCZ1FEU1loS2R1YzB1YUQ2VW45NW0yTmZJelRaNWxaNmZZdFFyCkZHbzByWWlTelZCRlZrNnR3akI5dmhtdmtjZjBNU21wQ1NPUUZGcjJ3Zk9UZGtBTnlxTWxwNXdHK3ZpRi9LeGMKcXNMQ1RROGhwNmFnazMzRE9MVEl2OXpKdkhnU2NsWW9pOTZqNk9Zc28rWUtITkxmTU1jVWw3dThqYmZ3YWx2dwp4Tno3WkdRVVlRS0JnSFdsZWRKamJSbFphVWxnUVV0QWZBL3FGbGR4Y01xOGM1aVZrZnpJT1lleVVLMklOMWQvCkYrTkFpSFVaeXdkcWYxWXJyQzBhd2w5MS9LWDFBZGxpeTBDaXZzT09UamdHUjJMSmJyemFNNW5uejVNM1hHd24KaWhMQnczNnZjMGFuMWNZQzVTZkM1dVZTOGM2ekxGUWNMYzdIVUx5ZVh3aHZWRlFjaUZTeStLNlZBb0dBUkFObQpwMDBBOHliS1RId2VoenRGRDJxZ1dOQXc5ckFaalUvTlFmaHo5Wm1nZ0xuMU42RlcwZC9hSi9OR0pFQ2Npa1FsCkZoZ3VqQ1dKbkR1WFc1NE4va2RnWHJWV0VPTHR5Z3QrYVJoR2N3ZmpDM2lES05DMVNVMFZrTFo0VHVaZHlqL2wKbXpIWTc4ZVF2K1l2bWU0SC9qVkxnUnFEdzVwdTNMaVlCRUdoUlNFQ2dZRUExdmNGWmsxOXVLS0JSWDhFRlgzbQphTlk2QWVhWTVJV2xVbDFJbEpHUHBFNnBnejh1aVRYNU9paG5KbGh4NDIzdjBIRU1QV0ZxNXQzcCtJdGRKZ24zCnlTQ0RNcXhyZUo4cytCS3BqeUcwVHFjN0pkbkpUcm1NN1FUMCtVUXExYmlBOENiU0FvMWVybHJpcEZ1blVMblEKSXp3SURyM1VzN0ROQkxNZmlOaDZuVWs9Ci0tLS0tRU5EIFBSSVZBVEUgS0VZLS0tLS0K\n",
             "tls_crt": "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURDakNDQWZJQ0NRRGdYUjZ3V1Z6Wk9EQU5CZ2txaGtpRzl3MEJBUVVGQURCSE1SNHdIQVlEVlFRRERCVnkKWVhSbGJHbHRhWFF1WkdGMFlYZHBjbVV1YVc4eEpUQWpCZ2txaGtpRzl3MEJDUUVXRm1odmMzUnRZWE4wWlhKQQpaR0YwWVhkcGNtVXVhVzh3SGhjTk1Ua3dPVEU1TVRnek16QXlXaGNOTWpFd09ERTVNVGd6TXpBeVdqQkhNUjR3CkhBWURWUVFEREJWeVlYUmxiR2x0YVhRdVpHRjBZWGRwY21VdWFXOHhKVEFqQmdrcWhraUc5dzBCQ1FFV0ZtaHYKYzNSdFlYTjBaWEpBWkdGMFlYZHBjbVV1YVc4d2dnRWlNQTBHQ1NxR1NJYjNEUUVCQVFVQUE0SUJEd0F3Z2dFSwpBb0lCQVFDeWw5VkJtVjVCcFYxOHZzclNqUktyZGlEVnZZS0dxNlZVaGFTRTlZSWNRODhiSTFaeHlhUE9zUVlRCmMycmY4Q0RKdUp4M1hoUjUzMENwN3pQNmVSMjNwMkZBOSsxSWs5SHZhWUx0WDRtQTJOdjh4V1kxaEhua1BURnMKVFRwazBMREdYYjVZWnh2QkczNTNKL3NFKzFrSUUxenpKZldpQUpUMzZzMk5PRzRVQWhoVmFPS2p1K3grYXJwbQoyZnNhTldKTTFEMS9CUXVVN1Vid0p0QmIyZFo2WUtUNHE4M2doQWgybDhad1hQcFdJQmtpWGpNNXJ0WkQ3QmN4CkRxdFNtVE1ZejVjZWNwbmhiNEw4Z3hFVUJyWlRxQ3g4RVkvcDArY05mN2hScmFWbTd6Q3BaRDhvSUtLS0IvUDQKM1dHZHRHNlpHS0VFSmtXNjB5QWtxRmI3czNWdEFnTUJBQUV3RFFZSktvWklodmNOQVFFRkJRQURnZ0VCQUFJUwp2Znh1K3dQcUxicVRZV1NLTUt6S3JmNUxxWlpBZFpZZXNIR0oxNmFyVmt6eGhzcElGRGZpblZ1UmI1eERxWVVSCnFta0U1K0dCNDh5UGoxaUQvdXdPOEI0ckFnNW1Pekw1MEpUMDVQT1dyc0hjK1loLzAvUXpGNmlqNHlVNWZ6dloKRHpJdFBiNE5qWTMxUE44WkJMYTFGSHk5d2JGSzdyS2lWK2MxTzd0UHVjQTVUWnoxS0h5VUVYaWxHdmNoczB4OApzazRJR2xrVTNoSDFVWHBzTmw0NTI4VjR0L3dXOTdiYmhFeHYvYnBwR3RLbjRKei9hYkNScjA3Q3kzUytjUzc5CnlQNTZiQVZxa1R2TTVkUkhiNG9zOGYzNUJuQTdPci9YRTQ2K2VRMXNVY21IVG5OUWdFVkpWZGVwR3V4Sk5pNFMKejJ0WHhHSStTdTFlUnlQcVNGWT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=",
             "tls_key": "LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0tCk1JSUV2UUlCQURBTkJna3Foa2lHOXcwQkFRRUZBQVNDQktjd2dnU2pBZ0VBQW9JQkFRQ3lsOVZCbVY1QnBWMTgKdnNyU2pSS3JkaURWdllLR3E2VlVoYVNFOVlJY1E4OGJJMVp4eWFQT3NRWVFjMnJmOENESnVKeDNYaFI1MzBDcAo3elA2ZVIyM3AyRkE5KzFJazlIdmFZTHRYNG1BMk52OHhXWTFoSG5rUFRGc1RUcGswTERHWGI1WVp4dkJHMzUzCkovc0UrMWtJRTF6ekpmV2lBSlQzNnMyTk9HNFVBaGhWYU9LanUreCthcnBtMmZzYU5XSk0xRDEvQlF1VTdVYncKSnRCYjJkWjZZS1Q0cTgzZ2hBaDJsOFp3WFBwV0lCa2lYak01cnRaRDdCY3hEcXRTbVRNWXo1Y2VjcG5oYjRMOApneEVVQnJaVHFDeDhFWS9wMCtjTmY3aFJyYVZtN3pDcFpEOG9JS0tLQi9QNDNXR2R0RzZaR0tFRUprVzYweUFrCnFGYjdzM1Z0QWdNQkFBRUNnZ0VBS3hvNzdOWWdDb1hubHpqUTZKb0ZuSDRwRkl6bFdLMUtmS2k0ZVNKcm9YaTQKSGx1Yi9HQm0rWFo5K1RCeDVkUWxoYW5aa1hHU1RZdVZKcTVGaERrQTlCY2dnTGFWZlFPNEVpa0w0VkJDZG1kZwpTSlEzdzhqU1JrU0NqaG5oY3YxdS9LRVpWR3FtSnlnRWtLdUVpTUpFelk4bXlzUXBrVXpFcDBUekVSZENjZTljClNKT2Q2V2dGYUdzN3ZmTEpMajBmTk1SYytwcjFORnBmcTk0R2lyZFVyQUIvOHhlL2lpT3hnZXJoM1JPR0I4Z1MKZWpMeTZmZEhZK0Y1d2cyREtFMjVjeHcrdWFUeEo4MElucktWYTdhVjlqeGl1L0YvWW42a0FGT201cUFaTEdJUQo3bDVDY0dMWCtKdS96UGNpSEJRRWx2R2dSTGdZTCtxWHNPYStyZ3VvZ1FLQmdRRFpVU25xQUdvd2Zma3h1QTB2CnVxc042M3NaMHFVVUMraDB1aGZCanV1ZGxEZU8rM2U5WC9ncW1vTHFnYmpLbUNxcHZ0eFRKT2RZbWlkTG42QysKU3ZIMkw5V3RBNzVFMDB1bDdWb0VEOWs5S1c5aEU4M1ZoM0hJcnowQ3RtLzAvMEtJaVlXb2VkaWw2YktlTndUSApXci9MdlI5M2F2dHo2NUkwVWFBVjVyMjhqUUtCZ1FEU1loS2R1YzB1YUQ2VW45NW0yTmZJelRaNWxaNmZZdFFyCkZHbzByWWlTelZCRlZrNnR3akI5dmhtdmtjZjBNU21wQ1NPUUZGcjJ3Zk9UZGtBTnlxTWxwNXdHK3ZpRi9LeGMKcXNMQ1RROGhwNmFnazMzRE9MVEl2OXpKdkhnU2NsWW9pOTZqNk9Zc28rWUtITkxmTU1jVWw3dThqYmZ3YWx2dwp4Tno3WkdRVVlRS0JnSFdsZWRKamJSbFphVWxnUVV0QWZBL3FGbGR4Y01xOGM1aVZrZnpJT1lleVVLMklOMWQvCkYrTkFpSFVaeXdkcWYxWXJyQzBhd2w5MS9LWDFBZGxpeTBDaXZzT09UamdHUjJMSmJyemFNNW5uejVNM1hHd24KaWhMQnczNnZjMGFuMWNZQzVTZkM1dVZTOGM2ekxGUWNMYzdIVUx5ZVh3aHZWRlFjaUZTeStLNlZBb0dBUkFObQpwMDBBOHliS1RId2VoenRGRDJxZ1dOQXc5ckFaalUvTlFmaHo5Wm1nZ0xuMU42RlcwZC9hSi9OR0pFQ2Npa1FsCkZoZ3VqQ1dKbkR1WFc1NE4va2RnWHJWV0VPTHR5Z3QrYVJoR2N3ZmpDM2lES05DMVNVMFZrTFo0VHVaZHlqL2wKbXpIWTc4ZVF2K1l2bWU0SC9qVkxnUnFEdzVwdTNMaVlCRUdoUlNFQ2dZRUExdmNGWmsxOXVLS0JSWDhFRlgzbQphTlk2QWVhWTVJV2xVbDFJbEpHUHBFNnBnejh1aVRYNU9paG5KbGh4NDIzdjBIRU1QV0ZxNXQzcCtJdGRKZ24zCnlTQ0RNcXhyZUo4cytCS3BqeUcwVHFjN0pkbkpUcm1NN1FUMCtVUXExYmlBOENiU0FvMWVybHJpcEZ1blVMblEKSXp3SURyM1VzN0ROQkxNZmlOaDZuVWs9Ci0tLS0tRU5EIFBSSVZBVEUgS0VZLS0tLS0K"
         },
@@ -92,19 +114,23 @@
             "_referenced_by": {},
             "alpn_protocols": "h2",
             "ambassador_id": "ratelimitv1withtlstest",
-            "apiVersion": "ambassador/v1",
+            "apiVersion": "getambassador.io/v1",
             "kind": "TLSContext",
             "location": "ratelimitv1withtlstest-http.default.1",
+            "metadata_labels": {
+                "kat-ambassador-id": "ratelimitv1withtlstest",
+                "scope": "AmbassadorTest"
+            },
             "name": "ratelimit-tls-context",
             "namespace": "default",
             "rkey": "ratelimitv1withtlstest-http.default.1",
             "secret": "ratelimit-tls-secret",
-            "serialization": "alpn_protocols: h2\nambassador_id: ratelimitv1withtlstest\napiVersion: ambassador/v1\nkind: TLSContext\nname: ratelimit-tls-context\nsecret: ratelimit-tls-secret\n"
+            "serialization": "alpn_protocols: h2\nambassador_id: ratelimitv1withtlstest\napiVersion: ambassador/v1\nkind: TLSContext\nmetadata_labels:\n  kat-ambassador-id: ratelimitv1withtlstest\n  scope: AmbassadorTest\nname: ratelimit-tls-context\nsecret: ratelimit-tls-secret\n"
         },
         "ratelimitv1withtlstest-http.default.2": {
             "_referenced_by": {},
             "ambassador_id": "ratelimitv1withtlstest",
-            "apiVersion": "ambassador/v1",
+            "apiVersion": "getambassador.io/v1",
             "kind": "Mapping",
             "labels": {
                 "ambassador": [
@@ -121,23 +147,32 @@
                 ]
             },
             "location": "ratelimitv1withtlstest-http.default.2",
+            "metadata_labels": {
+                "kat-ambassador-id": "ratelimitv1withtlstest",
+                "scope": "AmbassadorTest"
+            },
             "name": "ratelimit_target_mapping",
             "namespace": "default",
             "prefix": "/target/",
             "rkey": "ratelimitv1withtlstest-http.default.2",
-            "serialization": "ambassador_id: ratelimitv1withtlstest\napiVersion: ambassador/v1\nkind: Mapping\nlabels:\n  ambassador:\n  - request_label_group:\n    - x-ambassador-test-allow:\n        header: x-ambassador-test-allow\n        omit_if_not_present: true\nname: ratelimit_target_mapping\nprefix: /target/\nservice: ratelimitv1withtlstest-http\n",
+            "serialization": "ambassador_id: ratelimitv1withtlstest\napiVersion: ambassador/v1\nkind: Mapping\nlabels:\n  ambassador:\n  - request_label_group:\n    - x-ambassador-test-allow:\n        header: x-ambassador-test-allow\n        omit_if_not_present: true\nmetadata_labels:\n  kat-ambassador-id: ratelimitv1withtlstest\n  scope: AmbassadorTest\nname: ratelimit_target_mapping\nprefix: /target/\nservice: ratelimitv1withtlstest-http\n",
             "service": "ratelimitv1withtlstest-http"
         },
         "ratelimitv1withtlstest.default.1": {
             "_referenced_by": {},
             "ambassador_id": "ratelimitv1withtlstest",
-            "apiVersion": "ambassador/v1",
+            "apiVersion": "getambassador.io/v1",
             "kind": "RateLimitService",
             "location": "ratelimitv1withtlstest.default.1",
+            "metadata_labels": {
+                "app.kubernetes.io/component": "ambassador-service",
+                "kat-ambassador-id": "ratelimitv1withtlstest",
+                "scope": "AmbassadorTest"
+            },
             "name": "ratelimit-tls",
             "namespace": "default",
             "rkey": "ratelimitv1withtlstest.default.1",
-            "serialization": "ambassador_id: ratelimitv1withtlstest\napiVersion: ambassador/v1\nkind: RateLimitService\nname: ratelimit-tls\nservice: rate-limit-tls:5000\ntimeout_ms: 500\ntls: ratelimit-tls-context\n",
+            "serialization": "ambassador_id: ratelimitv1withtlstest\napiVersion: ambassador/v1\nkind: RateLimitService\nmetadata_labels:\n  app.kubernetes.io/component: ambassador-service\n  kat-ambassador-id: ratelimitv1withtlstest\n  scope: AmbassadorTest\nname: ratelimit-tls\nservice: rate-limit-tls:5000\ntimeout_ms: 500\ntls: ratelimit-tls-context\n",
             "service": "rate-limit-tls:5000",
             "timeout_ms": 500,
             "tls": "ratelimit-tls-context"
@@ -146,7 +181,7 @@
     "mappings": {
         "ratelimit_target_mapping": {
             "ambassador_id": "ratelimitv1withtlstest",
-            "apiVersion": "ambassador/v1",
+            "apiVersion": "getambassador.io/v1",
             "kind": "Mapping",
             "labels": {
                 "ambassador": [
@@ -162,6 +197,10 @@
                     }
                 ]
             },
+            "metadata_labels": {
+                "kat-ambassador-id": "ratelimitv1withtlstest",
+                "scope": "AmbassadorTest"
+            },
             "name": "ratelimit_target_mapping",
             "namespace": "default",
             "prefix": "/target/",
@@ -171,8 +210,13 @@
     "ratelimit_configs": {
         "ratelimit-tls": {
             "ambassador_id": "ratelimitv1withtlstest",
-            "apiVersion": "ambassador/v1",
+            "apiVersion": "getambassador.io/v1",
             "kind": "RateLimitService",
+            "metadata_labels": {
+                "app.kubernetes.io/component": "ambassador-service",
+                "kat-ambassador-id": "ratelimitv1withtlstest",
+                "scope": "AmbassadorTest"
+            },
             "name": "ratelimit-tls",
             "namespace": "default",
             "service": "rate-limit-tls:5000",
@@ -183,8 +227,12 @@
     "secrets": {
         "ratelimit-tls-secret.default.1": {
             "ambassador_id": "ratelimitv1withtlstest",
-            "apiVersion": "ambassador/v1",
+            "apiVersion": "getambassador.io/v2",
             "kind": "Secret",
+            "metadata_labels": {
+                "kat-ambassador-id": "ratelimitv1withtlstest",
+                "scope": "AmbassadorTest"
+            },
             "name": "ratelimit-tls-secret",
             "namespace": "default",
             "secret_type": "kubernetes.io/tls",
@@ -195,33 +243,51 @@
     "service": {
         "k8s-rate-limit-tls-default": {
             "ambassador_id": "ratelimitv1withtlstest",
-            "apiVersion": "ambassador/v1",
+            "apiVersion": "getambassador.io/v2",
             "endpoints": {},
             "kind": "Service",
+            "metadata_labels": {
+                "kat-ambassador-id": "ratelimitv1withtlstest",
+                "scope": "AmbassadorTest"
+            },
             "name": "rate-limit-tls",
             "namespace": "default"
         },
         "k8s-ratelimitv1withtlstest-admin-default": {
             "ambassador_id": "ratelimitv1withtlstest",
-            "apiVersion": "ambassador/v1",
+            "apiVersion": "getambassador.io/v2",
             "endpoints": {},
             "kind": "Service",
+            "metadata_labels": {
+                "kat-ambassador-id": "ratelimitv1withtlstest",
+                "scope": "AmbassadorTest",
+                "service": "ratelimitv1withtlstest-admin"
+            },
             "name": "ratelimitv1withtlstest-admin",
             "namespace": "default"
         },
         "k8s-ratelimitv1withtlstest-default": {
             "ambassador_id": "ratelimitv1withtlstest",
-            "apiVersion": "ambassador/v1",
+            "apiVersion": "getambassador.io/v2",
             "endpoints": {},
             "kind": "Service",
+            "metadata_labels": {
+                "app.kubernetes.io/component": "ambassador-service",
+                "kat-ambassador-id": "ratelimitv1withtlstest",
+                "scope": "AmbassadorTest"
+            },
             "name": "ratelimitv1withtlstest",
             "namespace": "default"
         },
         "k8s-ratelimitv1withtlstest-http-default": {
             "ambassador_id": "ratelimitv1withtlstest",
-            "apiVersion": "ambassador/v1",
+            "apiVersion": "getambassador.io/v2",
             "endpoints": {},
             "kind": "Service",
+            "metadata_labels": {
+                "kat-ambassador-id": "ratelimitv1withtlstest",
+                "scope": "AmbassadorTest"
+            },
             "name": "ratelimitv1withtlstest-http",
             "namespace": "default"
         }
@@ -230,8 +296,12 @@
         "ratelimit-tls-context": {
             "alpn_protocols": "h2",
             "ambassador_id": "ratelimitv1withtlstest",
-            "apiVersion": "ambassador/v1",
+            "apiVersion": "getambassador.io/v1",
             "kind": "TLSContext",
+            "metadata_labels": {
+                "kat-ambassador-id": "ratelimitv1withtlstest",
+                "scope": "AmbassadorTest"
+            },
             "name": "ratelimit-tls-context",
             "namespace": "default",
             "secret": "ratelimit-tls-secret"

--- a/python/tests/gold/ratelimitv1withtlstest/snapshots/econf.json
+++ b/python/tests/gold/ratelimitv1withtlstest/snapshots/econf.json
@@ -126,6 +126,9 @@
                                     ],
                                     "http_filters": [
                                         {
+                                            "name": "envoy.cors"
+                                        },
+                                        {
                                             "config": {
                                                 "domain": "ambassador",
                                                 "rate_limit_service": {
@@ -139,9 +142,6 @@
                                                 "timeout": "0.500s"
                                             },
                                             "name": "envoy.rate_limit"
-                                        },
-                                        {
-                                            "name": "envoy.cors"
                                         },
                                         {
                                             "name": "envoy.router"

--- a/python/tests/gold/ratelimitv1withtlstest/snapshots/ir.json
+++ b/python/tests/gold/ratelimitv1withtlstest/snapshots/ir.json
@@ -116,6 +116,10 @@
                 "alpn_protocols": "h2",
                 "kind": "TLSContext",
                 "location": "ratelimitv1withtlstest-http.default.1",
+                "metadata_labels": {
+                    "kat-ambassador-id": "ratelimitv1withtlstest",
+                    "scope": "AmbassadorTest"
+                },
                 "name": "ratelimit-tls-context",
                 "namespace": "default",
                 "secret_info": {
@@ -167,6 +171,16 @@
         {
             "_active": true,
             "_errored": false,
+            "_rkey": "ir.cors",
+            "config": {},
+            "kind": "ir.cors",
+            "location": "--internal--",
+            "name": "cors",
+            "namespace": "default"
+        },
+        {
+            "_active": true,
+            "_errored": false,
             "_referenced_by": [
                 "ratelimitv1withtlstest.default.1"
             ],
@@ -210,6 +224,10 @@
                     "alpn_protocols": "h2",
                     "kind": "TLSContext",
                     "location": "ratelimitv1withtlstest-http.default.1",
+                    "metadata_labels": {
+                        "kat-ambassador-id": "ratelimitv1withtlstest",
+                        "scope": "AmbassadorTest"
+                    },
                     "name": "ratelimit-tls-context",
                     "namespace": "default",
                     "secret_info": {
@@ -270,6 +288,10 @@
                     "alpn_protocols": "h2",
                     "kind": "TLSContext",
                     "location": "ratelimitv1withtlstest-http.default.1",
+                    "metadata_labels": {
+                        "kat-ambassador-id": "ratelimitv1withtlstest",
+                        "scope": "AmbassadorTest"
+                    },
                     "name": "ratelimit-tls-context",
                     "namespace": "default",
                     "secret_info": {
@@ -289,16 +311,6 @@
             "namespace": "default",
             "service": "rate-limit-tls:5000",
             "type": "decoder"
-        },
-        {
-            "_active": true,
-            "_errored": false,
-            "_rkey": "ir.cors",
-            "config": {},
-            "kind": "ir.cors",
-            "location": "--internal--",
-            "name": "cors",
-            "namespace": "default"
         },
         {
             "_active": true,
@@ -375,7 +387,7 @@
                     },
                     "group_id": "b4db12f5b638f1750062dd4220911c4f6f44fc57",
                     "headers": [],
-                    "kind": "IRMapping",
+                    "kind": "IRHTTPMapping",
                     "location": "--internal--",
                     "name": "internal_readiness_probe_mapping",
                     "namespace": "default",
@@ -464,7 +476,7 @@
                     },
                     "group_id": "7df546235997704c909d473af2cbcb5e606d20de",
                     "headers": [],
-                    "kind": "IRMapping",
+                    "kind": "IRHTTPMapping",
                     "location": "--internal--",
                     "name": "internal_liveness_probe_mapping",
                     "namespace": "default",
@@ -553,7 +565,7 @@
                     },
                     "group_id": "8de18501d2044fe30db225289b318d5fda913b64",
                     "headers": [],
-                    "kind": "IRMapping",
+                    "kind": "IRHTTPMapping",
                     "location": "--internal--",
                     "name": "internal_diagnostics_probe_mapping",
                     "namespace": "default",
@@ -669,6 +681,10 @@
                         ]
                     },
                     "location": "ratelimitv1withtlstest-http.default.2",
+                    "metadata_labels": {
+                        "kat-ambassador-id": "ratelimitv1withtlstest",
+                        "scope": "AmbassadorTest"
+                    },
                     "name": "ratelimit_target_mapping",
                     "namespace": "default",
                     "precedence": 0,
@@ -682,17 +698,21 @@
                         "/target/",
                         "GET"
                     ],
-                    "serialization": "ambassador_id: ratelimitv1withtlstest\napiVersion: ambassador/v1\nkind: Mapping\nlabels:\n  ambassador:\n  - request_label_group:\n    - x-ambassador-test-allow:\n        header: x-ambassador-test-allow\n        omit_if_not_present: true\nname: ratelimit_target_mapping\nprefix: /target/\nservice: ratelimitv1withtlstest-http\n",
+                    "serialization": "ambassador_id: ratelimitv1withtlstest\napiVersion: ambassador/v1\nkind: Mapping\nlabels:\n  ambassador:\n  - request_label_group:\n    - x-ambassador-test-allow:\n        header: x-ambassador-test-allow\n        omit_if_not_present: true\nmetadata_labels:\n  kat-ambassador-id: ratelimitv1withtlstest\n  scope: AmbassadorTest\nname: ratelimit_target_mapping\nprefix: /target/\nservice: ratelimitv1withtlstest-http\n",
                     "service": "ratelimitv1withtlstest-http",
                     "weight": 100
                 }
             ],
+            "metadata_labels": {
+                "kat-ambassador-id": "ratelimitv1withtlstest",
+                "scope": "AmbassadorTest"
+            },
             "name": "GROUP: ratelimit_target_mapping",
             "namespace": "default",
             "precedence": 0,
             "prefix": "/target/",
             "rewrite": "/",
-            "serialization": "ambassador_id: ratelimitv1withtlstest\napiVersion: ambassador/v1\nkind: Mapping\nlabels:\n  ambassador:\n  - request_label_group:\n    - x-ambassador-test-allow:\n        header: x-ambassador-test-allow\n        omit_if_not_present: true\nname: ratelimit_target_mapping\nprefix: /target/\nservice: ratelimitv1withtlstest-http\n"
+            "serialization": "ambassador_id: ratelimitv1withtlstest\napiVersion: ambassador/v1\nkind: Mapping\nlabels:\n  ambassador:\n  - request_label_group:\n    - x-ambassador-test-allow:\n        header: x-ambassador-test-allow\n        omit_if_not_present: true\nmetadata_labels:\n  kat-ambassador-id: ratelimitv1withtlstest\n  scope: AmbassadorTest\nname: ratelimit_target_mapping\nprefix: /target/\nservice: ratelimitv1withtlstest-http\n"
         }
     ],
     "grpc_services": {
@@ -735,6 +755,10 @@
                 "alpn_protocols": "h2",
                 "kind": "TLSContext",
                 "location": "ratelimitv1withtlstest-http.default.1",
+                "metadata_labels": {
+                    "kat-ambassador-id": "ratelimitv1withtlstest",
+                    "scope": "AmbassadorTest"
+                },
                 "name": "ratelimit-tls-context",
                 "namespace": "default",
                 "secret_info": {
@@ -819,6 +843,10 @@
                 "alpn_protocols": "h2",
                 "kind": "TLSContext",
                 "location": "ratelimitv1withtlstest-http.default.1",
+                "metadata_labels": {
+                    "kat-ambassador-id": "ratelimitv1withtlstest",
+                    "scope": "AmbassadorTest"
+                },
                 "name": "ratelimit-tls-context",
                 "namespace": "default",
                 "secret_info": {
@@ -879,6 +907,10 @@
                 "alpn_protocols": "h2",
                 "kind": "TLSContext",
                 "location": "ratelimitv1withtlstest-http.default.1",
+                "metadata_labels": {
+                    "kat-ambassador-id": "ratelimitv1withtlstest",
+                    "scope": "AmbassadorTest"
+                },
                 "name": "ratelimit-tls-context",
                 "namespace": "default",
                 "secret_info": {
@@ -903,50 +935,68 @@
         "k8s-rate-limit-tls-default": {
             "_referenced_by": {},
             "ambassador_id": "ratelimitv1withtlstest",
-            "apiVersion": "ambassador/v1",
+            "apiVersion": "getambassador.io/v2",
             "endpoints": {},
             "kind": "Service",
             "location": "k8s-rate-limit-tls-default",
+            "metadata_labels": {
+                "kat-ambassador-id": "ratelimitv1withtlstest",
+                "scope": "AmbassadorTest"
+            },
             "name": "rate-limit-tls",
             "namespace": "default",
             "rkey": "k8s-rate-limit-tls-default",
-            "serialization": "ambassador_id: ratelimitv1withtlstest\napiVersion: ambassador/v1\nendpoints: {}\nkind: Service\nname: rate-limit-tls\nnamespace: default\n"
+            "serialization": "ambassador_id: ratelimitv1withtlstest\napiVersion: getambassador.io/v2\nendpoints: {}\nkind: Service\nmetadata_labels:\n  kat-ambassador-id: ratelimitv1withtlstest\n  scope: AmbassadorTest\nname: rate-limit-tls\nnamespace: default\n"
         },
         "k8s-ratelimitv1withtlstest-admin-default": {
             "_referenced_by": {},
             "ambassador_id": "ratelimitv1withtlstest",
-            "apiVersion": "ambassador/v1",
+            "apiVersion": "getambassador.io/v2",
             "endpoints": {},
             "kind": "Service",
             "location": "k8s-ratelimitv1withtlstest-admin-default",
+            "metadata_labels": {
+                "kat-ambassador-id": "ratelimitv1withtlstest",
+                "scope": "AmbassadorTest",
+                "service": "ratelimitv1withtlstest-admin"
+            },
             "name": "ratelimitv1withtlstest-admin",
             "namespace": "default",
             "rkey": "k8s-ratelimitv1withtlstest-admin-default",
-            "serialization": "ambassador_id: ratelimitv1withtlstest\napiVersion: ambassador/v1\nendpoints: {}\nkind: Service\nname: ratelimitv1withtlstest-admin\nnamespace: default\n"
+            "serialization": "ambassador_id: ratelimitv1withtlstest\napiVersion: getambassador.io/v2\nendpoints: {}\nkind: Service\nmetadata_labels:\n  kat-ambassador-id: ratelimitv1withtlstest\n  scope: AmbassadorTest\n  service: ratelimitv1withtlstest-admin\nname: ratelimitv1withtlstest-admin\nnamespace: default\n"
         },
         "k8s-ratelimitv1withtlstest-default": {
             "_referenced_by": {},
             "ambassador_id": "ratelimitv1withtlstest",
-            "apiVersion": "ambassador/v1",
+            "apiVersion": "getambassador.io/v2",
             "endpoints": {},
             "kind": "Service",
             "location": "k8s-ratelimitv1withtlstest-default",
+            "metadata_labels": {
+                "app.kubernetes.io/component": "ambassador-service",
+                "kat-ambassador-id": "ratelimitv1withtlstest",
+                "scope": "AmbassadorTest"
+            },
             "name": "ratelimitv1withtlstest",
             "namespace": "default",
             "rkey": "k8s-ratelimitv1withtlstest-default",
-            "serialization": "ambassador_id: ratelimitv1withtlstest\napiVersion: ambassador/v1\nendpoints: {}\nkind: Service\nname: ratelimitv1withtlstest\nnamespace: default\n"
+            "serialization": "ambassador_id: ratelimitv1withtlstest\napiVersion: getambassador.io/v2\nendpoints: {}\nkind: Service\nmetadata_labels:\n  app.kubernetes.io/component: ambassador-service\n  kat-ambassador-id: ratelimitv1withtlstest\n  scope: AmbassadorTest\nname: ratelimitv1withtlstest\nnamespace: default\n"
         },
         "k8s-ratelimitv1withtlstest-http-default": {
             "_referenced_by": {},
             "ambassador_id": "ratelimitv1withtlstest",
-            "apiVersion": "ambassador/v1",
+            "apiVersion": "getambassador.io/v2",
             "endpoints": {},
             "kind": "Service",
             "location": "k8s-ratelimitv1withtlstest-http-default",
+            "metadata_labels": {
+                "kat-ambassador-id": "ratelimitv1withtlstest",
+                "scope": "AmbassadorTest"
+            },
             "name": "ratelimitv1withtlstest-http",
             "namespace": "default",
             "rkey": "k8s-ratelimitv1withtlstest-http-default",
-            "serialization": "ambassador_id: ratelimitv1withtlstest\napiVersion: ambassador/v1\nendpoints: {}\nkind: Service\nname: ratelimitv1withtlstest-http\nnamespace: default\n"
+            "serialization": "ambassador_id: ratelimitv1withtlstest\napiVersion: getambassador.io/v2\nendpoints: {}\nkind: Service\nmetadata_labels:\n  kat-ambassador-id: ratelimitv1withtlstest\n  scope: AmbassadorTest\nname: ratelimitv1withtlstest-http\nnamespace: default\n"
         }
     },
     "tls_contexts": [
@@ -961,6 +1011,10 @@
             "alpn_protocols": "h2",
             "kind": "TLSContext",
             "location": "ratelimitv1withtlstest-http.default.1",
+            "metadata_labels": {
+                "kat-ambassador-id": "ratelimitv1withtlstest",
+                "scope": "AmbassadorTest"
+            },
             "name": "ratelimit-tls-context",
             "namespace": "default",
             "secret_info": {

--- a/python/tests/gold/ratelimitv1withtlstest/snapshots/snapshot.yaml
+++ b/python/tests/gold/ratelimitv1withtlstest/snapshots/snapshot.yaml
@@ -26,16 +26,16 @@
                     "annotations": {
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"data\":{\"tls.crt\":\"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURDakNDQWZJQ0NRRGdYUjZ3V1Z6Wk9EQU5CZ2txaGtpRzl3MEJBUVVGQURCSE1SNHdIQVlEVlFRRERCVnkKWVhSbGJHbHRhWFF1WkdGMFlYZHBjbVV1YVc4eEpUQWpCZ2txaGtpRzl3MEJDUUVXRm1odmMzUnRZWE4wWlhKQQpaR0YwWVhkcGNtVXVhVzh3SGhjTk1Ua3dPVEU1TVRnek16QXlXaGNOTWpFd09ERTVNVGd6TXpBeVdqQkhNUjR3CkhBWURWUVFEREJWeVlYUmxiR2x0YVhRdVpHRjBZWGRwY21VdWFXOHhKVEFqQmdrcWhraUc5dzBCQ1FFV0ZtaHYKYzNSdFlYTjBaWEpBWkdGMFlYZHBjbVV1YVc4d2dnRWlNQTBHQ1NxR1NJYjNEUUVCQVFVQUE0SUJEd0F3Z2dFSwpBb0lCQVFDeWw5VkJtVjVCcFYxOHZzclNqUktyZGlEVnZZS0dxNlZVaGFTRTlZSWNRODhiSTFaeHlhUE9zUVlRCmMycmY4Q0RKdUp4M1hoUjUzMENwN3pQNmVSMjNwMkZBOSsxSWs5SHZhWUx0WDRtQTJOdjh4V1kxaEhua1BURnMKVFRwazBMREdYYjVZWnh2QkczNTNKL3NFKzFrSUUxenpKZldpQUpUMzZzMk5PRzRVQWhoVmFPS2p1K3grYXJwbQoyZnNhTldKTTFEMS9CUXVVN1Vid0p0QmIyZFo2WUtUNHE4M2doQWgybDhad1hQcFdJQmtpWGpNNXJ0WkQ3QmN4CkRxdFNtVE1ZejVjZWNwbmhiNEw4Z3hFVUJyWlRxQ3g4RVkvcDArY05mN2hScmFWbTd6Q3BaRDhvSUtLS0IvUDQKM1dHZHRHNlpHS0VFSmtXNjB5QWtxRmI3czNWdEFnTUJBQUV3RFFZSktvWklodmNOQVFFRkJRQURnZ0VCQUFJUwp2Znh1K3dQcUxicVRZV1NLTUt6S3JmNUxxWlpBZFpZZXNIR0oxNmFyVmt6eGhzcElGRGZpblZ1UmI1eERxWVVSCnFta0U1K0dCNDh5UGoxaUQvdXdPOEI0ckFnNW1Pekw1MEpUMDVQT1dyc0hjK1loLzAvUXpGNmlqNHlVNWZ6dloKRHpJdFBiNE5qWTMxUE44WkJMYTFGSHk5d2JGSzdyS2lWK2MxTzd0UHVjQTVUWnoxS0h5VUVYaWxHdmNoczB4OApzazRJR2xrVTNoSDFVWHBzTmw0NTI4VjR0L3dXOTdiYmhFeHYvYnBwR3RLbjRKei9hYkNScjA3Q3kzUytjUzc5CnlQNTZiQVZxa1R2TTVkUkhiNG9zOGYzNUJuQTdPci9YRTQ2K2VRMXNVY21IVG5OUWdFVkpWZGVwR3V4Sk5pNFMKejJ0WHhHSStTdTFlUnlQcVNGWT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=\",\"tls.key\":\"LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0tCk1JSUV2UUlCQURBTkJna3Foa2lHOXcwQkFRRUZBQVNDQktjd2dnU2pBZ0VBQW9JQkFRQ3lsOVZCbVY1QnBWMTgKdnNyU2pSS3JkaURWdllLR3E2VlVoYVNFOVlJY1E4OGJJMVp4eWFQT3NRWVFjMnJmOENESnVKeDNYaFI1MzBDcAo3elA2ZVIyM3AyRkE5KzFJazlIdmFZTHRYNG1BMk52OHhXWTFoSG5rUFRGc1RUcGswTERHWGI1WVp4dkJHMzUzCkovc0UrMWtJRTF6ekpmV2lBSlQzNnMyTk9HNFVBaGhWYU9LanUreCthcnBtMmZzYU5XSk0xRDEvQlF1VTdVYncKSnRCYjJkWjZZS1Q0cTgzZ2hBaDJsOFp3WFBwV0lCa2lYak01cnRaRDdCY3hEcXRTbVRNWXo1Y2VjcG5oYjRMOApneEVVQnJaVHFDeDhFWS9wMCtjTmY3aFJyYVZtN3pDcFpEOG9JS0tLQi9QNDNXR2R0RzZaR0tFRUprVzYweUFrCnFGYjdzM1Z0QWdNQkFBRUNnZ0VBS3hvNzdOWWdDb1hubHpqUTZKb0ZuSDRwRkl6bFdLMUtmS2k0ZVNKcm9YaTQKSGx1Yi9HQm0rWFo5K1RCeDVkUWxoYW5aa1hHU1RZdVZKcTVGaERrQTlCY2dnTGFWZlFPNEVpa0w0VkJDZG1kZwpTSlEzdzhqU1JrU0NqaG5oY3YxdS9LRVpWR3FtSnlnRWtLdUVpTUpFelk4bXlzUXBrVXpFcDBUekVSZENjZTljClNKT2Q2V2dGYUdzN3ZmTEpMajBmTk1SYytwcjFORnBmcTk0R2lyZFVyQUIvOHhlL2lpT3hnZXJoM1JPR0I4Z1MKZWpMeTZmZEhZK0Y1d2cyREtFMjVjeHcrdWFUeEo4MElucktWYTdhVjlqeGl1L0YvWW42a0FGT201cUFaTEdJUQo3bDVDY0dMWCtKdS96UGNpSEJRRWx2R2dSTGdZTCtxWHNPYStyZ3VvZ1FLQmdRRFpVU25xQUdvd2Zma3h1QTB2CnVxc042M3NaMHFVVUMraDB1aGZCanV1ZGxEZU8rM2U5WC9ncW1vTHFnYmpLbUNxcHZ0eFRKT2RZbWlkTG42QysKU3ZIMkw5V3RBNzVFMDB1bDdWb0VEOWs5S1c5aEU4M1ZoM0hJcnowQ3RtLzAvMEtJaVlXb2VkaWw2YktlTndUSApXci9MdlI5M2F2dHo2NUkwVWFBVjVyMjhqUUtCZ1FEU1loS2R1YzB1YUQ2VW45NW0yTmZJelRaNWxaNmZZdFFyCkZHbzByWWlTelZCRlZrNnR3akI5dmhtdmtjZjBNU21wQ1NPUUZGcjJ3Zk9UZGtBTnlxTWxwNXdHK3ZpRi9LeGMKcXNMQ1RROGhwNmFnazMzRE9MVEl2OXpKdkhnU2NsWW9pOTZqNk9Zc28rWUtITkxmTU1jVWw3dThqYmZ3YWx2dwp4Tno3WkdRVVlRS0JnSFdsZWRKamJSbFphVWxnUVV0QWZBL3FGbGR4Y01xOGM1aVZrZnpJT1lleVVLMklOMWQvCkYrTkFpSFVaeXdkcWYxWXJyQzBhd2w5MS9LWDFBZGxpeTBDaXZzT09UamdHUjJMSmJyemFNNW5uejVNM1hHd24KaWhMQnczNnZjMGFuMWNZQzVTZkM1dVZTOGM2ekxGUWNMYzdIVUx5ZVh3aHZWRlFjaUZTeStLNlZBb0dBUkFObQpwMDBBOHliS1RId2VoenRGRDJxZ1dOQXc5ckFaalUvTlFmaHo5Wm1nZ0xuMU42RlcwZC9hSi9OR0pFQ2Npa1FsCkZoZ3VqQ1dKbkR1WFc1NE4va2RnWHJWV0VPTHR5Z3QrYVJoR2N3ZmpDM2lES05DMVNVMFZrTFo0VHVaZHlqL2wKbXpIWTc4ZVF2K1l2bWU0SC9qVkxnUnFEdzVwdTNMaVlCRUdoUlNFQ2dZRUExdmNGWmsxOXVLS0JSWDhFRlgzbQphTlk2QWVhWTVJV2xVbDFJbEpHUHBFNnBnejh1aVRYNU9paG5KbGh4NDIzdjBIRU1QV0ZxNXQzcCtJdGRKZ24zCnlTQ0RNcXhyZUo4cytCS3BqeUcwVHFjN0pkbkpUcm1NN1FUMCtVUXExYmlBOENiU0FvMWVybHJpcEZ1blVMblEKSXp3SURyM1VzN0ROQkxNZmlOaDZuVWs9Ci0tLS0tRU5EIFBSSVZBVEUgS0VZLS0tLS0K\"},\"kind\":\"Secret\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"ratelimitv1withtlstest\",\"scope\":\"AmbassadorTest\"},\"name\":\"ratelimit-tls-secret\",\"namespace\":\"default\"},\"type\":\"kubernetes.io/tls\"}\n"
                     },
-                    "creationTimestamp": "2019-11-04T05:43:55Z",
+                    "creationTimestamp": "2019-11-13T20:38:23Z",
                     "labels": {
                         "kat-ambassador-id": "ratelimitv1withtlstest",
                         "scope": "AmbassadorTest"
                     },
                     "name": "ratelimit-tls-secret",
                     "namespace": "default",
-                    "resourceVersion": "12975",
+                    "resourceVersion": "103466",
                     "selfLink": "/api/v1/namespaces/default/secrets/ratelimit-tls-secret",
-                    "uid": "17238d3d-fec6-11e9-8b1f-120e67b61000"
+                    "uid": "8988fc1f-0655-11ea-8a6b-063c64bfaacb"
                 },
                 "type": "kubernetes.io/tls"
             }
@@ -46,107 +46,21 @@
                 "kind": "Service",
                 "metadata": {
                     "annotations": {
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"ratelimitv1withtlstest\",\"scope\":\"AmbassadorTest\",\"service\":\"ratelimitv1withtlstest-admin\"},\"name\":\"ratelimitv1withtlstest-admin\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"ratelimitv1withtlstest-admin\",\"port\":8877,\"targetPort\":8877}],\"selector\":{\"service\":\"ratelimitv1withtlstest\"},\"type\":\"NodePort\"}}\n"
-                    },
-                    "creationTimestamp": "2019-11-04T05:43:53Z",
-                    "labels": {
-                        "kat-ambassador-id": "ratelimitv1withtlstest",
-                        "scope": "AmbassadorTest",
-                        "service": "ratelimitv1withtlstest-admin"
-                    },
-                    "name": "ratelimitv1withtlstest-admin",
-                    "namespace": "default",
-                    "resourceVersion": "12949",
-                    "selfLink": "/api/v1/namespaces/default/services/ratelimitv1withtlstest-admin",
-                    "uid": "16137bd5-fec6-11e9-8b1f-120e67b61000"
-                },
-                "spec": {
-                    "clusterIP": "10.101.65.151",
-                    "externalTrafficPolicy": "Cluster",
-                    "ports": [
-                        {
-                            "name": "ratelimitv1withtlstest-admin",
-                            "nodePort": 30843,
-                            "port": 8877,
-                            "protocol": "TCP",
-                            "targetPort": 8877
-                        }
-                    ],
-                    "selector": {
-                        "service": "ratelimitv1withtlstest"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "NodePort"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: TLSContext\nname: ratelimit-tls-context\nsecret: ratelimit-tls-secret\nalpn_protocols: h2\nambassador_id: ratelimitv1withtlstest\n---\napiVersion: ambassador/v1\nkind: Mapping\nname: ratelimit_target_mapping\nprefix: /target/\nservice: ratelimitv1withtlstest-http\nlabels:\n  ambassador:\n  - request_label_group:\n    - x-ambassador-test-allow:\n        header: \"x-ambassador-test-allow\"\n        omit_if_not_present: true\nambassador_id: ratelimitv1withtlstest\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: TLSContext\\nname: ratelimit-tls-context\\nsecret: ratelimit-tls-secret\\nalpn_protocols: h2\\nambassador_id: ratelimitv1withtlstest\\n---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: ratelimit_target_mapping\\nprefix: /target/\\nservice: ratelimitv1withtlstest-http\\nlabels:\\n  ambassador:\\n  - request_label_group:\\n    - x-ambassador-test-allow:\\n        header: \\\"x-ambassador-test-allow\\\"\\n        omit_if_not_present: true\\nambassador_id: ratelimitv1withtlstest\\n\"},\"labels\":{\"kat-ambassador-id\":\"ratelimitv1withtlstest\",\"scope\":\"AmbassadorTest\"},\"name\":\"ratelimitv1withtlstest-http\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8110},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8473}],\"selector\":{\"backend\":\"superpod-default\"}}}\n"
-                    },
-                    "creationTimestamp": "2019-11-04T05:43:55Z",
-                    "labels": {
-                        "kat-ambassador-id": "ratelimitv1withtlstest",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "ratelimitv1withtlstest-http",
-                    "namespace": "default",
-                    "resourceVersion": "12988",
-                    "selfLink": "/api/v1/namespaces/default/services/ratelimitv1withtlstest-http",
-                    "uid": "17387687-fec6-11e9-8b1f-120e67b61000"
-                },
-                "spec": {
-                    "clusterIP": "10.97.59.52",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8110
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8473
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-default"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"ratelimitv1withtlstest\",\"scope\":\"AmbassadorTest\"},\"name\":\"rate-limit-tls\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"grpc\",\"port\":5000,\"targetPort\":\"grpc\"}],\"selector\":{\"app\":\"rate-limit-tls\"},\"type\":\"ClusterIP\"}}\n"
                     },
-                    "creationTimestamp": "2019-11-04T05:43:55Z",
+                    "creationTimestamp": "2019-11-13T20:38:23Z",
                     "labels": {
                         "kat-ambassador-id": "ratelimitv1withtlstest",
                         "scope": "AmbassadorTest"
                     },
                     "name": "rate-limit-tls",
                     "namespace": "default",
-                    "resourceVersion": "12966",
+                    "resourceVersion": "103450",
                     "selfLink": "/api/v1/namespaces/default/services/rate-limit-tls",
-                    "uid": "16f2d3b8-fec6-11e9-8b1f-120e67b61000"
+                    "uid": "895184b3-0655-11ea-8a6b-063c64bfaacb"
                 },
                 "spec": {
-                    "clusterIP": "10.97.130.127",
+                    "clusterIP": "10.110.246.161",
                     "ports": [
                         {
                             "name": "grpc",
@@ -173,7 +87,7 @@
                         "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: RateLimitService\nname: ratelimit-tls\nservice: rate-limit-tls:5000\ntimeout_ms: 500\ntls: ratelimit-tls-context\nambassador_id: ratelimitv1withtlstest\n",
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: RateLimitService\\nname: ratelimit-tls\\nservice: rate-limit-tls:5000\\ntimeout_ms: 500\\ntls: ratelimit-tls-context\\nambassador_id: ratelimitv1withtlstest\\n\"},\"labels\":{\"app.kubernetes.io/component\":\"ambassador-service\",\"kat-ambassador-id\":\"ratelimitv1withtlstest\",\"scope\":\"AmbassadorTest\"},\"name\":\"ratelimitv1withtlstest\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8080},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8443}],\"selector\":{\"service\":\"ratelimitv1withtlstest\"},\"type\":\"NodePort\"}}\n"
                     },
-                    "creationTimestamp": "2019-11-04T05:43:52Z",
+                    "creationTimestamp": "2019-11-13T20:38:23Z",
                     "labels": {
                         "app.kubernetes.io/component": "ambassador-service",
                         "kat-ambassador-id": "ratelimitv1withtlstest",
@@ -181,24 +95,24 @@
                     },
                     "name": "ratelimitv1withtlstest",
                     "namespace": "default",
-                    "resourceVersion": "12944",
+                    "resourceVersion": "103439",
                     "selfLink": "/api/v1/namespaces/default/services/ratelimitv1withtlstest",
-                    "uid": "1554fd53-fec6-11e9-8b1f-120e67b61000"
+                    "uid": "89298af5-0655-11ea-8a6b-063c64bfaacb"
                 },
                 "spec": {
-                    "clusterIP": "10.104.16.255",
+                    "clusterIP": "10.106.155.219",
                     "externalTrafficPolicy": "Cluster",
                     "ports": [
                         {
                             "name": "http",
-                            "nodePort": 30408,
+                            "nodePort": 31366,
                             "port": 80,
                             "protocol": "TCP",
                             "targetPort": 8080
                         },
                         {
                             "name": "https",
-                            "nodePort": 32722,
+                            "nodePort": 31107,
                             "port": 443,
                             "protocol": "TCP",
                             "targetPort": 8443
@@ -209,6 +123,92 @@
                     },
                     "sessionAffinity": "None",
                     "type": "NodePort"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"ratelimitv1withtlstest\",\"scope\":\"AmbassadorTest\",\"service\":\"ratelimitv1withtlstest-admin\"},\"name\":\"ratelimitv1withtlstest-admin\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"ratelimitv1withtlstest-admin\",\"port\":8877,\"targetPort\":8877}],\"selector\":{\"service\":\"ratelimitv1withtlstest\"},\"type\":\"NodePort\"}}\n"
+                    },
+                    "creationTimestamp": "2019-11-13T20:38:23Z",
+                    "labels": {
+                        "kat-ambassador-id": "ratelimitv1withtlstest",
+                        "scope": "AmbassadorTest",
+                        "service": "ratelimitv1withtlstest-admin"
+                    },
+                    "name": "ratelimitv1withtlstest-admin",
+                    "namespace": "default",
+                    "resourceVersion": "103443",
+                    "selfLink": "/api/v1/namespaces/default/services/ratelimitv1withtlstest-admin",
+                    "uid": "89354afc-0655-11ea-8a6b-063c64bfaacb"
+                },
+                "spec": {
+                    "clusterIP": "10.105.45.72",
+                    "externalTrafficPolicy": "Cluster",
+                    "ports": [
+                        {
+                            "name": "ratelimitv1withtlstest-admin",
+                            "nodePort": 31340,
+                            "port": 8877,
+                            "protocol": "TCP",
+                            "targetPort": 8877
+                        }
+                    ],
+                    "selector": {
+                        "service": "ratelimitv1withtlstest"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "NodePort"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: TLSContext\nname: ratelimit-tls-context\nsecret: ratelimit-tls-secret\nalpn_protocols: h2\nambassador_id: ratelimitv1withtlstest\n---\napiVersion: ambassador/v1\nkind: Mapping\nname: ratelimit_target_mapping\nprefix: /target/\nservice: ratelimitv1withtlstest-http\nlabels:\n  ambassador:\n  - request_label_group:\n    - x-ambassador-test-allow:\n        header: \"x-ambassador-test-allow\"\n        omit_if_not_present: true\nambassador_id: ratelimitv1withtlstest\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: TLSContext\\nname: ratelimit-tls-context\\nsecret: ratelimit-tls-secret\\nalpn_protocols: h2\\nambassador_id: ratelimitv1withtlstest\\n---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: ratelimit_target_mapping\\nprefix: /target/\\nservice: ratelimitv1withtlstest-http\\nlabels:\\n  ambassador:\\n  - request_label_group:\\n    - x-ambassador-test-allow:\\n        header: \\\"x-ambassador-test-allow\\\"\\n        omit_if_not_present: true\\nambassador_id: ratelimitv1withtlstest\\n\"},\"labels\":{\"kat-ambassador-id\":\"ratelimitv1withtlstest\",\"scope\":\"AmbassadorTest\"},\"name\":\"ratelimitv1withtlstest-http\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8082},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8445}],\"selector\":{\"backend\":\"superpod-default\"}}}\n"
+                    },
+                    "creationTimestamp": "2019-11-13T20:38:23Z",
+                    "labels": {
+                        "kat-ambassador-id": "ratelimitv1withtlstest",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "ratelimitv1withtlstest-http",
+                    "namespace": "default",
+                    "resourceVersion": "103472",
+                    "selfLink": "/api/v1/namespaces/default/services/ratelimitv1withtlstest-http",
+                    "uid": "8995800f-0655-11ea-8a6b-063c64bfaacb"
+                },
+                "spec": {
+                    "clusterIP": "10.110.44.184",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8082
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8445
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-default"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
                 },
                 "status": {
                     "loadBalancer": {}


### PR DESCRIPTION
Turns out we need CORS to take effect before rate limiting.

Also, this PR fixes a bug with `KAT_RUN_MODE=envoy`.