### PR TITLE
Edgectl Intercept using mappings

### DIFF
--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -105,6 +105,10 @@ FROM ${artifacts} as artifacts
 
 FROM ${base} as ambassador
 
+# Always have an "ambassador" user as UID 8888. This is what we recommend
+# people run as. (Note that the "-D" actually leaves the password locked.)
+RUN adduser ambassador -u 8888 -G root -D -H -s /bin/false
+
 # External stuff that should change infrequently
 RUN apk --no-cache add bash curl python3 libcap
 RUN ln -s /usr/bin/python3 /usr/bin/python

--- a/cmd/edgectl/aes_license.go
+++ b/cmd/edgectl/aes_license.go
@@ -32,7 +32,8 @@ func aesLicense(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return errors.Wrap(err, "kubectl apply")
 	}
-	fmt.Println("Please wait a minute or two for your license to be refreshed in your running Ambassador Edge Stack.")
+
+	fmt.Println("License applied!")
 	return nil
 }
 

--- a/cmd/edgectl/cli.go
+++ b/cmd/edgectl/cli.go
@@ -187,7 +187,17 @@ func (d *Daemon) getRootCommand(p *supervisor.Process, out *Emitter, data *Clien
 			default:
 				out.Printf("Found %d interceptable deployment(s):\n", len(d.trafficMgr.interceptables))
 				for idx, deployment := range d.trafficMgr.interceptables {
-					out.Printf("%4d. %s\n", idx+1, deployment)
+					fields := strings.SplitN(deployment, "/", 2)
+
+					appName := fields[0]
+					appNamespace := d.cluster.namespace
+
+					if len(fields) > 1 {
+						appNamespace = fields[0]
+						appName = fields[1]
+					}
+
+					out.Printf("%4d. %s in namespace %s\n", idx+1, appName, appNamespace)
 					out.Send(fmt.Sprintf("interceptable.deployment.%d", idx+1), deployment)
 				}
 			}
@@ -229,9 +239,9 @@ func (d *Daemon) getRootCommand(p *supervisor.Process, out *Emitter, data *Clien
 				intercept.Name = fmt.Sprintf("cept-%d", time.Now().Unix())
 			}
 
-			if intercept.Namespace == "" {
-				intercept.Namespace = "default"
-			}
+			// if intercept.Namespace == "" {
+			// 	intercept.Namespace = "default"
+			// }
 
 			if intercept.Prefix == "" {
 				intercept.Prefix = "/"

--- a/cmd/edgectl/cli.go
+++ b/cmd/edgectl/cli.go
@@ -220,13 +220,21 @@ func (d *Daemon) getRootCommand(p *supervisor.Process, out *Emitter, data *Clien
 	})
 	intercept := InterceptInfo{}
 	interceptAddCmd := &cobra.Command{
-		Use:   "add DEPLOYMENT -t [HOST:]PORT -m HEADER=REGEX ...",
+		Use:   "add DEPLOYMENT [--namespace NAMESPACE] [-p PREFIX] -t [HOST:]PORT -m HEADER=REGEX ...",
 		Short: "Add a deployment intercept",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
 			intercept.Deployment = args[0]
 			if intercept.Name == "" {
 				intercept.Name = fmt.Sprintf("cept-%d", time.Now().Unix())
+			}
+
+			if intercept.Namespace == "" {
+				intercept.Namespace = "default"
+			}
+
+			if intercept.Prefix == "" {
+				intercept.Prefix = "/"
 			}
 
 			var host, portStr string
@@ -256,10 +264,12 @@ func (d *Daemon) getRootCommand(p *supervisor.Process, out *Emitter, data *Clien
 		},
 	}
 	interceptAddCmd.Flags().StringVarP(&intercept.Name, "name", "n", "", "a name for this intercept")
+	interceptAddCmd.Flags().StringVarP(&intercept.Prefix, "prefix", "p", "", "prefix to intercept (default /)")
 	interceptAddCmd.Flags().StringVarP(&intercept.TargetHost, "target", "t", "", "the [HOST:]PORT to forward to")
 	_ = interceptAddCmd.MarkFlagRequired("target")
 	interceptAddCmd.Flags().StringToStringVarP(&intercept.Patterns, "match", "m", nil, "match expression (HEADER=REGEX)")
 	_ = interceptAddCmd.MarkFlagRequired("match")
