### PR TITLE
Update YAML formatting

### DIFF
--- a/docs/yaml/ambassador/ambassador-crds.yaml
+++ b/docs/yaml/ambassador/ambassador-crds.yaml
@@ -1,10 +1,16 @@
----
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: authservices.getambassador.io
 spec:
   group: getambassador.io
+  names:
+    categories:
+    - ambassador-crds
+    kind: AuthService
+    plural: authservices
+    singular: authservice
+  scope: Namespaced
   version: v1
   versions:
   - name: v1
@@ -13,13 +19,6 @@ spec:
   - name: v2
     served: true
     storage: true
-  scope: Namespaced
-  names:
-    plural: authservices
-    singular: authservice
-    kind: AuthService
-    categories:
-    - ambassador-crds
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
@@ -27,6 +26,13 @@ metadata:
   name: consulresolvers.getambassador.io
 spec:
   group: getambassador.io
+  names:
+    categories:
+    - ambassador-crds
+    kind: ConsulResolver
+    plural: consulresolvers
+    singular: consulresolver
+  scope: Namespaced
   version: v1
   versions:
   - name: v1
@@ -35,39 +41,36 @@ spec:
   - name: v2
     served: true
     storage: true
-  scope: Namespaced
-  names:
-    plural: consulresolvers
-    singular: consulresolver
-    kind: ConsulResolver
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: hosts.getambassador.io
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .spec.hostname
+    name: Hostname
+    type: string
+  - JSONPath: .status.state
+    name: State
+    type: string
+  - JSONPath: .status.phaseCompleted
+    name: Phase Completed
+    type: string
+  - JSONPath: .status.phasePending
+    name: Phase Pending
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    name: Age
+    type: date
   group: getambassador.io
   names:
+    categories:
+    - ambassador-crds
+    kind: Host
     plural: hosts
     singular: host
-    kind: Host
   scope: Namespaced
-  additionalPrinterColumns:
-  - name: Hostname
-    type: string
-    JSONPath: .spec.hostname
-  - name: State
-    type: string
-    JSONPath: .status.state
-  - name: Phase Completed
-    type: string
-    JSONPath: .status.phaseCompleted
-  - name: Phase Pending
-    type: string
-    JSONPath: .status.phasePending
-  - name: Age
-    type: date
-    JSONPath: .metadata.creationTimestamp
   version: v2
   versions:
   - name: v2
@@ -80,6 +83,13 @@ metadata:
   name: kubernetesendpointresolvers.getambassador.io
 spec:
   group: getambassador.io
+  names:
+    categories:
+    - ambassador-crds
+    kind: KubernetesEndpointResolver
+    plural: kubernetesendpointresolvers
+    singular: kubernetesendpointresolver
+  scope: Namespaced
   version: v1
   versions:
   - name: v1
@@ -88,11 +98,6 @@ spec:
   - name: v2
     served: true
     storage: true
-  scope: Namespaced
-  names:
-    plural: kubernetesendpointresolvers
-    singular: kubernetesendpointresolver
-    kind: KubernetesEndpointResolver
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
@@ -100,6 +105,13 @@ metadata:
   name: kubernetesserviceresolvers.getambassador.io
 spec:
   group: getambassador.io
+  names:
+    categories:
+    - ambassador-crds
+    kind: KubernetesServiceResolver
+    plural: kubernetesserviceresolvers
+    singular: kubernetesserviceresolver
+  scope: Namespaced
   version: v1
   versions:
   - name: v1
@@ -108,11 +120,6 @@ spec:
   - name: v2
     served: true
     storage: true
-  scope: Namespaced
-  names:
-    plural: kubernetesserviceresolvers
-    singular: kubernetesserviceresolver
-    kind: KubernetesServiceResolver
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
@@ -120,6 +127,13 @@ metadata:
   name: logservices.getambassador.io
 spec:
   group: getambassador.io
+  names:
+    categories:
+    - ambassador-crds
+    kind: LogService
+    plural: logservices
+    singular: logservice
+  scope: Namespaced
   version: v1
   versions:
   - name: v1
@@ -128,20 +142,35 @@ spec:
   - name: v2
     served: true
     storage: true
-  scope: Namespaced
-  names:
-    plural: logservices
-    singular: logservice
-    kind: LogService
-    categories:
-    - ambassador-crds
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: mappings.getambassador.io
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .spec.prefix
+    name: Prefix
+    type: string
+  - JSONPath: .spec.service
+    name: Service
+    type: string
+  - JSONPath: .status.state
+    name: State
+    type: string
+  - JSONPath: .status.reason
+    name: Reason
+    type: string
   group: getambassador.io
+  names:
+    categories:
+    - ambassador-crds
+    kind: Mapping
+    plural: mappings
+    singular: mapping
+  scope: Namespaced
+  subresources:
+    status: {}
   version: v1
   versions:
   - name: v1
@@ -150,28 +179,6 @@ spec:
   - name: v2
     served: true
     storage: true
