### PR TITLE
Correctly show Ambassador 0.86.1 rather than 0.86.0.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,12 +71,15 @@ behavior before upgrading your CRDs.
 - CORS now happens before rate limiting
 - The reconfiguration engine is better protected from exceptions
 
-## [0.86.0] December 10, 2019
-[0.86.0]: https://github.com/datawire/ambassador/compare/v0.84.1...v0.86.0
+## [0.86.1] December 10, 2019
+[0.86.1]: https://github.com/datawire/ambassador/compare/v0.84.1...v0.86.0
 
 - Envoy updated to 1.12.2 for security fixes
 - Envoy TCP keepalives are now supported (thanks, [Bartek Kowalczyk](https://github.com/KowalczykBartek)!)
 - Envoy remote access logs are now supported
+- Correctly handle upgrades when the `LogService` CRD is not present
+
+(Ambassador 0.86.0 was superseded by Ambassador 0.86.1.)
 
 ## [0.85.0] October 22, 2019
 [0.85.0]: https://github.com/datawire/ambassador/compare/v0.84.1...v0.85.0


### PR DESCRIPTION
This was updated correctly on the `release/0.86` branch, but should be done here too.