### PR TITLE
Looping over a copied list of keys, to prevent mutating tvars_cache while iterating

### DIFF
--- a/python/ambassador_diag/diagd.py
+++ b/python/ambassador_diag/diagd.py
@@ -217,9 +217,10 @@ def standard_handler(f):
 
         app.logger.debug("%s handler %s" % (prefix, func_name))
 
-        # getting elements in the `tvars_cache` will make sure eviction happens on `max_age_seconds` TTL
-        # for removed patch_client rather than waiting to fill `max_len`
-        for k in iter(tvars_cache):
+        # Getting elements in the `tvars_cache` will make sure eviction happens on `max_age_seconds` TTL
+        # for removed patch_client rather than waiting to fill `max_len`.
+        # Looping over a copied list of keys, to prevent mutating tvars_cache while iterating.
+        for k in list(tvars_cache.keys()):
             tvars_cache.get(k)
 
         # Default to the exception case


### PR DESCRIPTION
## Description
Looping over a copied list of keys, to prevent mutating tvars_cache while iterating.

## Related Issues
https://github.com/datawire/apro/issues/827

## Testing
Manual tests while observing logs shows proper cache eviction, no RuntimeError and a stable webui connection.

## Todos
- [x] Tests
- [ ] Documentation

## Other
* If this is a documentation change, please open the pull request at https://github.com/datawire/ambassador-docs instead.
* Code changes should occur against `master`.
