### PR TITLE
Mockery fixes

### DIFF
--- a/python/ambassador/config/config.py
+++ b/python/ambassador/config/config.py
@@ -252,8 +252,10 @@ class Config:
             if Config.ambassador_id in allowed_ids:
                 return True
             else:
-                self.logger.debug(f"Ambassador ID {Config.ambassador_id} does not exist in allowed IDs {allowed_ids}")
-                self.logger.debug(resource)
+                rkey = resource.get('rkey', '-anonymous-yaml-')
+                name = resource.get('name', '-no-name-')
+
+                self.logger.debug(f"{rkey}: {resource_kind} {name} has IDs {allowed_ids}, no match with {Config.ambassador_id}")
                 return False
 
     def save_source(self, resource: ACResource) -> None:

--- a/python/ambassador/ir/ir.py
+++ b/python/ambassador/ir/ir.py
@@ -373,7 +373,7 @@ class IR:
 
         if ss:
             # Done. Return it.
-            self.logger.info(f"resolve_secret {ss_key}: using cached SavedSecret")
+            self.logger.debug(f"resolve_secret {ss_key}: using cached SavedSecret")
             self.secret_handler.still_needed(resource, secret_name, namespace)
             return ss
 
@@ -383,11 +383,11 @@ class IR:
         secret_info = self.secret_info.get(ss_key, None)
 
         if secret_info:
-            self.logger.info(f"resolve_secret {ss_key}: found secret_info")
+            self.logger.debug(f"resolve_secret {ss_key}: found secret_info")
             self.secret_handler.still_needed(resource, secret_name, namespace)
         else:
             # No secret_info, so ask the secret_handler to find us one.
-            self.logger.info(f"resolve_secret {ss_key}: no secret_info, asking handler to load")
+            self.logger.debug(f"resolve_secret {ss_key}: no secret_info, asking handler to load")
             secret_info = self.secret_handler.load_secret(resource, secret_name, namespace)
 
         if not secret_info:
@@ -395,7 +395,7 @@ class IR:
 
             ss = SavedSecret(secret_name, namespace, None, None, None, None)
         else:
-            self.logger.info(f"resolve_secret {ss_key}: found secret, asking handler to cache")
+            self.logger.debug(f"resolve_secret {ss_key}: found secret, asking handler to cache")
 
             # OK, we got a secret_info. Cache that using the secret handler.
             ss = self.secret_handler.cache_secret(resource, secret_info)

--- a/python/ambassador/ir/irtlscontext.py
+++ b/python/ambassador/ir/irtlscontext.py
@@ -138,7 +138,7 @@ class IRTLSContext(IRResource):
         secret_namespacing = self.lookup('secret_namespacing', True,
                                          default_key='tls_secret_namespacing')
 
-        self.ir.logger.info(f"TLSContext.resolve_secret {secret_name}, namespace {namespace}: namespacing is {secret_namespacing}")
+        self.ir.logger.debug(f"TLSContext.resolve_secret {secret_name}, namespace {namespace}: namespacing is {secret_namespacing}")
 
         if "." in secret_name and secret_namespacing:
             secret_name, namespace = secret_name.split('.', 1)

--- a/python/mockery.py
+++ b/python/mockery.py
@@ -8,6 +8,7 @@ import difflib
 import errno
 import filecmp
 import functools
+import io
 import json
 import logging
 import os
@@ -15,6 +16,7 @@ import shlex
 import shutil
 
 import click
+from watch_hook import WatchHook
 
 # Use this instead of click.option
 click_option = functools.partial(click.option, show_default=True)
@@ -237,37 +239,21 @@ class Mockery:
         for kind in collected.keys():
             watt_k8s[kind] = list(collected[kind].values())
 
+        self.snapshot = json.dumps({ 'Consul': {}, 'Kubernetes': watt_k8s }, sort_keys=True, indent=4)
+
         return watt_k8s
 
