### PR TITLE
Updated with right yaml for tour service to run in minikube environment

### DIFF
--- a/docs/user-guide/getting-started.md
+++ b/docs/user-guide/getting-started.md
@@ -85,12 +85,15 @@ kind: Service
 metadata:
   name: tour
 spec:
+  type: NodePort
   ports:
   - name: ui
     port: 5000
+    protocol: TCP
     targetPort: 5000
   - name: backend
     port: 8080
+    protocol: TCP
     targetPort: 8080
   selector:
     app: tour


### PR DESCRIPTION
## Description
Its missing the type NodePort and protocol which basically does not expose the tour service to be accessible in minikube from a browser. the changes are minikube specific only.

## Related Issues
List related issues.

## Testing
A few sentences describing what testing you've done, e.g., manual tests, automated tests, deployed in production, etc.

## Todos
- [ ] Tests
- [ ] Documentation

## Other
* If this is a documentation change, please open the pull request at https://github.com/datawire/ambassador-docs instead.
* Code changes should occur against `master`.
