### PR TITLE
Avoid Linkerd sidecar injection like Consul/Istio

### DIFF
--- a/docs/yaml/ambassador/ambassador-rbac.yaml
+++ b/docs/yaml/ambassador/ambassador-rbac.yaml
@@ -73,6 +73,7 @@ spec:
       annotations:
         consul.hashicorp.com/connect-inject: 'false'
         sidecar.istio.io/inject: 'false'
+        linkerd.io/inject: disabled
       labels:
         service: ambassador
     spec:


### PR DESCRIPTION
As described by Alvaro in his results for the LinkerD forklift upgrade scenario (F4), we need to add an annotation to Ambassador's Deployment to avoid it being injected with LinkerD's sidecar.

Related:
https://github.com/datawire/getambassador.io/pull/122
https://github.com/datawire/apro/pull/604
