### PR TITLE
More custom-build-name stuff

### DIFF
--- a/builder/builder.mk
+++ b/builder/builder.mk
@@ -347,80 +347,87 @@ results.
 
 The build system doesn't try to magically handle all dependencies. In
 general, if you change something that is not pure source code, you will
-likely need to do a $(BLD)make clean$(END) in order to see the effect. For example,
+likely need to do a $(BLD)$(MAKE) clean$(END) in order to see the effect. For example,
 Python code only gets set up once, so if you change $(BLD)requirements.txt$(END) or
 $(BLD)setup.py$(END), then you will need to do a clean build to see the effects.
-Assuming you didn't $(BLD)make clobber$(END), this shouldn't take long due to the
+Assuming you didn't $(BLD)$(MAKE) clobber$(END), this shouldn't take long due to the
 cache in the Docker volume.
 
 Use $(BLD)$(MAKE) $(BLU)targets$(END) for help about available $(BLD)make$(END) targets.
 endef
 
 define _help.targets
-  $(BLD)make $(BLU)help$(END)      -- displays the main help message.
+  $(BLD)$(MAKE) $(BLU)help$(END)      -- displays the main help message.
 
-  $(BLD)make $(BLU)targets$(END)   -- displays this message.
+  $(BLD)$(MAKE) $(BLU)targets$(END)   -- displays this message.
 
-  $(BLD)make $(BLU)env$(END)       -- display the value of important env vars.
+  $(BLD)$(MAKE) $(BLU)env$(END)       -- display the value of important env vars.
 
-  $(BLD)make $(BLU)export$(END)    -- display important env vars in shell syntax, for use with $(BLD)eval$(END).
+  $(BLD)$(MAKE) $(BLU)export$(END)    -- display important env vars in shell syntax, for use with $(BLD)eval$(END).
 
-  $(BLD)make $(BLU)preflight$(END) -- checks dependencies of this makefile.
+  $(BLD)$(MAKE) $(BLU)preflight$(END) -- checks dependencies of this makefile.
 
-  $(BLD)make $(BLU)sync$(END)      -- syncs source code into the build container.
+  $(BLD)$(MAKE) $(BLU)sync$(END)      -- syncs source code into the build container.
 
-  $(BLD)make $(BLU)version$(END)   -- display source code version.
+  $(BLD)$(MAKE) $(BLU)version$(END)   -- display source code version.
 
-  $(BLD)make $(BLU)compile$(END)   -- syncs and compiles the source code in the build container.
+  $(BLD)$(MAKE) $(BLU)compile$(END)   -- syncs and compiles the source code in the build container.
 
-  $(BLD)make $(BLU)images$(END)    -- creates images from the build container.
+  $(BLD)$(MAKE) $(BLU)images$(END)    -- creates images from the build container.
 
-  $(BLD)make $(BLU)push$(END)      -- pushes images to $(BLD)\$$DEV_REGISTRY$(END). ($(DEV_REGISTRY))
+  $(BLD)$(MAKE) $(BLU)push$(END)      -- pushes images to $(BLD)\$$DEV_REGISTRY$(END). ($(DEV_REGISTRY))
 
-  $(BLD)make $(BLU)test$(END)      -- runs Go and Python tests inside the build container.
+  $(BLD)$(MAKE) $(BLU)test$(END)      -- runs Go and Python tests inside the build container.
 
     The tests require a Kubernetes cluster and a Docker registry in order to
-    function. These must be supplied via the $(BLD)make$(END)/$(BLD)env$(END) variables $(BLD)\$$DEV_KUBECONFIG$(END)
+    function. These must be supplied via the $(BLD)$(MAKE)$(END)/$(BLD)env$(END) variables $(BLD)\$$DEV_KUBECONFIG$(END)
     and $(BLD)\$$DEV_REGISTRY$(END).
 
