### PR TITLE
Handle missing CRDs at runtime

### DIFF
--- a/cmd/watt/aggregator.go
+++ b/cmd/watt/aggregator.go
@@ -143,7 +143,7 @@ func (a *aggregator) isComplete(p *supervisor.Process, watchset WatchSet) bool {
 
 	for _, w := range watchset.ConsulWatches {
 		if _, ok := a.ids[w.WatchId()]; ok {
-			p.Logf("initialized k8s watch: %s", w.WatchId())
+			p.Logf("initialized consul watch: %s", w.WatchId())
 		} else {
 			complete = false
 			p.Logf("waiting for consul watch: %s", w.WatchId())

--- a/cmd/watt/aggregator.go
+++ b/cmd/watt/aggregator.go
@@ -28,8 +28,14 @@ type Aggregator struct {
 	consulWatches chan<- []ConsulWatchSpec
 	// Output channel used to communicate with the invoker.
 	snapshots chan<- string
-	// We won't consider ourselves "bootstrapped" until we hear
-	// about all these kinds.
+	// We won't consider ourselves "bootstrapped" until we hear about
+	// every kind that has a true value here (i.e. if we find that
+	// requiredKinds["service"] == true, but requiredKinds["Mappings"] == false,
+	// we will require service to be present but we won't require Mappings
+	// to be present.
+	//
+	// (This is a map rather than a list because it makes it easier to be
+	// certain that we don't list the same requiredKind twice.)
 	requiredKinds       map[string]bool
 	watchHook           WatchHook
 	limiter             limiter.Limiter

--- a/cmd/watt/aggregator_test.go
+++ b/cmd/watt/aggregator_test.go
@@ -20,7 +20,7 @@ type aggIsolator struct {
 	snapshots     chan string
 	k8sWatches    chan []KubernetesWatchSpec
 	consulWatches chan []ConsulWatchSpec
-	aggregator    *Aggregator
+	aggregator    *aggregator
 	sup           *supervisor.Supervisor
 	done          chan struct{}
 	t             *testing.T

--- a/cmd/watt/kubewatchman.go
+++ b/cmd/watt/kubewatchman.go
@@ -187,7 +187,9 @@ func (b *kubebootstrap) Work(p *supervisor.Process) error {
 	}
 
 	p.Logf("Watching resources...")
-	b.kubeAPIWatcher.Start()
+	b.kubeAPIWatcher.StartWithErrorHandler(func(kind string, stage string, err error) {
+		p.Logf("could not watch %q at stage %q: %q", kind, stage, err)
+	})
 	p.Ready()
 
 	for range p.Shutdown() {

--- a/cmd/watt/kubewatchman.go
+++ b/cmd/watt/kubewatchman.go
@@ -156,13 +156,6 @@ func (b *kubebootstrap) makeWatcherFunc(ns, kind string) func(watcher *k8s.Watch
 	}
 }
 
-// // addWatcher is a convenience function to add a selective watcher for
-// // a given resource, using our current namespace, field selector, and
-// // label selector.
-// func (b *kubebootstrap) addWatcher(kind string, watcherFunc func(*k8s.Watcher)) error {
-// 	return b.kubeAPIWatcher.SelectiveWatch(b.namespace, kind, b.fieldSelector, b.labelSelector, watcherFunc)
-// }
-
 // tryToWatchAllPending walks over all of our pendingResources and tries
 // to get their watchers running.
 //

--- a/cmd/watt/main.go
+++ b/cmd/watt/main.go
@@ -92,13 +92,13 @@ func _runWatt(cmd *cobra.Command, args []string) int {
 		ExecWatchHook(watchHooks), limiter)
 
 	kubebootstrap := kubebootstrap{
-		aggregator:     aggregator,
 		namespace:      kubernetesNamespace,
 		kinds:          initialSources,
 		fieldSelector:  initialFieldSelector,
 		labelSelector:  initialLabelSelector,
 		kubeAPIWatcher: kubeAPIWatcher,
 		notify:         []chan<- k8sEvent{aggregator.KubernetesEvents},
+		markRequired:   aggregator.MarkRequired,
 	}
 
 	consulwatchman := consulwatchman{

--- a/cmd/watt/main.go
+++ b/cmd/watt/main.go
@@ -89,9 +89,10 @@ func _runWatt(cmd *cobra.Command, args []string) int {
 	invoker := NewInvoker(port, notifyReceivers)
 	limiter := limiter.NewComposite(limiter.NewUnlimited(), limiter.NewInterval(interval), interval)
 	aggregator := NewAggregator(invoker.Snapshots, aggregatorToKubewatchmanCh, aggregatorToConsulwatchmanCh,
-		initialSources, ExecWatchHook(watchHooks), limiter)
+		ExecWatchHook(watchHooks), limiter)
 
 	kubebootstrap := kubebootstrap{
+		aggregator:     aggregator,
 		namespace:      kubernetesNamespace,
 		kinds:          initialSources,
 		fieldSelector:  initialFieldSelector,

--- a/pkg/k8s/watcher.go
+++ b/pkg/k8s/watcher.go
@@ -37,6 +37,7 @@ func (lw listWatchAdapter) Watch(options v1.ListOptions) (pwatch.Interface, erro
 	return lw.resource.Watch(options)
 }
 
+// Watcher is a kubernetes watcher that can watch multiple queries simultaneously
 type Watcher struct {
 	Client  *Client
 	watches map[ResourceType]watch
@@ -92,6 +93,10 @@ func (w *Watcher) Watch(resources string, listener func(*Watcher)) error {
 
 func (w *Watcher) WatchNamespace(namespace, resources string, listener func(*Watcher)) error {
 	return w.SelectiveWatch(namespace, resources, "", "", listener)
+}
+
+func (w *Watcher) Refresh() error {
+	return w.Client.Refresh()
 }
 
 func (w *Watcher) SelectiveWatch(namespace, resources, fieldSelector, labelSelector string,
@@ -190,6 +195,7 @@ func (w *Watcher) WatchQuery(query Query, listener func(*Watcher)) error {
 	return nil
 }
 
+// Start starts the watcher
 func (w *Watcher) Start() {
 	w.mutex.Lock()
 	if w.started {
@@ -229,6 +235,7 @@ func (w *Watcher) sync(kind ResourceType) {
 	}
 }
 
+// List lists all the resources with kind `kind`
 func (w *Watcher) List(kind string) []Resource {
 	ri, err := w.Client.ResolveResourceType(kind)
 	if err != nil {
@@ -247,6 +254,7 @@ func (w *Watcher) List(kind string) []Resource {
 	}
 }
 
+// UpdateStatus updates the status of the `resource` provided
 func (w *Watcher) UpdateStatus(resource Resource) (Resource, error) {
 	ri, err := w.Client.ResolveResourceType(resource.QKind())
 	if err != nil {
@@ -276,6 +284,7 @@ func (w *Watcher) UpdateStatus(resource Resource) (Resource, error) {
 	}
 }
 
+// Get gets the `qname` resource (of kind `kind`)
 func (w *Watcher) Get(kind, qname string) Resource {
 	resources := w.List(kind)
 	for _, res := range resources {
@@ -286,6 +295,7 @@ func (w *Watcher) Get(kind, qname string) Resource {
 	return Resource{}
 }
 
+// Exists returns true if the `qname` resource (of kind `kind`) exists
 func (w *Watcher) Exists(kind, qname string) bool {
 	return w.Get(kind, qname).Name() != ""
 }

--- a/python/entrypoint.sh
+++ b/python/entrypoint.sh
@@ -364,25 +364,25 @@ wait_for_url "diagd" "http://localhost:8877/_internal/v0/ping"
 if [[ -z "${AMBASSADOR_NO_KUBEWATCH}" ]]; then
     KUBEWATCH_SYNC_KINDS="-s service"
 
-    if [ ! -f "${AMBASSADOR_CONFIG_BASE_DIR}/.ambassador_ignore_ingress" ]; then
+    # if [ ! -f "${AMBASSADOR_CONFIG_BASE_DIR}/.ambassador_ignore_ingress" ]; then
         KUBEWATCH_SYNC_KINDS="$KUBEWATCH_SYNC_KINDS -s ingresses"
-    fi
+    # fi
 
-    if [ ! -f "${AMBASSADOR_CONFIG_BASE_DIR}/.ambassador_ignore_crds" ]; then
+    # if [ ! -f "${AMBASSADOR_CONFIG_BASE_DIR}/.ambassador_ignore_crds" ]; then
         KUBEWATCH_SYNC_KINDS="$KUBEWATCH_SYNC_KINDS -s AuthService -s Mapping -s Module -s RateLimitService -s TCPMapping -s TLSContext -s TracingService"
-    fi
+    # fi
 
-    if [ ! -f "${AMBASSADOR_CONFIG_BASE_DIR}/.ambassador_ignore_crds_2" ]; then
+    # if [ ! -f "${AMBASSADOR_CONFIG_BASE_DIR}/.ambassador_ignore_crds_2" ]; then
         KUBEWATCH_SYNC_KINDS="$KUBEWATCH_SYNC_KINDS -s ConsulResolver -s KubernetesEndpointResolver -s KubernetesServiceResolver"
-    fi
+    # fi
 
-    if [ ! -f "${AMBASSADOR_CONFIG_BASE_DIR}/.ambassador_ignore_crds_3" ]; then
+    # if [ ! -f "${AMBASSADOR_CONFIG_BASE_DIR}/.ambassador_ignore_crds_3" ]; then
         KUBEWATCH_SYNC_KINDS="$KUBEWATCH_SYNC_KINDS -s Host"
-    fi
+    # fi
 
-    if [ ! -f "${AMBASSADOR_CONFIG_BASE_DIR}/.ambassador_ignore_crds_4" ]; then
+    # if [ ! -f "${AMBASSADOR_CONFIG_BASE_DIR}/.ambassador_ignore_crds_4" ]; then
         KUBEWATCH_SYNC_KINDS="$KUBEWATCH_SYNC_KINDS -s LogService"
-    fi
+    # fi
 
     AMBASSADOR_FIELD_SELECTOR_ARG=""
     if [ -n "$AMBASSADOR_FIELD_SELECTOR" ] ; then


### PR DESCRIPTION
Two things about this:

1. This is using the old, more static, error-reporting code. I'm not going to fix that until @ark3's error-path code is merged.

2. If you delete a CRD type once we're watching for it, then re-add it, you'll need to restart the Ambassador pod. We should tackle this Soon™.

3. Props to @inercia for writing the beginning of this, and to @LukeShu for help with the catcher!