### PR TITLE
Increase kubectl wait timeout to 90s

### DIFF
--- a/docs/user-guide/install.md
+++ b/docs/user-guide/install.md
@@ -21,7 +21,7 @@ The Ambassador Edge Stack is typically deployed to Kubernetes from the command l
     kubectl apply -f https://deploy-preview-91--datawire-ambassador.netlify.com/yaml/aes-crds.yaml && \
     kubectl wait --for condition=established --timeout=60s crd -lproduct=aes && \
     kubectl apply -f https://deploy-preview-91--datawire-ambassador.netlify.com/yaml/aes.yaml && \
-    kubectl -n ambassador wait --for condition=available --timeout=60s deploy -lproduct=aes
+    kubectl -n ambassador wait --for condition=available --timeout=90s deploy -lproduct=aes
     ```
 
 2. Determine the IP address of your cluster by running the following command:


### PR DESCRIPTION
Increase kubectl wait timeout to 90s so we don't get any timeout while installing on non-power intensive machines