### PR TITLE
Fix #2202

### DIFF
--- a/python/ambassador/config/config.py
+++ b/python/ambassador/config/config.py
@@ -49,6 +49,7 @@ class Config:
     ambassador_id: ClassVar[str] = os.environ.get('AMBASSADOR_ID', 'default')
     ambassador_namespace: ClassVar[str] = os.environ.get('AMBASSADOR_NAMESPACE', 'default')
     single_namespace: ClassVar[bool] = bool(os.environ.get('AMBASSADOR_SINGLE_NAMESPACE'))
+    certs_single_namespace: ClassVar[bool] = bool(os.environ.get('AMBASSADOR_CERTS_SINGLE_NAMESPACE', os.environ.get('AMBASSADOR_SINGLE_NAMESPACE')))
     enable_endpoints: ClassVar[bool] = not bool(os.environ.get('AMBASSADOR_DISABLE_ENDPOINTS'))
 
     StorageByKind: ClassVar[Dict[str, str]] = {

--- a/python/ambassador/config/resourcefetcher.py
+++ b/python/ambassador/config/resourcefetcher.py
@@ -781,7 +781,7 @@ class ResourceFetcher:
             self.logger.debug("ignoring K8s Secret with no name")
             skip = True
 
-        if not skip and (Config.single_namespace and (resource_namespace != Config.ambassador_namespace)):
+        if not skip and (Config.single_namespace and (resource_namespace != Config.ambassador_namespace) and Config.certs_single_namespace):
             # This should never happen in actual usage, since we shouldn't be given things
             # in the wrong namespace. However, in development, this can happen a lot.
             self.logger.debug("ignoring K8s Secret in wrong namespace")


### PR DESCRIPTION
## Description
This patch allows namespaced ambassador to get K8s secrets in an other namespace.

If you want to accept this PR, I will create an other for master

## Related Issues
* #2202

## Testing
I deployed a namespaced ambassador, and I just added `AMBASSADOR_CERTS_SINGLE_NAMESPACE` env var with empty value.
```
        - name: AMBASSADOR_SINGLE_NAMESPACE
          value: "YES"
        - name: AMBASSADOR_CERTS_SINGLE_NAMESPACE
        - name: AMBASSADOR_NAMESPACE
          valueFrom:
            fieldRef:
              apiVersion: v1
              fieldPath: metadata.namespace
```
Then in my TLScontext I'm able the set a certificate from an other namespace. (the service account of ambassador has a rolebinding allowing reading secret in the other namespace)

## Todos
- [ ] Tests
- [ ] Documentation

## Other
* If this is a documentation change, please open the pull request at https://github.com/datawire/ambassador-docs instead.
* Code changes should occur against `master`.
