### PR TITLE
Simple ridethrough if the LogService CRD isn't present

### DIFF
--- a/python/ambassador/config/resourcefetcher.py
+++ b/python/ambassador/config/resourcefetcher.py
@@ -186,6 +186,9 @@ class ResourceFetcher:
         if os.path.isfile(os.path.join(basedir, '.ambassador_ignore_crds_3')):
             self.aconf.post_error("Ambassador could not find the Host CRD definition. Please visit https://www.getambassador.io/reference/core/crds/ for more information. You can continue using Ambassador via Kubernetes annotations, any configuration via CRDs will be ignored...")
 
+        if os.path.isfile(os.path.join(basedir, '.ambassador_ignore_crds_4')):
+            self.aconf.post_error("Ambassador could not find the LogService CRD definition. Please visit https://www.getambassador.io/reference/core/crds/ for more information. You can continue using Ambassador via Kubernetes annotations, any configuration via CRDs will be ignored...")
+
         if os.path.isfile(os.path.join(basedir, '.ambassador_ignore_ingress')):
             self.aconf.post_error("Ambassador is not permitted to read Ingress resources. Please visit https://www.getambassador.io/user-guide/ingress-controller/ for more information. You can continue using Ambassador, but Ingress resources will be ignored...")
         

--- a/python/entrypoint.sh
+++ b/python/entrypoint.sh
@@ -369,7 +369,7 @@ if [[ -z "${AMBASSADOR_NO_KUBEWATCH}" ]]; then
     fi
 
     if [ ! -f "${AMBASSADOR_CONFIG_BASE_DIR}/.ambassador_ignore_crds" ]; then
-        KUBEWATCH_SYNC_KINDS="$KUBEWATCH_SYNC_KINDS -s AuthService -s LogService -s Mapping -s Module -s RateLimitService -s TCPMapping -s TLSContext -s TracingService"
+        KUBEWATCH_SYNC_KINDS="$KUBEWATCH_SYNC_KINDS -s AuthService -s Mapping -s Module -s RateLimitService -s TCPMapping -s TLSContext -s TracingService"
     fi
 
     if [ ! -f "${AMBASSADOR_CONFIG_BASE_DIR}/.ambassador_ignore_crds_2" ]; then
@@ -378,6 +378,10 @@ if [[ -z "${AMBASSADOR_NO_KUBEWATCH}" ]]; then
 
     if [ ! -f "${AMBASSADOR_CONFIG_BASE_DIR}/.ambassador_ignore_crds_3" ]; then
         KUBEWATCH_SYNC_KINDS="$KUBEWATCH_SYNC_KINDS -s Host"
+    fi
+
+    if [ ! -f "${AMBASSADOR_CONFIG_BASE_DIR}/.ambassador_ignore_crds_4" ]; then
+        KUBEWATCH_SYNC_KINDS="$KUBEWATCH_SYNC_KINDS -s LogService"
     fi
 
     AMBASSADOR_FIELD_SELECTOR_ARG=""

--- a/python/kubewatch.py
+++ b/python/kubewatch.py
@@ -208,7 +208,13 @@ def main(debug):
                 [
                     'hosts.getambassador.io'
                 ]
-            )            
+            ),
+            (
+                '.ambassador_ignore_crds_4', 'LogService CRDs',
+                [
+                    'logservices.getambassador.io'
+                ]
+            )
         ]
 
         # Flynn would say "Ew.", but we need to patch this till https://github.com/kubernetes-client/python/issues/376

--- a/python/tests/abstract_tests.py
+++ b/python/tests/abstract_tests.py
@@ -42,7 +42,9 @@ def assert_default_errors(errors, include_ingress_errors=True):
         ["",
          "Ambassador could not find Resolver type CRD definitions. Please visit https://www.getambassador.io/reference/core/crds/ for more information. You can continue using Ambassador via Kubernetes annotations, any configuration via CRDs will be ignored..."],
         ["",
-         "Ambassador could not find the Host CRD definition. Please visit https://www.getambassador.io/reference/core/crds/ for more information. You can continue using Ambassador via Kubernetes annotations, any configuration via CRDs will be ignored..."]
+         "Ambassador could not find the Host CRD definition. Please visit https://www.getambassador.io/reference/core/crds/ for more information. You can continue using Ambassador via Kubernetes annotations, any configuration via CRDs will be ignored..."],
+        ["",
+         "Ambassador could not find the LogService CRD definition. Please visit https://www.getambassador.io/reference/core/crds/ for more information. You can continue using Ambassador via Kubernetes annotations, any configuration via CRDs will be ignored..."]
     ]
 
     if include_ingress_errors:


### PR DESCRIPTION
# Description

Ignore the `LogService` CRD missing.

```
[...]
2019-11-25 09:13:45 diagd 0.86.0-rc5-268-g06ed6a14-dirty [P305TAmbassadorEventWatcher] INFO: ...update finished, rc 0
2019-11-25 09:13:45 diagd 0.86.0-rc5-268-g06ed6a14-dirty [P305TAmbassadorEventWatcher] INFO: configuration updated from snapshot 1
2019-11-25 09:13:45 diagd 0.86.0-rc5-268-g06ed6a14-dirty [P305TAmbassadorEventWatcher] INFO: starting Envoy status updater
2019-11-25 09:13:45 diagd 0.86.0-rc5-268-g06ed6a14-dirty [P305TAmbassadorEventWatcher] INFO: error  Ambassador could not find the Host CRD definition. Please visit https://www.getambassador.io/reference/core/crds/ for more information. You can continue using Ambassador via Kubernetes annotations, any configuration via CRDs will be ignored...
2019-11-25 09:13:45 diagd 0.86.0-rc5-268-g06ed6a14-dirty [P305TAmbassadorEventWatcher] INFO: error  Ambassador could not find the LogService CRD definition. Please visit https://www.getambassador.io/reference/core/crds/ for more information. You can continue using Ambassador via Kubernetes annotations, any configuration via CRDs will be ignored...
2019-11-25 09:13:46 diagd 0.86.0-rc5-268-g06ed6a14-dirty [P305TAmbassadorEventWatcher] INFO: Scout reports {"latest_version": "0.85.0", "application": "ambassador", "cached": false, "timestamp": 1574673226.31647}
2019-11-25 09:13:46 diagd 0.86.0-rc5-268-g06ed6a14-dirty [P305TAmbassadorEventWatcher] INFO: Scout notices: []
```

Fix datawire/apro#514

## Related Issues

Copycat of https://github.com/datawire/ambassador/commit/dce9e3f03954725ff3ec9bee8acda3d723e06415


