### PR TITLE
Simple ridethrough if the Host CRD isn't present

### DIFF
--- a/python/ambassador/config/resourcefetcher.py
+++ b/python/ambassador/config/resourcefetcher.py
@@ -183,6 +183,9 @@ class ResourceFetcher:
         if os.path.isfile(os.path.join(basedir, '.ambassador_ignore_crds_2')):
             self.aconf.post_error("Ambassador could not find Resolver type CRD definitions. Please visit https://www.getambassador.io/reference/core/crds/ for more information. You can continue using Ambassador via Kubernetes annotations, any configuration via CRDs will be ignored...")
 
+        if os.path.isfile(os.path.join(basedir, '.ambassador_ignore_crds_3')):
+            self.aconf.post_error("Ambassador could not find the Host CRD definition. Please visit https://www.getambassador.io/reference/core/crds/ for more information. You can continue using Ambassador via Kubernetes annotations, any configuration via CRDs will be ignored...")
+
         if os.path.isfile(os.path.join(basedir, '.ambassador_ignore_ingress')):
             self.aconf.post_error("Ambassador is not permitted to read Ingress resources. Please visit https://www.getambassador.io/user-guide/ingress-controller/ for more information. You can continue using Ambassador, but Ingress resources will be ignored...")
         

--- a/python/entrypoint.sh
+++ b/python/entrypoint.sh
@@ -362,7 +362,7 @@ wait_for_url "diagd" "http://localhost:8877/_internal/v0/ping"
 # WORKER: KUBEWATCH                                                            #
 ################################################################################
 if [[ -z "${AMBASSADOR_NO_KUBEWATCH}" ]]; then
-    KUBEWATCH_SYNC_KINDS="-s service -s Host"
+    KUBEWATCH_SYNC_KINDS="-s service"
 
     if [ ! -f "${AMBASSADOR_CONFIG_BASE_DIR}/.ambassador_ignore_ingress" ]; then
         KUBEWATCH_SYNC_KINDS="$KUBEWATCH_SYNC_KINDS -s ingresses"
@@ -374,6 +374,10 @@ if [[ -z "${AMBASSADOR_NO_KUBEWATCH}" ]]; then
 
     if [ ! -f "${AMBASSADOR_CONFIG_BASE_DIR}/.ambassador_ignore_crds_2" ]; then
         KUBEWATCH_SYNC_KINDS="$KUBEWATCH_SYNC_KINDS -s ConsulResolver -s KubernetesEndpointResolver -s KubernetesServiceResolver"
+    fi
+
+    if [ ! -f "${AMBASSADOR_CONFIG_BASE_DIR}/.ambassador_ignore_crds_3" ]; then
+        KUBEWATCH_SYNC_KINDS="$KUBEWATCH_SYNC_KINDS -s Host"
     fi
 
     AMBASSADOR_FIELD_SELECTOR_ARG=""

--- a/python/kubewatch.py
+++ b/python/kubewatch.py
@@ -202,7 +202,13 @@ def main(debug):
                     'kubernetesendpointresolvers.getambassador.io',
                     'kubernetesserviceresolvers.getambassador.io'
                 ]
-            )
+            ),
+            (
+                '.ambassador_ignore_crds_3', 'Host CRDs',
+                [
+                    'hosts.getambassador.io'
+                ]
+            )            
         ]
 
         # Flynn would say "Ew.", but we need to patch this till https://github.com/kubernetes-client/python/issues/376


### PR DESCRIPTION
Do the cheap and simple way to ride through the Host CRD not being present. More cleverness coming later.
