### PR TITLE
Include TLSContexts in the diag snapshot (and in mockery)

### DIFF
--- a/python/ambassador/diagnostics/diagnostics.py
+++ b/python/ambassador/diagnostics/diagnostics.py
@@ -585,7 +585,8 @@ class Diagnostics:
             'errors': self.errors,
             'notices': self.notices,
             'groups': { key: value.as_dict() for key, value in self.groups.items() },
-            'clusters': { key: value.as_dict() for key, value in self.clusters.items() }
+            'clusters': { key: value.as_dict() for key, value in self.clusters.items() },
+            'tlscontexts': [ x.as_dict() for x in self.ir.tls_contexts.values() ]
         }
 
     def _remember_source(self, src_key: str, dest_key: str) -> None:

--- a/python/mockery.py
+++ b/python/mockery.py
@@ -21,7 +21,7 @@ click_option = functools.partial(click.option, show_default=True)
 click_option_no_default = functools.partial(click.option, show_default=False)
 
 
-from ambassador import Config, IR, EnvoyConfig
+from ambassador import Config, IR, Diagnostics, EnvoyConfig
 from ambassador.config.resourcefetcher import ResourceFetcher
 from ambassador.utils import parse_yaml, SecretHandler
 from kat.utils import ShellCommand
@@ -425,6 +425,11 @@ def main(k8s_yaml_path: str, debug: bool, force_pod_labels: bool, update: bool,
 
     with open("/tmp/ambassador/snapshots/bootstrap.json", "w", encoding="utf-8") as outfile:
         outfile.write(json.dumps(bootstrap_config, sort_keys=True, indent=4))
+
+    diag = Diagnostics(ir, econf)
+
+    with open("/tmp/ambassador/snapshots/diag.json", "w", encoding="utf-8") as outfile:
+        outfile.write(json.dumps(diag.as_dict(), sort_keys=True, indent=4))
 
     if diff_path:
         diffs = False


### PR DESCRIPTION
This should make it much easier for Edge Stack's admin UI to work with TLSContexts.