### PR TITLE
The chart will now create and manage AES resources

### DIFF
--- a/docs/user-guide/helm.md
+++ b/docs/user-guide/helm.md
@@ -15,7 +15,7 @@ helm repo add datawire https://www.getambassador.io
 
 If you are installing the Ambassador Edge Stack for the first time on your host, complete the following directions:
 
-1. Create the `ambassador` namespace for Ambassador Edge Stack:
+1. Create the `ambassador` namespace for the Ambassador Edge Stack:
 
 ```
 kubectl create namespace ambassador
@@ -37,9 +37,9 @@ This will install the necessary deployments, RBAC, Custom Resource Definitions, 
 
 ## Upgrading an Existing Edge Stack Installation
 
-**Note:** If your existing installation is not already running Ambassador **Edge Stack** as opposed to Ambassador API Gateway, **do not use these instructions**. See "Migrating to Ambassador Edge Stack" below.
+**Note:** If your existing installation is not already running the Ambassador **Edge Stack** as opposed to Ambassador API Gateway, **do not use these instructions**. See "Migrating to the Ambassador Edge Stack" below.
 
-Upgrading an existing installation of Ambassador Edge Stack is a two-step process:
+Upgrading an existing installation of the Ambassador Edge Stack is a two-step process:
 
 1. First, apply any CRD updates (as of Helm 3, this is not supported in the chart itself):
 
@@ -55,15 +55,15 @@ helm upgrade ambassador datawire/ambassador
 
 This will upgrade the image and deploy and other necessary resources for the Ambassador Edge Stack. 
 
-## Migrating to Ambassador Edge Stack
+## Migrating to the Ambassador Edge Stack
 
-If you have an existing Ambassador API Gateway installation, but are not yet running Ambassador Edge Stack, the upgrade process is somewhat different than above.
+If you have an existing Ambassador API Gateway installation, but are not yet running the Ambassador Edge Stack, the upgrade process is somewhat different than above.
 
 **Note:** It is strongly encouraged for you to move your Ambassador release to the `ambassador` namespace as shown below. If this isn't an option for you, remove the `--namespace ambassador` argument to `helm upgrade`.
 
-1. Upgrade CRDs for Ambassador Edge Stack. 
+1. Upgrade CRDs for the Ambassador Edge Stack. 
 
-To take full advantage of Ambassador Edge Stack, you'll need the new `Host` CRD, and you'll need the new `getambassador.io/v2` version of earlier CRDs. To upgrade all the CRDs, run
+To take full advantage of the Ambassador Edge Stack, you'll need the new `Host` CRD, and you'll need the new `getambassador.io/v2` version of earlier CRDs. To upgrade all the CRDs, run
 
 
 ```
