### PR TITLE
Ambassador 1.0.0-ea9 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,15 @@ Format:
 --->
 
 <!--- CueAddReleaseNotes --->
+## [1.0.0-ea9] December 23, 2019
+[1.0.0-ea9]: https://github.com/datawire/ambassador/compare/v0.86.0...v1.0.0-ea9
+
+
+### Minor changes:
+- Bugfix: Use proper executable name for Windows edgectl
+- Bugfix: Don't force SNI routes to be lower-priority than non-SNI routes
+- Bugfix: Prevent the self-signed fallback context from conflicting with a manual context
+
 ## [1.0.0-ea7] December 19, 2019
 [1.0.0-ea7]: https://github.com/datawire/ambassador/compare/v0.86.0...v1.0.0-ea7
 

--- a/docs/versions.yml
+++ b/docs/versions.yml
@@ -1,3 +1,3 @@
-version: 1.0.0-ea7
+version: 1.0.0-ea9
 aproVersion: 0.11.0
 qotmVersion: 1.7


### PR DESCRIPTION
### Minor changes:
- Bugfix: Use proper executable name for Windows edgectl
- Bugfix: Don't force SNI routes to be lower-priority than non-SNI routes
- Bugfix: Prevent the self-signed fallback context from conflicting with a manual context