-  scope: Namespaced
-  names:
-    plural: mappings
-    singular: mapping
-    kind: Mapping
-    categories:
-    - ambassador-crds
-  additionalPrinterColumns:
-  - name: Prefix
-    type: string
-    JSONPath: .spec.prefix
-  - name: Service
-    type: string
-    JSONPath: .spec.service
-  - name: State
-    type: string
-    JSONPath: .status.state
-  - name: Reason
-    type: string
-    JSONPath: .status.reason
-  subresources:
-    status: {}   
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
@@ -179,6 +186,13 @@ metadata:
   name: modules.getambassador.io
 spec:
   group: getambassador.io
+  names:
+    categories:
+    - ambassador-crds
+    kind: Module
+    plural: modules
+    singular: module
+  scope: Namespaced
   version: v1
   versions:
   - name: v1
@@ -187,13 +201,6 @@ spec:
   - name: v2
     served: true
     storage: true
-  scope: Namespaced
-  names:
-    plural: modules
-    singular: module
-    kind: Module
-    categories:
-    - ambassador-crds
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
@@ -201,6 +208,13 @@ metadata:
   name: ratelimitservices.getambassador.io
 spec:
   group: getambassador.io
+  names:
+    categories:
+    - ambassador-crds
+    kind: RateLimitService
+    plural: ratelimitservices
+    singular: ratelimitservice
+  scope: Namespaced
   version: v1
   versions:
   - name: v1
@@ -209,13 +223,6 @@ spec:
   - name: v2
     served: true
     storage: true
-  scope: Namespaced
-  names:
-    plural: ratelimitservices
-    singular: ratelimitservice
-    kind: RateLimitService
-    categories:
-    - ambassador-crds
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
@@ -223,6 +230,13 @@ metadata:
   name: tcpmappings.getambassador.io
 spec:
   group: getambassador.io
+  names:
+    categories:
+    - ambassador-crds
+    kind: TCPMapping
+    plural: tcpmappings
+    singular: tcpmapping
+  scope: Namespaced
   version: v1
   versions:
   - name: v1
@@ -231,13 +245,6 @@ spec:
   - name: v2
     served: true
     storage: true
-  scope: Namespaced
-  names:
-    plural: tcpmappings
-    singular: tcpmapping
-    kind: TCPMapping
-    categories:
-    - ambassador-crds
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
@@ -245,6 +252,13 @@ metadata:
   name: tlscontexts.getambassador.io
 spec:
   group: getambassador.io
+  names:
+    categories:
+    - ambassador-crds
+    kind: TLSContext
+    plural: tlscontexts
+    singular: tlscontext
+  scope: Namespaced
   version: v1
   versions:
   - name: v1
@@ -253,13 +267,6 @@ spec:
   - name: v2
     served: true
     storage: true
-  scope: Namespaced
-  names:
-    plural: tlscontexts
-    singular: tlscontext
-    kind: TLSContext
-    categories:
-    - ambassador-crds
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
@@ -267,6 +274,13 @@ metadata:
   name: tracingservices.getambassador.io
 spec:
   group: getambassador.io
+  names:
+    categories:
+    - ambassador-crds
+    kind: TracingService
+    plural: tracingservices
+    singular: tracingservice
+  scope: Namespaced
   version: v1
   versions:
   - name: v1
@@ -275,10 +289,3 @@ spec:
   - name: v2
     served: true
     storage: true
-  scope: Namespaced
-  names:
-    plural: tracingservices
-    singular: tracingservice
-    kind: TracingService
-    categories:
-    - ambassador-crds

