### PR TITLE
Don't append the service namespace for `localhost` [apro #840]

### DIFF
--- a/python/ambassador/ir/irserviceresolver.py
+++ b/python/ambassador/ir/irserviceresolver.py
@@ -121,7 +121,7 @@ class IRServiceResolver(IRResource):
     def _k8s_svc_resolver(self, ir: 'IR', cluster: 'IRCluster', svc_name: str, svc_namespace: str, port: int) -> Optional[SvcEndpointSet]:
         # The K8s service resolver always returns a single endpoint.
 
-        fully_qualified = "." in svc_name
+        fully_qualified = "." in svc_name or "localhost" == svc_name
         if not ir.ambassador_module.use_ambassador_namespace_for_service_resolution and not fully_qualified and svc_namespace:
             # The target service name is not fully qualified.
             # We are most likely targeting a simple k8s svc with kube-dns resolution.


### PR DESCRIPTION
## Description
Don't append the service namespace for `localhost`.

## Related Issues
https://github.com/datawire/apro/issues/840

## Testing
Kat tests and manual validation.

## Todos
- [x] Tests
- [ ] Documentation
