### PR TITLE
Support overriding the BUILDER_NAME

### DIFF
--- a/builder/builder.mk
+++ b/builder/builder.mk
@@ -18,7 +18,9 @@ module = $(eval MODULES += $(1))$(eval SOURCE_$(1)=$(abspath $(2)))
 
 BUILDER_HOME := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 
-BUILDER = BUILDER_NAME=$(NAME) $(abspath $(BUILDER_HOME)/builder.sh)
+BUILDER_NAME ?= $(NAME)
+
+BUILDER = BUILDER_NAME=$(BUILDER_NAME) $(abspath $(BUILDER_HOME)/builder.sh)
 DBUILD = $(abspath $(BUILDER_HOME)/dbuild.sh)
 
 all: help
@@ -31,7 +33,7 @@ export DOCKER_ERR=$(RED)ERROR: cannot find docker, please make sure docker is in
 
 # the name of the Docker network
 # note: use your local k3d/microk8s/kind network for running tests
-DOCKER_NETWORK ?= $(NAME)
+DOCKER_NETWORK ?= $(BUILDER_NAME)
 
 preflight:
 ifeq ($(strip $(shell $(BUILDER))),)

--- a/builder/builder.sh
+++ b/builder/builder.sh
@@ -81,7 +81,7 @@ bootstrap() {
         fi
 
         echo_on
-        $DOCKER_RUN --network "${DOCKER_NETWORK}" --network-alias "builder" --group-add ${DOCKER_GID} -d --rm -v /var/run/docker.sock:/var/run/docker.sock -v $(builder_volume):/home/dw ${BUILDER_MOUNTS} --cap-add NET_ADMIN -lbuilder -l${BUILDER_NAME} ${BUILDER_PORTMAPS} -e BUILDER_NAME=${BUILDER_NAME} --entrypoint tail builder -f /dev/null > /dev/null
+        $DOCKER_RUN --name "builder-${BUILDER_NAME}" --network "${DOCKER_NETWORK}" --network-alias "builder" --group-add ${DOCKER_GID} -d --rm -v /var/run/docker.sock:/var/run/docker.sock -v $(builder_volume):/home/dw ${BUILDER_MOUNTS} --cap-add NET_ADMIN -lbuilder -l${BUILDER_NAME} ${BUILDER_PORTMAPS} -e BUILDER_NAME=${BUILDER_NAME} --entrypoint tail builder -f /dev/null > /dev/null
         echo_off
 
         printf "${GRN}Started build container ${BLU}$(builder)${END}\n"


### PR DESCRIPTION
I've gotten burned _hard_ by this over the last few days. If you clone `ambassador.git` twice, then try to build in both clones at once, _the two clones will use the same builder container_ and you will end up with only inconsistent, irrepreducible madness for results. 

This PR allows setting `BUILDER_NAME` by hand in one or both directories, to explicitly choose the name to use for all the builder resources so that you can actually separate your builds and not be totally horked. Also, it gives the builder containers a !*@&#!*@#& name so that you can see which is which with `docker ps` -- in practice, a collision on the name is _not_ something to ignore, it means that you're probably about to screw yourself up!

After I play with it a bit, I'll likely add to this by defaulting `BUILDER_NAME` to the basename of the clone, but this is a start.