### PR TITLE
Add Host CRD error to default

### DIFF
--- a/python/tests/abstract_tests.py
+++ b/python/tests/abstract_tests.py
@@ -40,7 +40,9 @@ def assert_default_errors(errors, include_ingress_errors=True):
         ["",
          "Ambassador could not find core CRD definitions. Please visit https://www.getambassador.io/reference/core/crds/ for more information. You can continue using Ambassador via Kubernetes annotations, any configuration via CRDs will be ignored..."],
         ["",
-         "Ambassador could not find Resolver type CRD definitions. Please visit https://www.getambassador.io/reference/core/crds/ for more information. You can continue using Ambassador via Kubernetes annotations, any configuration via CRDs will be ignored..."]
+         "Ambassador could not find Resolver type CRD definitions. Please visit https://www.getambassador.io/reference/core/crds/ for more information. You can continue using Ambassador via Kubernetes annotations, any configuration via CRDs will be ignored..."],
+        ["",
+         "Ambassador could not find the Host CRD definition. Please visit https://www.getambassador.io/reference/core/crds/ for more information. You can continue using Ambassador via Kubernetes annotations, any configuration via CRDs will be ignored..."]
     ]
 
     if include_ingress_errors:


### PR DESCRIPTION
This PR adds the missing host CRD error to the default errors list that we have in our tests. This is required because #2055 shows the missing CRD error to the users but our tests don't account for it, which means a couple of test (Empty and Plain) have been failing due to this.