### PR TITLE
Watch ambassadorinstallations.getambassador.io

### DIFF
--- a/python/kubewatch.py
+++ b/python/kubewatch.py
@@ -245,6 +245,13 @@ def main(debug):
                          ' To enable Ingress support, configure RBAC to allow Ambassador to read Ingress resources,' +
                          ' then restart the Ambassador pod.')
 
+        # Check for our operator's CRD now
+        if check_crd_type('ambassadorinstallations.getambassador.io'):
+            touch_file('.ambassadorinstallations_ok')
+            logger.debug('ambassadorinstallations.getambassador.io CRD available')
+        else:
+            logger.debug('ambassadorinstallations.getambassador.io CRD not available')
+
         # Have we been asked to do Knative support?
         if os.environ.get('AMBASSADOR_KNATIVE_SUPPORT', '').lower() == 'true':
             # Yes. Check for their CRD types.

--- a/python/watch_hook.py
+++ b/python/watch_hook.py
@@ -231,12 +231,15 @@ class WatchHook:
             # If the edge stack is allowed, make sure we watch for our fallback context.
             self.add_kube_watch("Fallback TLSContext", "TLSContext", namespace=Config.ambassador_namespace)
 
+        ambassador_basedir = os.environ.get('AMBASSADOR_CONFIG_BASE_DIR', '/ambassador')
+
+        if os.path.exists(os.path.join(ambassador_basedir, '.ambassadorinstallations_ok')):
+            self.add_kube_watch("AmbassadorInstallations", "ambassadorinstallations.getambassador.io", Config.ambassador_namespace)
+
         ambassador_knative_requested = (os.environ.get("AMBASSADOR_KNATIVE_SUPPORT", "-unset-").lower() == 'true')
 
         if ambassador_knative_requested:
             self.logger.debug('Looking for Knative support...')
-
-            ambassador_basedir = os.environ.get('AMBASSADOR_CONFIG_BASE_DIR', '/ambassador')
 
             if os.path.exists(os.path.join(ambassador_basedir, '.knative_clusteringress_ok')):
                 # Watch for clusteringresses.networking.internal.knative.dev in any namespace and with any labels.


### PR DESCRIPTION
This commit makes Ambassador watch for
ambassadorinstallations.getambassador.io CRD if it exists in the
cluster.