### PR TITLE
make {pull,push}-docs: Expect to use a fixed git-subtree

### DIFF
--- a/build-aux-local/docs.mk
+++ b/build-aux-local/docs.mk
@@ -1,23 +1,45 @@
 # This is the branch from ambassador-docs.git to pull for "make pull-docs".
 # Override if you need to.
-PULL_BRANCH ?= master
+PULL_BRANCH ?= early-access
+
+# This is the branch from ambassador-docs.git to push to for "make push-docs".
+# Override if you need to.
+PUSH_BRANCH ?= early-access
 
 # ------------------------------------------------------------------------------
 # Website
 # ------------------------------------------------------------------------------
 
+subtree-preflight:
+	@if ! grep -q split_list_relevant_parents $(firstword $(wildcard $(shell git --exec-path)/git-subtree $(shell which git-subtree) /dev/null)); then \
+	    printf '$(RED)Please upgrade your git-subtree:$(END)\n'; \
+	    printf '$(BLD)  sudo curl -fL https://raw.githubusercontent.com/LukeShu/git/lukeshu/subtree-2020-01-03/contrib/subtree/git-subtree.sh -o $$(git --exec-path)/git-subtree && sudo chmod 755 $$(git --exec-path)/git-subtree$(END)\n'; \
+	    false; \
+	fi
+.PHONY: subtree-preflight
+
 pull-docs: ## Pull the docs from ambassador-docs.git
+pull-docs: subtree-preflight
+	git subtree pull --prefix=docs https://github.com/datawire/ambassador-docs $(PULL_BRANCH)
+.PHONY: pull-docs
+
+push-docs: ## Push the docs to ambassador-docs.git
+push-docs: subtree-preflight
+# 1. As long as both (1) ${subtree_dir}/${subtree_dir}/ exists (i.e. the
+#   'docs/' subtree contains a 'docs/' directory), and (2) there
+#   subtree-merges in the relevant history that don't have 'git-subtree-dir:'
+#   annotations (with current (2020-01-03) versions of git subtree that's all
+#   non-rejoin merges), then:
+#
+#   You need to specify --onto to get it do to the right thing.  That's not an
+#   implementation bug, it's an inherent consequence of the design of git
+#   subtree.
+#
+# 2. Yes, fetch $(PULL_BRANCH) instead of $(PUSH_BRANCH); that way you can
+#    `make push-docs PUSH_BRANCH=my-new-branch-that-does-not-yet-exist` and it
+#    will do the right thing.
 	@PS4=; set -ex; { \
 	    git fetch https://github.com/datawire/ambassador-docs $(PULL_BRANCH); \
-	    docs_head=$$(git rev-parse FETCH_HEAD); \
-	    git subtree merge --prefix=docs "$${docs_head}"; \
-	    git subtree split --prefix=docs --rejoin --onto="$${docs_head}"; \
+	    git subtree push --prefix=docs --rejoin --onto=$$(git rev-parse FETCH_HEAD) $(if $(GH_TOKEN),https://d6e-automaton:${GH_TOKEN}@github.com/,git@github.com:)datawire/ambassador-docs.git $(PUSH_BRANCH); \
 	}
-push-docs: ## Push the docs to ambassador-docs.git
-	@PS4=; set -ex; { \
-	    git fetch https://github.com/datawire/ambassador-docs master; \
-	    docs_old=$$(git rev-parse FETCH_HEAD); \
-	    docs_new=$$(git subtree split --prefix=docs --rejoin --onto="$${docs_old}"); \
-	    git push $(if $(GH_TOKEN),https://d6e-automaton:${GH_TOKEN}@github.com/,git@github.com:)datawire/ambassador-docs.git "$${docs_new}:refs/heads/$(or $(PUSH_BRANCH),master)"; \
-	}
-.PHONY: pull-docs push-docs
+.PHONY: push-docs


### PR DESCRIPTION
## Description

This adds a preflight-check to `make pull-docs` and `make push-docs` that checks whether the installed `git subtree` behaves reasonably.  If it doesn't, then it errors and prints instructions for installing a better `git subtree`.

This lets us drop all of the hacks in `make pull-docs`, and most of the hacks in `make push-docs` (we still need to say `--onto`).

This has substantial devex improvement that `make push-docs` on my laptop now takes about 7 seconds instead of about 40 minutes.  Oh, and also the progress output is actually kinda helpful, and isn't the worse-than-nothing garbage that was there before.  Here's a screencast of that ![gifrecord_2020-01-03_16:21:10 190445364](https://user-images.githubusercontent.com/90273/71750181-ad19ed00-2e45-11ea-8941-48ee9b06c126.gif)

Also while I'm at it, for the time-being, have PUSH_BRANCH and PULL_BRANCH default to `early-access` instead of `master`.

## Testing

I did test `make pull-docs` and `make push-docs` (recorded above).  Not in the recording is me inspecting the results to make sure that sane things happened.