--- a/docs/yaml/ambassador/ambassador-rbac.yaml
+++ b/docs/yaml/ambassador/ambassador-rbac.yaml
@@ -59,209 +59,6 @@ subjects:
   name: ambassador
   namespace: default
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  name: authservices.getambassador.io
-spec:
-  group: getambassador.io
-  version: v1
-  versions:
-  - name: v1
-    served: true
-    storage: true
-  scope: Namespaced
-  names:
-    plural: authservices
-    singular: authservice
-    kind: AuthService
-    categories:
-    - ambassador-crds
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  name: consulresolvers.getambassador.io
-spec:
-  group: getambassador.io
-  version: v1
-  versions:
-  - name: v1
-    served: true
-    storage: true
-  scope: Namespaced
-  names:
-    plural: consulresolvers
-    singular: consulresolver
-    kind: ConsulResolver
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  name: kubernetesendpointresolvers.getambassador.io
-spec:
-  group: getambassador.io
-  version: v1
-  versions:
-  - name: v1
-    served: true
-    storage: true
-  scope: Namespaced
-  names:
-    plural: kubernetesendpointresolvers
-    singular: kubernetesendpointresolver
-    kind: KubernetesEndpointResolver
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  name: kubernetesserviceresolvers.getambassador.io
-spec:
-  group: getambassador.io
-  version: v1
-  versions:
-  - name: v1
-    served: true
-    storage: true
-  scope: Namespaced
-  names:
-    plural: kubernetesserviceresolvers
-    singular: kubernetesserviceresolver
-    kind: KubernetesServiceResolver
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  name: mappings.getambassador.io
-spec:
-  group: getambassador.io
-  version: v1
-  versions:
-  - name: v1
-    served: true
-    storage: true
-  scope: Namespaced
-  names:
-    plural: mappings
-    singular: mapping
-    kind: Mapping
-    categories:
-    - ambassador-crds
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  name: modules.getambassador.io
-spec:
-  group: getambassador.io
-  version: v1
-  versions:
-  - name: v1
-    served: true
-    storage: true
-  scope: Namespaced
-  names:
-    plural: modules
-    singular: module
-    kind: Module
-    categories:
-    - ambassador-crds
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  name: ratelimitservices.getambassador.io
-spec:
-  group: getambassador.io
-  version: v1
-  versions:
-  - name: v1
-    served: true
-    storage: true
-  scope: Namespaced
-  names:
-    plural: ratelimitservices
-    singular: ratelimitservice
-    kind: RateLimitService
-    categories:
-    - ambassador-crds
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  name: tcpmappings.getambassador.io
-spec:
-  group: getambassador.io
-  version: v1
-  versions:
-  - name: v1
-    served: true
-    storage: true
-  scope: Namespaced
-  names:
-    plural: tcpmappings
-    singular: tcpmapping
-    kind: TCPMapping
-    categories:
-    - ambassador-crds
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  name: tlscontexts.getambassador.io
-spec:
-  group: getambassador.io
-  version: v1
-  versions:
-  - name: v1
-    served: true
-    storage: true
-  scope: Namespaced
-  names:
-    plural: tlscontexts
-    singular: tlscontext
-    kind: TLSContext
-    categories:
-    - ambassador-crds
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  name: tracingservices.getambassador.io
-spec:
-  group: getambassador.io
-  version: v1
-  versions:
-  - name: v1
-    served: true
-    storage: true
-  scope: Namespaced
-  names:
-    plural: tracingservices
-    singular: tracingservice
-    kind: TracingService
-    categories:
-    - ambassador-crds
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  name: logservices.getambassador.io
-spec:
-  group: getambassador.io
-  version: v1
-  versions:
-  - name: v1
-    served: true
-    storage: true
-  scope: Namespaced
-  names:
-    plural: logservices
-    singular: logservice
-    kind: LogService
-    categories:
-    - ambassador-crds
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -274,24 +71,47 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/inject: "false"
-        "consul.hashicorp.com/connect-inject": "false"
+        consul.hashicorp.com/connect-inject: 'false'
+        sidecar.istio.io/inject: 'false'
       labels:
         service: ambassador
     spec:
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 100
-            podAffinityTerm:
+          - podAffinityTerm:
               labelSelector:
                 matchLabels:
                   service: ambassador
               topologyKey: kubernetes.io/hostname
-      serviceAccountName: ambassador
+            weight: 100
       containers:
-      - name: ambassador
+      - env:
+        - name: AMBASSADOR_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         image: quay.io/datawire/ambassador:$version$
+        livenessProbe:
+          httpGet:
+            path: /ambassador/v0/check_alive
+            port: 8877
+          initialDelaySeconds: 30
+          periodSeconds: 3
+        name: ambassador
+        ports:
+        - containerPort: 8080
+          name: http
+        - containerPort: 8443
+          name: https
+        - containerPort: 8877
+          name: admin
+        readinessProbe:
+          httpGet:
+            path: /ambassador/v0/check_ready
+            port: 8877
+          initialDelaySeconds: 30
+          periodSeconds: 3
         resources:
           limits:
             cpu: 1
@@ -299,40 +119,17 @@ spec:
           requests:
             cpu: 200m
             memory: 100Mi
-        env:
-        - name: AMBASSADOR_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
-        ports:
-        - name: http
-          containerPort: 8080
-        - name: https
-          containerPort: 8443
-        - name: admin
-          containerPort: 8877
-        livenessProbe:
-          httpGet:
-            path: /ambassador/v0/check_alive
-            port: 8877
-          initialDelaySeconds: 30
-          periodSeconds: 3
-        readinessProbe:
-          httpGet:
-            path: /ambassador/v0/check_ready
-            port: 8877
-          initialDelaySeconds: 30
-          periodSeconds: 3
         volumeMounts:
-        - name: ambassador-pod-info
-          mountPath: /tmp/ambassador-pod-info
-      volumes:
-      - name: ambassador-pod-info
-        downwardAPI:
-          items:
-          - path: "labels"
-            fieldRef:
-              fieldPath: metadata.labels
+        - mountPath: /tmp/ambassador-pod-info
+          name: ambassador-pod-info
       restartPolicy: Always
       securityContext:
         runAsUser: 8888
+      serviceAccountName: ambassador
+      volumes:
+      - downwardAPI:
+          items:
+          - fieldRef:
+              fieldPath: metadata.labels
+            path: labels
+        name: ambassador-pod-info


### PR DESCRIPTION
This is mostly reformatting and ordering to be a reasonable base for the update-yaml script for Edge Stack releases. There are two content changes:

1. Adding the `ambassador-crds` category where it was missing.
2. Removing the out-of-date copy of the Ambassador CRDs from `ambassador-rbac.yaml`. Soon that file will become a derived object.
