### PR TITLE
Only create the forced 8080 listener if it's not already there.

### DIFF
--- a/python/ambassador/envoy/v2/v2listener.py
+++ b/python/ambassador/envoy/v2/v2listener.py
@@ -964,9 +964,7 @@ class V2Listener(dict):
         logger.debug(f"V2Listeners: after IRListeners")
         cls.dump_listeners(logger, listeners_by_port)
 
-        # Make sure that each listener has a '*' vhost, and remember if we have a
-        # listener on 8080. (Why do we need to remember this? Because
-
+        # Make sure that each listener has a '*' vhost.
         for port, listener in listeners_by_port.items():
             if not '*' in listener.vhosts:
                 # Force the first VHost to '*'. I know, this is a little weird, but it's arguably


### PR DESCRIPTION
This looks bigger than it is: the main logic change is centered around `if 8080 not in listeners_by_port` rather than just always grabbing the 8080 listener.

Breakdown of changes:
- The `__contains__` implementation at line 645 was just wrong. The `bool()` call was making for strange behavior.
- The `irlistener8443` is kind of pointless, since if you're doing cleartext-only it's a degenerate case with no 8443 listener.
- Instead, we now look for the listener on the service_port, and
- we only do the override logic if no listener was present at all (this is the `if 8080 not in listeners_by_port` bit).