### PR TITLE
More backports from the Envoy 1.13 adventure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ branches:
   only:
     - master
     - /^shared\/.*/
+    - /^rel\/v.*/
     - /^v[0-9]+\.[0-9]+\.[0-9]+(-.*)?$/
 
 services:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,20 +24,25 @@ for all users, and includes all the functionality of the Ambassador API Gateway 
 to the additional capabilities mentioned above. Due to popular demand, we’re offering a free
 tier of our core features as part of the Ambassador Edge Stack, designed for startups.
 
-There is one breaking change between Ambassador 0.85.0 and Edge Stack 1.0.0: the `RateLimitService`
-protocol `pb.lyft.ratelimit.RateLimitService` is no longer supported. `RateLimitService`s must now
-use the `envoy.service.ratelimit.v2.RateLimitService`.
-
 ### UPCOMING PROTOCOL CHANGES
 
-*In a future version*, Ambassador will change the version of the GRPC protocol used to
-communicate with `AuthService`s:
+*In a future version*, Ambassador will change the version of the gRPC service name used to
+communicate with `AuthService`s and `RateLimitService`s:
 
-| Resource | Current version | Upcoming version |
-| :------- | :-------------- | :--------------- |
-| `AuthService` | `envoy.service.auth.v2alpha` | `envoy.service.auth.v2` |
+| Resource           | Current service name                       | Upcoming service name                         |
+| :----------------- | :----------------------------------------- | :-------------------------------------------- |
+| `AuthService`      | `envoy.service.auth.v2alpha.Authorization` | `envoy.service.auth.v2.Authorization`         |
+| `RateLimitService` | `pb.lyft.ratelimit.RateLimitService`       | `envoy.service.ratelimit.v2.RateLimitService` |
 
-These changes will not take effect until at least Ambassador 1.1.0. We expect to support both protocol versions during a transition period.
+- In some future version of Ambassador, there will be settings to control which name is
+  used; with the default being the current name; it will be opt-in to the new names.
+- In some future version of Ambassador after that, *no sooner than Ambassador 1.3.0*, the
+  default values of those setting swill change; making them opt-out from the new names.
+- In some future version of Ambassador after that, *no sooner than Ambassador 1.4.0*, the
+  settings will go away, and Ambassador will always use the new names.
+
+Note that Ambassador Edge Stack `External` Filters already unconditionally use the newer
+`envoy.service.auth.v2.Authorization` name.
 
 ## RELEASE NOTES
 

--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -66,7 +66,7 @@ RUN apk --no-cache add bash bash-completion ncurses curl jq rsync python3 python
 RUN sh -c "/usr/bin/kubectl completion bash > /usr/share/bash-completion/completions/kubectl"
 RUN chmod u+s $(which docker)
 
-COPY --from=envoy /usr/local/bin/envoy /usr/local/bin/envoy
+COPY --from=envoy /usr/local/bin/envoy-static-stripped /usr/local/bin/envoy
 
 ENV KUBECONFIG=/buildroot/kubeconfig.yaml
 
@@ -109,7 +109,7 @@ RUN apk --no-cache add bash curl python3 libcap
 
 RUN ln -s /usr/bin/python3 /usr/bin/python
 
-COPY --from=envoy /usr/local/bin/envoy /usr/local/bin/envoy
+COPY --from=envoy /usr/local/bin/envoy-static-stripped /usr/local/bin/envoy
 COPY --from=artifacts /usr/lib/python3.7/site-packages /usr/lib/python3.7/site-packages
 COPY --from=artifacts /usr/lib/libyaml* /usr/lib/
 

