### PR TITLE
Add a way for (user-facing) errors to make it into watt snapshots

### DIFF
--- a/cmd/watt/aggregator_test.go
+++ b/cmd/watt/aggregator_test.go
@@ -147,7 +147,7 @@ func TestAggregatorBootstrap(t *testing.T) {
 	defer iso.Stop()
 
 	// initial kubernetes state is just services
-	iso.aggregator.KubernetesEvents <- k8sEvent{"", "service", SERVICES}
+	iso.aggregator.KubernetesEvents <- k8sEvent{"", "service", SERVICES, nil}
 
 	// we should not generate a snapshot or consulWatches yet
 	// because we specified configmaps are required
@@ -156,7 +156,7 @@ func TestAggregatorBootstrap(t *testing.T) {
 
 	// the configmap references a consul service, so we shouldn't
 	// get a snapshot yet, but we should get watches
-	iso.aggregator.KubernetesEvents <- k8sEvent{"", "configmap", RESOLVER}
+	iso.aggregator.KubernetesEvents <- k8sEvent{"", "configmap", RESOLVER, nil}
 	expect(t, iso.snapshots, Timeout(100*time.Millisecond))
 	expect(t, iso.consulWatches, func(watches []ConsulWatchSpec) bool {
 		if len(watches) != 1 {

--- a/cmd/watt/kubewatchman.go
+++ b/cmd/watt/kubewatchman.go
@@ -15,6 +15,16 @@ type k8sEvent struct {
 	errors    []watt.Error
 }
 
+// makeErrorEvent returns a k8sEvent that contains one error entry for each
+// message passed in, all attributed to the same source.
+func makeErrorEvent(source string, messages ...string) k8sEvent {
+	errors := make([]watt.Error, len(messages))
+	for idx, message := range messages {
+		errors[idx] = watt.NewError(source, message)
+	}
+	return k8sEvent{errors: errors}
+}
+
 type KubernetesWatchMaker struct {
 	kubeAPI *k8s.Client
 	notify  chan<- k8sEvent
@@ -122,9 +132,11 @@ func fmtNamespace(ns string) string {
 	return ns
 }
 
+// SaveError emits an error from kubebootstrap with the given message
 func (b *kubebootstrap) SaveError(message string) {
+	evt := makeErrorEvent("kubebootstrap", message)
 	for _, n := range b.notify {
-		n <- k8sEvent{errors: []watt.Error{watt.NewError("kubebootstrap", message)}}
+		n <- evt
 	}
 }
 
@@ -149,7 +161,7 @@ func (b *kubebootstrap) Work(p *supervisor.Process) error {
 		}
 	}
 
-	b.SaveError("gratuitous error before starting")
+	// b.SaveError("gratuitous error before starting")
 
 	b.kubeAPIWatcher.Start()
 	p.Ready()

--- a/pkg/watt/types.go
+++ b/pkg/watt/types.go
@@ -2,6 +2,7 @@ package watt
 
 import (
 	"encoding/json"
+	"time"
 
 	"github.com/datawire/ambassador/pkg/consulwatch"
 
@@ -24,7 +25,18 @@ func (s *ConsulSnapshot) DeepCopy() (*ConsulSnapshot, error) {
 	return res, err
 }
 
+type Error struct {
+	Source    string
+	Message   string
+	Timestamp int64
+}
+
+func NewError(source, message string) Error {
+	return Error{Source: source, Message: message, Timestamp: time.Now().Unix()}
+}
+
 type Snapshot struct {
 	Consul     ConsulSnapshot            `json:",omitempty"`
 	Kubernetes map[string][]k8s.Resource `json:",omitempty"`
+	Errors     map[string][]Error        `json:",omitempty"`
 }


### PR DESCRIPTION
The only sample usage is commented out, so this should have no visible effects yet, until we start using it.