### PR TITLE
Updated cluster-health stats

### DIFF
--- a/python/ambassador/diagnostics/envoy_stats.py
+++ b/python/ambassador/diagnostics/envoy_stats.py
@@ -292,7 +292,8 @@ class EnvoyStats (object):
 
                 # Weird.
                 # upstream_ok = cluster.get('upstream_rq_2xx', 0)
-                upstream_total = cluster.get('upstream_rq_pending_total', 0)
+                # upstream_total = cluster.get('upstream_rq_pending_total', 0)
+                upstream_total = cluster.get('upstream_rq_completed', 0)
 
                 upstream_4xx = cluster.get('upstream_rq_4xx', 0)
                 upstream_5xx = cluster.get('upstream_rq_5xx', 0)


### PR DESCRIPTION
Switch to using upstream_rq_completed as the base for cluster-health calculations.
