### PR TITLE
Scout reports aes app and version

### DIFF
--- a/python/ambassador/ambscout.py
+++ b/python/ambassador/ambscout.py
@@ -85,7 +85,9 @@ class AmbScout:
         self.runtime = "kubernetes" if os.environ.get('KUBERNETES_SERVICE_HOST', None) else "docker"
         self.namespace = os.environ.get('AMBASSADOR_NAMESPACE', 'default')
 
-        self.version = self.parse_git_description(Version, Build)
+        self.is_edge_stack = os.path.exists('/ambassador/.edge_stack')
+        self.app = "aes" if self.is_edge_stack else "ambassador"
+        self.version = Version if self.is_edge_stack else self.parse_git_description(Version, Build)
         self.semver = self.get_semver(self.version)
 
         self.logger = logging.getLogger("ambassador.scout")
@@ -126,11 +128,11 @@ class AmbScout:
         if not self._scout:
             if self._local_only:
                 self._scout = LocalScout(logger=self.logger,
-                                         app="ambassador", version=self.version, install_id=self.install_id)
+                                         app=self.app, version=self.version, install_id=self.install_id)
                 self.logger.debug("LocalScout initialized")
             else:
                 try:
-                    self._scout = Scout(app="ambassador", version=self.version, install_id=self.install_id)
+                    self._scout = Scout(app=self.app, version=self.version, install_id=self.install_id)
                     self._scout_error = None
                     self.logger.debug("Scout connection established")
                 except OSError as e:


### PR DESCRIPTION
## Description
When running in the context of AES, scout tags the app as `aes` and will report the same version as diag UI and Edge Console.
The behaviour change is required because we build Ambassador from a detached head and the current version parsing assumes we are running a local build.

## Testing
For AES, scout will report: `aes`, `1.0.0-ea5-18-g56976d54-dirty`
For AOSS, scout will report: `ambassador`, `1.0.0-local+33.gcb0a71ac5.dirty`
