### PR TITLE
Prevent stalls if we get an exception during a reconfigure

### DIFF
--- a/python/ambassador_diag/diagd.py
+++ b/python/ambassador_diag/diagd.py
@@ -710,12 +710,14 @@ class AmbassadorEventWatcher(threading.Thread):
                 except Exception as e:
                     self.logger.error("could not update estats: %s" % e)
                     self.logger.exception(e)
+                    self._respond(rqueue, 500, 'Envoy stats update failed')
             elif cmd == 'CONFIG_FS':
                 try:
                     self.load_config_fs(rqueue, arg)
                 except Exception as e:
                     self.logger.error("could not reconfigure: %s" % e)
                     self.logger.exception(e)
+                    self._respond(rqueue, 500, 'configuration from filesystem failed')
             elif cmd == 'CONFIG':
                 version, url = arg
 
@@ -729,6 +731,7 @@ class AmbassadorEventWatcher(threading.Thread):
                 except Exception as e:
                     self.logger.error("could not reconfigure: %s" % e)
                     self.logger.exception(e)
+                    self._respond(rqueue, 500, 'configuration failed')
             elif cmd == 'SCOUT':
                 try:
                     self._respond(rqueue, 200, 'checking Scout')
@@ -736,8 +739,10 @@ class AmbassadorEventWatcher(threading.Thread):
                 except Exception as e:
                     self.logger.error("could not reconfigure: %s" % e)
                     self.logger.exception(e)
+                    self._respond(rqueue, 500, 'scout check failed')
             else:
-                self.logger.error("unknown event type: '%s' '%s'" % (cmd, arg))
+                self.logger.error(f"unknown event type: '{cmd}' '{arg}'")
+                self._respond(rqueue, 400, f"unknown event type '{cmd}' '{arg}'")
 
     def _respond(self, rqueue: queue.Queue, status: int, info='') -> None:
         self.logger.debug("responding to query with %s %s" % (status, info))


### PR DESCRIPTION
The core of `diagd` is an event loop running on its own thread, with various other things posting events to be handled. This design lets us do several things:

1. Handle a variety of event sources (e.g. reconfiguration requests, scout updates, envoy-stats updates, etc.) without landing in horrible multithreading-data-structure hell

2. Serialize reconfigurations.

3. Apply back pressure to prevent reconfigurations from overwhelming everything.

Serialization and back pressure work by requiring a response from the event handler thread before the caller is allowed to return. In the case of reconfiguration, "the caller" is ultimately `watt` via the `diagd` web server, so once `watt` requests a reconfiguration, it's stuck until it gets a response.

Turns out that if an exception was raised in the reconfiguration code, no response would ever get posted and the whole world would freeze until you cycled the pod. ☹️ This fixes that problem.