-  $(BLD)make $(BLU)gotest$(END)    -- runs just the Go tests inside the build container.
+  $(BLD)$(MAKE) $(BLU)gotest$(END)    -- runs just the Go tests inside the build container.
 
     Use $(BLD)\$$GOTEST_PKGS$(END) to control which packages are passed to $(BLD)gotest$(END). ($(GOTEST_PKGS))
     Use $(BLD)\$$GOTEST_ARGS$(END) to supply additional non-package arguments. ($(GOTEST_ARGS))
-    Example: $(BLD)make gotest GOTEST_PKGS=./cmd/edgectl GOTEST_ARGS=-v$(END)  # run edgectl tests verbosely
+    Example: $(BLD)$(MAKE) gotest GOTEST_PKGS=./cmd/edgectl GOTEST_ARGS=-v$(END)  # run edgectl tests verbosely
 
-  $(BLD)make $(BLU)pytest$(END)    -- runs just the Python tests inside the build container.
+  $(BLD)$(MAKE) $(BLU)pytest$(END)    -- runs just the Python tests inside the build container.
+
+    Use $(BLD)\$$KAT_RUN_MODE=envoy$(END) to force the Python tests to ignore local caches, and run everything
+    in the cluster.
+
+    Use $(BLD)\$$KAT_RUN_MODE=local$(END) to force the Python tests to ignore the cluster, and only run tests
+    with a local cache.
 
     Use $(BLD)\$$PYTEST_ARGS$(END) to pass args to $(BLD)pytest$(END). ($(PYTEST_ARGS))
-    Example: $(BLD)make pytest PYTEST_ARGS=\"-k schemas\"$(END)  # run only tests with \"schemas\" in the name
 
-  $(BLD)make $(BLU)shell$(END)     -- starts a shell in the build container.
+    Example: $(BLD)$(MAKE) pytest KAT_RUN_MODE=envoy PYTEST_ARGS=\"-k Lua\"$(END)  # run only the Lua test, with a real Envoy
 
-  $(BLD)make $(BLU)release/bits$(END) -- do the 'push some bits' part of a release
+  $(BLD)$(MAKE) $(BLU)shell$(END)     -- starts a shell in the build container.
+
+  $(BLD)$(MAKE) $(BLU)release/bits$(END) -- do the 'push some bits' part of a release
 
     The current commit must be tagged for this to work, and your tree must be clean.
     If the tag is of the form 'vX.Y.Z-(ea|rc).[0-9]*'.
 
-  $(BLD)make $(BLU)release/promote-oss/to-ea-latest$(END) -- promote an early-access '-ea.N' release to '-ea-latest'
+  $(BLD)$(MAKE) $(BLU)release/promote-oss/to-ea-latest$(END) -- promote an early-access '-ea.N' release to '-ea-latest'
 
     The current commit must be tagged for this to work, and your tree must be clean.
     Additionally, the tag must be of the form 'vX.Y.Z-ea.N'. You must also have previously
     built an EA for the same tag using $(BLD)release/bits$(END).
 
-  $(BLD)make $(BLU)release/promote-oss/to-rc-latest$(END) -- promote a release candidate '-rc.N' release to '-rc-latest'
+  $(BLD)$(MAKE) $(BLU)release/promote-oss/to-rc-latest$(END) -- promote a release candidate '-rc.N' release to '-rc-latest'
 
     The current commit must be tagged for this to work, and your tree must be clean.
     Additionally, the tag must be of the form 'vX.Y.Z-rc.N'. You must also have previously
     built an RC for the same tag using $(BLD)release/bits$(END).
 
-  $(BLD)make $(BLU)release/promote-oss/to-ga$(END) -- promote a release candidate to general availability
+  $(BLD)$(MAKE) $(BLU)release/promote-oss/to-ga$(END) -- promote a release candidate to general availability
 
     The current commit must be tagged for this to work, and your tree must be clean.
     Additionally, the tag must be of the form 'vX.Y.Z'. You must also have previously
     built and promoted the RC that will become GA, using $(BLD)release/bits$(END) and
     $(BLD)release/promote-oss/to-rc-latest$(END).
 
