### PR TITLE
Keep watching CRDs after bootstrap

### DIFF
--- a/cmd/watt/aggregator.go
+++ b/cmd/watt/aggregator.go
@@ -143,7 +143,7 @@ func (a *aggregator) isComplete(p *supervisor.Process, watchset WatchSet) bool {
 
 	for _, w := range watchset.ConsulWatches {
 		if _, ok := a.ids[w.WatchId()]; ok {
-			p.Logf("initialized k8s watch: %s", w.WatchId())
+			p.Logf("initialized consul watch: %s", w.WatchId())
 		} else {
 			complete = false
 			p.Logf("waiting for consul watch: %s", w.WatchId())

--- a/pkg/k8s/watcher.go
+++ b/pkg/k8s/watcher.go
@@ -37,6 +37,7 @@ func (lw listWatchAdapter) Watch(options v1.ListOptions) (pwatch.Interface, erro
 	return lw.resource.Watch(options)
 }
 
+// Watcher is a kubernetes watcher that can watch multiple queries simultaneously
 type Watcher struct {
 	Client  *Client
 	watches map[ResourceType]watch
@@ -92,6 +93,10 @@ func (w *Watcher) Watch(resources string, listener func(*Watcher)) error {
 
 func (w *Watcher) WatchNamespace(namespace, resources string, listener func(*Watcher)) error {
 	return w.SelectiveWatch(namespace, resources, "", "", listener)
+}
+
+func (w *Watcher) Refresh() error {
+	return w.Client.Refresh()
 }
 
 func (w *Watcher) SelectiveWatch(namespace, resources, fieldSelector, labelSelector string,
@@ -190,6 +195,7 @@ func (w *Watcher) WatchQuery(query Query, listener func(*Watcher)) error {
 	return nil
 }
 
+// Start starts the watcher
 func (w *Watcher) Start() {
 	w.mutex.Lock()
 	if w.started {
@@ -229,6 +235,7 @@ func (w *Watcher) sync(kind ResourceType) {
 	}
 }
 
+// List lists all the resources with kind `kind`
 func (w *Watcher) List(kind string) []Resource {
 	ri, err := w.Client.ResolveResourceType(kind)
 	if err != nil {
@@ -247,6 +254,7 @@ func (w *Watcher) List(kind string) []Resource {
 	}
 }
 
+// UpdateStatus updates the status of the `resource` provided
 func (w *Watcher) UpdateStatus(resource Resource) (Resource, error) {
 	ri, err := w.Client.ResolveResourceType(resource.QKind())
 	if err != nil {
@@ -276,6 +284,7 @@ func (w *Watcher) UpdateStatus(resource Resource) (Resource, error) {
 	}
 }
 
+// Get gets the `qname` resource (of kind `kind`)
 func (w *Watcher) Get(kind, qname string) Resource {
 	resources := w.List(kind)
 	for _, res := range resources {
@@ -286,6 +295,7 @@ func (w *Watcher) Get(kind, qname string) Resource {
 	return Resource{}
 }
 
+// Exists returns true if the `qname` resource (of kind `kind`) exists
 func (w *Watcher) Exists(kind, qname string) bool {
 	return w.Get(kind, qname).Name() != ""
 }


### PR DESCRIPTION
## Description

Some Custom Resource Definitions can be missing from the cluster (like after an upgrade, where users have changed only the image). In that case we should not fail on bootstrap but

1) install a watcher for `customresourcedefinition`s, and then
2) retry to watch the all the pending Custom Resources

