### PR TITLE
Make edgectl easier to use [apro #785]

### DIFF
--- a/cmd/edgectl/cli.go
+++ b/cmd/edgectl/cli.go
@@ -262,6 +262,13 @@ func (d *Daemon) getRootCommand(p *supervisor.Process, out *Emitter, data *Clien
 	_ = interceptAddCmd.MarkFlagRequired("match")
 
 	interceptCmd.AddCommand(interceptAddCmd)
+	interceptCG := []CmdGroup{
+		CmdGroup{
+			GroupName: "Available Commands",
+			CmdNames:  []string{"available", "list", "add", "remove"},
+		},
+	}
+	interceptCmd.SetUsageFunc(NewCmdUsage(interceptCmd, interceptCG))
 	rootCmd.AddCommand(interceptCmd)
 
 	return rootCmd

--- a/cmd/edgectl/cmdUsage.go
+++ b/cmd/edgectl/cmdUsage.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+// CmdGroup represents a group of commands and the name of that group
+type CmdGroup struct {
+	GroupName string
+	CmdNames  []string
+}
+
+// NewCmdUsage constructs a cobra UsageFunc for a command based on the command
+// groups passed in. Requires that the command has exactly the subcommands
+// mentioned in the groups, panicking otherwise.
+func NewCmdUsage(cmd *cobra.Command, groups []CmdGroup) func(*cobra.Command) error {
+	origUF := cmd.UsageFunc()
+	cmdMap := make(map[string]*cobra.Command)
+	for _, subCmd := range cmd.Commands() {
+		if subCmd.IsAvailableCommand() || subCmd.Name() == "help" {
+			cmdMap[subCmd.Name()] = subCmd
+		}
+	}
+	lines := []string{}
+	for _, cmdGroup := range groups {
+		lines = append(lines, fmt.Sprintf("%s:", cmdGroup.GroupName))
+		for _, cmdName := range cmdGroup.CmdNames {
+			cmd, ok := cmdMap[cmdName]
+			if !ok {
+				panic(fmt.Sprintf("Unknown command %q in group %q", cmdName, cmdGroup.GroupName))
+			}
+			delete(cmdMap, cmdName)
+			line := fmt.Sprintf("  %s %s", rpad(cmd.Name(), cmd.NamePadding()), cmd.Short)
+			lines = append(lines, line)
+		}
+		lines = append(lines, "")
+	}
+	usage := strings.Join(lines, "\n")
+
+	if len(cmdMap) != 0 {
+		panic(fmt.Sprintf("CmdUsage is not empty: %+v", cmdMap))
+	}
+
+	return func(cmd *cobra.Command) error {
+		origOutput := cmd.OutOrStderr()
+		var buf bytes.Buffer
+		cmd.SetOutput(&buf)
+		if err := origUF(cmd); err != nil {
+			return err
+		}
+		scanner := bufio.NewScanner(strings.NewReader(buf.String()))
+		state := 0 // States described in switch statement cases
+		for scanner.Scan() {
+			line := scanner.Text()
+			switch state {
+			case 0:
+				// Before the original command list. Pass through until we see
+				// the start of the original command list, at which point we go
+				// to state 1.
+				if line == "Available Commands:" {
+					state = 1
+					fmt.Fprintln(origOutput, usage)
+				} else {
+					fmt.Fprintln(origOutput, line)
+				}
+			case 1:
+				// Skipping past the original command list, which should end
+				// with a blank line. We've already output our own command list
+				// at the state transition, so do nothing else.
+				if line == "" {
+					state = 2
+				}
+			case 2:
+				// Done skipping past the original command list. Just pass
+				// through the rest.
+				fmt.Fprintln(origOutput, line)
+			default:
+				panic(fmt.Sprintf("Unknown state %d", state))
+			}
+		}
+		return scanner.Err()
+	}
+}
+
+func rpad(s string, padding int) string {
+	template := fmt.Sprintf("%%-%ds", padding)
+	return fmt.Sprintf(template, s)
+}

--- a/cmd/edgectl/main.go
+++ b/cmd/edgectl/main.go
@@ -92,9 +92,15 @@ func getRootCommand() *cobra.Command {
 		myName = "Edge Control (daemon unavailable)"
 	}
 
+	myHelp := myName + `
+  Edge Stack: https://www.getambassador.io/user-guide/install/
+  Intercept:  https://www.getambassador.io/reference/edge-control/
+`
+
 	rootCmd := &cobra.Command{
 		Use:          "edgectl",
 		Short:        myName,
+		Long:         myHelp,
 		SilenceUsage: true, // https://github.com/spf13/cobra/issues/340
 	}
 
@@ -148,7 +154,7 @@ func getRootCommand() *cobra.Command {
 	}
 	loginCmd := &cobra.Command{
 		Use:   "login [flags] HOSTNAME",
-		Short: "Access the Ambassador Edge Stack admin UI",
+		Short: "Access the Ambassador Edge Policy Console",
 		Args:  cobra.ExactArgs(1),
 		RunE:  aesLogin,
 	}

--- a/cmd/edgectl/main.go
+++ b/cmd/edgectl/main.go
@@ -32,33 +32,6 @@ to troubleshoot problems.
 // edgectl is the full path to the Edge Control binary
 var edgectl string
 
-/*
-Future command help layout
-
-Edge Stack Commands:
-  login             Access the Ambassador Edge Stack admin UI
-  license           Set or update the Ambassador Edge Stack license key
-
-Cluster Commands:
-  status            Show connectivity status
-  connect           Connect to a cluster
-  disconnect        Disconnect from the connected cluster
-  intercept         Manage deployment intercepts
-
-Daemon Commands:
-  daemon            Launch Edge Control Daemon in the background (sudo)
-  pause             Turn off network overrides (to use a VPN)
-  resume            Turn network overrides on (after using edgectl pause)
-  quit              Tell Edge Control Daemon to quit (for upgrades)
-
-Other Commands:
-  version           Show program's version number and exit
-  help              Help about any command
-
-https://github.com/kubernetes/kubernetes/blob/master/pkg/kubectl/cmd/cmd.go#L487
-
- */
-
 func main() {
 	// Figure out our executable and save it
 	if executable, err := os.Executable(); err != nil {
@@ -69,6 +42,28 @@ func main() {
 	}
 
 	rootCmd := getRootCommand()
+
+	cg := []CmdGroup{
+		CmdGroup{
+			GroupName: "Edge Stack Commands",
+			CmdNames:  []string{"login", "license"},
+		},
+		CmdGroup{
+			GroupName: "Cluster Commands",
+			CmdNames:  []string{"status", "connect", "disconnect", "intercept"},
+		},
+		CmdGroup{
+			GroupName: "Daemon Commands",
+			CmdNames:  []string{"daemon", "pause", "resume", "quit"},
+		},
+		CmdGroup{
+			GroupName: "Other Commands",
+			CmdNames:  []string{"version", "help"},
+		},
+	}
+
+	usageFunc := NewCmdUsage(rootCmd, cg)
+	rootCmd.SetUsageFunc(usageFunc)
 	err := rootCmd.Execute()
 	if err != nil {
 		os.Exit(1)
@@ -174,6 +169,8 @@ func getRootCommand() *cobra.Command {
 	rootCmd.AddCommand(daemonCmd.Commands()...)
 	rootCmd.PersistentFlags().AddFlagSet(daemonCmd.PersistentFlags())
 
+	rootCmd.InitDefaultHelpCmd()
+
 	return rootCmd
 }
 
@@ -198,4 +195,3 @@ func forwardToDaemon(cmd *cobra.Command, _ []string) error {
 	}
 	return err
 }
-

--- a/cmd/edgectl/main.go
+++ b/cmd/edgectl/main.go
@@ -49,15 +49,15 @@ func main() {
 	if DaemonWorks() {
 		cg = []CmdGroup{
 			CmdGroup{
-				GroupName: "Edge Stack Commands",
+				GroupName: "Management Commands",
 				CmdNames:  []string{"login", "license"},
 			},
 			CmdGroup{
-				GroupName: "Cluster Commands",
+				GroupName: "Development Commands",
 				CmdNames:  []string{"status", "connect", "disconnect", "intercept"},
 			},
 			CmdGroup{
-				GroupName: "Daemon Commands",
+				GroupName: "Advanced Commands",
 				CmdNames:  []string{"daemon", "pause", "resume", "quit"},
 			},
 			CmdGroup{
@@ -68,7 +68,7 @@ func main() {
 	} else {
 		cg = []CmdGroup{
 			CmdGroup{
-				GroupName: "Edge Stack Commands",
+				GroupName: "Management Commands",
 				CmdNames:  []string{"login", "license"},
 			},
 			CmdGroup{
@@ -93,8 +93,7 @@ func getRootCommand() *cobra.Command {
 	}
 
 	myHelp := myName + `
-  Edge Stack: https://www.getambassador.io/user-guide/install/
-  Intercept:  https://www.getambassador.io/reference/edge-control/
+  https://www.getambassador.io/user-guide/install/
 `
 
 	rootCmd := &cobra.Command{

--- a/cmd/edgectl/misc_noop.go
+++ b/cmd/edgectl/misc_noop.go
@@ -24,3 +24,8 @@ func launchDaemon(_ *cobra.Command, _ []string) error {
 func GetFreePort() (int, error) {
 	return 0, errors.New("Not implemented on this platform")
 }
+
+// DaemonWorks returns whether the daemon can function on this platform
+func DaemonWorks() bool {
+	return false
+}

--- a/cmd/edgectl/misc_unix.go
+++ b/cmd/edgectl/misc_unix.go
@@ -152,3 +152,7 @@ func GetFreePort() (int, error) {
 	return l.Addr().(*net.TCPAddr).Port, nil
 }
 
+// DaemonWorks returns whether the daemon can function on this platform
+func DaemonWorks() bool {
+	return true
+}


### PR DESCRIPTION
- Group the available commands in a sensible way, much like `kubectl help`
- Disable commands on Windows that are known not to work (cluster/daemon commands)
- Include URLs for ways to learn about Edge Control

Note that the URLs point to where we expect the documentation to be after GA. These are b0rked links right now!

datawire/apro#785

Old

```console
$ edgectl
Edge Control

Usage:
  edgectl [command]

Available Commands:
  connect           Connect to a cluster
  daemon            Launch Edge Control Daemon in the background (sudo)
  disconnect        Disconnect from the connected cluster
  help              Help about any command
  intercept         Manage deployment intercepts
  license           Set or update the Ambassador Edge Stack license key
  login             Access the Ambassador Edge Stack admin UI
  pause             Turn off network overrides (to use a VPN)
  quit              Tell Edge Control Daemon to quit (for upgrades)
  resume            Turn network overrides on (after using edgectl pause)
  status            Show connectivity status
  version           Show program's version number and exit

Flags:
  -h, --help   help for edgectl

Use "edgectl [command] --help" for more information about a command.
```

New

```console
$ go run ./cmd/edgectl
Edge Control
  Edge Stack: https://www.getambassador.io/user-guide/install/
  Intercept:  https://www.getambassador.io/reference/edge-control/

Usage:
  edgectl [command]

Edge Stack Commands:
  login             Access the Ambassador Edge Policy Console
  license           Set or update the Ambassador Edge Stack license key

Cluster Commands:
  status            Show connectivity status
  connect           Connect to a cluster
  disconnect        Disconnect from the connected cluster
  intercept         Manage deployment intercepts

Daemon Commands:
  daemon            Launch Edge Control Daemon in the background (sudo)
  pause             Turn off network overrides (to use a VPN)
  resume            Turn network overrides on (after using edgectl pause)
  quit              Tell Edge Control Daemon to quit (for upgrades)

Other Commands:
  version           Show program's version number and exit
  help              Help about any command

Flags:
  -h, --help   help for edgectl

Use "edgectl [command] --help" for more information about a command.
```