### PR TITLE
Support disabling Edge Policy Console

### DIFF
--- a/docs/about/edge-policy-console.md
+++ b/docs/about/edge-policy-console.md
@@ -107,6 +107,10 @@ See the [Developer Portal](../../reference/dev-portal) documentation for more in
 
 The Documentation page provides you direct links to the Ambassador Edge Stack documentation (these very pages!), available resources and case studies, as well as the Ambassador blog.
 
+### Disabling the Edge Policy Console
+
+If necessary, you can disable external access to the Edge Policy Console using the [Ambassador module](../../reference/core/ambassador.md).
+
 ### Support
 
 Need help? Check in here to ask for help on Slack, file an issue, or contact us. See [Support](../support) for additional information.

--- a/docs/reference/core/ambassador.md
+++ b/docs/reference/core/ambassador.md
@@ -70,8 +70,8 @@ cors:
 
 `diagnostics` configures Ambassador's diagnostics services.
 
-- Both API Gateway and Edge Stack provide low-level diagnostics at `/ambassador/v0/diag/`.
-- Ambassador Edge Stack also provides the higher-level Edge Policy Console at `/edge_stack/admin/`.
+- Both the API Gateway and the Edge Stack provide low-level diagnostics at `/ambassador/v0/diag/`.
+- The Ambassador Edge Stack also provides the higher-level Edge Policy Console at `/edge_stack/admin/`.
 
 By default, both services are enabled: 
 

