### PR TITLE
Have AES redirect cleartext to TLS

### DIFF
--- a/python/ambassador/ir/irhost.py
+++ b/python/ambassador/ir/irhost.py
@@ -78,7 +78,8 @@ class IRHost(IRResource):
                                                namespace=self.namespace,
                                                location=self.location,
                                                hosts=[ self.hostname ],
-                                               secret=tls_name)
+                                               secret=tls_name,
+                                               redirect_cleartext_from=8080)
 
                             match_labels = self.get('matchLabels')
 

--- a/python/tests/gold/hostdouble/snapshots/econf.json
+++ b/python/tests/gold/hostdouble/snapshots/econf.json
@@ -399,6 +399,63 @@
                     }
                 ],
                 "name": "ambassador-listener-8443"
+            },
+            {
+                "address": {
+                    "socket_address": {
+                        "address": "0.0.0.0",
+                        "port_value": 8080,
+                        "protocol": "TCP"
+                    }
+                },
+                "filter_chains": [
+                    {
+                        "filters": [
+                            {
+                                "config": {
+                                    "access_log": [],
+                                    "http_filters": [
+                                        {
+                                            "name": "envoy.router"
+                                        }
+                                    ],
+                                    "http_protocol_options": {
+                                        "accept_http_10": false
+                                    },
+                                    "normalize_path": true,
+                                    "route_config": {
+                                        "virtual_hosts": [
+                                            {
+                                                "domains": [
+                                                    "*"
+                                                ],
+                                                "name": "backend",
+                                                "require_tls": "EXTERNAL_ONLY",
+                                                "routes": [
+                                                    {
+                                                        "match": {
+                                                            "prefix": "/"
+                                                        },
+                                                        "redirect": {
+                                                            "https_redirect": true
+                                                        }
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "server_name": "envoy",
+                                    "stat_prefix": "ingress_http",
+                                    "use_remote_address": true,
+                                    "xff_num_trusted_hops": 0
+                                },
+                                "name": "envoy.http_connection_manager"
+                            }
+                        ],
+                        "use_proxy_proto": false
+                    }
+                ],
+                "name": "redirect_listener"
             }
         ]
     }

--- a/python/tests/gold/hostdouble/snapshots/ir.json
+++ b/python/tests/gold/hostdouble/snapshots/ir.json
@@ -547,6 +547,7 @@
                         "location": "host-2.default.1",
                         "name": "host-2-context",
                         "namespace": "default",
+                        "redirect_cleartext_from": 8080,
                         "secret_info": {
                             "cert_chain_file": "/tmp/ambassador/snapshots/default/secrets-decoded/test-tlscontext-secret-2/4CB5C4C15C3BBBF727E8572838933519EA42D103.crt",
                             "private_key_file": "/tmp/ambassador/snapshots/default/secrets-decoded/test-tlscontext-secret-2/4CB5C4C15C3BBBF727E8572838933519EA42D103.key",
@@ -583,6 +584,7 @@
                 "location": "host-2.default.1",
                 "name": "host-2-context",
                 "namespace": "default",
+                "redirect_cleartext_from": 8080,
                 "secret_info": {
                     "cert_chain_file": "/tmp/ambassador/snapshots/default/secrets-decoded/test-tlscontext-secret-2/4CB5C4C15C3BBBF727E8572838933519EA42D103.crt",
                     "private_key_file": "/tmp/ambassador/snapshots/default/secrets-decoded/test-tlscontext-secret-2/4CB5C4C15C3BBBF727E8572838933519EA42D103.key",
@@ -702,6 +704,7 @@
                         "location": "host-1.default.1",
                         "name": "host-1-context",
                         "namespace": "default",
+                        "redirect_cleartext_from": 8080,
                         "secret_info": {
                             "cert_chain_file": "/tmp/ambassador/snapshots/default/secrets-decoded/test-tlscontext-secret-1/6B4919697C5D70BB8E4A73A59DDF51A53AE24264.crt",
                             "private_key_file": "/tmp/ambassador/snapshots/default/secrets-decoded/test-tlscontext-secret-1/6B4919697C5D70BB8E4A73A59DDF51A53AE24264.key",
@@ -738,6 +741,7 @@
                 "location": "host-1.default.1",
                 "name": "host-1-context",
                 "namespace": "default",
+                "redirect_cleartext_from": 8080,
                 "secret_info": {
                     "cert_chain_file": "/tmp/ambassador/snapshots/default/secrets-decoded/test-tlscontext-secret-1/6B4919697C5D70BB8E4A73A59DDF51A53AE24264.crt",
                     "private_key_file": "/tmp/ambassador/snapshots/default/secrets-decoded/test-tlscontext-secret-1/6B4919697C5D70BB8E4A73A59DDF51A53AE24264.key",
@@ -846,6 +850,7 @@
                     "location": "host-1.default.1",
                     "name": "host-1-context",
                     "namespace": "default",
+                    "redirect_cleartext_from": 8080,
                     "secret_info": {
                         "cert_chain_file": "/tmp/ambassador/snapshots/default/secrets-decoded/test-tlscontext-secret-1/6B4919697C5D70BB8E4A73A59DDF51A53AE24264.crt",
                         "private_key_file": "/tmp/ambassador/snapshots/default/secrets-decoded/test-tlscontext-secret-1/6B4919697C5D70BB8E4A73A59DDF51A53AE24264.key",
@@ -866,6 +871,7 @@
                     "location": "host-2.default.1",
                     "name": "host-2-context",
                     "namespace": "default",
+                    "redirect_cleartext_from": 8080,
                     "secret_info": {
                         "cert_chain_file": "/tmp/ambassador/snapshots/default/secrets-decoded/test-tlscontext-secret-2/4CB5C4C15C3BBBF727E8572838933519EA42D103.crt",
                         "private_key_file": "/tmp/ambassador/snapshots/default/secrets-decoded/test-tlscontext-secret-2/4CB5C4C15C3BBBF727E8572838933519EA42D103.key",
@@ -873,6 +879,22 @@
                     }
                 }
             },
+            "use_proxy_proto": false,
+            "use_remote_address": true,
+            "xff_num_trusted_hops": 0
+        },
+        {
+            "_active": true,
+            "_errored": false,
+            "_rkey": "ir.listener",
+            "kind": "IRListener",
+            "location": "host-2.default.1",
+            "name": "ir.listener",
+            "namespace": "default",
+            "redirect_listener": true,
+            "require_tls": true,
+            "server_name": "envoy",
+            "service_port": 8080,
             "use_proxy_proto": false,
             "use_remote_address": true,
             "xff_num_trusted_hops": 0
@@ -961,6 +983,7 @@
             "location": "host-1.default.1",
             "name": "host-1-context",
             "namespace": "default",
+            "redirect_cleartext_from": 8080,
             "secret_info": {
                 "cert_chain_file": "/tmp/ambassador/snapshots/default/secrets-decoded/test-tlscontext-secret-1/6B4919697C5D70BB8E4A73A59DDF51A53AE24264.crt",
                 "private_key_file": "/tmp/ambassador/snapshots/default/secrets-decoded/test-tlscontext-secret-1/6B4919697C5D70BB8E4A73A59DDF51A53AE24264.key",
@@ -981,6 +1004,7 @@
             "location": "host-2.default.1",
             "name": "host-2-context",
             "namespace": "default",
+            "redirect_cleartext_from": 8080,
             "secret_info": {
                 "cert_chain_file": "/tmp/ambassador/snapshots/default/secrets-decoded/test-tlscontext-secret-2/4CB5C4C15C3BBBF727E8572838933519EA42D103.crt",
                 "private_key_file": "/tmp/ambassador/snapshots/default/secrets-decoded/test-tlscontext-secret-2/4CB5C4C15C3BBBF727E8572838933519EA42D103.key",

--- a/python/tests/gold/hostdouble/snapshots/snapshot.yaml
+++ b/python/tests/gold/hostdouble/snapshots/snapshot.yaml
@@ -12,7 +12,7 @@
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"getambassador.io/v2\",\"kind\":\"Host\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"hostdouble\",\"scope\":\"AmbassadorTest\"},\"name\":\"host-1\",\"namespace\":\"default\"},\"spec\":{\"acmeProvider\":{\"authority\":\"ACME\"},\"ambassador_id\":[\"hostdouble\"],\"hostname\":\"tls-context-host-1\",\"selector\":{\"matchLabels\":{\"hostname\":\"tls-context-host-1\"}},\"tlsSecret\":{\"name\":\"test-tlscontext-secret-1\"}}}\n"
                     },
                     "clusterName": "",
-                    "creationTimestamp": "2019-12-06T08:21:30Z",
+                    "creationTimestamp": "2019-12-07T23:40:43Z",
                     "generation": 1,
                     "labels": {
                         "kat-ambassador-id": "hostdouble",
@@ -20,9 +20,9 @@
                     },
                     "name": "host-1",
                     "namespace": "default",
-                    "resourceVersion": "38498",
+                    "resourceVersion": "30844",
                     "selfLink": "/apis/getambassador.io/v2/namespaces/default/hosts/host-1",
-                    "uid": "67e2e609-1801-11ea-b0a1-0e9564dc4001"
+                    "uid": "fc1d91dc-194a-11ea-a779-0aef9020d397"
                 },
                 "spec": {
                     "acmeProvider": {
@@ -50,7 +50,7 @@
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"getambassador.io/v2\",\"kind\":\"Host\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"hostdouble\",\"scope\":\"AmbassadorTest\"},\"name\":\"host-2\",\"namespace\":\"default\"},\"spec\":{\"acmeProvider\":{\"authority\":\"ACME\"},\"ambassador_id\":[\"hostdouble\"],\"hostname\":\"tls-context-host-2\",\"selector\":{\"matchLabels\":{\"hostname\":\"tls-context-host-2\"}},\"tlsSecret\":{\"name\":\"test-tlscontext-secret-2\"}}}\n"
                     },
                     "clusterName": "",
-                    "creationTimestamp": "2019-12-06T08:21:30Z",
+                    "creationTimestamp": "2019-12-07T23:40:43Z",
                     "generation": 1,
                     "labels": {
                         "kat-ambassador-id": "hostdouble",
@@ -58,9 +58,9 @@
                     },
                     "name": "host-2",
                     "namespace": "default",
-                    "resourceVersion": "38499",
+                    "resourceVersion": "30845",
                     "selfLink": "/apis/getambassador.io/v2/namespaces/default/hosts/host-2",
-                    "uid": "67ea94b7-1801-11ea-b0a1-0e9564dc4001"
+                    "uid": "fc2623f7-194a-11ea-a779-0aef9020d397"
                 },
                 "spec": {
                     "acmeProvider": {
@@ -93,7 +93,7 @@
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"getambassador.io/v1\",\"kind\":\"Mapping\",\"metadata\":{\"annotations\":{},\"labels\":{\"hostname\":\"tls-context-host-1\",\"kat-ambassador-id\":\"hostdouble\",\"scope\":\"AmbassadorTest\"},\"name\":\"host-1-mapping\",\"namespace\":\"default\"},\"spec\":{\"ambassador_id\":[\"hostdouble\"],\"host\":\"tls-context-host-1\",\"prefix\":\"/target/\",\"service\":\"hostdouble-http-target1\"}}\n"
                     },
                     "clusterName": "",
-                    "creationTimestamp": "2019-12-06T08:21:30Z",
+                    "creationTimestamp": "2019-12-07T23:40:43Z",
                     "generation": 1,
                     "labels": {
                         "hostname": "tls-context-host-1",
@@ -102,9 +102,9 @@
                     },
                     "name": "host-1-mapping",
                     "namespace": "default",
-                    "resourceVersion": "38500",
+                    "resourceVersion": "30846",
                     "selfLink": "/apis/getambassador.io/v1/namespaces/default/mappings/host-1-mapping",
-                    "uid": "67f26b14-1801-11ea-b0a1-0e9564dc4001"
+                    "uid": "fc2ef9b5-194a-11ea-a779-0aef9020d397"
                 },
                 "spec": {
                     "ambassador_id": [
@@ -123,7 +123,7 @@
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"getambassador.io/v1\",\"kind\":\"Mapping\",\"metadata\":{\"annotations\":{},\"labels\":{\"hostname\":\"tls-context-host-2\",\"kat-ambassador-id\":\"hostdouble\",\"scope\":\"AmbassadorTest\"},\"name\":\"host-2-mapping\",\"namespace\":\"default\"},\"spec\":{\"ambassador_id\":[\"hostdouble\"],\"host\":\"tls-context-host-2\",\"prefix\":\"/target/\",\"service\":\"hostdouble-http-target2\"}}\n"
                     },
                     "clusterName": "",
-                    "creationTimestamp": "2019-12-06T08:21:30Z",
+                    "creationTimestamp": "2019-12-07T23:40:43Z",
                     "generation": 1,
                     "labels": {
                         "hostname": "tls-context-host-2",
@@ -132,9 +132,9 @@
                     },
                     "name": "host-2-mapping",
                     "namespace": "default",
-                    "resourceVersion": "38501",
+                    "resourceVersion": "30847",
                     "selfLink": "/apis/getambassador.io/v1/namespaces/default/mappings/host-2-mapping",
-                    "uid": "67fa0778-1801-11ea-b0a1-0e9564dc4001"
+                    "uid": "fc3c585a-194a-11ea-a779-0aef9020d397"
                 },
                 "spec": {
                     "ambassador_id": [
@@ -164,16 +164,16 @@
                     "annotations": {
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"data\":{\"tls.crt\":\"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURnRENDQW1pZ0F3SUJBZ0lKQUpycUl0ekY2MTBpTUEwR0NTcUdTSWIzRFFFQkN3VUFNRlV4Q3pBSkJnTlYKQkFZVEFsVlRNUXN3Q1FZRFZRUUlEQUpOUVRFUE1BMEdBMVVFQnd3R1FtOXpkRzl1TVFzd0NRWURWUVFLREFKRQpWekViTUJrR0ExVUVBd3dTZEd4ekxXTnZiblJsZUhRdGFHOXpkQzB4TUI0WERURTRNVEV3TVRFek5UTXhPRm9YCkRUSTRNVEF5T1RFek5UTXhPRm93VlRFTE1Ba0dBMVVFQmhNQ1ZWTXhDekFKQmdOVkJBZ01BazFCTVE4d0RRWUQKVlFRSERBWkNiM04wYjI0eEN6QUpCZ05WQkFvTUFrUlhNUnN3R1FZRFZRUUREQkowYkhNdFkyOXVkR1Y0ZEMxbwpiM04wTFRFd2dnRWlNQTBHQ1NxR1NJYjNEUUVCQVFVQUE0SUJEd0F3Z2dFS0FvSUJBUUM5T2dDOHd4eUlyUHpvCkdYc0xwUEt0NzJERXgyd2p3VzhuWFcyd1dieWEzYzk2bjJuU0NLUEJuODVoYnFzaHpqNWloU1RBTURJb2c5RnYKRzZSS1dVUFhUNEtJa1R2M0NESHFYc0FwSmxKNGxTeW5ReW8yWnYwbytBZjhDTG5nWVpCK3JmenRad3llRGhWcAp3WXpCVjIzNXp6NisycWJWbUNabHZCdVhiVXFUbEVZWXZ1R2xNR3o3cFBmT1dLVXBlWW9kYkcyZmIraEZGcGVvCkN4a1VYclFzT29SNUpkSEc1aldyWnVCTzQ1NVNzcnpCTDhSbGU1VUhvMDVXY0s3YkJiaVF6MTA2cEhDSllaK3AKdmxQSWNOU1g1S2gzNEZnOTZVUHg5bFFpQTN6RFRLQmZ5V2NMUStxMWNabExjV2RnUkZjTkJpckdCLzdyYTFWVApnRUplR2tQekFnTUJBQUdqVXpCUk1CMEdBMVVkRGdRV0JCUkRWVUtYWWJsRFdNTzE3MUJuWWZhYlkzM0NFVEFmCkJnTlZIU01FR0RBV2dCUkRWVUtYWWJsRFdNTzE3MUJuWWZhYlkzM0NFVEFQQmdOVkhSTUJBZjhFQlRBREFRSC8KTUEwR0NTcUdTSWIzRFFFQkN3VUFBNElCQVFBUE8vRDRUdDUyWHJsQ0NmUzZnVUVkRU5DcnBBV05YRHJvR2M2dApTVGx3aC8rUUxRYk5hZEtlaEtiZjg5clhLaituVXF0cS9OUlpQSXNBSytXVWtHOVpQb1FPOFBRaVY0V1g1clE3CjI5dUtjSmZhQlhrZHpVVzdxTlFoRTRjOEJhc0JySWVzcmtqcFQ5OVF4SktuWFFhTitTdzdvRlBVSUFOMzhHcWEKV2wvS1BNVHRicWt3eWFjS01CbXExVkx6dldKb0g1Q2l6Skp3aG5rWHh0V0tzLzY3clROblBWTXorbWVHdHZTaQpkcVg2V1NTbUdMRkVFcjJoZ1VjQVpqazNWdVFoLzc1aFh1K1UySXRzQys1cXBsaEc3Q1hzb1huS0t5MVhsT0FFCmI4a3IyZFdXRWs2STVZNm5USnpXSWxTVGtXODl4d1hyY3RtTjlzYjlxNFNuaVZsegotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==\",\"tls.key\":\"LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0tCk1JSUV2UUlCQURBTkJna3Foa2lHOXcwQkFRRUZBQVNDQktjd2dnU2pBZ0VBQW9JQkFRQzlPZ0M4d3h5SXJQem8KR1hzTHBQS3Q3MkRFeDJ3andXOG5YVzJ3V2J5YTNjOTZuMm5TQ0tQQm44NWhicXNoemo1aWhTVEFNRElvZzlGdgpHNlJLV1VQWFQ0S0lrVHYzQ0RIcVhzQXBKbEo0bFN5blF5bzJadjBvK0FmOENMbmdZWkIrcmZ6dFp3eWVEaFZwCndZekJWMjM1eno2KzJxYlZtQ1psdkJ1WGJVcVRsRVlZdnVHbE1HejdwUGZPV0tVcGVZb2RiRzJmYitoRkZwZW8KQ3hrVVhyUXNPb1I1SmRIRzVqV3JadUJPNDU1U3NyekJMOFJsZTVVSG8wNVdjSzdiQmJpUXoxMDZwSENKWVorcAp2bFBJY05TWDVLaDM0Rmc5NlVQeDlsUWlBM3pEVEtCZnlXY0xRK3ExY1psTGNXZGdSRmNOQmlyR0IvN3JhMVZUCmdFSmVHa1B6QWdNQkFBRUNnZ0VBQmFsN3BpcE1hMGFKMXNRVWEzZkhEeTlQZlBQZXAzODlQVGROZGU1cGQxVFYKeFh5SnBSQS9IaWNTL05WYjU0b05VZE5jRXlnZUNCcFJwUHAxd3dmQ3dPbVBKVmo3SzF3aWFqbmxsQldpZUJzMgpsOWFwcDdFVE9DdWJ5WTNWU2dLQldWa0piVzBjOG9uSFdEL0RYM0duUjhkTXdGYzRrTUdadkllUlo4bU1acmdHCjZPdDNKOHI2eVZsZWI2OGF1WmtneXMwR2VGc3pNdVRubHJCOEw5djI1UUtjVGtESjIvRWx1Y1p5aER0eGF0OEIKTzZOUnNubmNyOHhwUVdPci9sV3M5VVFuZEdCdHFzbXMrdGNUN1ZUNU9UanQ4WHY5NVhNSHB5Z29pTHk3czhvYwpJMGprNDJabzRKZW5JT3c2Rm0weUFEZ0E3eWlXcks0bEkzWGhqaTVSb1FLQmdRRGRqaWNkTUpYVUZWc28rNTJkCkUwT2EwcEpVMFNSaC9JQmdvRzdNakhrVWxiaXlpR1pNanA5MEo5VHFaL1ErM1pWZVdqMmxPSWF0OG5nUzB6MDAKVzA3T1ZxYXprMVNYaFZlY2tGNWFEcm5PRDNhU2VWMSthV3JUdDFXRWdqOVFxYnJZYVA5emd4UkpkRzV3WENCUApGNDNFeXE5ZEhXOWF6SSt3UHlJQ0JqNnZBd0tCZ1FEYXBTelhPR2ViMi9SMWhlWXdWV240czNGZEtYVjgzemtTCnFSWDd6d1pLdkk5OGMybDU1Y1ZNUzBoTGM0bTVPMXZCaUd5SG80eTB2SVAvR0k0Rzl4T1FhMXdpVnNmUVBiSU4KLzJPSDFnNXJLSFdCWVJUaHZGcERqdHJRU2xyRHVjWUNSRExCd1hUcDFrbVBkL09mY2FybG42MjZEamthZllieAp3dWUydlhCTVVRS0JnQm4vTmlPOHNiZ0RFWUZMbFFEN1k3RmxCL3FmMTg4UG05aTZ1b1dSN2hzMlBrZmtyV3hLClIvZVBQUEtNWkNLRVNhU2FuaVVtN3RhMlh0U0dxT1hkMk85cFI0Skd4V1JLSnkrZDJSUmtLZlU5NTBIa3I4M0gKZk50KzVhLzR3SWtzZ1ZvblorSWIvV05wSUJSYkd3ZHMwaHZIVkxCdVpjU1h3RHlFQysrRTRCSVZBb0dCQUoxUQp6eXlqWnRqYnI4NkhZeEpQd29teEF0WVhLSE9LWVJRdUdLVXZWY1djV2xrZTZUdE51V0dsb1FTNHd0VkdBa1VECmxhTWFaL2o2MHJaT3dwSDhZRlUvQ2ZHakl1MlFGbmEvMUtzOXR1NGZGRHpjenh1RVhDWFR1Vmk0eHdtZ3R2bVcKZkRhd3JTQTZrSDdydlp4eE9wY3hCdHloc3pCK05RUHFTckpQSjJlaEFvR0FkdFJKam9vU0lpYURVU25lZUcyZgpUTml1T01uazJkeFV3RVF2S1E4eWNuUnpyN0QwaEtZVWIycThHKzE2bThQUjNCcFMzZDFLbkpMVnI3TUhaWHpSCitzZHNaWGtTMWVEcEZhV0RFREFEWWI0ckRCb2RBdk8xYm03ZXdTMzhSbk1UaTlhdFZzNVNTODNpZG5HbFZiSmsKYkZKWG0rWWxJNHFkaXowTFdjWGJyREE9Ci0tLS0tRU5EIFBSSVZBVEUgS0VZLS0tLS0K\"},\"kind\":\"Secret\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"hostdouble\",\"scope\":\"AmbassadorTest\"},\"name\":\"test-tlscontext-secret-1\",\"namespace\":\"default\"},\"type\":\"kubernetes.io/tls\"}\n"
                     },
-                    "creationTimestamp": "2019-12-06T08:21:30Z",
+                    "creationTimestamp": "2019-12-07T23:40:43Z",
                     "labels": {
                         "kat-ambassador-id": "hostdouble",
                         "scope": "AmbassadorTest"
                     },
                     "name": "test-tlscontext-secret-1",
                     "namespace": "default",
-                    "resourceVersion": "38493",
+                    "resourceVersion": "30839",
                     "selfLink": "/api/v1/namespaces/default/secrets/test-tlscontext-secret-1",
-                    "uid": "67c4710e-1801-11ea-b0a1-0e9564dc4001"
+                    "uid": "fc0965e5-194a-11ea-a779-0aef9020d397"
                 },
                 "type": "kubernetes.io/tls"
             },
@@ -188,16 +188,16 @@
                     "annotations": {
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"data\":{\"tls.crt\":\"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURnRENDQW1pZ0F3SUJBZ0lKQUlIWTY3cFNoZ3NyTUEwR0NTcUdTSWIzRFFFQkN3VUFNRlV4Q3pBSkJnTlYKQkFZVEFsVlRNUXN3Q1FZRFZRUUlEQUpOUVRFUE1BMEdBMVVFQnd3R1FtOXpkRzl1TVFzd0NRWURWUVFLREFKRQpWekViTUJrR0ExVUVBd3dTZEd4ekxXTnZiblJsZUhRdGFHOXpkQzB5TUI0WERURTRNVEV3TVRFME1EUXhObG9YCkRUSTRNVEF5T1RFME1EUXhObG93VlRFTE1Ba0dBMVVFQmhNQ1ZWTXhDekFKQmdOVkJBZ01BazFCTVE4d0RRWUQKVlFRSERBWkNiM04wYjI0eEN6QUpCZ05WQkFvTUFrUlhNUnN3R1FZRFZRUUREQkowYkhNdFkyOXVkR1Y0ZEMxbwpiM04wTFRJd2dnRWlNQTBHQ1NxR1NJYjNEUUVCQVFVQUE0SUJEd0F3Z2dFS0FvSUJBUURjQThZdGgvUFdhT0dTCm9ObXZFSFoyNGpRN1BLTitENG93TEhXZWl1UmRtaEEwWU92VTN3cUczVnFZNFpwbFpBVjBQS2xELysyWlNGMTQKejh3MWVGNFFUelphWXh3eTkrd2ZITmtUREVwTWpQOEpNMk9FYnlrVVJ4VVJ2VzQrN0QzMEUyRXo1T1BseG1jMApNWU0vL0pINUVEUWhjaURybFlxZTFTUk1SQUxaZVZta2FBeXU2TkhKVEJ1ajBTSVB1ZExUY2grOTBxK3Jkd255CmZrVDF4M09UYW5iV2pub21FSmU3TXZ5NG12dnFxSUh1NDhTOUM4WmQxQkdWUGJ1OFYvVURyU1dROXpZQ1g0U0cKT2FzbDhDMFhtSDZrZW1oUERsRC9UdjB4dnlINXE1TVVjSGk0bUp0Titnem9iNTREd3pWR0VqZWY1TGVTMVY1RgowVEFQMGQrWEFnTUJBQUdqVXpCUk1CMEdBMVVkRGdRV0JCUWRGMEdRSGRxbHRoZG5RWXFWaXVtRXJsUk9mREFmCkJnTlZIU01FR0RBV2dCUWRGMEdRSGRxbHRoZG5RWXFWaXVtRXJsUk9mREFQQmdOVkhSTUJBZjhFQlRBREFRSC8KTUEwR0NTcUdTSWIzRFFFQkN3VUFBNElCQVFBbUFLYkNsdUhFZS9JRmJ1QWJneDBNenV6aTkwd2xtQVBiOGdtTwpxdmJwMjl1T1ZzVlNtUUFkZFBuZEZhTVhWcDFaaG1UVjVDU1F0ZFgyQ1ZNVyswVzQ3Qy9DT0Jkb1NFUTl5akJmCmlGRGNseG04QU4yUG1hR1FhK3hvT1hnWkxYZXJDaE5LV0JTWlIrWktYTEpTTTlVYUVTbEhmNXVuQkxFcENqK2oKZEJpSXFGY2E3eElGUGtyKzBSRW9BVmMveFBubnNhS2pMMlV5Z0dqUWZGTnhjT042Y3VjYjZMS0pYT1pFSVRiNQpINjhKdWFSQ0tyZWZZK0l5aFFWVk5taWk3dE1wY1UyS2pXNXBrVktxVTNkS0l0RXEyVmtTZHpNVUtqTnhZd3FGCll6YnozNFQ1MENXbm9HbU5SQVdKc0xlVmlPWVUyNmR3YkFXZDlVYitWMDFRam43OAotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==\",\"tls.key\":\"LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0tCk1JSUV2d0lCQURBTkJna3Foa2lHOXcwQkFRRUZBQVNDQktrd2dnU2xBZ0VBQW9JQkFRRGNBOFl0aC9QV2FPR1MKb05tdkVIWjI0alE3UEtOK0Q0b3dMSFdlaXVSZG1oQTBZT3ZVM3dxRzNWcVk0WnBsWkFWMFBLbEQvKzJaU0YxNAp6OHcxZUY0UVR6WmFZeHd5OSt3ZkhOa1RERXBNalA4Sk0yT0VieWtVUnhVUnZXNCs3RDMwRTJFejVPUGx4bWMwCk1ZTS8vSkg1RURRaGNpRHJsWXFlMVNSTVJBTFplVm1rYUF5dTZOSEpUQnVqMFNJUHVkTFRjaCs5MHErcmR3bnkKZmtUMXgzT1RhbmJXam5vbUVKZTdNdnk0bXZ2cXFJSHU0OFM5QzhaZDFCR1ZQYnU4Vi9VRHJTV1E5ellDWDRTRwpPYXNsOEMwWG1INmtlbWhQRGxEL1R2MHh2eUg1cTVNVWNIaTRtSnROK2d6b2I1NER3elZHRWplZjVMZVMxVjVGCjBUQVAwZCtYQWdNQkFBRUNnZ0VCQUk2U3I0anYwZForanJhN0gzVnZ3S1RYZnl0bjV6YVlrVjhZWUh3RjIyakEKbm9HaTBSQllIUFU2V2l3NS9oaDRFWVM2anFHdkptUXZYY3NkTldMdEJsK2hSVUtiZVRtYUtWd2NFSnRrV24xeQozUTQwUytnVk5OU2NINDRvYUZuRU0zMklWWFFRZnBKMjJJZ2RFY1dVUVcvWnpUNWpPK3dPTXc4c1plSTZMSEtLCkdoOENsVDkrRGUvdXFqbjNCRnQwelZ3cnFLbllKSU1DSWFrb2lDRmtIcGhVTURFNVkyU1NLaGFGWndxMWtLd0sKdHFvWFpKQnlzYXhnUTFRa21mS1RnRkx5WlpXT01mRzVzb1VrU1RTeURFRzFsYnVYcHpUbTlVSTlKU2lsK01yaAp1LzVTeXBLOHBCSHhBdFg5VXdiTjFiRGw3Sng1SWJyMnNoM0F1UDF4OUpFQ2dZRUE4dGNTM09URXNOUFpQZlptCk9jaUduOW9STTdHVmVGdjMrL05iL3JodHp1L1RQUWJBSzhWZ3FrS0dPazNGN1krY2txS1NTWjFnUkF2SHBsZEIKaTY0Y0daT1dpK01jMWZVcEdVV2sxdnZXbG1nTUlQVjVtbFpvOHowMlNTdXhLZTI1Y2VNb09oenFlay9vRmFtdgoyTmxFeTh0dEhOMUxMS3grZllhMkpGcWVycThDZ1lFQTUvQUxHSXVrU3J0K0dkektJLzV5cjdSREpTVzIzUTJ4CkM5ZklUTUFSL1Q4dzNsWGhyUnRXcmlHL3l0QkVPNXdTMVIwdDkydW1nVkhIRTA5eFFXbzZ0Tm16QVBNb1RSekMKd08yYnJqQktBdUJkQ0RISjZsMlFnOEhPQWovUncrK2x4bEN0VEI2YS8xWEZIZnNHUGhqMEQrWlJiWVZzaE00UgpnSVVmdmpmQ1Y1a0NnWUVBMzdzL2FieHJhdThEaTQ3a0NBQ3o1N3FsZHBiNk92V2d0OFF5MGE5aG0vSmhFQ3lVCkNML0VtNWpHeWhpMWJuV05yNXVRWTdwVzR0cG5pdDJCU2d1VFlBMFYrck8zOFhmNThZcTBvRTFPR3l5cFlBUkoKa09SanRSYUVXVTJqNEJsaGJZZjNtL0xnSk9oUnp3T1RPNXFSUTZHY1dhZVlod1ExVmJrelByTXUxNGtDZ1lCbwp4dEhjWnNqelVidm5wd3hTTWxKUStaZ1RvZlAzN0lWOG1pQk1POEJrclRWQVczKzFtZElRbkFKdWRxTThZb2RICmF3VW03cVNyYXV3SjF5dU1wNWFadUhiYkNQMjl5QzVheFh3OHRtZlk0TTVtTTBmSjdqYW9ydGFId1pqYmNObHMKdTJsdUo2MVJoOGVpZ1pJU1gyZHgvMVB0ckFhWUFCZDcvYWVYWU0wVWtRS0JnUUNVbkFIdmRQUGhIVnJDWU1rTgpOOFBEK0t0YmhPRks2S3MvdlgyUkcyRnFmQkJPQWV3bEo1d0xWeFBLT1RpdytKS2FSeHhYMkcvREZVNzduOEQvCkR5V2RjM2ZCQWQ0a1lJamZVaGRGa1hHNEFMUDZBNVFIZVN4NzNScTFLNWxMVWhPbEZqc3VPZ0NKS28wVlFmRC8KT05paDB6SzN5Wmc3aDVQamZ1TUdGb09OQWc9PQotLS0tLUVORCBQUklWQVRFIEtFWS0tLS0tCg==\"},\"kind\":\"Secret\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"hostdouble\",\"scope\":\"AmbassadorTest\"},\"name\":\"test-tlscontext-secret-2\",\"namespace\":\"default\"},\"type\":\"kubernetes.io/tls\"}\n"
                     },
-                    "creationTimestamp": "2019-12-06T08:21:30Z",
+                    "creationTimestamp": "2019-12-07T23:40:43Z",
                     "labels": {
                         "kat-ambassador-id": "hostdouble",
                         "scope": "AmbassadorTest"
                     },
                     "name": "test-tlscontext-secret-2",
                     "namespace": "default",
-                    "resourceVersion": "38496",
+                    "resourceVersion": "30843",
                     "selfLink": "/api/v1/namespaces/default/secrets/test-tlscontext-secret-2",
-                    "uid": "67cd81ff-1801-11ea-b0a1-0e9564dc4001"
+                    "uid": "fc1508b1-194a-11ea-a779-0aef9020d397"
                 },
                 "type": "kubernetes.io/tls"
             }
@@ -208,9 +208,53 @@
                 "kind": "Service",
                 "metadata": {
                     "annotations": {
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"hostdouble\",\"scope\":\"AmbassadorTest\"},\"name\":\"hostdouble-http-target2\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8082},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8445}],\"selector\":{\"backend\":\"superpod-default\"}}}\n"
+                    },
+                    "creationTimestamp": "2019-12-07T23:40:43Z",
+                    "labels": {
+                        "kat-ambassador-id": "hostdouble",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "hostdouble-http-target2",
+                    "namespace": "default",
+                    "resourceVersion": "30852",
+                    "selfLink": "/api/v1/namespaces/default/services/hostdouble-http-target2",
+                    "uid": "fc52f29e-194a-11ea-a779-0aef9020d397"
+                },
+                "spec": {
+                    "clusterIP": "10.97.107.154",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8082
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8445
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-default"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"app.kubernetes.io/component\":\"ambassador-service\",\"kat-ambassador-id\":\"hostdouble\",\"scope\":\"AmbassadorTest\"},\"name\":\"hostdouble\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8080},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8443}],\"selector\":{\"service\":\"hostdouble\"},\"type\":\"NodePort\"}}\n"
                     },
-                    "creationTimestamp": "2019-12-06T08:21:29Z",
+                    "creationTimestamp": "2019-12-07T23:40:43Z",
                     "labels": {
                         "app.kubernetes.io/component": "ambassador-service",
                         "kat-ambassador-id": "hostdouble",
@@ -218,24 +262,24 @@
                     },
                     "name": "hostdouble",
                     "namespace": "default",
-                    "resourceVersion": "38481",
+                    "resourceVersion": "30828",
                     "selfLink": "/api/v1/namespaces/default/services/hostdouble",
-                    "uid": "6777db53-1801-11ea-b0a1-0e9564dc4001"
+                    "uid": "fbe545c8-194a-11ea-a779-0aef9020d397"
                 },
                 "spec": {
-                    "clusterIP": "10.108.6.203",
+                    "clusterIP": "10.106.98.46",
                     "externalTrafficPolicy": "Cluster",
                     "ports": [
                         {
                             "name": "http",
-                            "nodePort": 32753,
+                            "nodePort": 32618,
                             "port": 80,
                             "protocol": "TCP",
                             "targetPort": 8080
                         },
                         {
                             "name": "https",
-                            "nodePort": 30883,
+                            "nodePort": 32474,
                             "port": 443,
                             "protocol": "TCP",
                             "targetPort": 8443
@@ -258,7 +302,7 @@
                     "annotations": {
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"hostdouble\",\"scope\":\"AmbassadorTest\",\"service\":\"hostdouble-admin\"},\"name\":\"hostdouble-admin\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"hostdouble-admin\",\"port\":8877,\"targetPort\":8877}],\"selector\":{\"service\":\"hostdouble\"},\"type\":\"NodePort\"}}\n"
                     },
-                    "creationTimestamp": "2019-12-06T08:21:30Z",
+                    "creationTimestamp": "2019-12-07T23:40:43Z",
                     "labels": {
                         "kat-ambassador-id": "hostdouble",
                         "scope": "AmbassadorTest",
@@ -266,17 +310,17 @@
                     },
                     "name": "hostdouble-admin",
                     "namespace": "default",
-                    "resourceVersion": "38486",
+                    "resourceVersion": "30832",
                     "selfLink": "/api/v1/namespaces/default/services/hostdouble-admin",
-                    "uid": "67a3a6c7-1801-11ea-b0a1-0e9564dc4001"
+                    "uid": "fbeed6b3-194a-11ea-a779-0aef9020d397"
                 },
                 "spec": {
-                    "clusterIP": "10.101.113.60",
+                    "clusterIP": "10.107.97.249",
                     "externalTrafficPolicy": "Cluster",
                     "ports": [
                         {
                             "name": "hostdouble-admin",
-                            "nodePort": 31481,
+                            "nodePort": 31533,
                             "port": 8877,
                             "protocol": "TCP",
                             "targetPort": 8877
@@ -297,77 +341,33 @@
                 "kind": "Service",
                 "metadata": {
                     "annotations": {
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"hostdouble\",\"scope\":\"AmbassadorTest\"},\"name\":\"hostdouble-http-target1\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8083},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8446}],\"selector\":{\"backend\":\"superpod-default\"}}}\n"
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"hostdouble\",\"scope\":\"AmbassadorTest\"},\"name\":\"hostdouble-http-target1\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8081},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8444}],\"selector\":{\"backend\":\"superpod-default\"}}}\n"
                     },
-                    "creationTimestamp": "2019-12-06T08:21:30Z",
+                    "creationTimestamp": "2019-12-07T23:40:43Z",
                     "labels": {
                         "kat-ambassador-id": "hostdouble",
                         "scope": "AmbassadorTest"
                     },
                     "name": "hostdouble-http-target1",
                     "namespace": "default",
-                    "resourceVersion": "38503",
+                    "resourceVersion": "30849",
                     "selfLink": "/api/v1/namespaces/default/services/hostdouble-http-target1",
-                    "uid": "6802e659-1801-11ea-b0a1-0e9564dc4001"
+                    "uid": "fc465443-194a-11ea-a779-0aef9020d397"
                 },
                 "spec": {
-                    "clusterIP": "10.97.70.203",
+                    "clusterIP": "10.97.113.53",
                     "ports": [
                         {
                             "name": "http",
                             "port": 80,
                             "protocol": "TCP",
-                            "targetPort": 8083
+                            "targetPort": 8081
                         },
                         {
                             "name": "https",
                             "port": 443,
                             "protocol": "TCP",
-                            "targetPort": 8446
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-default"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"hostdouble\",\"scope\":\"AmbassadorTest\"},\"name\":\"hostdouble-http-target2\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8084},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8447}],\"selector\":{\"backend\":\"superpod-default\"}}}\n"
-                    },
-                    "creationTimestamp": "2019-12-06T08:21:30Z",
-                    "labels": {
-                        "kat-ambassador-id": "hostdouble",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "hostdouble-http-target2",
-                    "namespace": "default",
-                    "resourceVersion": "38506",
-                    "selfLink": "/api/v1/namespaces/default/services/hostdouble-http-target2",
-                    "uid": "680e0b40-1801-11ea-b0a1-0e9564dc4001"
-                },
-                "spec": {
-                    "clusterIP": "10.107.244.223",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8084
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8447
+                            "targetPort": 8444
                         }
                     ],
                     "selector": {

--- a/python/tests/gold/hostsingle/snapshots/econf.json
+++ b/python/tests/gold/hostsingle/snapshots/econf.json
@@ -214,6 +214,63 @@
                     }
                 ],
                 "name": "ambassador-listener-8443"
+            },
+            {
+                "address": {
+                    "socket_address": {
+                        "address": "0.0.0.0",
+                        "port_value": 8080,
+                        "protocol": "TCP"
+                    }
+                },
+                "filter_chains": [
+                    {
+                        "filters": [
+                            {
+                                "config": {
+                                    "access_log": [],
+                                    "http_filters": [
+                                        {
+                                            "name": "envoy.router"
+                                        }
+                                    ],
+                                    "http_protocol_options": {
+                                        "accept_http_10": false
+                                    },
+                                    "normalize_path": true,
+                                    "route_config": {
+                                        "virtual_hosts": [
+                                            {
+                                                "domains": [
+                                                    "*"
+                                                ],
+                                                "name": "backend",
+                                                "require_tls": "EXTERNAL_ONLY",
+                                                "routes": [
+                                                    {
+                                                        "match": {
+                                                            "prefix": "/"
+                                                        },
+                                                        "redirect": {
+                                                            "https_redirect": true
+                                                        }
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "server_name": "envoy",
+                                    "stat_prefix": "ingress_http",
+                                    "use_remote_address": true,
+                                    "xff_num_trusted_hops": 0
+                                },
+                                "name": "envoy.http_connection_manager"
+                            }
+                        ],
+                        "use_proxy_proto": false
+                    }
+                ],
+                "name": "redirect_listener"
             }
         ]
     }

--- a/python/tests/gold/hostsingle/snapshots/ir.json
+++ b/python/tests/gold/hostsingle/snapshots/ir.json
@@ -570,6 +570,7 @@
                     "location": "edgy-host.default.1",
                     "name": "edgy-host-context",
                     "namespace": "default",
+                    "redirect_cleartext_from": 8080,
                     "secret_info": {
                         "cert_chain_file": "/tmp/ambassador/snapshots/default/secrets-decoded/edgy-secret/F94E4DCF30ABC50DEF240AA8024599B67CC03991.crt",
                         "private_key_file": "/tmp/ambassador/snapshots/default/secrets-decoded/edgy-secret/F94E4DCF30ABC50DEF240AA8024599B67CC03991.key",
@@ -577,6 +578,22 @@
                     }
                 }
             },
+            "use_proxy_proto": false,
+            "use_remote_address": true,
+            "xff_num_trusted_hops": 0
+        },
+        {
+            "_active": true,
+            "_errored": false,
+            "_rkey": "ir.listener",
+            "kind": "IRListener",
+            "location": "edgy-host.default.1",
+            "name": "ir.listener",
+            "namespace": "default",
+            "redirect_listener": true,
+            "require_tls": true,
+            "server_name": "envoy",
+            "service_port": 8080,
             "use_proxy_proto": false,
             "use_remote_address": true,
             "xff_num_trusted_hops": 0
@@ -649,6 +666,7 @@
             "location": "edgy-host.default.1",
             "name": "edgy-host-context",
             "namespace": "default",
+            "redirect_cleartext_from": 8080,
             "secret_info": {
                 "cert_chain_file": "/tmp/ambassador/snapshots/default/secrets-decoded/edgy-secret/F94E4DCF30ABC50DEF240AA8024599B67CC03991.crt",
                 "private_key_file": "/tmp/ambassador/snapshots/default/secrets-decoded/edgy-secret/F94E4DCF30ABC50DEF240AA8024599B67CC03991.key",

--- a/python/tests/gold/hostsingle/snapshots/snapshot.yaml
+++ b/python/tests/gold/hostsingle/snapshots/snapshot.yaml
@@ -12,7 +12,7 @@
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"getambassador.io/v2\",\"kind\":\"Host\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"hostsingle\",\"scope\":\"AmbassadorTest\"},\"name\":\"edgy-host\",\"namespace\":\"default\"},\"spec\":{\"acmeProvider\":{\"authority\":\"ACME\"},\"ambassador_id\":[\"hostsingle\"],\"hostname\":\"edgy.example.com\",\"selector\":{\"matchLabels\":{\"hostname\":\"edgy.example.com\"}},\"tlsSecret\":{\"name\":\"edgy-secret\"}}}\n"
                     },
                     "clusterName": "",
-                    "creationTimestamp": "2019-12-06T08:21:27Z",
+                    "creationTimestamp": "2019-12-07T23:40:42Z",
                     "generation": 1,
                     "labels": {
                         "kat-ambassador-id": "hostsingle",
@@ -20,9 +20,9 @@
                     },
                     "name": "edgy-host",
                     "namespace": "default",
-                    "resourceVersion": "38406",
+                    "resourceVersion": "30814",
                     "selfLink": "/apis/getambassador.io/v2/namespaces/default/hosts/edgy-host",
-                    "uid": "6604e546-1801-11ea-b0a1-0e9564dc4001"
+                    "uid": "fbac452e-194a-11ea-a779-0aef9020d397"
                 },
                 "spec": {
                     "acmeProvider": {
@@ -55,7 +55,7 @@
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"getambassador.io/v1\",\"kind\":\"Mapping\",\"metadata\":{\"annotations\":{},\"labels\":{\"hostname\":\"edgy.example.com\",\"kat-ambassador-id\":\"hostsingle\",\"scope\":\"AmbassadorTest\"},\"name\":\"edgy-target-mapping\",\"namespace\":\"default\"},\"spec\":{\"ambassador_id\":[\"hostsingle\"],\"prefix\":\"/target/\",\"service\":\"hostsingle-http\"}}\n"
                     },
                     "clusterName": "",
-                    "creationTimestamp": "2019-12-06T08:21:27Z",
+                    "creationTimestamp": "2019-12-07T23:40:42Z",
                     "generation": 1,
                     "labels": {
                         "hostname": "edgy.example.com",
@@ -64,9 +64,9 @@
                     },
                     "name": "edgy-target-mapping",
                     "namespace": "default",
-                    "resourceVersion": "38407",
+                    "resourceVersion": "30815",
                     "selfLink": "/apis/getambassador.io/v1/namespaces/default/mappings/edgy-target-mapping",
-                    "uid": "660ec9f9-1801-11ea-b0a1-0e9564dc4001"
+                    "uid": "fbb68acc-194a-11ea-a779-0aef9020d397"
                 },
                 "spec": {
                     "ambassador_id": [
@@ -95,16 +95,16 @@
                     "annotations": {
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"data\":{\"tls.crt\":\"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwakNDQW82Z0F3SUJBZ0lKQUpxa1Z4Y1RtQ1FITUEwR0NTcUdTSWIzRFFFQkN3VUFNR2d4Q3pBSkJnTlYKQkFZVEFsVlRNUXN3Q1FZRFZRUUlEQUpOUVRFUE1BMEdBMVVFQnd3R1FtOXpkRzl1TVJFd0R3WURWUVFLREFoRQpZWFJoZDJseVpURVVNQklHQTFVRUN3d0xSVzVuYVc1bFpYSnBibWN4RWpBUUJnTlZCQU1NQ1d4dlkyRnNhRzl6CmREQWVGdzB4T0RFd01UQXhNREk1TURKYUZ3MHlPREV3TURjeE1ESTVNREphTUdneEN6QUpCZ05WQkFZVEFsVlQKTVFzd0NRWURWUVFJREFKTlFURVBNQTBHQTFVRUJ3d0dRbTl6ZEc5dU1SRXdEd1lEVlFRS0RBaEVZWFJoZDJseQpaVEVVTUJJR0ExVUVDd3dMUlc1bmFXNWxaWEpwYm1jeEVqQVFCZ05WQkFNTUNXeHZZMkZzYUc5emREQ0NBU0l3CkRRWUpLb1pJaHZjTkFRRUJCUUFEZ2dFUEFEQ0NBUW9DZ2dFQkFMcTZtdS9FSzlQc1Q0YkR1WWg0aEZPVnZiblAKekV6MGpQcnVzdXcxT05MQk9jT2htbmNSTnE4c1FyTGxBZ3NicDBuTFZmQ1pSZHQ4UnlOcUFGeUJlR29XS3IvZAprQVEybVBucjBQRHlCTzk0UHo4VHdydDBtZEtEU1dGanNxMjlOYVJaT0JqdStLcGV6RytOZ3pLMk04M0ZtSldUCnFYdTI3ME9pOXlqb2VGQ3lPMjdwUkdvcktkQk9TcmIwd3ozdFdWUGk4NFZMdnFKRWprT0JVZjJYNVF3b25XWngKMktxVUJ6OUFSZVVUMzdwUVJZQkJMSUdvSnM4U042cjF4MSt1dTNLdTVxSkN1QmRlSHlJbHpKb2V0aEp2K3pTMgowN0pFc2ZKWkluMWNpdXhNNzNPbmVRTm1LUkpsL2NEb3BLemswSldRSnRSV1NnbktneFNYWkRrZjJMOENBd0VBCkFhTlRNRkV3SFFZRFZSME9CQllFRkJoQzdDeVRpNGFkSFVCd0wvTkZlRTZLdnFIRE1COEdBMVVkSXdRWU1CYUEKRkJoQzdDeVRpNGFkSFVCd0wvTkZlRTZLdnFIRE1BOEdBMVVkRXdFQi93UUZNQU1CQWY4d0RRWUpLb1pJaHZjTgpBUUVMQlFBRGdnRUJBSFJvb0xjcFdEa1IyMEhENEJ5d1BTUGRLV1hjWnN1U2tXYWZyekhoYUJ5MWJZcktIR1o1CmFodFF3L1gwQmRnMWtidlpZUDJSTzdGTFhBSlNTdXVJT0NHTFVwS0pkVHE1NDREUThNb1daWVZKbTc3UWxxam0KbHNIa2VlTlRNamFOVjdMd0MzalBkMERYelczbGVnWFRoYWpmZ2dtLzBJZXNGRzBVWjFEOTJHNURmc0hLekpSagpNSHZyVDNtVmJGZjkrSGJhRE4yT2g5VjIxUWhWSzF2M0F2dWNXczhUWCswZHZFZ1dtWHBRcndEd2pTMU04QkRYCldoWjVsZTZjVzhNYjhnZmRseG1JckpnQStuVVZzMU9EbkJKS1F3MUY4MVdkc25tWXdweVUrT2xVais4UGt1TVoKSU4rUlhQVnZMSWJ3czBmamJ4UXRzbTArZVBpRnN2d0NsUFk9Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K\",\"tls.key\":\"LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0tCk1JSUV2Z0lCQURBTkJna3Foa2lHOXcwQkFRRUZBQVNDQktnd2dnU2tBZ0VBQW9JQkFRQzZ1cHJ2eEN2VDdFK0cKdzdtSWVJUlRsYjI1ejh4TTlJejY3ckxzTlRqU3dUbkRvWnAzRVRhdkxFS3k1UUlMRzZkSnkxWHdtVVhiZkVjagphZ0JjZ1hocUZpcS8zWkFFTnBqNTY5RHc4Z1R2ZUQ4L0U4SzdkSm5TZzBsaFk3S3R2VFdrV1RnWTd2aXFYc3h2CmpZTXl0alBOeFppVms2bDd0dTlEb3ZjbzZIaFFzanR1NlVScUt5blFUa3EyOU1NOTdWbFQ0dk9GUzc2aVJJNUQKZ1ZIOWwrVU1LSjFtY2RpcWxBYy9RRVhsRTkrNlVFV0FRU3lCcUNiUEVqZXE5Y2RmcnJ0eXJ1YWlRcmdYWGg4aQpKY3lhSHJZU2IvczB0dE95UkxIeVdTSjlYSXJzVE85enAza0RaaWtTWmYzQTZLU3M1TkNWa0NiVVZrb0p5b01VCmwyUTVIOWkvQWdNQkFBRUNnZ0VBSVFsZzNpamNCRHViK21Eb2syK1hJZDZ0V1pHZE9NUlBxUm5RU0NCR2RHdEIKV0E1Z2NNNTMyVmhBV0x4UnR6dG1ScFVXR0dKVnpMWlpNN2ZPWm85MWlYZHdpcytkYWxGcWtWVWFlM2FtVHVQOApkS0YvWTRFR3Nnc09VWSs5RGlZYXRvQWVmN0xRQmZ5TnVQTFZrb1JQK0FrTXJQSWFHMHhMV3JFYmYzNVp3eFRuCnd5TTF3YVpQb1oxWjZFdmhHQkxNNzlXYmY2VFY0WXVzSTRNOEVQdU1GcWlYcDNlRmZ4L0tnNHhtYnZtN1JhYzcKOEJ3Z3pnVmljNXlSbkVXYjhpWUh5WGtyazNTL0VCYUNEMlQwUjM5VmlVM1I0VjBmMUtyV3NjRHowVmNiVWNhKwpzeVdyaVhKMHBnR1N0Q3FWK0dRYy9aNmJjOGt4VWpTTWxOUWtudVJRZ1FLQmdRRHpwM1ZaVmFzMTA3NThVT00rCnZUeTFNL0V6azg4cWhGb21kYVFiSFRlbStpeGpCNlg3RU9sRlkya3JwUkwvbURDSEpwR0MzYlJtUHNFaHVGSUwKRHhSQ2hUcEtTVmNsSytaaUNPaWE1ektTVUpxZnBOcW15RnNaQlhJNnRkNW9mWk42aFpJVTlJR2RUaGlYMjBONwppUW01UnZlSUx2UHVwMWZRMmRqd2F6Ykgvd0tCZ1FERU1MN21Mb2RqSjBNTXh6ZnM3MW1FNmZOUFhBMVY2ZEgrCllCVG4xS2txaHJpampRWmFNbXZ6dEZmL1F3Wkhmd3FKQUVuNGx2em5ncUNzZTMvUElZMy8zRERxd1p2NE1vdy8KRGdBeTBLQmpQYVJGNjhYT1B1d0VuSFN1UjhyZFg2UzI3TXQ2cEZIeFZ2YjlRRFJuSXc4a3grSFVreml4U0h5Ugo2NWxESklEdlFRS0JnUURpQTF3ZldoQlBCZk9VYlpQZUJydmhlaVVycXRob29BemYwQkJCOW9CQks1OHczVTloCjdQWDFuNWxYR3ZEY2x0ZXRCbUhEK3RQMFpCSFNyWit0RW5mQW5NVE5VK3E2V0ZhRWFhOGF3WXR2bmNWUWdTTXgKd25oK1pVYm9udnVJQWJSajJyTC9MUzl1TTVzc2dmKy9BQWM5RGs5ZXkrOEtXY0Jqd3pBeEU4TGxFUUtCZ0IzNwoxVEVZcTFoY0I4Tk1MeC9tOUtkN21kUG5IYUtqdVpSRzJ1c1RkVWNxajgxdklDbG95MWJUbVI5Si93dXVQczN4ClhWekF0cVlyTUtNcnZMekxSQWgyZm9OaVU1UDdKYlA5VDhwMFdBN1N2T2h5d0NobE5XeisvRlltWXJxeWcxbngKbHFlSHRYNU03REtJUFhvRndhcTlZYVk3V2M2K1pVdG4xbVNNajZnQkFvR0JBSTgwdU9iTkdhRndQTVYrUWhiZApBelkrSFNGQjBkWWZxRytzcTBmRVdIWTNHTXFmNFh0aVRqUEFjWlg3RmdtT3Q5Uit3TlFQK0dFNjZoV0JpKzBWCmVLV3prV0lXeS9sTVZCSW0zVWtlSlRCT3NudTFVaGhXbm5WVDhFeWhEY1FxcndPSGlhaUo3bFZSZmRoRWFyQysKSnpaU0czOHVZUVlyc0lITnRVZFgySmdPCi0tLS0tRU5EIFBSSVZBVEUgS0VZLS0tLS0K\"},\"kind\":\"Secret\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"hostsingle\",\"scope\":\"AmbassadorTest\"},\"name\":\"edgy-secret\",\"namespace\":\"default\"},\"type\":\"kubernetes.io/tls\"}\n"
                     },
-                    "creationTimestamp": "2019-12-06T08:21:27Z",
+                    "creationTimestamp": "2019-12-07T23:40:39Z",
                     "labels": {
                         "kat-ambassador-id": "hostsingle",
                         "scope": "AmbassadorTest"
                     },
                     "name": "edgy-secret",
                     "namespace": "default",
-                    "resourceVersion": "38402",
+                    "resourceVersion": "30805",
                     "selfLink": "/api/v1/namespaces/default/secrets/edgy-secret",
-                    "uid": "65cfe7c9-1801-11ea-b0a1-0e9564dc4001"
+                    "uid": "f9cf48c2-194a-11ea-a779-0aef9020d397"
                 },
                 "type": "kubernetes.io/tls"
             }
@@ -117,7 +117,7 @@
                     "annotations": {
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"app.kubernetes.io/component\":\"ambassador-service\",\"kat-ambassador-id\":\"hostsingle\",\"scope\":\"AmbassadorTest\"},\"name\":\"hostsingle\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8080},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8443}],\"selector\":{\"service\":\"hostsingle\"},\"type\":\"NodePort\"}}\n"
                     },
-                    "creationTimestamp": "2019-12-06T08:21:26Z",
+                    "creationTimestamp": "2019-12-07T23:40:39Z",
                     "labels": {
                         "app.kubernetes.io/component": "ambassador-service",
                         "kat-ambassador-id": "hostsingle",
@@ -125,24 +125,24 @@
                     },
                     "name": "hostsingle",
                     "namespace": "default",
-                    "resourceVersion": "38392",
+                    "resourceVersion": "30795",
                     "selfLink": "/api/v1/namespaces/default/services/hostsingle",
-                    "uid": "6591bcc6-1801-11ea-b0a1-0e9564dc4001"
+                    "uid": "f9b6131e-194a-11ea-a779-0aef9020d397"
                 },
                 "spec": {
-                    "clusterIP": "10.104.68.54",
+                    "clusterIP": "10.105.141.138",
                     "externalTrafficPolicy": "Cluster",
                     "ports": [
                         {
                             "name": "http",
-                            "nodePort": 32142,
+                            "nodePort": 31520,
                             "port": 80,
                             "protocol": "TCP",
                             "targetPort": 8080
                         },
                         {
                             "name": "https",
-                            "nodePort": 32202,
+                            "nodePort": 32572,
                             "port": 443,
                             "protocol": "TCP",
                             "targetPort": 8443
@@ -165,7 +165,7 @@
                     "annotations": {
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"hostsingle\",\"scope\":\"AmbassadorTest\",\"service\":\"hostsingle-admin\"},\"name\":\"hostsingle-admin\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"hostsingle-admin\",\"port\":8877,\"targetPort\":8877}],\"selector\":{\"service\":\"hostsingle\"},\"type\":\"NodePort\"}}\n"
                     },
-                    "creationTimestamp": "2019-12-06T08:21:26Z",
+                    "creationTimestamp": "2019-12-07T23:40:39Z",
                     "labels": {
                         "kat-ambassador-id": "hostsingle",
                         "scope": "AmbassadorTest",
@@ -173,17 +173,17 @@
                     },
                     "name": "hostsingle-admin",
                     "namespace": "default",
-                    "resourceVersion": "38396",
+                    "resourceVersion": "30799",
                     "selfLink": "/api/v1/namespaces/default/services/hostsingle-admin",
-                    "uid": "659aba80-1801-11ea-b0a1-0e9564dc4001"
+                    "uid": "f9be1fcb-194a-11ea-a779-0aef9020d397"
                 },
                 "spec": {
-                    "clusterIP": "10.96.206.235",
+                    "clusterIP": "10.97.230.150",
                     "externalTrafficPolicy": "Cluster",
                     "ports": [
                         {
                             "name": "hostsingle-admin",
-                            "nodePort": 31349,
+                            "nodePort": 31112,
                             "port": 8877,
                             "protocol": "TCP",
                             "targetPort": 8877
@@ -206,19 +206,19 @@
                     "annotations": {
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"hostsingle\",\"scope\":\"AmbassadorTest\"},\"name\":\"hostsingle-http\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8080},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8443}],\"selector\":{\"backend\":\"superpod-default\"}}}\n"
                     },
-                    "creationTimestamp": "2019-12-06T08:21:27Z",
+                    "creationTimestamp": "2019-12-07T23:40:43Z",
                     "labels": {
                         "kat-ambassador-id": "hostsingle",
                         "scope": "AmbassadorTest"
                     },
                     "name": "hostsingle-http",
                     "namespace": "default",
-                    "resourceVersion": "38409",
+                    "resourceVersion": "30817",
                     "selfLink": "/api/v1/namespaces/default/services/hostsingle-http",
-                    "uid": "6618101b-1801-11ea-b0a1-0e9564dc4001"
+                    "uid": "fbbf7b02-194a-11ea-a779-0aef9020d397"
                 },
                 "spec": {
-                    "clusterIP": "10.96.28.146",
+                    "clusterIP": "10.101.194.170",
                     "ports": [
                         {
                             "name": "http",


### PR DESCRIPTION
https://github.com/datawire/apro/pull/635

This has AES set `redirect_from_cleartext: 8080` (a) the synthesized TLSContexts for Hosts (in ambassador.git), and (b) the fallback TLSContext (in apro.git).

This currently does *not* punch a hole in that for `/.well-known/acme-challenge/`, so this relies on the ACME provider dealing with it if you redirect them to an URL with a bad certificate.  It seems that these days, Let's Encrypt deals with it; we (me, Flynn, Cynthia) agree that we shouldn't rely on that, but that it shouldn't be a blocker for Dec 10.