--- a/cxx/envoy.mk
+++ b/cxx/envoy.mk
@@ -10,10 +10,11 @@ IS_PRIVATE ?= $(findstring private,$(_git_remote_urls))
 
 # IF YOU MESS WITH ANY OF THESE VALUES, YOU MUST RUN `make update-base`.
   ENVOY_REPO ?= $(if $(IS_PRIVATE),git@github.com:datawire/envoy-private.git,git://github.com/datawire/envoy.git)
-  ENVOY_COMMIT ?= d17d947caef13f1bdd235c3fccff77814883bb46
+  ENVOY_COMMIT ?= 3bc432257e20e07a49d6213c8f255bbeb4edd561
   ENVOY_COMPILATION_MODE ?= opt
-  # Increment BASE_ENVOY_RELVER on changes to `docker/base-envoy/Dockerfile`, or Envoy recipes
-  BASE_ENVOY_RELVER ?= 8
+  # Increment BASE_ENVOY_RELVER on changes to `docker/base-envoy/Dockerfile`, or Envoy recipes.
+  # You may reset BASE_ENVOY_RELVER when adjusting ENVOY_COMMIT.
+  BASE_ENVOY_RELVER ?= 1
 
   ENVOY_DOCKER_REPO ?= quay.io/datawire/ambassador-base$(if $(IS_PRIVATE),-private)
   ENVOY_DOCKER_VERSION ?= $(BASE_ENVOY_RELVER).$(ENVOY_COMMIT).$(ENVOY_COMPILATION_MODE)

--- a/cxx/envoy.mk
+++ b/cxx/envoy.mk
@@ -13,7 +13,7 @@ IS_PRIVATE ?= $(findstring private,$(_git_remote_urls))
   ENVOY_COMMIT ?= d17d947caef13f1bdd235c3fccff77814883bb46
   ENVOY_COMPILATION_MODE ?= opt
   # Increment BASE_ENVOY_RELVER on changes to `docker/base-envoy/Dockerfile`, or Envoy recipes
-  BASE_ENVOY_RELVER ?= 7
+  BASE_ENVOY_RELVER ?= 8
 
   ENVOY_DOCKER_REPO ?= quay.io/datawire/ambassador-base$(if $(IS_PRIVATE),-private)
   ENVOY_DOCKER_VERSION ?= $(BASE_ENVOY_RELVER).$(ENVOY_COMMIT).$(ENVOY_COMPILATION_MODE)
@@ -103,7 +103,7 @@ ENVOY_SYNC_DOCKER_TO_HOST = rsync -Pav --delete --blocking-io -e "docker exec -i
 ENVOY_BASH.cmd = bash -c 'PS4=; set -ex; $(ENVOY_SYNC_HOST_TO_DOCKER); trap '\''$(ENVOY_SYNC_DOCKER_TO_HOST)'\'' EXIT; '$(call quote.shell,$1)
 ENVOY_BASH.deps = $(srcdir)/envoy-build-container.txt
 
-$(OSS_HOME)/bin_linux_amd64/envoy-static: $(ENVOY_BASH.deps) FORCE
+$(OSS_HOME)/docker/base-envoy/envoy-static: $(ENVOY_BASH.deps) FORCE
 	mkdir -p $(@D)
 	@PS4=; set -ex; { \
 	    if docker run --rm --entrypoint=true $(ENVOY_DOCKER_TAG); then \
@@ -154,9 +154,8 @@ envoy-shell: $(ENVOY_BASH.deps)
 $(OSS_HOME)/api/envoy: $(srcdir)/envoy
 	rsync --recursive --delete --delete-excluded --prune-empty-dirs --include='*/' --include='*.proto' --exclude='*' $</api/envoy/ $@
 
-update-base: $(OSS_HOME)/bin_linux_amd64/envoy-static-stripped
-	cp --force $(OSS_HOME)/bin_linux_amd64/envoy-static-stripped $(srcdir)/envoy-static
-	docker build -f $(OSS_HOME)/docker/base-envoy/Dockerfile $(srcdir) -t $(ENVOY_DOCKER_TAG)
+update-base: $(srcdir)/envoy-build-image.txt $(OSS_HOME)/docker/base-envoy/envoy-static $(OSS_HOME)/docker/base-envoy/envoy-static-stripped
+	docker build --build-arg=base=$$(cat $(srcdir)/envoy-build-image.txt) -t $(ENVOY_DOCKER_TAG) $(OSS_HOME)/docker/base-envoy
 	$(MAKE) generate
 	docker push $(ENVOY_DOCKER_TAG)
 .PHONY: update-base
@@ -171,14 +170,22 @@ _clean-envoy: _clean-envoy-old
 _clean-envoy: $(srcdir)/envoy-build-container.txt.clean
 	rm -f $(srcdir)/envoy-build-image.txt
 _clobber-envoy: _clean-envoy
+	rm -f $(OSS_HOME)/docker/base-envoy/envoy-static
+	rm -f $(OSS_HOME)/docker/base-envoy/envoy-static-stripped
 	$(if $(filter-out -,$(ENVOY_COMMIT)),rm -rf $(srcdir)/envoy)
 .PHONY: _clean-envoy _clobber-envoy
 
 # Files made by older versions.  Remove the tail of this list when the
 # commit making the change gets far enough in to the past.
-_clean-envoy-old:
+
 # 2019-10-11
 _clean-envoy-old: $(OSS_HOME)/envoy-build-container.txt.clean
+
+_clean-envoy-old:
+# 2020-02-20
+	rm -f $(OSS_HOME)/cxx/envoy-static
+	rm -f $(OSS_HOME)/bin_linux_amd64/envoy-static
+	rm -f $(OSS_HOME)/bin_linux_amd64/envoy-static-stripped
 # 2019-10-11
 	rm -rf $(OSS_HOME)/envoy-bin
 	$(if $(filter-out -,$(ENVOY_COMMIT)),rm -rf $(OSS_HOME)/envoy-src)

--- a/docker/base-envoy/.gitignore
+++ b/docker/base-envoy/.gitignore
@@ -1,0 +1,2 @@
+/envoy-static
+/envoy-static-stripped

--- a/docker/base-envoy/Dockerfile
+++ b/docker/base-envoy/Dockerfile
@@ -17,6 +17,7 @@
 # in the Makefile, then run "make update-base" to build and push the
 # new image.
 
-FROM ubuntu:18.04
+ARG base="i-forgot-to-set-build-arg-base"
+FROM ${base}
 
-ADD ./envoy-static /usr/local/bin/envoy
+ADD ./envoy-static ./envoy-static-stripped /usr/local/bin/

--- a/go.sum
+++ b/go.sum
@@ -67,6 +67,7 @@ github.com/emicklei/go-restful v2.9.5+incompatible/go.mod h1:otzb+WCGbkyDHkqmQmT
 github.com/envoyproxy/protoc-gen-validate v0.0.15-0.20190405222122-d6164de49109 h1:U1RyeEwqO++6RvIA7bY98AcYIFPQMwrOeWNmw+dvq9w=
 github.com/envoyproxy/protoc-gen-validate v0.0.15-0.20190405222122-d6164de49109/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/envoyproxy/protoc-gen-validate v0.1.0 h1:EQciDnbrYxy13PgWoY8AqoxGiPrpgBZ1R8UNe3ddc+A=
+github.com/envoyproxy/protoc-gen-validate v0.3.0 h1:Y2J74o+yAfcD8jpqtkLnUqRo+yshLr4eR1WPYGX0cic=
 github.com/evanphx/json-patch v4.2.0+incompatible h1:fUDGZCv/7iAN7u0puUVhvKCcsR6vRfwrJatElLBEf0I=
 github.com/evanphx/json-patch v4.2.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=

--- a/python/tests/t_headerrouting.py
+++ b/python/tests/t_headerrouting.py
@@ -95,7 +95,7 @@ spec:
         yield ("url", Query("http://%s/ambassador/check/" % self.path.fqdn))
 
 class AuthenticationHeaderRouting(AmbassadorTest):
-    target: ServiceType
+    target1: ServiceType
     target2: ServiceType
     auth: ServiceType
 


### PR DESCRIPTION
## Description

These are some changes that I made when working on the Envoy 1.13 upgrade that I super duper want to land before we build another Envoy (regardless of whether it's a 1.13.x or still a 1.12.x).

## Testing

 - [x] `make update-base` is currently still running (so I expect CI to fail until that finishes)
 - [x] verify that the binary in the new Docker image matches what we've been shipping (result: it's not, but within expected difference of GCC vs Clang)
 - [x] `make pytest KAT_RUN_MODE=envoy`
 - [ ] `make check-envoy`

## Todos
- [ ] Tests (see above)

## Other

This is targeted at `rel/v1.2.0`; but I can re-target at a different branch if necessary.