### PR TITLE
Removed /beta routes from edgectl metriton endpoints

### DIFF
--- a/cmd/edgectl/aes_install.go
+++ b/cmd/edgectl/aes_install.go
@@ -467,7 +467,7 @@ func (i *Installer) Perform(kcontext string) error {
 	i.log.Printf("Using email address %q", emailAddress)
 
 	// Send a request to acquire a DNS name for this cluster's IP address
-	regURL := "https://metriton.datawire.io/beta/register-domain"
+	regURL := "https://metriton.datawire.io/register-domain"
 	buf := new(bytes.Buffer)
 	_ = json.NewEncoder(buf).Encode(registration{emailAddress, ipAddress})
 	resp, err := http.Post(regURL, "application/json", buf)

--- a/cmd/edgectl/scout.go
+++ b/cmd/edgectl/scout.go
@@ -117,8 +117,7 @@ func (s *Scout) Report(action string, meta ...ScoutMeta) error {
 	if err != nil {
 		panic(err)
 	}
-	// metritonEndpoint := "https://metriton.datawire.io/scout"   // Prod URL
-	metritonEndpoint := "https://metriton.datawire.io/beta/scout" // Beta URL
+	metritonEndpoint := "https://metriton.datawire.io/scout"
 	resp, err := http.Post(metritonEndpoint, "application/json", bytes.NewBuffer(body))
 	if err != nil {
 		return errors.Wrap(err, "scout report")


### PR DESCRIPTION
## Description
Removed `/beta` routes from edgectl metriton endpoints.

## Related Issues


## Testing
Manual build and `edgectl install` validation.

## Todos
- [x Tests
- [ ] Documentation

## Other
* If this is a documentation change, please open the pull request at https://github.com/datawire/ambassador-docs instead.
* Code changes should occur against `master`.
