### PR TITLE
Make sure that test_docker gives the test container a chance to crash

### DIFF
--- a/python/tests/test_docker.py
+++ b/python/tests/test_docker.py
@@ -88,11 +88,14 @@ def test_docker():
             logfile.write('No $AMBASSADOR_DOCKER_IMAGE??\n')
         else:
             if docker_start(logfile):
-                logfile.write("Demo started, sleeping 10 seconds just in case...")
-                time.sleep(10)
+                logfile.write("Demo started, first check...")
 
                 if check_http(logfile):
-                    test_status = True
+                    logfile.write("Sleeping for second check...")
+                    time.sleep(10)
+
+                    if check_http(logfile):
+                        test_status = True
 
                 docker_kill(logfile)
 


### PR DESCRIPTION
The `test_docker` container currently crashes when run under Edge Stack (cf #2227) and the test wasn't catching that, because it was quick enough on the draw that it got a "successful" result before the container crashed. Slow it down to catch that.

This should pass OSS KAT, but fail Edge Stack KAT until #2227 is fixed.