### PR TITLE
Add --url and --token options to edgectl login; add edgectl pause/resume

### DIFF
--- a/builder/builder.sh
+++ b/builder/builder.sh
@@ -197,7 +197,7 @@ clean() {
     if [ -n "${nid}" ] ; then
         printf "${GRN}Removing docker network ${BLU}${DOCKER_NETWORK} (${nid})${END}\n"
         # This will fail if the network has some other endpoints alive: silence any errors
-        docker network rm ${nid} 2&>1 >/dev/null || true
+        docker network rm ${nid} 2>&1 >/dev/null || true
     fi
 }
 

--- a/cmd/edgectl/cluster.go
+++ b/cmd/edgectl/cluster.go
@@ -34,6 +34,11 @@ func (d *Daemon) Connect(
 		out.Send("connect", "Not ready: Trying to disconnect")
 		return nil
 	}
+	if d.network == nil {
+		out.Println("Not ready: Network overrides are paused (use \"edgectl resume\")")
+		out.Send("connect", "Not ready: Paused")
+		return nil
+	}
 	if !d.network.IsOkay() {
 		out.Println("Not ready: Establishing network overrides")
 		out.Send("connect", "Not ready: Establishing network overrides")

--- a/cmd/edgectl/d_resource.go
+++ b/cmd/edgectl/d_resource.go
@@ -120,6 +120,7 @@ func (rb *ResourceBase) processor(p *supervisor.Process) error {
 			return err
 		}
 		if rb.done {
+			MaybeNotify(p, rb.name, rb.okay, false)
 			p.Log("done")
 			return nil
 		}

--- a/cmd/edgectl/daemon.go
+++ b/cmd/edgectl/daemon.go
@@ -81,7 +81,7 @@ func (d *Daemon) acceptLoop(p *supervisor.Process) error {
 
 	p.Ready()
 	Notify(p, "Running")
-	defer Notify(p, "Terminated")
+	defer Notify(p, "Shutting down...")
 
 	return p.DoClean(
 		func() error {

--- a/cmd/edgectl/main.go
+++ b/cmd/edgectl/main.go
@@ -36,6 +36,33 @@ to troubleshoot problems.
 // edgectl is the full path to the Edge Control binary
 var edgectl string
 
+/*
+Future command help layout
+
+Edge Stack Commands:
+  login             Access the Ambassador Edge Stack admin UI
+  license           Set or update the Ambassador Edge Stack license key
+
+Cluster Commands:
+  status            Show connectivity status
+  connect           Connect to a cluster
+  disconnect        Disconnect from the connected cluster
+  intercept         Manage deployment intercepts
+
+Daemon Commands:
+  daemon            Launch Edge Control Daemon in the background (sudo)
+  pause             Turn off network overrides (to use a VPN)
+  resume            Turn network overrides on (after using edgectl pause)
+  quit              Tell Edge Control Daemon to quit (for upgrades)
+
+Other Commands:
+  version           Show program's version number and exit
+  help              Help about any command
+
+https://github.com/kubernetes/kubernetes/blob/master/pkg/kubectl/cmd/cmd.go#L487
+
+ */
+
 func main() {
 	// Figure out our executable and save it
 	if executable, err := os.Executable(); err != nil {

--- a/cmd/edgectl/main.go
+++ b/cmd/edgectl/main.go
@@ -124,6 +124,8 @@ func getRootCommand() *cobra.Command {
 		"namespace", "n", "ambassador",
 		"The Kubernetes namespace to use. Defaults to ambassador.",
 	)
+	_ = loginCmd.Flags().Bool("url", false, "Just show the URL (don't launch a browser)")
+	_ = loginCmd.Flags().Bool("token", false, "Also display the login token")
 	rootCmd.AddCommand(loginCmd)
 	licenseCmd := &cobra.Command{
 		Use:   "license [flags] LICENSE_KEY",

--- a/cmd/edgectl/status.go
+++ b/cmd/edgectl/status.go
@@ -6,6 +6,11 @@ import (
 
 // Status reports the current status of the daemon
 func (d *Daemon) Status(_ *supervisor.Process, out *Emitter) error {
+	out.Send("paused", d.network == nil)
+	if d.network == nil {
+		out.Println("Network overrides are paused")
+		return nil
+	}
 	if !d.network.IsOkay() {
 		out.Println("Network overrides NOT established")
 	}


### PR DESCRIPTION
Here's the sample for `edgectl login` as the other bits don't directly affect AES.

```console
$ git status
On branch ark3/edgectl-cli
nothing to commit, working tree clean

$ go run ./cmd/edgectl help login 
Access the Ambassador Edge Stack admin UI

Usage:
  edgectl login [flags] HOSTNAME

Flags:
  -c, --context string     The Kubernetes context to use. Defaults to the current kubectl context.
  -h, --help               help for login
  -n, --namespace string   The Kubernetes namespace to use. Defaults to ambassador. (default "ambassador")
      --token              Also display the login token
      --url                Just show the URL (don't launch a browser)

$ go run ./cmd/edgectl login --url hostname.goes.here
Connecting to the Ambassador Edge Stack admin UI in this cluster...
Visit the following URL to access the Ambassador Edge Stack admin UI:
     https://hostname.goes.here/edge_stack/admin/#eyJhbGciOiJQUzUxMiIsInR5cCI6IkpXVCJ9.eyJsb2dpbl90b2tlbl92ZXJzaW9uIjoidjEiLCJleHAiOjE1NzQ3OTc3MzgsImlhdCI6MTU3NDc5NTkzOCwibmJmIjoxNTc0Nzk1OTM4fQ.IHIBIcvk9sIJBDKUHZIIizyu_pH2KJsAC7WovVVybI1mpZJ8EgV4fDI7jqgL9JIUURfK5D4TrvxUbEuGgWb21kXIxGLmEGH7_YalV1nqMvdlh_hLphkNiQKmhPIMYXfqnSwJTes3WReVBJLN7G8syxLJoE0u9XsYSVVZU_JzdcAW8DPN3_5wVSCIPIhM4A5YxyH-ZcvhKZDzApP09qRJAOApywSGCVdukOhhplqgGEp9iQ8AsdV_3PltnEDO56n3M3L49SDwqnC0f7B8CI3QF0HzYAd09u43tlWOGjFgLtGejKqoTZRcH7-VtuTzQwxV3MDNS_pWVnYluOLfuU20lw

$ # No browser opened

$ 

$ go run ./cmd/edgectl login hostname.goes.here
Connecting to the Ambassador Edge Stack admin UI in this cluster...
Ambassador Edge Stack admin UI has been opened in your browser.
     https://hostname.goes.here/edge_stack/admin/#eyJhbGciOiJQUzUxMiIsInR5cCI6IkpXVCJ9.eyJsb2dpbl90b2tlbl92ZXJzaW9uIjoidjEiLCJleHAiOjE1NzQ3OTc3OTMsImlhdCI6MTU3NDc5NTk5MywibmJmIjoxNTc0Nzk1OTkzfQ.p7jy66_mebx0X07dkCjFX7xYNgLHPAcV5WCbDQ7usUH5bkxLUf1LKrin11JkEjMWqUwXm6IcQd93ykFuNWGgnIyjBpHey28cjOn2U1U8dORxhqWg_q1TBYRIFo_6uVOggMeUji92Qncj2NLkJ1pnIp20Y8rHEn-4XK5cMxjYofO6ayuiu_iGZw_ZuKQ0lU2AlykZTg8km5yfxfJ6EJPsBd_fpFm7FTJaVWCoja2zbSG6Zj3Go_bSgA6uruxkag0vw0n7LgIFDDe8RTrtKQGIkT69iUWMvE2vHpvE5T7vjX6TegJzqU_UscTGEndXuUhQsKGvStUlU8j_PVbKQ7FxOw

$ # Browser opened that time. Different message too.

$ 

$ go run ./cmd/edgectl login --url --token hostname.goes.here
Connecting to the Ambassador Edge Stack admin UI in this cluster...
Visit the following URL to access the Ambassador Edge Stack admin UI:
     https://hostname.goes.here/edge_stack/admin/#eyJhbGciOiJQUzUxMiIsInR5cCI6IkpXVCJ9.eyJsb2dpbl90b2tlbl92ZXJzaW9uIjoidjEiLCJleHAiOjE1NzQ3OTc4MTYsImlhdCI6MTU3NDc5NjAxNiwibmJmIjoxNTc0Nzk2MDE2fQ.Wm7nT6KyRDUWUUHpp8ps-94SNCTjIOl566JBMkeNbQ8y-KE8iIY0rHKaX0K4AgjWPEX2BlA6gOHcsKIlKp7SLo3hB_NWkAeEntfWmE1rnJ_-b0_ekUQSu8kG69Ezb7Wi2nWmvfwBUwo02rLFBdHRgi8UrgrxnzrptxsBJmPd9NtlLmO8Nk4ov7wqxKIcA8pNV-g37hr0JLkHXb3wZgvJDQva8Gsnd6FmJNkq77SeRn-pPuaMd_-MjulPQJkR1SgtXP5ZY39ihGoAJQwExZGxknFuQd8edmffu1djfY7vm9bZYZCTIWdNwn7S4fFrnmJUp0Zphu24yhMCw-COwvqniQ

The login token is
     eyJhbGciOiJQUzUxMiIsInR5cCI6IkpXVCJ9.eyJsb2dpbl90b2tlbl92ZXJzaW9uIjoidjEiLCJleHAiOjE1NzQ3OTc4MTYsImlhdCI6MTU3NDc5NjAxNiwibmJmIjoxNTc0Nzk2MDE2fQ.Wm7nT6KyRDUWUUHpp8ps-94SNCTjIOl566JBMkeNbQ8y-KE8iIY0rHKaX0K4AgjWPEX2BlA6gOHcsKIlKp7SLo3hB_NWkAeEntfWmE1rnJ_-b0_ekUQSu8kG69Ezb7Wi2nWmvfwBUwo02rLFBdHRgi8UrgrxnzrptxsBJmPd9NtlLmO8Nk4ov7wqxKIcA8pNV-g37hr0JLkHXb3wZgvJDQva8Gsnd6FmJNkq77SeRn-pPuaMd_-MjulPQJkR1SgtXP5ZY39ihGoAJQwExZGxknFuQd8edmffu1djfY7vm9bZYZCTIWdNwn7S4fFrnmJUp0Zphu24yhMCw-COwvqniQ

$ # No browser again, plus a separate copy of the token, in case that's useful.

```

I've search-replaced away the hostname just in case.