### PR TITLE
Treat "ambassador_id" and "ambassadorId" in a resource as synonymous [ambassador #2171]

### DIFF
--- a/python/ambassador/config/config.py
+++ b/python/ambassador/config/config.py
@@ -232,7 +232,14 @@ class Config:
             return True
 
         # Is an ambassador_id present in this object?
-        allowed_ids: StringOrList = resource.get('ambassador_id', 'default')
+        #
+        # NOTE WELL: when we update the status of a Host (or a Mapping?) then reserialization
+        # can cause the `ambassador_id` element to turn into an `ambassadorId` element. So
+        # treat those as synonymous.
+        allowed_ids: StringOrList = resource.get('ambassadorId', None)
+
+        if allowed_ids is None:
+            allowed_ids = resource.get('ambassador_id', 'default')
 
         # If we find the array [ '_automatic_' ] then allow it, so that hardcoded resources
         # can have a useful effect. This is mostly for init-config, but could be used for


### PR DESCRIPTION
The status update for a `Host` can cause it to be reserialized in a way that turns `ambassador_id` into `ambassadorId`, so if we don't do this, the `Host` resource can suddenly vanish.