### PR TITLE
Add DNS options to `edgectl` and pass them through to Teleproxy [apro 871]

### DIFF
--- a/cmd/edgectl/daemon.go
+++ b/cmd/edgectl/daemon.go
@@ -19,15 +19,17 @@ type Daemon struct {
 	bridge     Resource
 	trafficMgr *TrafficManager
 	intercepts []*Intercept
+	dns        string
+	fallback   string
 }
 
 // RunAsDaemon is the main function when executing as the daemon
-func RunAsDaemon() error {
+func RunAsDaemon(dns, fallback string) error {
 	if os.Geteuid() != 0 {
 		return errors.New("edgectl daemon must run as root")
 	}
 
-	d := &Daemon{}
+	d := &Daemon{dns: dns, fallback: fallback}
 
 	sup := supervisor.WithContext(context.Background())
 	sup.Logger = SetUpLogging()

--- a/cmd/edgectl/main.go
+++ b/cmd/edgectl/main.go
@@ -109,10 +109,10 @@ func getRootCommand() *cobra.Command {
 	rootCmd.AddCommand(&cobra.Command{
 		Use:    "daemon-foreground",
 		Short:  "Launch Edge Control Daemon in the foreground (debug)",
-		Args:   cobra.ExactArgs(0),
+		Args:   cobra.ExactArgs(2),
 		Hidden: true,
-		RunE: func(_ *cobra.Command, _ []string) error {
-			return RunAsDaemon()
+		RunE: func(_ *cobra.Command, args []string) error {
+			return RunAsDaemon(args[0], args[1])
 		},
 	})
 	teleproxyCmd := &cobra.Command{
@@ -143,13 +143,22 @@ func getRootCommand() *cobra.Command {
 	// Client commands. These are never sent to the daemon.
 
 	if DaemonWorks() {
-		rootCmd.AddCommand(&cobra.Command{
+		daemonCmd := &cobra.Command{
 			Use:   "daemon",
 			Short: "Launch Edge Control Daemon in the background (sudo)",
 			Long:  daemonHelp,
 			Args:  cobra.ExactArgs(0),
 			RunE:  launchDaemon,
-		})
+		}
+		_ = daemonCmd.Flags().String(
+			"dns", "",
+			"DNS IP address to intercept. Defaults to the first nameserver listed in /etc/resolv.conf.",
+		)
+		_ = daemonCmd.Flags().String(
+			"fallback", "",
+			"DNS fallback, how non-cluster DNS queries are resolved. Defaults to Google DNS (8.8.8.8).",
+		)
+		rootCmd.AddCommand(daemonCmd)
 	}
 	loginCmd := &cobra.Command{
 		Use:   "login [flags] HOSTNAME",

--- a/cmd/edgectl/main.go
+++ b/cmd/edgectl/main.go
@@ -123,10 +123,10 @@ func getRootCommand() *cobra.Command {
 	teleproxyCmd.AddCommand(&cobra.Command{
 		Use:    "intercept",
 		Short:  "Impersonate Teleproxy Intercept (for internal use)",
-		Args:   cobra.NoArgs,
+		Args:   cobra.ExactArgs(2),
 		Hidden: true,
-		RunE: func(_ *cobra.Command, _ []string) error {
-			return RunAsTeleproxyIntercept()
+		RunE: func(_ *cobra.Command, args []string) error {
+			return RunAsTeleproxyIntercept(args[0], args[1])
 		},
 	})
 	teleproxyCmd.AddCommand(&cobra.Command{

--- a/cmd/edgectl/misc_unix.go
+++ b/cmd/edgectl/misc_unix.go
@@ -98,7 +98,10 @@ func launchDaemon(ccmd *cobra.Command, _ []string) error {
 	}
 	fmt.Println("Launching Edge Control Daemon", displayVersion)
 
-	cmd := exec.Command(edgectl, "daemon-foreground")
+	dns, _ := ccmd.Flags().GetString("dns")
+	fallback, _ := ccmd.Flags().GetString("fallback")
+
+	cmd := exec.Command(edgectl, "daemon-foreground", dns, fallback)
 	cmd.Env = os.Environ()
 	cmd.Stdin = nil
 	cmd.Stdout = nil

--- a/cmd/edgectl/net_override.go
+++ b/cmd/edgectl/net_override.go
@@ -16,7 +16,7 @@ func (d *Daemon) MakeNetOverride(p *supervisor.Process) error {
 	netOverride, err := CheckedRetryingCommand(
 		p,
 		"netOverride",
-		[]string{edgectl, "teleproxy", "intercept"},
+		[]string{edgectl, "teleproxy", "intercept", "", ""},
 		&RunAsInfo{},
 		checkNetOverride,
 		10*time.Second,

--- a/cmd/edgectl/net_override.go
+++ b/cmd/edgectl/net_override.go
@@ -16,7 +16,7 @@ func (d *Daemon) MakeNetOverride(p *supervisor.Process) error {
 	netOverride, err := CheckedRetryingCommand(
 		p,
 		"netOverride",
-		[]string{edgectl, "teleproxy", "intercept", "", ""},
+		[]string{edgectl, "teleproxy", "intercept", d.dns, d.fallback},
 		&RunAsInfo{},
 		checkNetOverride,
 		10*time.Second,

--- a/cmd/edgectl/teleproxy.go
+++ b/cmd/edgectl/teleproxy.go
@@ -12,11 +12,15 @@ import (
 
 // RunAsTeleproxyIntercept is the main function when executing as
 // teleproxy intercept
-func RunAsTeleproxyIntercept() error {
+func RunAsTeleproxyIntercept(dns, fallback string) error {
 	if os.Geteuid() != 0 {
 		return errors.New("edgectl daemon as teleproxy intercept must run as root")
 	}
-	tele := &teleproxy.Teleproxy{Mode: "intercept"}
+	tele := &teleproxy.Teleproxy{
+		Mode:       "intercept",
+		DNSIP:      dns,
+		FallbackIP: fallback,
+	}
 	return teleproxy.RunTeleproxy(tele, displayVersion)
 }
 


### PR DESCRIPTION
## Description
Teleproxy lets the user set some DNS options so it can work in restricted networks, e.g., if Google DNS is not accessible. Edge Control didn't offer those same options, leaning on Teleproxy's defaults instead. This PR adds the two most important ones.

- IP address to intercept as the DNS server
- IP address to use as the fallback DNS server for non-cluster queries

Documentation for this is in https://github.com/datawire/ambassador-docs/pull/239.

## Related Issues
https://github.com/datawire/apro/issues/871

## Testing
I tested this manually. It's hard to test Edge Control in an automated manner.