### PR TITLE
Manage output from the installer

### DIFF
--- a/cmd/edgectl/aes_install.go
+++ b/cmd/edgectl/aes_install.go
@@ -4,13 +4,13 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"log"
 	"net"
 	"net/http"
 	"os"
 	"os/exec"
-	"regexp"
 	"strings"
 	"time"
 
@@ -275,8 +275,8 @@ func (i *Installer) ShowKubectl(name string, args ...string) error {
 	}
 	i.log.Printf("$ kubectl %s", strings.Join(kargs, " "))
 	cmd := exec.Command("kubectl", kargs...)
-	cmd.Stdout = NewLoggingWriter(i.cmdOut, ioutil.Discard)
-	cmd.Stderr = NewLoggingWriter(i.cmdOut, ioutil.Discard)
+	cmd.Stdout = NewLoggingWriter(i.cmdOut)
+	cmd.Stderr = NewLoggingWriter(i.cmdErr)
 	if err := cmd.Run(); err != nil {
 		return errors.Wrap(err, name)
 	}
@@ -293,8 +293,8 @@ func (i *Installer) CaptureKubectl(name string, args ...string) (res string, err
 	resAsBytes := &bytes.Buffer{}
 	i.log.Printf("$ kubectl %s", strings.Join(kargs, " "))
 	cmd := exec.Command("kubectl", kargs...)
-	cmd.Stdout = NewLoggingWriter(i.cmdOut, resAsBytes)
-	cmd.Stderr = NewLoggingWriter(i.cmdOut, ioutil.Discard)
+	cmd.Stdout = io.MultiWriter(NewLoggingWriter(i.cmdOut), resAsBytes)
+	cmd.Stderr = NewLoggingWriter(i.cmdErr)
 	err = cmd.Run()
 	if err != nil {
 		err = errors.Wrap(err, name)

--- a/cmd/edgectl/aes_install.go
+++ b/cmd/edgectl/aes_install.go
@@ -5,10 +5,12 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"log"
 	"net"
 	"net/http"
 	"os"
 	"os/exec"
+	"regexp"
 	"strings"
 	"time"
 
@@ -37,8 +39,8 @@ func aesInstallCmd() *cobra.Command {
 }
 
 func aesInstall(cmd *cobra.Command, args []string) error {
-	installer := NewInstaller()
-	installer.Report("install")
+	i := NewInstaller()
+	i.Report("install")
 
 	// Display version information
 	// TODO: This displays the version of Edge Control, not the image version in
@@ -51,30 +53,30 @@ func aesInstall(cmd *cobra.Command, args []string) error {
 	// more complicated in the future without having to subject our users to
 	// increasing complexity, assuming this approach to installation gains
 	// traction.
-	fmt.Printf("-> Installing the Ambassador Edge Stack %s\n", Version)
+	i.show.Printf("-> Installing the Ambassador Edge Stack %s\n", Version)
 
 	// Attempt to talk to the specified cluster
 	context, _ := cmd.Flags().GetString("context")
 	namespace, _ := cmd.Flags().GetString("namespace")
-	installer.kubeinfo = k8s.NewKubeInfo("", context, namespace)
+	i.kubeinfo = k8s.NewKubeInfo("", context, namespace)
 
-	if err := installer.ShowKubectl("cluster-info", "cluster-info"); err != nil {
+	if err := i.ShowKubectl("cluster-info", "cluster-info"); err != nil {
 		return err
 	}
 
-	if err := installer.ShowKubectl("install CRDs", "apply", "-f", "https://www.getambassador.io/yaml/aes-crds.yaml"); err != nil {
+	if err := i.ShowKubectl("install CRDs", "apply", "-f", "https://www.getambassador.io/yaml/aes-crds.yaml"); err != nil {
 		return err
 	}
 
-	if err := installer.ShowKubectl("wait for CRDs", "wait", "--for", "condition=established", "--timeout=90s", "crd", "-lproduct=aes"); err != nil {
+	if err := i.ShowKubectl("wait for CRDs", "wait", "--for", "condition=established", "--timeout=90s", "crd", "-lproduct=aes"); err != nil {
 		return err
 	}
 
-	if err := installer.ShowKubectl("install AES", "apply", "-f", "https://www.getambassador.io/yaml/aes.yaml"); err != nil {
+	if err := i.ShowKubectl("install AES", "apply", "-f", "https://www.getambassador.io/yaml/aes.yaml"); err != nil {
 		return err
 	}
 
-	if err := installer.ShowKubectl("wait for AES", "-n", "ambassador", "wait", "--for", "condition=available", "--timeout=90s", "deploy", "-lproduct=aes"); err != nil {
+	if err := i.ShowKubectl("wait for AES", "-n", "ambassador", "wait", "--for", "condition=available", "--timeout=90s", "deploy", "-lproduct=aes"); err != nil {
 		return err
 	}
 
@@ -85,19 +87,19 @@ func aesInstall(cmd *cobra.Command, args []string) error {
 	for {
 		// FIXME This doesn't work with `kubectl` 1.13 (and possibly 1.14). We
 		// FIXME need to discover and use the pod name with `kubectl exec`.
-		if clusterID, err := installer.CaptureKubectl("get cluster ID", "-n", "ambassador", "exec", "deploy/ambassador", "python3", "kubewatch.py"); err == nil {
-			installer.SetMetadatum("Cluster ID", "aes_install_id", clusterID)
+		if clusterID, err := i.CaptureKubectl("get cluster ID", "-n", "ambassador", "exec", "deploy/ambassador", "python3", "kubewatch.py"); err == nil {
+			i.SetMetadatum("Cluster ID", "aes_install_id", clusterID)
 			break
 		}
 		time.Sleep(500 * time.Millisecond) // FIXME: Time out at some point...
 	}
 
-	installer.Report("deploy") // TODO: Send cluster type and Helm version
+	i.Report("deploy") // TODO: Send cluster type and Helm version
 
 	ipAddress := ""
 	for {
 		var err error
-		ipAddress, err = installer.CaptureKubectl("get IP address", "get", "-n", "ambassador", "service", "ambassador", "-o", `go-template={{range .status.loadBalancer.ingress}}{{print .ip "\n"}}{{end}}`)
+		ipAddress, err = i.CaptureKubectl("get IP address", "get", "-n", "ambassador", "service", "ambassador", "-o", `go-template={{range .status.loadBalancer.ingress}}{{print .ip "\n"}}{{end}}`)
 		if err != nil {
 			return err
 		}
@@ -108,7 +110,7 @@ func aesInstall(cmd *cobra.Command, args []string) error {
 		time.Sleep(250 * time.Millisecond) // FIXME: Time out at some point...
 	}
 
-	fmt.Println("\nYour IP address is", ipAddress)
+	i.show.Println("\nYour IP address is", ipAddress)
 
 	// Wait for Ambassador to be ready to serve ACME requests.
 	// FIXME: This assumes we can connect to the load balancer. If this
@@ -120,7 +122,7 @@ func aesInstall(cmd *cobra.Command, args []string) error {
 		// Verify that we can connect to something
 		resp, err := http.Get("http://" + ipAddress + "/.well-known/acme-challenge/")
 		if err != nil {
-			fmt.Printf("Waiting for Ambassador (get): %#v\n", err)
+			i.show.Printf("Waiting for Ambassador (get): %#v\n", err)
 			continue
 		}
 		_, _ = ioutil.ReadAll(resp.Body)
@@ -130,13 +132,13 @@ func aesInstall(cmd *cobra.Command, args []string) error {
 		// starting up, then Envoy may return "upstream request timeout" (503),
 		// in which case we should keep looping.
 		if resp.StatusCode != 404 {
-			fmt.Printf("Waiting for Ambassador: wrong status code: %d\n", resp.StatusCode)
+			i.show.Printf("Waiting for Ambassador: wrong status code: %d\n", resp.StatusCode)
 			continue
 		}
 
 		// Sanity check that we're talking to Envoy. This is probably unnecessary.
 		if resp.Header.Get("server") != "envoy" {
-			fmt.Printf("Waiting for Ambassador: wrong server header: %s\n", resp.Header.Get("server"))
+			i.show.Printf("Waiting for Ambassador: wrong server header: %s\n", resp.Header.Get("server"))
 			continue
 		}
 		break
@@ -159,7 +161,7 @@ func aesInstall(cmd *cobra.Command, args []string) error {
 
 	if resp.StatusCode == 200 {
 		hostname := string(content)
-		fmt.Println("-> Acquiring DNS name", hostname)
+		i.show.Println("-> Acquiring DNS name", hostname)
 
 		// Wait for DNS to propagate. This tries to avoid waiting for a ten
 		// minute error backoff if the ACME registration races ahead of the DNS
@@ -170,19 +172,19 @@ func aesInstall(cmd *cobra.Command, args []string) error {
 				conn.Close()
 				break
 			}
-			// fmt.Printf("Waiting for DNS: %#v\n", err)
+			// i.show.Printf("Waiting for DNS: %#v\n", err)
 			time.Sleep(500 * time.Millisecond)
 		}
-		fmt.Println("-> Automatically configuring TLS")
-		fmt.Println("Please enter an email address. We'll use this email address to notify you prior to domain and certification expiration [None]:", emailAddress)
-		fmt.Println("FIXME: let the user enter an address")
+		i.show.Println("-> Automatically configuring TLS")
+		i.show.Println("Please enter an email address. We'll use this email address to notify you prior to domain and certification expiration [None]:", emailAddress)
+		i.show.Println("FIXME: let the user enter an address")
 		// Create a Host resource
 		hostResource := fmt.Sprintf(hostManifest, hostname, namespace, hostname, emailAddress)
-		kargs, err := installer.kubeinfo.GetKubectlArray("apply", "-f", "-")
+		kargs, err := i.kubeinfo.GetKubectlArray("apply", "-f", "-")
 		if err != nil {
 			return errors.Wrapf(err, "cluster access for install AES")
 		}
-		fmt.Println("\n$ kubectl apply -f - < [Host Resource]")
+		i.log.Println("$ kubectl apply -f - < [Host Resource]")
 		cmd := exec.Command("kubectl", kargs...)
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr
@@ -191,10 +193,10 @@ func aesInstall(cmd *cobra.Command, args []string) error {
 			return errors.Wrap(err, "install AES")
 		}
 
-		fmt.Println("\n-> Obtaining a TLS certificate from Let's Encrypt")
+		i.show.Println("\n-> Obtaining a TLS certificate from Let's Encrypt")
 
 		for {
-			state, err := installer.CaptureKubectl("get Host state", "get", "host", hostname, "-o", "go-template={{.status.state}}")
+			state, err := i.CaptureKubectl("get Host state", "get", "host", hostname, "-o", "go-template={{.status.state}}")
 			if err != nil {
 				return err
 			}
@@ -205,39 +207,39 @@ func aesInstall(cmd *cobra.Command, args []string) error {
 			// FIXME: Do something smart for state == "Error"
 		}
 
-		installer.Report("cert_provisioned")
-		fmt.Println("-> TLS configured successfully")
-		if err := installer.ShowKubectl("show Host", "get", "host", hostname); err != nil {
+		i.Report("cert_provisioned")
+		i.show.Println("-> TLS configured successfully")
+		if err := i.ShowKubectl("show Host", "get", "host", hostname); err != nil {
 			return err
 		}
 
 		// Open a browser window to the Edge Policy Console
-		if err := do_login(installer.kubeinfo, context, "ambassador", hostname, false, false); err != nil {
+		if err := do_login(i.kubeinfo, context, "ambassador", hostname, false, false); err != nil {
 			return err
 		}
 
 	} else {
 		message := strings.TrimSpace(string(content))
-		fmt.Println("\n-> Failed to create a DNS name:", message)
-		fmt.Println()
-		fmt.Println("If this IP address is reachable from here, then the following command")
-		fmt.Println("will open the Edge Policy Console once you accept a self-signed")
-		fmt.Println("certificate in your browser.")
-		fmt.Println()
-		fmt.Println("    edgectl login -n ambassador", ipAddress)
-		fmt.Println()
-		fmt.Println("If the IP is not reachable from here, you can use port forwarding to")
-		fmt.Println("access the Edge Policy Console.")
-		fmt.Println()
-		fmt.Println("    kubectl -n ambassador port-forward deploy/ambassador 8443 &")
-		fmt.Println("    edgectl login -n ambassador 127.0.0.1:8443")
-		fmt.Println()
-		fmt.Println("You will need to accept a self-signed certificate in your browser.")
-		fmt.Println()
-		fmt.Println("See https://www.getambassador.io/user-guide/getting-started/")
+		i.show.Println("\n-> Failed to create a DNS name:", message)
+		i.show.Println()
+		i.show.Println("If this IP address is reachable from here, then the following command")
+		i.show.Println("will open the Edge Policy Console once you accept a self-signed")
+		i.show.Println("certificate in your browser.")
+		i.show.Println()
+		i.show.Println("    edgectl login -n ambassador", ipAddress)
+		i.show.Println()
+		i.show.Println("If the IP is not reachable from here, you can use port forwarding to")
+		i.show.Println("access the Edge Policy Console.")
+		i.show.Println()
+		i.show.Println("    kubectl -n ambassador port-forward deploy/ambassador 8443 &")
+		i.show.Println("    edgectl login -n ambassador 127.0.0.1:8443")
+		i.show.Println()
+		i.show.Println("You will need to accept a self-signed certificate in your browser.")
+		i.show.Println()
+		i.show.Println("See https://www.getambassador.io/user-guide/getting-started/")
 	}
 
-	installer.Report("aes_health_good") // or aes_health_bad TODO: Send cluster's install_id and AES version
+	i.Report("aes_health_good") // or aes_health_bad TODO: Send cluster's install_id and AES version
 
 	return nil
 }
@@ -245,11 +247,22 @@ func aesInstall(cmd *cobra.Command, args []string) error {
 type Installer struct {
 	kubeinfo *k8s.KubeInfo
 	scout    *Scout
+	show     *log.Logger
+	log      *log.Logger
+	cmdOut   *log.Logger
+	cmdErr   *log.Logger
 }
 
 func NewInstaller() *Installer {
+	// Although log, cmdOut, and cmdErr *can* go to different files and/or have
+	// different prefixes, they'll probably all go to the same file, possibly
+	// with different prefixes, for most cases.
 	return &Installer{
-		scout: NewScout("install"),
+		scout:  NewScout("install"),
+		show:   log.New(os.Stderr, "", 0),
+		log:    log.New(os.Stderr, "* ", log.Ltime),
+		cmdOut: log.New(os.Stderr, "  ", log.Ltime),
+		cmdErr: log.New(os.Stderr, "x ", log.Ltime),
 	}
 }
 
@@ -260,10 +273,10 @@ func (i *Installer) ShowKubectl(name string, args ...string) error {
 	if err != nil {
 		return errors.Wrapf(err, "cluster access for %s", name)
 	}
-	fmt.Printf("\n$ kubectl %s\n", strings.Join(kargs, " "))
+	i.log.Printf("$ kubectl %s", strings.Join(kargs, " "))
 	cmd := exec.Command("kubectl", kargs...)
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
+	cmd.Stdout = NewLoggingWriter(i.cmdOut, ioutil.Discard)
+	cmd.Stderr = NewLoggingWriter(i.cmdOut, ioutil.Discard)
 	if err := cmd.Run(); err != nil {
 		return errors.Wrap(err, name)
 	}
@@ -277,32 +290,30 @@ func (i *Installer) CaptureKubectl(name string, args ...string) (res string, err
 		err = errors.Wrapf(err, "cluster access for %s", name)
 		return
 	}
-	fmt.Printf("\n$ kubectl %s\n", strings.Join(kargs, " "))
+	resAsBytes := &bytes.Buffer{}
+	i.log.Printf("$ kubectl %s", strings.Join(kargs, " "))
 	cmd := exec.Command("kubectl", kargs...)
-	cmd.Stderr = nil
-	resAsBytes, err := cmd.Output()
+	cmd.Stdout = NewLoggingWriter(i.cmdOut, resAsBytes)
+	cmd.Stderr = NewLoggingWriter(i.cmdOut, ioutil.Discard)
+	err = cmd.Run()
 	if err != nil {
-		if ee, ok := err.(*exec.ExitError); ok {
-			fmt.Println(string(ee.Stderr))
-		}
 		err = errors.Wrap(err, name)
 	}
-	res = string(resAsBytes)
-	fmt.Println(res)
+	res = resAsBytes.String()
 	return
 }
 
 // Metrics
 
 func (i *Installer) SetMetadatum(name, key string, value interface{}) {
-	fmt.Printf("\n-> [Metrics] %s (%q) is %q", name, key, value)
+	i.log.Printf("[Metrics] %s (%q) is %q", name, key, value)
 	i.scout.SetMetadatum(key, value)
 }
 
 func (i *Installer) Report(eventName string, meta ...ScoutMeta) {
-	fmt.Println("\n-> [Metrics]", eventName)
+	i.log.Println("[Metrics]", eventName)
 	if err := i.scout.Report(eventName, meta...); err != nil {
-		fmt.Println("            ", err)
+		i.log.Println("[Metrics]", eventName, err)
 	}
 }
 

--- a/cmd/edgectl/writer.go
+++ b/cmd/edgectl/writer.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"log"
+)
+
+// NewLoggingWriter returns an io.Writer that passes through Write()s to the
+// underlying Writer while logging each write line-by-line. Unlike dexec's
+// logger, this one assumes the data is fine to log, blindly passing through
+// non-UTF-8 and over-long lines.
+func NewLoggingWriter(l *log.Logger, w io.Writer) io.Writer {
+	return &loggingWriter{
+		log:    func(s string) { l.Print(s) },
+		writer: w,
+	}
+}
+
+type loggingWriter struct {
+	log    func(string)
+	writer io.Writer
+}
+
+func (l *loggingWriter) Write(p []byte) (n int, err error) {
+	n, err = l.writer.Write(p)
+
+	toLog := p[:n]
+	for len(toLog) > 0 {
+		nl := bytes.IndexByte(toLog, '\n')
+		var line []byte
+		if nl < 0 {
+			line = toLog
+			toLog = nil
+		} else {
+			line = toLog[:nl+1]
+			toLog = toLog[nl+1:]
+		}
+		l.log(string(line))
+	}
+
+	if err != nil {
+		if err == io.EOF {
+			l.log("EOF")
+		} else {
+			l.log(fmt.Sprintf("error = %v", err))
+		}
+	}
+
+	return n, err
+}

--- a/cmd/edgectl/writer.go
+++ b/cmd/edgectl/writer.go
@@ -2,31 +2,22 @@ package main
 
 import (
 	"bytes"
-	"fmt"
 	"io"
 	"log"
 )
 
-// NewLoggingWriter returns an io.Writer that passes through Write()s to the
-// underlying Writer while logging each write line-by-line. Unlike dexec's
-// logger, this one assumes the data is fine to log, blindly passing through
-// non-UTF-8 and over-long lines.
-func NewLoggingWriter(l *log.Logger, w io.Writer) io.Writer {
-	return &loggingWriter{
-		log:    func(s string) { l.Print(s) },
-		writer: w,
-	}
+// NewLoggingWriter returns an io.Writer that logs each write line-by-line
+// blindly passing through non-UTF-8 and over-long lines.
+func NewLoggingWriter(l *log.Logger) io.Writer {
+	return &loggingWriter{l}
 }
 
 type loggingWriter struct {
-	log    func(string)
-	writer io.Writer
+	log *log.Logger
 }
 
-func (l *loggingWriter) Write(p []byte) (n int, err error) {
-	n, err = l.writer.Write(p)
-
-	toLog := p[:n]
+func (l *loggingWriter) Write(toLog []byte) (int, error) {
+	n := len(toLog)
 	for len(toLog) > 0 {
 		nl := bytes.IndexByte(toLog, '\n')
 		var line []byte
@@ -37,16 +28,7 @@ func (l *loggingWriter) Write(p []byte) (n int, err error) {
 			line = toLog[:nl+1]
 			toLog = toLog[nl+1:]
 		}
-		l.log(string(line))
+		l.log.Print(string(line))
 	}
-
-	if err != nil {
-		if err == io.EOF {
-			l.log("EOF")
-		} else {
-			l.log(fmt.Sprintf("error = %v", err))
-		}
-	}
-
-	return n, err
+	return n, nil
 }


### PR DESCRIPTION
- Offer concise and useful interactive output by default (as described in the story)
- Offer verbose output to the console via `--verbose`
- Always log everything to a unique file in /tmp or equivalent

Once again, probably want to read commit-by-commit.