### PR TITLE
Force the eviction tvars cached elements with max_age_seconds [apro #806]

### DIFF
--- a/python/ambassador_diag/diagd.py
+++ b/python/ambassador_diag/diagd.py
@@ -198,6 +198,11 @@ def standard_handler(f):
 
         app.logger.debug("%s handler %s" % (prefix, func_name))
 
+        # getting elements in the `tvars_cache` will make sure eviction happens on `max_age_seconds` TTL
+        # for removed patch_client rather than waiting to fill `max_len`
+        for k in iter(tvars_cache):
+            tvars_cache.get(k)
+
         # Default to the exception case
         result_to_log = "server error"
         status_to_log = 500
@@ -466,11 +471,6 @@ def check_ready():
 @standard_handler
 def show_overview(reqid=None):
     app.logger.debug("OV %s - showing overview" % reqid)
-
-    # getting elements in the `tvars_cache` will make sure eviction happens on `max_age_seconds` TTL
-    # for removed patch_client rather than waiting to fill `max_len`
-    for k in iter(tvars_cache):
-        tvars_cache.get(k)
 
     diag = app.diag
 

--- a/python/ambassador_diag/diagd.py
+++ b/python/ambassador_diag/diagd.py
@@ -60,6 +60,8 @@ if TYPE_CHECKING:
 __version__ = Version
 
 boot_time = datetime.datetime.now()
+
+# allows 10 concurrent users, with a request timeout of 60 seconds
 tvars_cache = ExpiringDict(max_len=10, max_age_seconds=60)
 
 logging.basicConfig(
@@ -464,6 +466,11 @@ def check_ready():
 @standard_handler
 def show_overview(reqid=None):
     app.logger.debug("OV %s - showing overview" % reqid)
+
+    # getting elements in the `tvars_cache` will make sure eviction happens on `max_age_seconds` TTL
+    # for removed patch_client rather than waiting to fill `max_len`
+    for k in iter(tvars_cache):
+        tvars_cache.get(k)
 
     diag = app.diag
 


### PR DESCRIPTION
## Description
Force the eviction tvars cached elements with max_age_seconds. Should improve stability when running low on memory.

## Related Issues
https://github.com/datawire/apro/issues/806
https://github.com/datawire/apro/issues/827

## Testing
Manually tested the eviction and memory footprint.

## Todos
- [x] Tests
- [ ] Documentation
