### PR TITLE
Use the correct cluster namespace for the Edge Stack ACME hole-punching.

### DIFF
--- a/python/ambassador/envoy/v2/v2listener.py
+++ b/python/ambassador/envoy/v2/v2listener.py
@@ -523,7 +523,9 @@ class V2VirtualHost(dict):
                     # exists. Try cluster_127_0_0_1_8500_{namespace} first (that should exist, it's
                     # the amb-sidecar). If that doesn't work, how is Edge Stack running exactly?
 
-                    if not self._config.ir.get_cluster("cluster_127_0_0_1_8500_" + self._config.ir.ambassador_namespace):
+                    ns = self._config.ir.ambasssador_namespace.replace("-", "_")
+
+                    if not self._config.ir.get_cluster("cluster_127_0_0_1_8500_" + ns):
                         raise Exception("Edge Stack claims to be running, but we have no sidecar cluster??")
 
                     self["routes"].insert(0, {
@@ -532,7 +534,7 @@ class V2VirtualHost(dict):
                             "prefix": "/.well-known/acme-challenge/"
                         },
                         "route": {
-                            "cluster": "cluster_127_0_0_1_8500_" + self._config.ir.ambassador_namespace,
+                            "cluster": "cluster_127_0_0_1_8500_" + ns,
                             "prefix_rewrite": "/.well-known/acme-challenge/",
                             "timeout": "3.000s"
                         }


### PR DESCRIPTION
This is silly. We should have a "give me the cluster name for this service" method.