-    def run_hook(self, watt_k8s: WattDict) -> Tuple[bool, bool]:
-        json.dump({ 'Consul': {}, 'Kubernetes': watt_k8s },
-                  open("/tmp/mockery.json", "w"), sort_keys=True, indent=4)
+    def run_hook(self) -> Tuple[bool, bool]:
+        self.logger.info("RUNNING HOOK")
 
-        cmdline = shlex.split(self.watch)
+        yaml_stream = io.StringIO(self.snapshot)
 
-        if self.debug:
-            cmdline.append("--debug")
-
-        cmdline.append("/tmp/mockery.json")
-
-        self.logger.info(f"Running watch hook {cmdline}")
-
-        hook = ShellCommand(*cmdline)
-
-        if not hook.check(" ".join(cmdline)):
-            return False, False
-
-        for line in hook.stderr.splitlines(keepends=False):
-            self.logger.info(f"hook stderr: {line}")
+        wh = WatchHook(self.logger, yaml_stream)
 
         any_changes = False
-        hook_output = hook.stdout
 
-        if hook_output:
-            new_watches = json.loads(hook_output)
-            self.logger.info(f"new watches: {new_watches}")
-
-            for w in new_watches.get("kubernetes-watches") or []:
+        if wh.watchset:
+            for w in wh.watchset.get("kubernetes-watches") or []:
                 potential = WatchSpec(
                     logger=self.logger,
                     kind=w['kind'],
@@ -393,22 +379,21 @@ def main(k8s_yaml_path: str, debug: bool, force_pod_labels: bool, update: bool,
             logger.error("Not stable after 10 iterations, failing")
             sys.exit(1)
 
-        print(f"==== ITERATION {iteration}")
+        logger.info(f"======== START ITERATION {iteration}")
 
-        watt_k8s = w.load(manifest)
+        w.load(manifest)
 
-        logger.info(f"WATT_K8S: {json.dumps(watt_k8s, sort_keys=True, indent=4)}")
+        logger.info(f"WATT_K8S: {w.snapshot}")
 
-        hook_ok, any_changes = w.run_hook(watt_k8s)
+        hook_ok, any_changes = w.run_hook()
         
         if not hook_ok:
             raise Exception("hook failed")
             
         if any_changes:
-            logger.info("WATT_K8S: some changes from the hook!")
-            print("====== watches changed!")
+            logger.info(f"======== END ITERATION {iteration}: watches changed!")
         else:
-            print("====== stable!")
+            logger.info(f"======== END ITERATION {iteration}: stable!")
             break
 
     # Once here, we should be good to go.
@@ -425,8 +410,10 @@ def main(k8s_yaml_path: str, debug: bool, force_pod_labels: bool, update: bool,
     logger.debug(f"Config.ambassador_id {Config.ambassador_id}")
     logger.debug(f"Config.ambassador_namespace {Config.ambassador_namespace}")
 
+    logger.info(f"STABLE WATT_K8S: {w.snapshot}")
+
     fetcher = ResourceFetcher(logger, aconf)
-    fetcher.parse_watt(open("/tmp/mockery.json", "r", encoding="utf-8").read())
+    fetcher.parse_watt(w.snapshot)
     aconf.load_all(fetcher.sorted())
 
     open("/tmp/ambassador/snapshots/aconf.json", "w", encoding="utf-8").write(aconf.as_json())

--- a/python/mockery.py
+++ b/python/mockery.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple, TYPE_CHECKING
 
 import sys
 
@@ -27,6 +27,9 @@ from ambassador import Config, IR, Diagnostics, EnvoyConfig
 from ambassador.config.resourcefetcher import ResourceFetcher
 from ambassador.utils import parse_yaml, SecretHandler
 from kat.utils import ShellCommand
+
+if TYPE_CHECKING:
+    from ambassador.ir import IRResource
 
 KubeResource = Dict[str, Any]
 KubeList = List[KubeResource]

--- a/python/watch_hook.py
+++ b/python/watch_hook.py
@@ -2,8 +2,7 @@
 
 from ambassador.utils import ParsedService as Service
 
-from typing import Dict, List, Optional, Tuple, TYPE_CHECKING
-from typing import cast as typecast
+from typing import Dict, Optional, Tuple, TYPE_CHECKING
 
 import sys
 
@@ -11,45 +10,11 @@ import json
 import logging
 import os
 
-from urllib.parse import urlparse
-
-loglevel = logging.INFO
-
-args = sys.argv[1:]
-
-if args:
-    if args[0] == '--debug':
-        loglevel = logging.DEBUG
-        args.pop(0)
-    elif args[0].startswith('--'):
-        raise Exception(f'Usage: {os.path.basename(sys.argv[0])} [--debug] [path]')
-
-logging.basicConfig(
-    level=loglevel,
-    format="%(asctime)s watch-hook %(levelname)s: %(message)s",
-    datefmt="%Y-%m-%d %H:%M:%S"
-)
-
-alogger = logging.getLogger('ambassador')
-alogger.setLevel(logging.INFO)
-
-logger = logging.getLogger('watch_hook')
-logger.setLevel(loglevel)
-
-ambassador_knative_requested = (os.environ.get("AMBASSADOR_KNATIVE_SUPPORT", "-unset-").lower() == 'true')
-
-logger.debug(f'AMBASSADOR_KNATIVE_REQUESTED {ambassador_knative_requested}')
-
 from ambassador import Config, IR
 from ambassador.config.resourcefetcher import ResourceFetcher
-from ambassador.ir.irserviceresolver import IRServiceResolverFactory
-from ambassador.ir.irtls import TLSModuleFactory, IRAmbassadorTLS
-from ambassador.ir.irhost import HostFactory
-from ambassador.ir.irambassador import IRAmbassador
 from ambassador.utils import SecretInfo, SavedSecret, SecretHandler
 
 if TYPE_CHECKING:
-    from ambassador.ir.irtlscontext import IRTLSContext
     from ambassador.ir.irresource import IRResource
 
 
@@ -118,160 +83,200 @@ class FakeIR(IR):
         return resource
 
 
-# Watch management
+class WatchHook:
+    def __init__(self, logger, yaml_stream) -> None:
+        # Watch management
 
-consul_watches = []
-kube_watches = []
+        self.logger = logger
 
+        self.consul_watches = []
+        self.kube_watches = []
 
-def add_kube_watch(what: str, kind: str, namespace: Optional[str],
-                   field_selector: Optional[str]=None, label_selector: Optional[str]=None) -> None:
-    watch = { "kind": kind }
+        self.load_yaml(yaml_stream)
 
-    if namespace:
-        watch["namespace"] = namespace
+    def add_kube_watch(self, what: str, kind: str, namespace: Optional[str],
+                       field_selector: Optional[str]=None, label_selector: Optional[str]=None) -> None:
+        watch = { "kind": kind }
 
-    if field_selector:
-        watch["field-selector"] = field_selector
+        if namespace:
+            watch["namespace"] = namespace
 
-    if label_selector:
-        watch["label-selector"] = label_selector
+        if field_selector:
+            watch["field-selector"] = field_selector
 
-    logger.debug(f"{what}: add watch {watch}")
-    kube_watches.append(watch)
+        if label_selector:
+            watch["label-selector"] = label_selector
+
+        self.logger.debug(f"{what}: add watch {watch}")
+        self.kube_watches.append(watch)
+
+    def load_yaml(self, yaml_stream):
+        self.aconf = Config()
+
+        fetcher = ResourceFetcher(self.logger, self.aconf, watch_only=True)
+        fetcher.parse_watt(yaml_stream.read())
+
+        self.aconf.load_all(fetcher.sorted())
+
+        # We can lift mappings straight from the aconf...
+        mappings = self.aconf.get_config('mappings') or {}
+
+        # ...but we need the fake IR to deal with resolvers and TLS contexts.
+        self.fake = FakeIR(self.aconf, logger=self.logger)
+
+        self.logger.debug("IR: %s" % self.fake.as_json())
+
+        resolvers = self.fake.resolvers
+        contexts = self.fake.tls_contexts
+
+        self.logger.debug(f'mappings: {len(mappings)}')
+        self.logger.debug(f'resolvers: {len(resolvers)}')
+        self.logger.debug(f'contexts: {len(contexts)}')
+
+        global_resolver = self.fake.ambassador_module.get('resolver', None)
+
+        global_label_selector = os.environ.get('AMBASSADOR_LABEL_SELECTOR', '')
+        self.logger.debug('label-selector: %s' % global_label_selector)
+
+        # Walk hosts.
+        for host in self.fake.get_hosts():
+            sel = host.get('selector') or {}
+            match_labels = sel.get('matchLabels') or {}
+
+            label_selector = None
+
+            if match_labels:
+                label_selector = ','.join([f"{l}={v}" for l, v in match_labels.items()])
+
+            for wanted_kind in ['service', 'secret']:
+                self.add_kube_watch(f"Host {host.name}", wanted_kind, host.namespace,
+                                    label_selector=label_selector)
+
+        for mname, mapping in mappings.items():
+            res_name = mapping.get('resolver', None)
+            res_source = 'mapping'
+
+            if not res_name:
+                res_name = global_resolver
+                res_source = 'defaults'
+
+            ctx_name = mapping.get('tls', None)
+
+            self.logger.debug(
+                f'Mapping {mname}: resolver {res_name} from {res_source}, service {mapping.service}, tls {ctx_name}')
+
+            if res_name:
+                resolver = resolvers.get(res_name, None)
+                self.logger.debug(f'-> resolver {resolver}')
+
+                if resolver:
+                    svc = Service(logger, mapping.service, ctx_name)
+
+                    if resolver.kind == 'ConsulResolver':
+                        self.logger.debug(f'Mapping {mname} uses Consul resolver {res_name}')
+
+                        # At the moment, we stuff the resolver's datacenter into the association
+                        # ID for this watch. The ResourceFetcher relies on that.
+
+                        self.consul_watches.append(
+                            {
+                                "id": resolver.datacenter,
+                                "consul-address": resolver.address,
+                                "datacenter": resolver.datacenter,
+                                "service-name": svc.hostname
+                            }
+                        )
+                    elif resolver.kind == 'KubernetesEndpointResolver':
+                        host = svc.hostname
+                        namespace = Config.ambassador_namespace
+
+                        if not host:
+                            # This is really kind of impossible.
+                            self.logger.error(f"KubernetesEndpointResolver {res_name} has no 'hostname'")
+                            continue
+
+                        if "." in host:
+                            (host, namespace) = host.split(".", 2)[0:2]
+
+                        self.logger.debug(f'...kube endpoints: svc {svc.hostname} -> host {host} namespace {namespace}')
+
+                        self.add_kube_watch(f"endpoint", "endpoints", namespace,
+                                            label_selector=global_label_selector,
+                                            field_selector=f"metadata.name={host}")
+
+        for secret_key, secret_info in self.fake.secret_recorder.needed.items():
+            self.logger.debug(f'need secret {secret_info.name}.{secret_info.namespace}')
+
+            self.add_kube_watch(f"needed secret", "secret", secret_info.namespace,
+                                field_selector=f"metadata.name={secret_info.name}")
+
+        if self.fake.edge_stack_allowed:
+            # If the edge stack is allowed, make sure we watch for our fallback context.
+            self.add_kube_watch("Fallback TLSContext", "TLSContext", namespace=Config.ambassador_namespace)
+
+        ambassador_knative_requested = (os.environ.get("AMBASSADOR_KNATIVE_SUPPORT", "-unset-").lower() == 'true')
+
+        if ambassador_knative_requested:
+            self.logger.debug('Looking for Knative support...')
+
+            ambassador_basedir = os.environ.get('AMBASSADOR_CONFIG_BASE_DIR', '/ambassador')
+
+            if os.path.exists(os.path.join(ambassador_basedir, '.knative_clusteringress_ok')):
+                # Watch for clusteringresses.networking.internal.knative.dev in any namespace and with any labels.
+
+                self.logger.debug('watching for clusteringresses.networking.internal.knative.dev')
+                self.add_kube_watch("Knative clusteringresses", "clusteringresses.networking.internal.knative.dev",
+                                    None)
+
+            if os.path.exists(os.path.join(ambassador_basedir, '.knative_ingress_ok')):
+                # Watch for ingresses.networking.internal.knative.dev in any namespace and
+                # with any labels.
+
+                self.add_kube_watch("Knative ingresses", "ingresses.networking.internal.knative.dev", None)
+
+        self.watchset = {
+            "kubernetes-watches": self.kube_watches,
+            "consul-watches": self.consul_watches
+        }
+
+        save_dir = os.environ.get('AMBASSADOR_WATCH_DIR', '/tmp')
+
+        if save_dir:
+            json.dump(self.watchset, open(os.path.join(save_dir, 'watch.json'), "w"))
 
 
 #### Mainline.
 
-yaml_stream = sys.stdin
+if __name__ == "__main__":
+    loglevel = logging.INFO
 
-if args:
-    yaml_stream = open(args[0], "r")
+    args = sys.argv[1:]
 
-aconf = Config()
-fetcher = ResourceFetcher(logger, aconf, watch_only=True)
-fetcher.parse_watt(yaml_stream.read())
+    if args:
+        if args[0] == '--debug':
+            loglevel = logging.DEBUG
+            args.pop(0)
+        elif args[0].startswith('--'):
+            raise Exception(f'Usage: {os.path.basename(sys.argv[0])} [--debug] [path]')
 
-aconf.load_all(fetcher.sorted())
+    logging.basicConfig(
+        level=loglevel,
+        format="%(asctime)s watch-hook %(levelname)s: %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S"
+    )
 
-# We can lift mappings straight from the aconf...
-mappings = aconf.get_config('mappings') or {}
+    alogger = logging.getLogger('ambassador')
+    alogger.setLevel(logging.INFO)
 
-# ...but we need the fake IR to deal with resolvers and TLS contexts.
-fake = FakeIR(aconf, logger=logger)
+    logger = logging.getLogger('watch_hook')
+    logger.setLevel(loglevel)
 
-logger.debug("IR: %s" % fake.as_json())
+    yaml_stream = sys.stdin
 
-resolvers = fake.resolvers
-contexts = fake.tls_contexts
+    if args:
+        yaml_stream = open(args[0], "r")
 
-logger.debug(f'mappings: {len(mappings)}')
-logger.debug(f'resolvers: {len(resolvers)}')
-logger.debug(f'contexts: {len(contexts)}')
+    wh = WatchHook(logger, yaml_stream)
 
-global_resolver = fake.ambassador_module.get('resolver', None)
+    json.dump(wh.watchset, sys.stdout)
 
-global_label_selector = os.environ.get('AMBASSADOR_LABEL_SELECTOR', '')
-logger.debug('label-selector: %s' % global_label_selector)
-
-# Walk hosts.
-for host in fake.get_hosts():
-    sel = host.get('selector') or {}
-    match_labels = sel.get('matchLabels') or {}
-
-    label_selector = None
-
-    if match_labels:
-        label_selector = ','.join([ f"{l}={v}" for l, v in match_labels.items() ])
-
-    for wanted_kind in [ 'service', 'secret' ]:
-        add_kube_watch(f"Host {host.name}", wanted_kind, host.namespace,
-                       label_selector=label_selector)
-
-for mname, mapping in mappings.items():
-    res_name = mapping.get('resolver', None)
-    res_source = 'mapping'
-
-    if not res_name:
-        res_name = global_resolver
-        res_source = 'defaults'
-
-    ctx_name = mapping.get('tls', None)
-
-    logger.debug(f'Mapping {mname}: resolver {res_name} from {res_source}, service {mapping.service}, tls {ctx_name}')
-
-    if res_name:
-        resolver = resolvers.get(res_name, None)
-        logger.debug(f'-> resolver {resolver}')
-
-        if resolver:
-            svc = Service(logger, mapping.service, ctx_name)
-
-            if resolver.kind == 'ConsulResolver':
-                logger.debug(f'Mapping {mname} uses Consul resolver {res_name}')
-
-                # At the moment, we stuff the resolver's datacenter into the association
-                # ID for this watch. The ResourceFetcher relies on that.
-
-                consul_watches.append(
-                    {
-                        "id": resolver.datacenter,
-                        "consul-address": resolver.address,
-                        "datacenter": resolver.datacenter,
-                        "service-name": svc.hostname
-                    }
-                )
-            elif resolver.kind == 'KubernetesEndpointResolver':
-                host = svc.hostname
-                namespace = Config.ambassador_namespace
-
-                if not host:
-                    # This is really kind of impossible.
-                    logger.error(f"KubernetesEndpointResolver {res_name} has no 'hostname'")
-                    continue
-
-                if "." in host:
-                    (host, namespace) = host.split(".", 2)[0:2]
-
-                logger.debug(f'...kube endpoints: svc {svc.hostname} -> host {host} namespace {namespace}')
-
-                add_kube_watch(f"endpoint", "endpoints", namespace,
-                               label_selector=global_label_selector, field_selector=f"metadata.name={host}")
-
-for secret_key, secret_info in fake.secret_recorder.needed.items():
-    logger.debug(f'need secret {secret_info.name}.{secret_info.namespace}')
-
-    add_kube_watch(f"needed secret", "secret", secret_info.namespace, field_selector=f"metadata.name={secret_info.name}")
-
-if fake.edge_stack_allowed:
-    # If the edge stack is allowed, make sure we watch for our fallback context.
-    add_kube_watch("Fallback TLSContext", "TLSContext", namespace=Config.ambassador_namespace)
-
-if ambassador_knative_requested:
-    logger.debug('Looking for Knative support...')
-
-    ambassador_basedir = os.environ.get('AMBASSADOR_CONFIG_BASE_DIR', '/ambassador')
-
-    if os.path.exists(os.path.join(ambassador_basedir, '.knative_clusteringress_ok')):
-        # Watch for clusteringresses.networking.internal.knative.dev in any namespace and with any labels.
-
-        logger.debug('watching for clusteringresses.networking.internal.knative.dev')
-        add_kube_watch("Knative clusteringresses", "clusteringresses.networking.internal.knative.dev", None)
-
-    if os.path.exists(os.path.join(ambassador_basedir, '.knative_ingress_ok')):
-        # Watch for ingresses.networking.internal.knative.dev in any namespace and
-        # with any labels.
-
-        add_kube_watch("Knative ingresses", "ingresses.networking.internal.knative.dev", None)
-
-watchset = {
-    "kubernetes-watches": kube_watches,
-    "consul-watches": consul_watches
-}
-
-save_dir = os.environ.get('AMBASSADOR_WATCH_DIR', '/tmp')
-
-if save_dir:
-    json.dump(watchset, open(os.path.join(save_dir, 'watch.json'), "w"))
-
-json.dump(watchset, sys.stdout)


### PR DESCRIPTION
Instead of running the `watch_hook` as an external Python program from `mockery`, just `import` it. This is prep for not having `watt` need to invoke it either.

Also, clean up some logging and typing stuff.