### PR TITLE
Tweaks to make init-config work all the time

### DIFF
--- a/python/ambassador/config/config.py
+++ b/python/ambassador/config/config.py
@@ -234,6 +234,14 @@ class Config:
         # Is an ambassador_id present in this object?
         allowed_ids: StringOrList = resource.get('ambassador_id', 'default')
 
+        # If we find the array [ '_automatic_' ] then allow it, so that hardcoded resources
+        # can have a useful effect. This is mostly for init-config, but could be used for
+        # other things, too.
+
+        if allowed_ids == [ "_automatic_" ]:
+            self.logger.debug(f"ambassador_id {allowed_ids} always accepted")
+            return True
+
         if allowed_ids:
             # Make sure it's a list. Yes, this is Draconian,
             # but the jsonschema will allow only a string or a list,

--- a/python/ambassador/config/resourcefetcher.py
+++ b/python/ambassador/config/resourcefetcher.py
@@ -70,9 +70,10 @@ class ResourceFetcher:
         self.helm_chart: Optional[str] = None
 
         if not skip_init_dir:
-            # Check AMBASSADOR_CONFIG_BASE_DIR/init_config for initialization resources.
-            base = os.environ.get('AMBASSADOR_CONFIG_BASE_DIR') or '/ambassador'
-            init_dir = os.path.join(base, 'init-config')
+            # Check /ambassador/init-config for initialization resources -- note NOT
+            # $AMBASSADOR_CONFIG_BASE_DIR/init-config! This is compile-time stuff that
+            # doesn't move around if you change the configuration base.
+            init_dir = '/ambassador/init-config'
 
             if os.path.isdir(init_dir):
                 self.load_from_filesystem(init_dir, k8s=True, recurse=True, finalize=False)


### PR DESCRIPTION
Resources in `init-config` were being mishandled if your `ambassador_id` or `AMBASSADOR_CONFIG_BASE_DIR` were changed from their defaults. Obviously that's a problem -- this fixes it.