### PR TITLE
Unbreak the Windows build of `edgectl`

### DIFF
--- a/builder/builder.mk
+++ b/builder/builder.mk
@@ -147,6 +147,10 @@ gotest: test-ready
 		-e GOTEST_PKGS \
 		-e GOTEST_ARGS \
 		-it $(shell $(BUILDER)) /buildroot/builder.sh gotest-internal
+	docker exec \
+		-w /buildroot/ambassador \
+		-e GOOS=windows \
+		-it $(shell $(BUILDER)) go build -o /dev/null ./cmd/edgectl
 .PHONY: gotest
 
 test: gotest pytest

--- a/cmd/edgectl/teleproxy_noop.go
+++ b/cmd/edgectl/teleproxy_noop.go
@@ -8,7 +8,7 @@ import (
 
 // RunAsTeleproxyIntercept is the main function when executing as
 // teleproxy intercept
-func RunAsTeleproxyIntercept() error {
+func RunAsTeleproxyIntercept(_, _ string) error {
 	return errors.New("Not implemented on this platform")
 }
 


### PR DESCRIPTION
Add in the change that I missed in https://github.com/datawire/ambassador/commit/769768bc. Also add a build/discard of `edgectl.exe` to the `gotest` target so that we can catch some errors of this sort automatically. Fixes https://github.com/datawire/apro/issues/913.