### PR TITLE
Switch to -ea.N and -rc.N

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -13,13 +13,13 @@ Note. PRs will pile up on `master`. **Don't accept PRs for which CI doesn't show
 When we get to the stage of creating a release, all the PRs that we want to merge will have been merged
 and the CI will be green.
 
-1. Once `master` has all the release drivers, tag `master` with an RC tag, e.g. `v0.77.0-rc1`. **This version tag must start with a 'v'.** For example:
-    git tag v0.77.0-rc1 master
+1. Once `master` has all the release drivers, tag `master` with an RC tag, e.g. `v0.77.0-rc.1`. **This version tag must start with a 'v'.** For example:
+    git tag v0.77.0-rc.1 master
     git push --tags origin master
 
 2. The RC tag will trigger CI to run a new build and new tests. It had better pass: if not, figure out why. Monitor https://travis-ci.com/datawire/amabassador/ until the CI for ambassador completes and is green.
 
-3. The RC build will be available as e.g. `quay.io/datawire/ambassador:0.77.0-rc1` and also as e.g. `quay.io/datawire/ambassador:0.77.0-rc-latest`. Any other testing you want to do against this image, rock on.
+3. The RC build will be available as e.g. `quay.io/datawire/ambassador:0.77.0-rc.1` and also as e.g. `quay.io/datawire/ambassador:0.77.0-rc-latest`. Any other testing you want to do against this image, rock on.
 
 4. When you're happy that the RC is ready for GA, **first** assemble the list of changes that you'll put into CHANGELOG.md: (Note: place this list in a separate file, maybe `~/temp-list.txt`, but definitely not in CHANGELOG.md at this time.
    - We always call out things contributed by the community, including who committed it

--- a/builder/builder.mk
+++ b/builder/builder.mk
@@ -232,7 +232,7 @@ release/promote-oss/to-ga:
 	@[[ "$(RELEASE_VERSION)" =~ ^[0-9]+\.[0-9]+\.[0-9]+$$ ]] || (printf '$(RED)ERROR: RELEASE_VERSION=%s does not look like a GA tag\n' "$(RELEASE_VERSION)"; exit 1)
 	@set -e; { \
 	  rc_latest=$$(curl -sL --fail https://s3.amazonaws.com/datawire-static-files/ambassador/teststable.txt); \
-	  if ! [[ "$$rc_latest" == "$(RELEASE_VERSION)"-rc* ]]; then \
+	  if ! [[ "$$rc_latest" == "$(RELEASE_VERSION)"-rc.* ]]; then \
 	    printf '$(RED)ERROR: https://s3.amazonaws.com/datawire-static-files/ambassador/teststable.txt => %s does not look like a RC of %s\n' "$$rc_latest" "$(RELEASE_VERSION)"; \
 	    exit 1; \
 	  fi; \

--- a/builder/builder.mk
+++ b/builder/builder.mk
@@ -205,7 +205,7 @@ release/promote-oss/.main:
 # At present, this is to be run by-hand.
 release/promote-oss/to-ea-latest:
 	@test -n "$(RELEASE_REGISTRY)" || (printf "$${RELEASE_REGISTRY_ERR}\n"; exit 1)
-	@[[ "$(RELEASE_VERSION)" =~ ^[0-9]+\.[0-9]+\.[0-9]+-ea[0-9]+$$ ]] || (printf '$(RED)ERROR: RELEASE_VERSION=%s does not look like an EA tag\n' "$(RELEASE_VERSION)"; exit 1)
+	@[[ "$(RELEASE_VERSION)" =~ ^[0-9]+\.[0-9]+\.[0-9]+-ea\.[0-9]+$$ ]] || (printf '$(RED)ERROR: RELEASE_VERSION=%s does not look like an EA tag\n' "$(RELEASE_VERSION)"; exit 1)
 	@{ $(MAKE) release/promote-oss/.main \
 	  PROMOTE_FROM_VERSION="$(RELEASE_VERSION)" \
 	  PROMOTE_TO_VERSION="$$(echo "$(RELEASE_VERSION)" | sed 's/-ea.*/-ea-latest/')" \
@@ -217,7 +217,7 @@ release/promote-oss/to-ea-latest:
 # At present, this is to be run by-hand.
 release/promote-oss/to-rc-latest:
 	@test -n "$(RELEASE_REGISTRY)" || (printf "$${RELEASE_REGISTRY_ERR}\n"; exit 1)
-	@[[ "$(RELEASE_VERSION)" =~ ^[0-9]+\.[0-9]+\.[0-9]+-rc[0-9]+$$ ]] || (printf '$(RED)ERROR: RELEASE_VERSION=%s does not look like an RC tag\n' "$(RELEASE_VERSION)"; exit 1)
+	@[[ "$(RELEASE_VERSION)" =~ ^[0-9]+\.[0-9]+\.[0-9]+-rc\.[0-9]+$$ ]] || (printf '$(RED)ERROR: RELEASE_VERSION=%s does not look like an RC tag\n' "$(RELEASE_VERSION)"; exit 1)
 	@{ $(MAKE) release/promote-oss/.main \
 	  PROMOTE_FROM_VERSION="$(RELEASE_VERSION)" \
 	  PROMOTE_TO_VERSION="$$(echo "$(RELEASE_VERSION)" | sed 's/-rc.*/-rc-latest/')" \
@@ -369,18 +369,18 @@ define _help.targets
   $(BLD)make $(BLU)release/bits$(END) -- do the 'push some bits' part of a release
 
     The current commit must be tagged for this to work, and your tree must be clean.
-    If the tag is of the form 'vX.Y.Z-(ea|rc)[0-9]*'.
+    If the tag is of the form 'vX.Y.Z-(ea|rc).[0-9]*'.
 
-  $(BLD)make $(BLU)release/promote-oss/to-ea-latest$(END) -- promote an early-access '-eaN' release to '-ea-latest'
+  $(BLD)make $(BLU)release/promote-oss/to-ea-latest$(END) -- promote an early-access '-ea.N' release to '-ea-latest'
 
     The current commit must be tagged for this to work, and your tree must be clean.
-    Additionally, the tag must be of the form 'vX.Y.Z-eaN'. You must also have previously
+    Additionally, the tag must be of the form 'vX.Y.Z-ea.N'. You must also have previously
     built an EA for the same tag using $(BLD)release/bits$(END).
 
-  $(BLD)make $(BLU)release/promote-oss/to-rc-latest$(END) -- promote a release candidate '-rcN' release to '-rc-latest'
+  $(BLD)make $(BLU)release/promote-oss/to-rc-latest$(END) -- promote a release candidate '-rc.N' release to '-rc-latest'
 
     The current commit must be tagged for this to work, and your tree must be clean.
-    Additionally, the tag must be of the form 'vX.Y.Z-rcN'. You must also have previously
+    Additionally, the tag must be of the form 'vX.Y.Z-rc.N'. You must also have previously
     built an RC for the same tag using $(BLD)release/bits$(END).
 
   $(BLD)make $(BLU)release/promote-oss/to-ga$(END) -- promote a release candidate to general availability

--- a/builder/builder.sh
+++ b/builder/builder.sh
@@ -131,7 +131,7 @@ module_version() {
     # BUILD_VERSION is of the same format, but is the version number that
     # we build into the image.  Because an image built as a "release
     # candidate" will ideally get promoted to be the GA image, we trim off
-    # the '-rcN' suffix.
+    # the '-rc.N' suffix.
     for VAR in "${TRAVIS_TAG}" "$(git describe --tags --always)"; do
         if [ -n "${VAR}" ]; then
             RELEASE_VERSION="${VAR}"
@@ -257,7 +257,7 @@ case "${cmd}" in
 
         if [[ "${RELVER}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo release
-        elif [[ "${RELVER}" =~ ^[0-9]+\.[0-9]+\.[0-9]+-rc[0-9]*$ ]]; then
+        elif [[ "${RELVER}" =~ ^[0-9]+\.[0-9]+\.[0-9]+-rc\.[0-9]*$ ]]; then
             echo rc
         else
             echo other

--- a/builder/builder.sh
+++ b/builder/builder.sh
@@ -125,7 +125,7 @@ module_version() {
     # RELEASE_VERSION is an X.Y.Z[-prerelease] (semver) string that we
     # will upload/release the image as.  It does NOT include a leading 'v'
     # (trimming the 'v' from the git tag is what the 'patsubst' is for).
-    # If this is an RC or EA, then it includes the '-rcN' or '-eaN'
+    # If this is an RC or EA, then it includes the '-rc.N' or '-ea.N'
     # suffix.
     #
     # BUILD_VERSION is of the same format, but is the version number that
@@ -148,7 +148,7 @@ module_version() {
     fi
 
     echo RELEASE_VERSION="\"${RELEASE_VERSION}\""
-    echo BUILD_VERSION="\"$(echo "${RELEASE_VERSION}" | sed 's/-rc[0-9]*$//')\""
+    echo BUILD_VERSION="\"$(echo "${RELEASE_VERSION}" | sed 's/-rc\.[0-9]*$//')\""
 }
 
 sync() {

--- a/builder/module_version.sh
+++ b/builder/module_version.sh
@@ -42,7 +42,7 @@ module_version() {
     # BUILD_VERSION is of the same format, but is the version number that
     # we build into the image.  Because an image built as a "release
     # candidate" will ideally get promoted to be the GA image, we trim off
-    # the '-rcN' suffix.
+    # the '-rc.N' suffix.
     for VAR in "${TRAVIS_TAG}" "$(git describe --tags --always)"; do
         if [ -n "${VAR}" ]; then
             RELEASE_VERSION="${VAR}"

--- a/builder/module_version.sh
+++ b/builder/module_version.sh
@@ -36,7 +36,7 @@ module_version() {
     # RELEASE_VERSION is an X.Y.Z[-prerelease] (semver) string that we
     # will upload/release the image as.  It does NOT include a leading 'v'
     # (trimming the 'v' from the git tag is what the 'patsubst' is for).
-    # If this is an RC or EA, then it includes the '-rcN' or '-eaN'
+    # If this is an RC or EA, then it includes the '-rc.N' or '-ea.N'
     # suffix.
     #
     # BUILD_VERSION is of the same format, but is the version number that
@@ -59,7 +59,7 @@ module_version() {
     fi
 
     echo RELEASE_VERSION="\"${RELEASE_VERSION}\""
-    echo BUILD_VERSION="\"$(echo "${RELEASE_VERSION}" | sed 's/-rc[0-9]*$//')\""
+    echo BUILD_VERSION="\"$(echo "${RELEASE_VERSION}" | sed 's/-rc\.[0-9]*$//')\""
 }
 
 module_version "$@"

--- a/docs/user-guide/early-access.md
+++ b/docs/user-guide/early-access.md
@@ -6,7 +6,7 @@ Looking for early access to the Ambassador Edge Stack? [Click here to get starte
 
 From time to time, the Ambassador Edge Stack may ship early access releases to test major changes. **Early access releases are not supported for production use** but are intended to gain early feedback from our community before shipping a release.
 
-Early access releases will always have names that include the string "-ea" followed by a build number. For example, `$version$`.
+Early access releases will always have names that include the string "-ea.$buildnumber" -- for example, `$version$`.
 
 ## Early Access Status
 

--- a/python/ambassador/ambscout.py
+++ b/python/ambassador/ambscout.py
@@ -297,19 +297,19 @@ class AmbScout:
         #
         # EA:
         # Version:               0.50.0
-        # build.git.branch:      0.50.0-ea2
+        # build.git.branch:      0.50.0-ea.2
         # build.git.commit:      05aefd5
         # build.git.dirty:       False
-        # build.git.description: 0.50.0-ea2
-        # --> 0.50.0-ea2
+        # build.git.description: 0.50.0-ea.2
+        # --> 0.50.0-ea.2
         #
         # RC
         # Version:               0.40.0
-        # build.git.branch:      0.40.0-rc1
+        # build.git.branch:      0.40.0-rc.1
         # build.git.commit:      d450dca
         # build.git.dirty:       False
-        # build.git.description: 0.40.0-rc1
-        # --> 0.40.0-rc1
+        # build.git.description: 0.40.0-rc.1
+        # --> 0.40.0-rc.1
         #
         # GA
         # Version:               0.40.0

--- a/python/ambassador/ambscout.py
+++ b/python/ambassador/ambscout.py
@@ -55,7 +55,7 @@ class LocalScout:
         self.events = []
 
 class AmbScout:
-    reTaggedBranch: ClassVar = re.compile(r'^v?(\d+\.\d+\.\d+)(-[a-zA-Z][a-zA-Z]\d+)?$')
+    reTaggedBranch: ClassVar = re.compile(r'^v?(\d+\.\d+\.\d+)(-[a-zA-Z][a-zA-Z]\.\d+)?$')
     reGitDescription: ClassVar = re.compile(r'-(\d+)-g([0-9a-f]+)$')
 
     install_id: str

--- a/releng/release-prep.sh
+++ b/releng/release-prep.sh
@@ -45,16 +45,16 @@ echo "^ these changes have been made since the last release, pick the right vers
 while true; do
 	read -p "Enter new version: " DESIRED_VERSION
 
-	if [[ "$DESIRED_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+-rc[0-9]+$ ]]; then
+	if [[ "$DESIRED_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+-rc\.[0-9]+$ ]]; then
 	    # RC: good.
 	    break
-	elif [[ "$DESIRED_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+-ea[0-9]+$ ]]; then
+	elif [[ "$DESIRED_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+-ea\.[0-9]+$ ]]; then
 	    # EA: good.
 	    break
 	else
 	    echo "'$DESIRED_VERSION' is not in one of the recognized tag formats:" >&2
-	    echo " - 'SEMVER-rcN'" >&2
-	    echo " - 'SEMVER-eaN'" >&2
+	    echo " - 'SEMVER-rc.N'" >&2
+	    echo " - 'SEMVER-ea.N'" >&2
 	    echo "Note that the tag name must not start with 'v'" >&2
 	fi
 done

--- a/releng/travis-script.sh
+++ b/releng/travis-script.sh
@@ -22,15 +22,15 @@ printf "== Begin: travis-script.sh ==\n"
 if [[ -n "$TRAVIS_TAG" ]]; then
     if [[ "$TRAVIS_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
         COMMIT_TYPE=GA
-    elif [[ "$TRAVIS_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+-rc[0-9]+$ ]]; then
+    elif [[ "$TRAVIS_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+-rc\.[0-9]+$ ]]; then
         COMMIT_TYPE=RC
-    elif [[ "$TRAVIS_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+-ea[0-9]+$ ]]; then
+    elif [[ "$TRAVIS_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+-ea\.[0-9]+$ ]]; then
         COMMIT_TYPE=EA
     else
         echo "TRAVIS_TAG '$TRAVIS_TAG' is not in one of the recognized tag formats:" >&2
         echo " - 'vSEMVER'" >&2
-        echo " - 'vSEMVER-rcN'" >&2
-        echo " - 'vSEMVER-eaN'" >&2
+        echo " - 'vSEMVER-rc.N'" >&2
+        echo " - 'vSEMVER-ea.N'" >&2
         echo "Note that the tag name must start with a lowercase 'v'" >&2
         exit 1
     fi


### PR DESCRIPTION
Instead of `-eaN` and `-rcN`, use `-ea.N` and `-rc.N`. 

Fixes #2211 for the `ambassador.git` side of the world.