-  $(BLD)make $(BLU)clean$(END)     -- kills the build container.
+  $(BLD)$(MAKE) $(BLU)clean$(END)     -- kills the build container.
 
-  $(BLD)make $(BLU)clobber$(END)   -- kills the build container and the cache volume.
+  $(BLD)$(MAKE) $(BLU)clobber$(END)   -- kills the build container and the cache volume.
 endef

--- a/builder/builder.mk
+++ b/builder/builder.mk
@@ -269,6 +269,7 @@ CURRENT_CONTEXT=$(shell kubectl --kubeconfig=$(DEV_KUBECONFIG) config current-co
 CURRENT_NAMESPACE=$(shell kubectl config view -o=jsonpath="{.contexts[?(@.name==\"$(CURRENT_CONTEXT)\")].context.namespace}")
 
 env:
+	@printf "$(BLD)BUILDER_NAME$(END)=$(BLU)\"$(BUILDER_NAME)\"$(END)\n"
 	@printf "$(BLD)DEV_KUBECONFIG$(END)=$(BLU)\"$(DEV_KUBECONFIG)\"$(END)"
 	@printf " # Context: $(BLU)$(CURRENT_CONTEXT)$(END), Namespace: $(BLU)$(CURRENT_NAMESPACE)$(END)\n"
 	@printf "$(BLD)DEV_REGISTRY$(END)=$(BLU)\"$(DEV_REGISTRY)\"$(END)\n"
@@ -279,6 +280,7 @@ env:
 .PHONY: env
 
 export:
+	@printf "export BUILDER_NAME=\"$(BUILDER_NAME)\"\n"
 	@printf "export DEV_KUBECONFIG=\"$(DEV_KUBECONFIG)\"\n"
 	@printf "export DEV_REGISTRY=\"$(DEV_REGISTRY)\"\n"
 	@printf "export RELEASE_REGISTRY=\"$(RELEASE_REGISTRY)\"\n"
@@ -329,6 +331,13 @@ cache and $(BLD)pip$(END) downloads) to be cached across builds.
 This arrangement also permits building multiple codebases. This is useful
 for producing builds with extended functionality. Each external codebase
 is synced into the container at the $(BLD)/buildroot/<name>$(END) path.
+
+You can control the name of the container and the images it builds by
+setting $(BLU)\$$BUILDER_NAME$(END), which defaults to $(BLU)$(NAME)$(END). $(BLD)Note well$(END) that if you
+want to make multiple clones of this repo and build in more than one of them
+at the same time, you $(BLD)must$(END) set $(BLU)\$$BUILDER_NAME$(END) so that each clone has its own
+builder! If you do not do this, your builds will collide with confusing 
+results.
 
 The build system doesn't try to magically handle all dependencies. In
 general, if you change something that is not pure source code, you will

--- a/builder/builder.mk
+++ b/builder/builder.mk
@@ -330,7 +330,7 @@ a Docker container. The $(BLD)$(REPO)$(END), $(BLD)kat-server$(END), and $(BLD)k
 created from this container after the build stage is finished.
 
 The build works by maintaining a running build container in the background.
-It gets source code into that container via $(BLD)rsync$(END). The $(BLD)/root$(END) directory in
+It gets source code into that container via $(BLD)rsync$(END). The $(BLD)/home/dw$(END) directory in
 this container is a Docker volume, which allows files (e.g. the Go build
 cache and $(BLD)pip$(END) downloads) to be cached across builds.
 

--- a/builder/builder.mk
+++ b/builder/builder.mk
@@ -290,7 +290,11 @@ export:
 .PHONY: export
 
 help:
-	@printf "$(subst $(NL),\n,$(HELP))\n"
+	@printf "$(subst $(NL),\n,$(HELP_INTRO))\n"
+.PHONY: help
+
+targets:
+	@printf "$(subst $(NL),\n,$(HELP_TARGETS))\n"
 .PHONY: help
 
 # NOTE: this is not a typo, this is actually how you spell newline in Make
@@ -306,9 +310,11 @@ endef
 
 COMMA = ,
 
-define HELP
+define HELP_INTRO
 $(_help.intro)
+endef
 
+define HELP_TARGETS
 $(BLD)Targets:$(END)
 
 $(_help.targets)
@@ -346,12 +352,18 @@ Python code only gets set up once, so if you change $(BLD)requirements.txt$(END)
 $(BLD)setup.py$(END), then you will need to do a clean build to see the effects.
 Assuming you didn't $(BLD)make clobber$(END), this shouldn't take long due to the
 cache in the Docker volume.
+
+Use $(BLD)$(MAKE) $(BLU)targets$(END) for help about available $(BLD)make$(END) targets.
 endef
 
 define _help.targets
-  $(BLD)make $(BLU)help$(END)      -- displays this message.
+  $(BLD)make $(BLU)help$(END)      -- displays the main help message.
+
+  $(BLD)make $(BLU)targets$(END)   -- displays this message.
 
   $(BLD)make $(BLU)env$(END)       -- display the value of important env vars.
+
+  $(BLD)make $(BLU)export$(END)    -- display important env vars in shell syntax, for use with $(BLD)eval$(END).
 
   $(BLD)make $(BLU)preflight$(END) -- checks dependencies of this makefile.
 

--- a/builder/builder.mk
+++ b/builder/builder.mk
@@ -83,13 +83,13 @@ compile:
 	@$(BUILDER) compile
 .PHONY: compile
 
-SNAPSHOT=snapshot-$(NAME)
+SNAPSHOT=snapshot-$(BUILDER_NAME)
 
 commit:
 	@$(BUILDER) commit $(SNAPSHOT)
 .PHONY: commit
 
-REPO=$(NAME)
+REPO=$(BUILDER_NAME)
 
 images:
 	@$(MAKE) --no-print-directory compile

--- a/builder/builder.sh
+++ b/builder/builder.sh
@@ -80,8 +80,9 @@ bootstrap() {
             exit 1
         fi
 
+        now=$(date +"%H%M%S")
         echo_on
-        $DOCKER_RUN --name "builder-${BUILDER_NAME}" --network "${DOCKER_NETWORK}" --network-alias "builder" --group-add ${DOCKER_GID} -d --rm -v /var/run/docker.sock:/var/run/docker.sock -v $(builder_volume):/home/dw ${BUILDER_MOUNTS} --cap-add NET_ADMIN -lbuilder -l${BUILDER_NAME} ${BUILDER_PORTMAPS} -e BUILDER_NAME=${BUILDER_NAME} --entrypoint tail builder -f /dev/null > /dev/null
+        $DOCKER_RUN --name "bld-${BUILDER_NAME}-${now}" --network "${DOCKER_NETWORK}" --network-alias "builder" --group-add ${DOCKER_GID} -d --rm -v /var/run/docker.sock:/var/run/docker.sock -v $(builder_volume):/home/dw ${BUILDER_MOUNTS} --cap-add NET_ADMIN -lbuilder -l${BUILDER_NAME} ${BUILDER_PORTMAPS} -e BUILDER_NAME=${BUILDER_NAME} --entrypoint tail builder -f /dev/null > /dev/null
         echo_off
 
         printf "${GRN}Started build container ${BLU}$(builder)${END}\n"


### PR DESCRIPTION
Extend the custom names into the `SNAPSHOT` and `REPO` variables, to fully isolate images across builds.

**NOTE WELL** that if you set `BUILDER_NAME=foo`, then instead of getting an image named e.g. `ambassador:latest`, you'll now get `foo:latest`. `make export` will show you the correct information, of course.