--- a/docs/reference/core/ambassador.md
+++ b/docs/reference/core/ambassador.md
@@ -68,12 +68,25 @@ cors:
   ...
 ```
 
-The `diagnostics` service (at /ambassador/v0/diag/) defaults on, but you can disable the API route. It will remain accessible on diag_port.
+`diagnostics` configures Ambassador's diagnostics services.
+
+- Both API Gateway and Edge Stack provide low-level diagnostics at `/ambassador/v0/diag/`.
+- Ambassador Edge Stack also provides the higher-level Edge Policy Console at `/edge_stack/admin/`.
+
+By default, both services are enabled: 
 
 ```
 diagnostics:
   enabled: true
 ```
+
+Setting `diagnostics.enabled` to `false` will disable the routes for both services (they will remain accessible from inside the Ambassador pod on port 8877):
+
+```
+diagnostics:
+  enabled: false
+```
+
 
 `keepalive` sets the global keepalive settings.
 Ambassador will use for all mappings unless overridden in a

--- a/python/ambassador/envoy/v2/v2listener.py
+++ b/python/ambassador/envoy/v2/v2listener.py
@@ -1115,8 +1115,8 @@ class V2Listener(dict):
                                 f"V2Listeners: {listener.name} {vhostname} {variant}: force Reject (rhosts {route_hostlist}, vhost {vhostname})")
                             action = "Reject"
                         elif (config.ir.edge_stack_allowed and
-                              (route["match"].get("prefix", None) == "/") and
-                              (route_precedence == -1000000)):
+                              (route_precedence == -1000000) and
+                              (route["match"].get("safe_regex", {}).get("regex", None) == "^/$")):
                             logger.debug(
                                 f"V2Listeners: {listener.name} {vhostname} {variant}: force Route for fallback Mapping")
                             action = "Route"

--- a/python/ambassador/envoy/v2/v2route.py
+++ b/python/ambassador/envoy/v2/v2route.py
@@ -92,7 +92,19 @@ class V2Route(dict):
         if envoy_route == 'prefix':
             match['prefix'] = route_prefix
         else:
-            match.update(regex_matcher(config, route_prefix))
+            # Cheat.
+            if config.ir.edge_stack_allowed and (self.get('_precedence', 0) == -1000000):
+                # Force the safe_regex engine.
+                match.update({
+                    "safe_regex": {
+                        "google_re2": {
+                            "max_program_size": 200,
+                        },
+                        "regex": route_prefix
+                    }
+                })
+            else:
+                match.update(regex_matcher(config, route_prefix))
 
         headers = self.generate_headers(config, group)
 

--- a/python/ambassador/ir/irambassador.py
+++ b/python/ambassador/ir/irambassador.py
@@ -276,6 +276,33 @@ class IRAmbassador (IRResource):
                 mapping.referenced_by(self)
                 ir.add_mapping(aconf, mapping)
 
+        if ir.edge_stack_allowed:
+            if self.diagnostics and self.diagnostics.get("enabled", False):
+                ir.logger.info("adding mappings for Edge Policy Console")
+                mapping = IRHTTPMapping(ir, aconf, rkey=self.rkey, location=self.location,
+                                        name="edgestack-direct-mapping",
+                                        metadata_labels={"ambassador_diag_class": "private"},
+                                        prefix="/edge_stack/",
+                                        rewrite="/edge_stack_ui/edge_stack/",
+                                        service="127.0.0.1:8500",
+                                        precedence=1000000,
+                                        timeout_ms=60000)
+                mapping.referenced_by(self)
+                ir.add_mapping(aconf, mapping)
+
+                mapping = IRHTTPMapping(ir, aconf, rkey=self.rkey, location=self.location,
+                                        name="edgestack-fallback-mapping",
+                                        metadata_labels={"ambassador_diag_class": "private"},
+                                        prefix="^/$", prefix_regex=True,
+                                        rewrite="/edge_stack_ui/",
+                                        service="127.0.0.1:8500",
+                                        precedence=-1000000,
+                                        timeout_ms=60000)
+                mapping.referenced_by(self)
+                ir.add_mapping(aconf, mapping)
+            else:
+                ir.logger.info("diagnostics disabled, skipping mapping for Edge Policy Console")
+
     def get_default_label_domain(self) -> str:
         return self.default_label_domain
 

--- a/python/tests/t_no_ui.py
+++ b/python/tests/t_no_ui.py
@@ -4,13 +4,24 @@ from abstract_tests import AmbassadorTest, ServiceType, HTTP
 
 
 class NoUITest (AmbassadorTest):
+    # Don't use single_namespace -- we want CRDs, so we want
+    # the cluster-scope RBAC instead of the namespace-scope
+    # RBAC. Our ambassador_id filters out the stuff we want.
+    namespace = "no-ui-namespace"
+
     def manifests(self) -> str:
         return self.format("""
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: no-ui-namespace
 ---
 apiVersion: getambassador.io/v2
 kind: Module
 metadata:
   name: ambassador
+  namespace: no-ui-namespace
   labels:
     kat-ambassador-id: {self.ambassador_id}
 spec:

--- a/python/tests/t_no_ui.py
+++ b/python/tests/t_no_ui.py
@@ -1,0 +1,26 @@
+from kat.harness import Query, EDGE_STACK
+
+from abstract_tests import AmbassadorTest, ServiceType, HTTP
+
+
+class NoUITest (AmbassadorTest):
+    def manifests(self) -> str:
+        return self.format("""
+---
+apiVersion: getambassador.io/v2
+kind: Module
+metadata:
+  name: ambassador
+  labels:
+    kat-ambassador-id: {self.ambassador_id}
+spec:
+  ambassador_id: [ {self.ambassador_id} ]
+  config:
+    diagnostics:
+      enabled: false
+""") + super().manifests()
+
+    def queries(self):
+        yield(Query(self.url("ambassador/v0/diag/"), expected=404))
+        yield(Query(self.url("edge_stack/admin/"), expected=404))
+

--- a/python/tests/test_ambassador.py
+++ b/python/tests/test_ambassador.py
@@ -17,6 +17,7 @@ import t_loadbalancer
 import t_logservice
 import t_lua_scripts
 import t_mappingtests
+import t_no_ui
 import t_optiontests
 import t_plain
 import t_ratelimit


### PR DESCRIPTION
Dynamically add Edge Policy Console mappings -- but only if diag isn't disabled.
