### PR TITLE
Add `make release/promote-oss/to-{ea-latest,rc-latest,ga}` targets

### DIFF
--- a/builder/builder.mk
+++ b/builder/builder.mk
@@ -178,21 +178,70 @@ release/bits: images
 	docker push $(AMB_IMAGE_RC)
 .PHONY: release/bits
 
+release/promote-oss/.main:
+	@[[ '$(PROMOTE_FROM_VERSION)' =~ ^[0-9]+\.[0-9]+\.[0-9]+(-.*)?$ ]]
+	@[[ '$(PROMOTE_TO_VERSION)'   =~ ^[0-9]+\.[0-9]+\.[0-9]+(-.*)?$ ]]
+	@[[ '$(PROMOTE_CHANNEL)' =~ ^(|early|test)$ ]]
+	@printf "$(CYN)==> $(GRN)Promoting $(BLU)%s$(GRN) to $(BLU)%s$(GRN)$(END) (channel=%s)\n" '$(PROMOTE_FROM_VERSION)' '$(PROMOTE_TO_VERSION)' '$(PROMOTE_CHANNEL)'
+
+	@printf '  $(CYN)$(RELEASE_REGISTRY)/$(REPO):$(PROMOTE_FROM_VERSION)$(END)\n'
+	docker pull $(RELEASE_REGISTRY)/$(REPO):$(PROMOTE_FROM_VERSION)
+	docker tag $(RELEASE_REGISTRY)/$(REPO):$(PROMOTE_FROM_VERSION) $(RELEASE_REGISTRY)/$(REPO):$(PROMOTE_TO_VERSION)
+	docker push $(RELEASE_REGISTRY)/$(REPO):$(PROMOTE_TO_VERSION)
+
+	@printf '  $(CYN)https://s3.amazonaws.com/datawire-static-files/ambassador/$(PROMOTE_CHANNEL)stable.txt$(END)\n'
+	printf '%s' '$(PROMOTE_FROM_VERSION)' | aws s3api put-object --bucket datawire-static-files --key ambassador/$(PROMOTE_CHANNEL)stable.txt --body -
+
+	@printf '  $(CYN)s3://scout-datawire-io/ambassador/$(PROMOTE_CHANNEL)app.json$(END)\n'
+	printf '{"application":"ambassador","latest_version":"%s","notices":[]}' '$(PROMOTE_FROM_VERSION)' | aws s3api put-object --bucket scout-datawire-io --key ambassador/$(PROMOTE_CHANNEL)app.json --body -
+.PHONY: release/promote-oss/.main
+
+# To be run from a checkout at the tag you are promoting _from_.
+# At present, this is to be run by-hand.
+release/promote-oss/to-ea-latest:
+	@test -n "$(RELEASE_REGISTRY)" || (printf "$${RELEASE_REGISTRY_ERR}\n"; exit 1)
+	@[[ "$(RELEASE_VERSION)" =~ ^[0-9]+\.[0-9]+\.[0-9]+-ea[0-9]+$$ ]] || (printf '$(RED)ERROR: RELEASE_VERSION=%s does not look like an EA tag\n'; exit 1)
+	@{ $(MAKE) release/promote-oss/.main \
+	  PROMOTE_FROM_VERSION="$(RELEASE_VERSION)" \
+	  PROMOTE_TO_VERSION="$$(echo "$(RELEASE_VERSION)" | sed 's/-ea.*/-ea-latest/')" \
+	  PROMOTE_CHANNEL=early \
+	; }
+.PHONY: release/promote-oss/to-ea-latest
+
+# To be run from a checkout at the tag you are promoting _from_.
+# At present, this is to be run by-hand.
+release/promote-oss/to-rc-latest:
+	@test -n "$(RELEASE_REGISTRY)" || (printf "$${RELEASE_REGISTRY_ERR}\n"; exit 1)
+	@[[ "$(RELEASE_VERSION)" =~ ^[0-9]+\.[0-9]+\.[0-9]+-rc[0-9]+$$ ]] || (printf '$(RED)ERROR: RELEASE_VERSION=%s does not look like an RC tag\n'; exit 1)
+	@{ $(MAKE) release/promote-oss/.main \
+	  PROMOTE_FROM_VERSION="$(RELEASE_VERSION)" \
+	  PROMOTE_TO_VERSION="$$(echo "$(RELEASE_VERSION)" | sed 's/-rc.*/-rc-latest/')" \
+	  PROMOTE_CHANNEL=test \
+	; }
+.PHONY: release/promote-oss/to-rc-latest
+
+# To be run from a checkout at the tag you are promoting _to_.
+# This is normally run from CI by creating the GA tag.
+release/promote-oss/to-ga:
+	@test -n "$(RELEASE_REGISTRY)" || (printf "$${RELEASE_REGISTRY_ERR}\n"; exit 1)
+	@[[ "$(RELEASE_VERSION)" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || (printf '$(RED)ERROR: RELEASE_VERSION=%s does not look like a GA tag\n'; exit 1)
+	@set -e; {
+	  rc_latest=$(curl -sL --fail https://s3.amazonaws.com/datawire-static-files/ambassador/teststable.txt); \
+	  if ! [[ "$$rc_latest" == "$(RELEASE_VERSION)"-rc* ]]; then \
+	    printf '$(RED)ERROR: https://s3.amazonaws.com/datawire-static-files/ambassador/teststable.txt => %s does not look like a RC of %s' "$$rc_latest" "$(RELEASE_VERSION)"; \
+	    exit 1; \
+	  fi; \
+	  $(MAKE) release/promote-oss/.main \
+	    PROMOTE_FROM_VERSION="$$rc_latest" \
+	    PROMOTE_TO_VERSION="$(RELEASE_VERSION)" \
+	    PROMOTE_CHANNEL='' \
+	    ; \
+	}
+.PHONY: release/promote-oss/to-ga
+
 release-prep:
 	bash $(OSS_HOME)/releng/release-prep.sh
 .PHONY: release-prep
-
-release:
-	@test -n "$(RELEASE_REGISTRY)" || (printf "$${RELEASE_REGISTRY_ERR}\n"; exit 1)
-	@$(MAKE) --no-print-directory sync
-	@if [ "$(RELEASE_TYPE)" != release ]; then \
-		(printf "$(RED)ERROR: 'make release' can only be used for release tags ('vX.Y.Z')$(END)\n" && exit 1); \
-	fi
-	@printf "$(CYN)==> $(GRN)Promoting release $(BLU)$(REPO)$(GRN) image$(END)\n"
-	docker pull $(AMB_IMAGE_RC_LATEST)
-	docker tag $(AMB_IMAGE_RC_LATEST) $(AMB_IMAGE_RELEASE)
-	docker push $(AMB_IMAGE_RELEASE)
-.PHONY: release
 
 clean:
 	@$(BUILDER) clean
@@ -298,17 +347,29 @@ define _help.targets
 
   $(BLD)make $(BLU)shell$(END)     -- starts a shell in the build container.
 
-  $(BLD)make $(BLU)release/bits$(END) -- do the "push some bits" part of a release
+  $(BLD)make $(BLU)release/bits$(END) -- do the 'push some bits' part of a release
 
     The current commit must be tagged for this to work, and your tree must be clean.
-    If the tag is of the form 'vX.Y.Z-rc[0-9]*', this will also push a tag of the
-    form 'vX.Y.Z-rc-latest'.
+    If the tag is of the form 'vX.Y.Z-(ea|rc)[0-9]*'.
 
-  $(BLD)make $(BLU)release$(END)   -- promote a release candidate to a release.
+  $(BLD)make $(BLU)release/promote-oss/to-ea-latest$(END) -- promote an early-access '-eaN' release to '-ea-latest'
+
+    The current commit must be tagged for this to work, and your tree must be clean.
+    Additionally, the tag must be of the form 'vX.Y.Z-eaN'. You must also have previously
+    built an EA for the same tag using $(BLD)release/bits$(END).
+
+  $(BLD)make $(BLU)release/promote-oss/to-rc-latest$(END) -- promote a release candidate '-rcN' release to '-rc-latest'
+
+    The current commit must be tagged for this to work, and your tree must be clean.
+    Additionally, the tag must be of the form 'vX.Y.Z-rcN'. You must also have previously
+    built an RC for the same tag using $(BLD)release/bits$(END).
+
+  $(BLD)make $(BLU)release/promote-oss/to-ga$(END) -- promote a release candidate to general availability
 
     The current commit must be tagged for this to work, and your tree must be clean.
     Additionally, the tag must be of the form 'vX.Y.Z'. You must also have previously
-    build an RC for the same tag using the current $(BLD)\$$RELEASE_REGISTRY$(END).
+    built and promoted the RC that will become GA, using $(BLD)release/bits$(END) and
+    $(BLD)release/promote-oss/to-rc-latest$(END).
 
   $(BLD)make $(BLU)clean$(END)     -- kills the build container.
 

--- a/releng/travis-script.sh
+++ b/releng/travis-script.sh
@@ -17,32 +17,6 @@
 set -o errexit
 set -o nounset
 
-update-aws() {
-    if [ -z "${AWS_ACCESS_KEY_ID}" ]; then
-        @echo 'AWS credentials not configured; not updating either https://s3.amazonaws.com/datawire-static-files/ambassador/$(STABLE_TXT_KEY) or the latest version in Scout'
-        exit
-    fi
-
-    if [ -n "${STABLE_TXT_KEY}" ]; then
-        printf "${RELEASE_VERSION}" > stable.txt
-        echo "updating ${STABLE_TXT_KEY} with $(cat stable.txt)"
-        aws s3api put-object \
-            --bucket datawire-static-files \
-            --key ambassador/${STABLE_TXT_KEY} \
-            --body stable.txt
-    fi
-
-    if [ -n "${SCOUT_APP_KEY}" ]; then
-        printf '{"application":"ambassador","latest_version":"${RELEASE_VERSION}","notices":[]}' > app.json
-        echo "updating ${SCOUT_APP_KEY} with $(cat app.json)"
-        aws s3api put-object \
-            --bucket scout-datawire-io \
-            --key ambassador/$(SCOUT_APP_KEY) \
-            --body app.json
-    fi
-}
-
-
 printf "== Begin: travis-script.sh ==\n"
 
 if [[ -n "$TRAVIS_TAG" ]]; then
@@ -107,25 +81,19 @@ case "$COMMIT_TYPE" in
         if [[ -n "${DOCKER_RELEASE_USERNAME:-}" ]]; then
             docker login -u="$DOCKER_RELEASE_USERNAME" --password-stdin "${RELEASE_REGISTRY}" <<<"$DOCKER_RELEASE_PASSWORD"
         fi
-        make release
-        # XXX
-	#SCOUT_APP_KEY=app.json STABLE_TXT_KEY=stable.txt update-aws
+        make release/promote-oss/to-ga
         ;;
     RC)
         if [[ -n "${DOCKER_RELEASE_USERNAME:-}" ]]; then
             docker login -u="$DOCKER_RELEASE_USERNAME" --password-stdin "${RELEASE_REGISTRY}" <<<"$DOCKER_RELEASE_PASSWORD"
         fi
         make release/bits
-        # XXX
-	#SCOUT_APP_KEY=testapp.json STABLE_TXT_KEY=teststable.txt update-aws
         ;;
     EA)
         if [[ -n "${DOCKER_RELEASE_USERNAME:-}" ]]; then
             docker login -u="$DOCKER_RELEASE_USERNAME" --password-stdin "${RELEASE_REGISTRY}" <<<"$DOCKER_RELEASE_PASSWORD"
         fi
         make release/bits
-        # XXX
-        #SCOUT_APP_KEY=earlyapp.json STABLE_TXT_KEY=earlystable.txt update-aws
         ;;
     *)
         : # Nothing to do


### PR DESCRIPTION
This adds `make` targets to handle promoting things.
 - `make release/promote-oss/to-ea-latest` would replace several steps in the daily EA document
 - `make release/promote-oss/to-rc-latest` is those same steps, for an RC.  It does 3 things: retag the docker image, update `teststable.txt`, and update `testapp.json`.  This is still run by hand by a human.
 - `make release/promote-oss/to-ga` does those same things for GA (`s/test//` to the filenames).  This is run from CI by creating the GA tag.

A very similar PR should be appearing in apro.git shortly. (edit: https://github.com/datawire/apro/pull/817)

Assuming this (and the apro.git one) looks fine,
1. I'll run `make release/promote-oss/to-rc-latest`
2. We'll merge it in to `rel/v1.0.0-rc0` (not `master`) (land this PR), the
3. We'll land #2174