### PR TITLE
Added edgestack.me welcome page

### DIFF
--- a/docs/edgestack.me/welcome.md
+++ b/docs/edgestack.me/welcome.md
@@ -1,0 +1,12 @@
+# Welcome to edgestack.me!
+
+edgestack.me is a URL used by getambassador.io to simplify the installation process for the Ambassador Edge Stack. 
+
+To learn more about the Ambassador Edge Stack, please visit [getambassador.io](http://getambassador.io). 
+
+If you are in the process of installing Ambassador Edge Stack and need help, please go to the installation documentation.
+
+<Button color="orange" to="/user-guide/getting-started/">Ambassador Edge Stack Installation Documentation</Button>
+
+Need Additional Help? 
+Join our [Slack channel](http://d6e.co/slack), [request a demo](https://www.getambassador.io/demo), or [talk to an expert about best practices](https://www.getambassador.io/best-practices).


### PR DESCRIPTION
## Description
Added edgestack.me welcome page for redirecting requests directly from edgestack.me to the ambassador website.

## Related Issues
https://github.com/datawire/apro/issues/904

## Testing
None -- I made an educated guess this is where the page should land for http://getambassador.io/edgestack.me/welcome but I couldn't get a fully functional dev loop.

## Todos
- [ ] Tests
- [ ] Documentation

## Other
* If this is a documentation change, please open the pull request at https://github.com/datawire/ambassador-docs instead.
* Code changes should occur against `master`.