+	interceptAddCmd.Flags().StringVarP(&intercept.Namespace, "namespace", "", "", "Kubernetes namespace in which to create mapping for intercept")
 
 	interceptCmd.AddCommand(interceptAddCmd)
 	interceptCG := []CmdGroup{

--- a/cmd/edgectl/cluster.go
+++ b/cmd/edgectl/cluster.go
@@ -42,7 +42,11 @@ func (d *Daemon) Connect(
 		return nil
 	}
 
-	out.Println("Connecting...")
+	if namespace == "" {
+		namespace = "ambassador"
+	}
+
+	out.Printf("Connecting to traffic manager in namespace %s...\n", namespace)
 	out.Send("connect", "Connecting...")
 	cluster, err := TrackKCluster(p, rai, context, namespace, kargs)
 	if err != nil {

--- a/cmd/edgectl/cluster.go
+++ b/cmd/edgectl/cluster.go
@@ -97,7 +97,7 @@ func (d *Daemon) Connect(
 func (d *Daemon) Disconnect(p *supervisor.Process, out *Emitter) error {
 	// Sanity checks
 	if d.cluster == nil {
-		out.Println("Not connected")
+		out.Println("Not connected (use 'edgectl connect' to connect to your cluster)")
 		out.Send("disconnect", "Not connected")
 		return nil
 	}

--- a/cmd/edgectl/cluster.go
+++ b/cmd/edgectl/cluster.go
@@ -157,7 +157,7 @@ type TrafficManager struct {
 // NewTrafficManager returns a TrafficManager resource for the given
 // cluster if it has a Traffic Manager service.
 func NewTrafficManager(p *supervisor.Process, cluster *KCluster) (*TrafficManager, error) {
-	cmd := cluster.GetKubectlCmd(p, "get", "svc/telepresence-proxy", "deploy/telepresence-proxy")
+	cmd := cluster.GetKubectlCmd(p, "get", "-n", cluster.namespace, "svc/telepresence-proxy", "deploy/telepresence-proxy")
 	err := cmd.Run()
 	if err != nil {
 		return nil, errors.Wrap(err, "kubectl get svc/deploy telepresency-proxy")
@@ -171,7 +171,7 @@ func NewTrafficManager(p *supervisor.Process, cluster *KCluster) (*TrafficManage
 	if err != nil {
 		return nil, errors.Wrap(err, "get free port for ssh")
 	}
-	kpfArgStr := fmt.Sprintf("port-forward svc/telepresence-proxy %d:8022 %d:8081", sshPort, apiPort)
+	kpfArgStr := fmt.Sprintf("port-forward -n %s svc/telepresence-proxy %d:8022 %d:8081", cluster.namespace, sshPort, apiPort)
 	kpfArgs := cluster.GetKubectlArgs(strings.Fields(kpfArgStr)...)
 	tm := &TrafficManager{apiPort: apiPort, sshPort: sshPort}
 

--- a/cmd/edgectl/d_resource.go
+++ b/cmd/edgectl/d_resource.go
@@ -144,16 +144,30 @@ func (c *KCluster) RAI() *RunAsInfo {
 }
 
 // GetKubectlArgs returns the kubectl command arguments to run a
-// kubectl command with this cluster
+// kubectl command with this cluster, including the namespace argument.
 func (c *KCluster) GetKubectlArgs(args ...string) []string {
+	return c.getKubectlArgs(true, args...)
+}
+
+// GetKubectlArgsNoNamespace returns the kubectl command arguments to run a
+// kubectl command with this cluster, but without the namespace argument.
+func (c *KCluster) GetKubectlArgsNoNamespace(args ...string) []string {
+	return c.getKubectlArgs(false, args...)
+}
+
+func (c *KCluster) getKubectlArgs(includeNamespace bool, args ...string) []string {
 	cmdArgs := make([]string, 0, 1+len(c.kargs)+len(args))
 	cmdArgs = append(cmdArgs, "kubectl")
 	if c.context != "" {
 		cmdArgs = append(cmdArgs, "--context", c.context)
 	}
-	if c.namespace != "" {
-		cmdArgs = append(cmdArgs, "--namespace", c.namespace)
+
+	if includeNamespace {
+		if c.namespace != "" {
+			cmdArgs = append(cmdArgs, "--namespace", c.namespace)
+		}
 	}
+
 	cmdArgs = append(cmdArgs, c.kargs...)
 	cmdArgs = append(cmdArgs, args...)
 	return cmdArgs
@@ -163,6 +177,13 @@ func (c *KCluster) GetKubectlArgs(args ...string) []string {
 // the appropriate environment to talk to the cluster
 func (c *KCluster) GetKubectlCmd(p *supervisor.Process, args ...string) *supervisor.Cmd {
 	return c.rai.Command(p, c.GetKubectlArgs(args...)...)
+}
+
+// GetKubectlCmdNoNamespace returns a Cmd that runs kubectl with the given arguments and
+// the appropriate environment to talk to the cluster, but it doesn't supply a namespace
+// arg.
+func (c *KCluster) GetKubectlCmdNoNamespace(p *supervisor.Process, args ...string) *supervisor.Cmd {
+	return c.rai.Command(p, c.GetKubectlArgsNoNamespace(args...)...)
 }
 
 // Context returns the cluster's context name

--- a/cmd/edgectl/edgectl_test.go
+++ b/cmd/edgectl/edgectl_test.go
@@ -150,7 +150,7 @@ func TestSmokeOutbound(t *testing.T) {
 	}()
 
 	fmt.Println("connect")
-	require.NoError(t, run(executable, "connect"), "connect")
+	require.NoError(t, run(executable, "connect", "-n", namespace), "connect")
 	out, err = capture(executable, "status")
 	require.NoError(t, err, "status connected")
 	if !strings.Contains(out, "Context") {

--- a/cmd/edgectl/intercept.go
+++ b/cmd/edgectl/intercept.go
@@ -17,7 +17,7 @@ import (
 func (d *Daemon) interceptMessage() string {
 	switch {
 	case d.cluster == nil:
-		return "Not connected"
+		return "Not connected (use 'edgectl connect' to connect to your cluster)"
 	case d.trafficMgr == nil:
 		return "Intercept unavailable: no traffic manager"
 	case !d.trafficMgr.IsOkay():

--- a/cmd/edgectl/intercept.go
+++ b/cmd/edgectl/intercept.go
@@ -309,7 +309,6 @@ func MakeIntercept(p *supervisor.Process, out *Emitter, tm *TrafficManager, clus
 	cept.setup(p.Supervisor(), ii.Name)
 
 	p.Logf("%s: Intercepting via port %v, using namespace %v", ii.Name, port, ii.Namespace)
-	out.Printf("%v: Intercepting\n", ii.Name)
 
 	mapping := interceptMapping{
 		APIVersion: "getambassador.io/v2",
@@ -334,7 +333,7 @@ func MakeIntercept(p *supervisor.Process, out *Emitter, tm *TrafficManager, clus
 	}
 
 	p.Logf("%s: Intercept using mapping %v", ii.Name, string(manifest))
-	out.Printf("Applying intercept mapping:\n%v\n", string(manifest))
+	out.Printf("%s: applying intercept mapping in namespace %s\n", ii.Name, ii.Namespace)
 
 	apply := cluster.GetKubectlCmdNoNamespace(p, "apply", "-f", "-")
 	apply.Stdin = strings.NewReader(string(manifest))
@@ -359,7 +358,7 @@ func MakeIntercept(p *supervisor.Process, out *Emitter, tm *TrafficManager, clus
 	}
 
 	p.Logf("%s: starting SSH tunnel", ii.Name)
-	out.Printf("%s: starting SSH tunnel", ii.Name)
+	out.Printf("%s: starting SSH tunnel\n", ii.Name)
 
 	ssh, err := CheckedRetryingCommand(p, ii.Name+"-ssh", sshCmd, nil, nil, 5*time.Second)
 

--- a/cmd/edgectl/status.go
+++ b/cmd/edgectl/status.go
@@ -16,7 +16,7 @@ func (d *Daemon) Status(_ *supervisor.Process, out *Emitter) error {
 	}
 	out.Send("net_overrides", d.network.IsOkay())
 	if d.cluster == nil {
-		out.Println("Not connected")
+		out.Println("Not connected (use 'edgectl connect' to connect to your cluster)")
 		out.Send("cluster", nil)
 		return nil
 	}

--- a/python/ambassador/config/resourcefetcher.py
+++ b/python/ambassador/config/resourcefetcher.py
@@ -72,6 +72,16 @@ class ResourceFetcher:
         # For deduplicating objects coming in from watt
         self.k8s_parsed: Dict[str, bool] = {}
 
+        # HACK
+        # If AGENT_SERVICE is set, skip the init dir: we'll force some defaults later
+        # instead.
+        #
+        # XXX This is rather a hack. We can do better.
+
+        if os.environ.get("AGENT_SERVICE", "").lower() != "":
+            logger.info("Intercept agent active: skipping init dir")
+            skip_init_dir = True
+
         if not skip_init_dir:
             # Check /ambassador/init-config for initialization resources -- note NOT
             # $AMBASSADOR_CONFIG_BASE_DIR/init-config! This is compile-time stuff that

--- a/python/ambassador/envoy/v2/v2listener.py
+++ b/python/ambassador/envoy/v2/v2listener.py
@@ -564,8 +564,9 @@ class V2VirtualHost(dict):
 
         self["filter_chain_match"] = match
 
-        # If we're on Edge Stack, punch a hole for ACME challenges, for every listener.
-        if self._config.ir.edge_stack_allowed:
+        # If we're on Edge Stack and we're not an intercept agent, punch a hole for ACME
+        # challenges, for every listener.
+        if self._config.ir.edge_stack_allowed and not self._config.ir.agent_active:
             found_acme = False
 
             for route in self["routes"]:
@@ -1005,9 +1006,9 @@ class V2Listener(dict):
                 first_vhost._hostname = '*'
                 first_vhost._name = f"{first_vhost._name}-forced-star"
 
-        if config.ir.edge_stack_allowed:
-            # If we're running Edge Stack, make sure we have a listener on port 8080, so that
-            # we have a place to stand for ACME.
+        if config.ir.edge_stack_allowed and not config.ir.agent_active:
+            # If we're running Edge Stack, and we're not an intercept agent, make sure we have
+            # a listener on port 8080, so that we have a place to stand for ACME.
 
             if 8080 not in listeners_by_port:
                 # Check for a listener on the main service port to see if the proxy proto

--- a/python/ambassador/ir/irhost.py
+++ b/python/ambassador/ir/irhost.py
@@ -103,7 +103,8 @@ class IRHost(IRResource):
         if self.get('acmeProvider', None):
             acme = self.acmeProvider
 
-            if ir.edge_stack_allowed:
+            # The ACME client is disabled if we're running as an intercept agent.
+            if ir.edge_stack_allowed and not ir.agent_active:
                 authority = acme.get('authority', None)
 
                 if authority and (authority.lower() != 'none'):
@@ -184,9 +185,13 @@ class HostFactory:
                 else:
                     ir.logger.info(f"HostFactory: not saving inactive host {host.pretty()}")
 
+    @classmethod
+    def finalize(cls, ir: 'IR', aconf: Config) -> None:
         if ir.edge_stack_allowed:
             # We're running Edge Stack. Figure out how many hosts we have, and whether
             # we have any termination contexts.
+            #
+            # If we're running as an intercept agent, there should be a Host in all cases.
             host_count = len(ir.get_hosts() or [])
             contexts = ir.get_tls_contexts() or []
 

--- a/python/ambassador/ir/irhttpmapping.py
+++ b/python/ambassador/ir/irhttpmapping.py
@@ -154,6 +154,12 @@ class IRHTTPMapping (IRBaseMapping):
         if 'method' in kwargs:
             hdrs.append(Header(":method", kwargs['method'], kwargs.get('method_regex', False)))
 
+        # XXX BRUTAL HACK HERE: 
+        # If we _don't_ have an origination context, but our IR has an agent_origination_ctx,
+        # force TLS origination because it's the agent. I know, I know. It's a hack.
+        if ('tls' not in new_args) and ir.agent_origination_ctx:
+            ir.logger.info(f"Mapping {name}: Agent forcing origination TLS context to {ir.agent_origination_ctx.name}")
+            new_args['tls'] = ir.agent_origination_ctx.name
 
         # ...and then init the superclass.
         super().__init__(


### PR DESCRIPTION
Neuter a lot of the old sidecar stuff and use an actual Ambassador to do routing, with `edgectl intercept` managing the mappings for the intercepts.

It's probably simplest to review the whole thing at once, rather than commit-by-commit.