### PR TITLE
Correctly update mapping status on error

### DIFF
--- a/python/ambassador/ir/irhttpmapping.py
+++ b/python/ambassador/ir/irhttpmapping.py
@@ -367,7 +367,7 @@ class IRHTTPMapping (IRBaseMapping):
         errstr = "(no errors)"
 
         if errors:
-            errstr = errors[0].error
+            errstr = errors[0].get('error') or 'unknown error?'
 
             if len(errors) > 1:
                 errstr += " (and more)"


### PR DESCRIPTION
When updating the status of a mapping with errors, the error has already been turned into a dict. Sigh.

The easiest way to reproduce this is to apply this mapping:

```
---
apiVersion: getambassador.io/v1
kind: Mapping
metadata:
  name: mapping-1
  labels: 
    hostname: edgy.kodachi.com
spec:
  prefix: /
  rewrite: /
  service: qotm.default
  resolver: consul-resolver
  load_balancer:
    policy: ring_hash
```

when you have no resolver named `consul-resolver`.

Here's a screenshot of what `kubectl get mappings` should show for that:

<img width="686" alt="Screen Shot 2019-11-26 at 12 56 06 AM" src="https://user-images.githubusercontent.com/1126180/69614590-312bba00-0fe8-11ea-8779-3d41297894fe.png">