@@ -84,7 +84,7 @@ If you're using Helm 2, you need to modify the command slightly:
 helm upgrade --set crds.create=false --namespace ambassador ambassador datawire/ambassador
 ```
 
-At this point, Ambassador Edge Stack should be running with the same functionality as Ambassador API Gateway as well as the added features of the Ambassador Edge Stack. It's safe to do any validation required and roll-back if neccessary. 
+At this point, the Ambassador Edge Stack should be running with the same functionality as Ambassador API Gateway as well as the added features of the Ambassador Edge Stack. It's safe to do any validation required and roll-back if neccessary. 
 
 **Note:**
 The Ambassador Edge Stack will be installed with an `AuthService` and `RateLimitService`. If you are using these plugins, set `authService.create=false` and/or `rateLimit.create=false` to avoid any conflict while testing the upgrade.

--- a/docs/user-guide/helm.md
+++ b/docs/user-guide/helm.md
@@ -35,15 +35,6 @@ helm install --name ambassador --namespace ambassador datawire/ambassador
 
 This will install the necessary deployments, RBAC, Custom Resource Definitions, etc. for the Ambassador Edge Stack to route traffic. Details on how to configure Ambassador using the Helm chart can be found in the Helm chart [README](https://github.com/datawire/ambassador-chart/tree/master).
 
-3. Apply additional Ambassador Edge Stack resources.
-
-The Helm chart deploys Ambassador Edge Stack itself, but does not create the additional resources necessary for authentication, rate limiting, automatic HTTPS, etc. To take full advantage of Ambassador Edge Stack, you'll need
-create these resources with `kubectl`:
-
-```
-kubectl apply -f https://www.getambassador.io/yaml/resources-migration.yaml
-```
-
 ## Upgrading an Existing Edge Stack Installation
 
 **Note:** If your existing installation is not already running Ambassador **Edge Stack** as opposed to Ambassador API Gateway, **do not use these instructions**. See "Migrating to Ambassador Edge Stack" below.
@@ -70,7 +61,16 @@ If you have an existing Ambassador API Gateway installation, but are not yet run
 
 **Note:** It is strongly encouraged for you to move your Ambassador release to the `ambassador` namespace as shown below. If this isn't an option for you, remove the `--namespace ambassador` argument to `helm upgrade`.
 
-1. Upgrade your Ambassador installation.
+1. Upgrade CRDs for Ambassador Edge Stack. 
+
+To take full advantage of Ambassador Edge Stack, you'll need the new `Host` CRD, and you'll need the new `getambassador.io/v2` version of earlier CRDs. To upgrade all the CRDs, run
+
+
+```
+kubectl apply -f https://www.getambassador.io/yaml/aes-crds.yaml
+```
+
+2. Upgrade your Ambassador installation.
 
 If you're using Helm 3, simply run
 
@@ -84,24 +84,7 @@ If you're using Helm 2, you need to modify the command slightly:
 helm upgrade --set crds.create=false --namespace ambassador ambassador datawire/ambassador
 ```
 
-(Helm 3 will not upgrade CRDs that already exist in the cluster, and we don't want Helm 2 to upgrade them yet either.)
+At this point, Ambassador Edge Stack should be running with the same functionality as Ambassador API Gateway as well as the added features of the Ambassador Edge Stack. It's safe to do any validation required and roll-back if neccessary. 
 
-At this point, Ambassador Edge Stack should be running with the same functionality as Ambassador API Gateway, and it's safe to do any validation required. To enable the full functionality of Ambassador Edge Stack requires two more steps:
-
-2. Upgrade CRDs for Ambassador Edge Stack. 
-
-To take full advantage of Ambassador Edge Stack, you'll need the new `Host` CRD, and you'll need the new `getambassador.io/v2` version of earlier CRDs. To upgrade all the CRDs, run
-
-
-```
-kubectl apply -f https://www.getambassador.io/yaml/aes-crds.yaml
-```
-
-3. Apply additional Ambassador Edge Stack resources.
-
-The Helm chart deploys Ambassador Edge Stack itself, but does not create the additional resources necessary for authentication, rate limiting, automatic HTTPS, etc. To take full advantage of Ambassador Edge Stack, you'll need
-create these resources with `kubectl`:
-
-```
-kubectl apply -f https://www.getambassador.io/yaml/resources-migration.yaml
-```
+**Note:**
+The Ambassador Edge Stack will be installed with an `AuthService` and `RateLimitService`. If you are using these plugins, set `authService.create=false` and/or `rateLimit.create=false` to avoid any conflict while testing the upgrade.


### PR DESCRIPTION
Since the AES resources are integral parts of the AES, it makes sense
from a consistency and ease of use perspective to have the chart install
them in the release.

This has been tested to work with both OSS and Pro upgrades. Current OSS
users who already have another `AuthService` or `RateLimitService`
configured can set flags to avoid creating them in the chart until they
are ready.

https://github.com/datawire/ambassador-chart/issues/7 changes the chart to install the resources in the release.

Signed-off-by: Noah Krause <krausenoah@gmail.com>

## Related Issues
https://github.com/datawire/ambassador-chart/issues/7

## Testing
Manual testing of upgrade scenarios
