### PR TITLE
Switch to Envoy proxy_protocol filter instead of using use_proxy_proto.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,15 @@ Format:
 --->
 
 <!--- CueAddReleaseNotes --->
+## [Next] TBD
+[Next]: https://github.com/datawire/ambassador/compare/v1.2.0...Next
+
+### Ambassador API Gateway + Ambassador Edge Stack
+
+- Bugfix: re-support PROXY protocol when terminating TLS ([#2348])
+
+[#2348]: https://github.com/datawire/ambassador/issues/2348
+
 ## [1.2.0] February 24, 2020
 [1.2.0]: https://github.com/datawire/ambassador/compare/v1.1.1...v1.2.0
 

--- a/python/tests/gold/acceptancegrpcbridgetest/snapshots/econf.json
+++ b/python/tests/gold/acceptancegrpcbridgetest/snapshots/econf.json
@@ -307,8 +307,7 @@
                                     "xff_num_trusted_hops": 0
                                 }
                             }
-                        ],
-                        "use_proxy_proto": false
+                        ]
                     }
                 ],
                 "listener_filters": [],

--- a/python/tests/gold/acceptancegrpcbridgetest/snapshots/snapshot.yaml
+++ b/python/tests/gold/acceptancegrpcbridgetest/snapshots/snapshot.yaml
@@ -23,7 +23,7 @@
                         "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Module\nname: ambassador\nconfig:\n  enable_grpc_http11_bridge: True\nambassador_id: acceptancegrpcbridgetest\n\n---\napiVersion: ambassador/v0\nkind: Mapping\ngrpc: True\nprefix: /echo.EchoService/\nrewrite: /echo.EchoService/\nname: acceptancegrpcbridgetest-egrpc\nservice: acceptancegrpcbridgetest-egrpc\nambassador_id: acceptancegrpcbridgetest\n",
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Module\\nname: ambassador\\nconfig:\\n  enable_grpc_http11_bridge: True\\nambassador_id: acceptancegrpcbridgetest\\n\\n---\\napiVersion: ambassador/v0\\nkind: Mapping\\ngrpc: True\\nprefix: /echo.EchoService/\\nrewrite: /echo.EchoService/\\nname: acceptancegrpcbridgetest-egrpc\\nservice: acceptancegrpcbridgetest-egrpc\\nambassador_id: acceptancegrpcbridgetest\\n\"},\"labels\":{\"app.kubernetes.io/component\":\"ambassador-service\",\"kat-ambassador-id\":\"acceptancegrpcbridgetest\",\"scope\":\"AmbassadorTest\"},\"name\":\"acceptancegrpcbridgetest\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8080},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8443}],\"selector\":{\"service\":\"acceptancegrpcbridgetest\"},\"type\":\"NodePort\"}}\n"
                     },
-                    "creationTimestamp": "2020-02-19T23:20:03Z",
+                    "creationTimestamp": "2020-02-26T15:51:45Z",
                     "labels": {
                         "app.kubernetes.io/component": "ambassador-service",
                         "kat-ambassador-id": "acceptancegrpcbridgetest",
@@ -31,24 +31,24 @@
                     },
                     "name": "acceptancegrpcbridgetest",
                     "namespace": "default",
-                    "resourceVersion": "55539",
+                    "resourceVersion": "66213",
                     "selfLink": "/api/v1/namespaces/default/services/acceptancegrpcbridgetest",
-                    "uid": "5b9c24d3-536e-11ea-85dd-167682b5c255"
+                    "uid": "e3e6d533-58af-11ea-86d6-0e674b3ff44f"
                 },
                 "spec": {
-                    "clusterIP": "10.97.176.134",
+                    "clusterIP": "10.104.137.61",
                     "externalTrafficPolicy": "Cluster",
                     "ports": [
                         {
                             "name": "http",
-                            "nodePort": 30134,
+                            "nodePort": 32683,
                             "port": 80,
                             "protocol": "TCP",
                             "targetPort": 8080
                         },
                         {
                             "name": "https",
-                            "nodePort": 30870,
+                            "nodePort": 30610,
                             "port": 443,
                             "protocol": "TCP",
                             "targetPort": 8443
@@ -71,7 +71,7 @@
                     "annotations": {
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"acceptancegrpcbridgetest\",\"scope\":\"AmbassadorTest\",\"service\":\"acceptancegrpcbridgetest-admin\"},\"name\":\"acceptancegrpcbridgetest-admin\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"acceptancegrpcbridgetest-admin\",\"port\":8877,\"targetPort\":8877}],\"selector\":{\"service\":\"acceptancegrpcbridgetest\"},\"type\":\"NodePort\"}}\n"
                     },
-                    "creationTimestamp": "2020-02-19T23:20:03Z",
+                    "creationTimestamp": "2020-02-26T15:51:45Z",
                     "labels": {
                         "kat-ambassador-id": "acceptancegrpcbridgetest",
                         "scope": "AmbassadorTest",
@@ -79,17 +79,17 @@
                     },
                     "name": "acceptancegrpcbridgetest-admin",
                     "namespace": "default",
-                    "resourceVersion": "55543",
+                    "resourceVersion": "66218",
                     "selfLink": "/api/v1/namespaces/default/services/acceptancegrpcbridgetest-admin",
-                    "uid": "5ba44630-536e-11ea-85dd-167682b5c255"
+                    "uid": "e3f1e5fc-58af-11ea-86d6-0e674b3ff44f"
                 },
                 "spec": {
-                    "clusterIP": "10.102.188.153",
+                    "clusterIP": "10.108.249.91",
                     "externalTrafficPolicy": "Cluster",
                     "ports": [
                         {
                             "name": "acceptancegrpcbridgetest-admin",
-                            "nodePort": 30554,
+                            "nodePort": 32665,
                             "port": 8877,
                             "protocol": "TCP",
                             "targetPort": 8877
@@ -112,19 +112,19 @@
                     "annotations": {
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"acceptancegrpcbridgetest\",\"scope\":\"AmbassadorTest\"},\"name\":\"acceptancegrpcbridgetest-egrpc\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8080},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8443}],\"selector\":{\"backend\":\"acceptancegrpcbridgetest-egrpc\"}}}\n"
                     },
-                    "creationTimestamp": "2020-02-19T23:20:03Z",
+                    "creationTimestamp": "2020-02-26T15:51:45Z",
                     "labels": {
                         "kat-ambassador-id": "acceptancegrpcbridgetest",
                         "scope": "AmbassadorTest"
                     },
                     "name": "acceptancegrpcbridgetest-egrpc",
                     "namespace": "default",
-                    "resourceVersion": "55549",
+                    "resourceVersion": "66224",
                     "selfLink": "/api/v1/namespaces/default/services/acceptancegrpcbridgetest-egrpc",
-                    "uid": "5bb22da8-536e-11ea-85dd-167682b5c255"
+                    "uid": "e4059bd7-58af-11ea-86d6-0e674b3ff44f"
                 },
                 "spec": {
-                    "clusterIP": "10.98.25.17",
+                    "clusterIP": "10.102.100.73",
                     "ports": [
                         {
                             "name": "http",

--- a/python/tests/gold/acceptancegrpctest/snapshots/econf.json
+++ b/python/tests/gold/acceptancegrpctest/snapshots/econf.json
@@ -303,8 +303,7 @@
                                     "xff_num_trusted_hops": 0
                                 }
                             }
-                        ],
-                        "use_proxy_proto": false
+                        ]
                     }
                 ],
                 "listener_filters": [],

--- a/python/tests/gold/acceptancegrpctest/snapshots/snapshot.yaml
+++ b/python/tests/gold/acceptancegrpctest/snapshots/snapshot.yaml
@@ -23,7 +23,7 @@
                         "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\ngrpc: True\nprefix: /echo.EchoService/\nrewrite: /echo.EchoService/\nname: acceptancegrpctest-egrpc\nservice: acceptancegrpctest-egrpc\nambassador_id: acceptancegrpctest\n",
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\ngrpc: True\\nprefix: /echo.EchoService/\\nrewrite: /echo.EchoService/\\nname: acceptancegrpctest-egrpc\\nservice: acceptancegrpctest-egrpc\\nambassador_id: acceptancegrpctest\\n\"},\"labels\":{\"app.kubernetes.io/component\":\"ambassador-service\",\"kat-ambassador-id\":\"acceptancegrpctest\",\"scope\":\"AmbassadorTest\"},\"name\":\"acceptancegrpctest\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8080},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8443}],\"selector\":{\"service\":\"acceptancegrpctest\"},\"type\":\"NodePort\"}}\n"
                     },
-                    "creationTimestamp": "2020-02-19T23:20:00Z",
+                    "creationTimestamp": "2020-02-26T15:51:43Z",
                     "labels": {
                         "app.kubernetes.io/component": "ambassador-service",
                         "kat-ambassador-id": "acceptancegrpctest",
@@ -31,24 +31,24 @@
                     },
                     "name": "acceptancegrpctest",
                     "namespace": "default",
-                    "resourceVersion": "55458",
+                    "resourceVersion": "66149",
                     "selfLink": "/api/v1/namespaces/default/services/acceptancegrpctest",
-                    "uid": "59926d1b-536e-11ea-85dd-167682b5c255"
+                    "uid": "e2e7e554-58af-11ea-86d6-0e674b3ff44f"
                 },
                 "spec": {
-                    "clusterIP": "10.99.182.201",
+                    "clusterIP": "10.111.31.139",
                     "externalTrafficPolicy": "Cluster",
                     "ports": [
                         {
                             "name": "http",
-                            "nodePort": 30468,
+                            "nodePort": 31885,
                             "port": 80,
                             "protocol": "TCP",
                             "targetPort": 8080
                         },
                         {
                             "name": "https",
-                            "nodePort": 30582,
+                            "nodePort": 31187,
                             "port": 443,
                             "protocol": "TCP",
                             "targetPort": 8443
@@ -71,7 +71,7 @@
                     "annotations": {
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"acceptancegrpctest\",\"scope\":\"AmbassadorTest\",\"service\":\"acceptancegrpctest-admin\"},\"name\":\"acceptancegrpctest-admin\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"acceptancegrpctest-admin\",\"port\":8877,\"targetPort\":8877}],\"selector\":{\"service\":\"acceptancegrpctest\"},\"type\":\"NodePort\"}}\n"
                     },
-                    "creationTimestamp": "2020-02-19T23:20:00Z",
+                    "creationTimestamp": "2020-02-26T15:51:43Z",
                     "labels": {
                         "kat-ambassador-id": "acceptancegrpctest",
                         "scope": "AmbassadorTest",
@@ -79,17 +79,17 @@
                     },
                     "name": "acceptancegrpctest-admin",
                     "namespace": "default",
-                    "resourceVersion": "55462",
+                    "resourceVersion": "66154",
                     "selfLink": "/api/v1/namespaces/default/services/acceptancegrpctest-admin",
-                    "uid": "599b6c0c-536e-11ea-85dd-167682b5c255"
+                    "uid": "e2f87640-58af-11ea-86d6-0e674b3ff44f"
                 },
                 "spec": {
-                    "clusterIP": "10.108.58.11",
+                    "clusterIP": "10.110.250.120",
                     "externalTrafficPolicy": "Cluster",
                     "ports": [
                         {
                             "name": "acceptancegrpctest-admin",
-                            "nodePort": 31334,
+                            "nodePort": 30553,
                             "port": 8877,
                             "protocol": "TCP",
                             "targetPort": 8877
@@ -112,19 +112,19 @@
                     "annotations": {
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"acceptancegrpctest\",\"scope\":\"AmbassadorTest\"},\"name\":\"acceptancegrpctest-egrpc\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8080},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8443}],\"selector\":{\"backend\":\"acceptancegrpctest-egrpc\"}}}\n"
                     },
-                    "creationTimestamp": "2020-02-19T23:20:00Z",
+                    "creationTimestamp": "2020-02-26T15:51:44Z",
                     "labels": {
                         "kat-ambassador-id": "acceptancegrpctest",
                         "scope": "AmbassadorTest"
                     },
                     "name": "acceptancegrpctest-egrpc",
                     "namespace": "default",
-                    "resourceVersion": "55469",
+                    "resourceVersion": "66161",
                     "selfLink": "/api/v1/namespaces/default/services/acceptancegrpctest-egrpc",
-                    "uid": "59a8ab1c-536e-11ea-85dd-167682b5c255"
+                    "uid": "e30e40f4-58af-11ea-86d6-0e674b3ff44f"
                 },
                 "spec": {
-                    "clusterIP": "10.107.100.112",
+                    "clusterIP": "10.97.30.54",
                     "ports": [
                         {
                             "name": "http",

--- a/python/tests/gold/acceptancegrpcwebtest/snapshots/econf.json
+++ b/python/tests/gold/acceptancegrpcwebtest/snapshots/econf.json
@@ -307,8 +307,7 @@
                                     "xff_num_trusted_hops": 0
                                 }
                             }
-                        ],
-                        "use_proxy_proto": false
+                        ]
                     }
                 ],
                 "listener_filters": [],

--- a/python/tests/gold/acceptancegrpcwebtest/snapshots/snapshot.yaml
+++ b/python/tests/gold/acceptancegrpcwebtest/snapshots/snapshot.yaml
@@ -20,9 +20,58 @@
                 "kind": "Service",
                 "metadata": {
                     "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Module\nname: ambassador\nconfig:\n  enable_grpc_web: True\nambassador_id: acceptancegrpcwebtest\n\n---\napiVersion: ambassador/v0\nkind: Mapping\ngrpc: True\nprefix: /echo.EchoService/\nrewrite: /echo.EchoService/\nname: acceptancegrpcwebtest-egrpc\nservice: acceptancegrpcwebtest-egrpc\nambassador_id: acceptancegrpcwebtest\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Module\\nname: ambassador\\nconfig:\\n  enable_grpc_web: True\\nambassador_id: acceptancegrpcwebtest\\n\\n---\\napiVersion: ambassador/v0\\nkind: Mapping\\ngrpc: True\\nprefix: /echo.EchoService/\\nrewrite: /echo.EchoService/\\nname: acceptancegrpcwebtest-egrpc\\nservice: acceptancegrpcwebtest-egrpc\\nambassador_id: acceptancegrpcwebtest\\n\"},\"labels\":{\"app.kubernetes.io/component\":\"ambassador-service\",\"kat-ambassador-id\":\"acceptancegrpcwebtest\",\"scope\":\"AmbassadorTest\"},\"name\":\"acceptancegrpcwebtest\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8080},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8443}],\"selector\":{\"service\":\"acceptancegrpcwebtest\"},\"type\":\"NodePort\"}}\n"
+                    },
+                    "creationTimestamp": "2020-02-26T15:51:45Z",
+                    "labels": {
+                        "app.kubernetes.io/component": "ambassador-service",
+                        "kat-ambassador-id": "acceptancegrpcwebtest",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "acceptancegrpcwebtest",
+                    "namespace": "default",
+                    "resourceVersion": "66240",
+                    "selfLink": "/api/v1/namespaces/default/services/acceptancegrpcwebtest",
+                    "uid": "e43ac4a5-58af-11ea-86d6-0e674b3ff44f"
+                },
+                "spec": {
+                    "clusterIP": "10.105.224.160",
+                    "externalTrafficPolicy": "Cluster",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "nodePort": 32149,
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8080
+                        },
+                        {
+                            "name": "https",
+                            "nodePort": 31338,
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8443
+                        }
+                    ],
+                    "selector": {
+                        "service": "acceptancegrpcwebtest"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "NodePort"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"acceptancegrpcwebtest\",\"scope\":\"AmbassadorTest\",\"service\":\"acceptancegrpcwebtest-admin\"},\"name\":\"acceptancegrpcwebtest-admin\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"acceptancegrpcwebtest-admin\",\"port\":8877,\"targetPort\":8877}],\"selector\":{\"service\":\"acceptancegrpcwebtest\"},\"type\":\"NodePort\"}}\n"
                     },
-                    "creationTimestamp": "2020-02-19T23:20:04Z",
+                    "creationTimestamp": "2020-02-26T15:51:46Z",
                     "labels": {
                         "kat-ambassador-id": "acceptancegrpcwebtest",
                         "scope": "AmbassadorTest",
@@ -30,17 +79,17 @@
                     },
                     "name": "acceptancegrpcwebtest-admin",
                     "namespace": "default",
-                    "resourceVersion": "55568",
+                    "resourceVersion": "66244",
                     "selfLink": "/api/v1/namespaces/default/services/acceptancegrpcwebtest-admin",
-                    "uid": "5bde39bc-536e-11ea-85dd-167682b5c255"
+                    "uid": "e4449c78-58af-11ea-86d6-0e674b3ff44f"
                 },
                 "spec": {
-                    "clusterIP": "10.97.42.91",
+                    "clusterIP": "10.109.68.210",
                     "externalTrafficPolicy": "Cluster",
                     "ports": [
                         {
                             "name": "acceptancegrpcwebtest-admin",
-                            "nodePort": 32631,
+                            "nodePort": 30585,
                             "port": 8877,
                             "protocol": "TCP",
                             "targetPort": 8877
@@ -63,19 +112,19 @@
                     "annotations": {
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"acceptancegrpcwebtest\",\"scope\":\"AmbassadorTest\"},\"name\":\"acceptancegrpcwebtest-egrpc\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8080},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8443}],\"selector\":{\"backend\":\"acceptancegrpcwebtest-egrpc\"}}}\n"
                     },
-                    "creationTimestamp": "2020-02-19T23:20:04Z",
+                    "creationTimestamp": "2020-02-26T15:51:46Z",
                     "labels": {
                         "kat-ambassador-id": "acceptancegrpcwebtest",
                         "scope": "AmbassadorTest"
                     },
                     "name": "acceptancegrpcwebtest-egrpc",
                     "namespace": "default",
-                    "resourceVersion": "55577",
+                    "resourceVersion": "66252",
                     "selfLink": "/api/v1/namespaces/default/services/acceptancegrpcwebtest-egrpc",
-                    "uid": "5bf55dd4-536e-11ea-85dd-167682b5c255"
+                    "uid": "e45b7a18-58af-11ea-86d6-0e674b3ff44f"
                 },
                 "spec": {
-                    "clusterIP": "10.96.73.82",
+                    "clusterIP": "10.103.2.217",
                     "ports": [
                         {
                             "name": "http",
@@ -95,55 +144,6 @@
                     },
                     "sessionAffinity": "None",
                     "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Module\nname: ambassador\nconfig:\n  enable_grpc_web: True\nambassador_id: acceptancegrpcwebtest\n\n---\napiVersion: ambassador/v0\nkind: Mapping\ngrpc: True\nprefix: /echo.EchoService/\nrewrite: /echo.EchoService/\nname: acceptancegrpcwebtest-egrpc\nservice: acceptancegrpcwebtest-egrpc\nambassador_id: acceptancegrpcwebtest\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Module\\nname: ambassador\\nconfig:\\n  enable_grpc_web: True\\nambassador_id: acceptancegrpcwebtest\\n\\n---\\napiVersion: ambassador/v0\\nkind: Mapping\\ngrpc: True\\nprefix: /echo.EchoService/\\nrewrite: /echo.EchoService/\\nname: acceptancegrpcwebtest-egrpc\\nservice: acceptancegrpcwebtest-egrpc\\nambassador_id: acceptancegrpcwebtest\\n\"},\"labels\":{\"app.kubernetes.io/component\":\"ambassador-service\",\"kat-ambassador-id\":\"acceptancegrpcwebtest\",\"scope\":\"AmbassadorTest\"},\"name\":\"acceptancegrpcwebtest\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8080},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8443}],\"selector\":{\"service\":\"acceptancegrpcwebtest\"},\"type\":\"NodePort\"}}\n"
-                    },
-                    "creationTimestamp": "2020-02-19T23:20:04Z",
-                    "labels": {
-                        "app.kubernetes.io/component": "ambassador-service",
-                        "kat-ambassador-id": "acceptancegrpcwebtest",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "acceptancegrpcwebtest",
-                    "namespace": "default",
-                    "resourceVersion": "55564",
-                    "selfLink": "/api/v1/namespaces/default/services/acceptancegrpcwebtest",
-                    "uid": "5bd5acc9-536e-11ea-85dd-167682b5c255"
-                },
-                "spec": {
-                    "clusterIP": "10.104.111.122",
-                    "externalTrafficPolicy": "Cluster",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "nodePort": 31477,
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8080
-                        },
-                        {
-                            "name": "https",
-                            "nodePort": 31809,
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8443
-                        }
-                    ],
-                    "selector": {
-                        "service": "acceptancegrpcwebtest"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "NodePort"
                 },
                 "status": {
                     "loadBalancer": {}

--- a/python/tests/gold/ambassadoridtest/snapshots/econf.json
+++ b/python/tests/gold/ambassadoridtest/snapshots/econf.json
@@ -390,8 +390,7 @@
                                     "xff_num_trusted_hops": 0
                                 }
                             }
-                        ],
-                        "use_proxy_proto": false
+                        ]
                     }
                 ],
                 "listener_filters": [],

--- a/python/tests/gold/ambassadoridtest/snapshots/snapshot.yaml
+++ b/python/tests/gold/ambassadoridtest/snapshots/snapshot.yaml
@@ -23,7 +23,7 @@
                         "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Module\nname: ambassador\nconfig:\n  use_ambassador_namespace_for_service_resolution: true\nambassador_id: ambassadoridtest\n",
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Module\\nname: ambassador\\nconfig:\\n  use_ambassador_namespace_for_service_resolution: true\\nambassador_id: ambassadoridtest\\n\"},\"labels\":{\"app.kubernetes.io/component\":\"ambassador-service\",\"kat-ambassador-id\":\"ambassadoridtest\",\"scope\":\"AmbassadorTest\"},\"name\":\"ambassadoridtest\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8080},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8443}],\"selector\":{\"service\":\"ambassadoridtest\"},\"type\":\"NodePort\"}}\n"
                     },
-                    "creationTimestamp": "2020-02-19T23:19:54Z",
+                    "creationTimestamp": "2020-02-26T15:51:36Z",
                     "labels": {
                         "app.kubernetes.io/component": "ambassador-service",
                         "kat-ambassador-id": "ambassadoridtest",
@@ -31,24 +31,24 @@
                     },
                     "name": "ambassadoridtest",
                     "namespace": "default",
-                    "resourceVersion": "55122",
+                    "resourceVersion": "65796",
                     "selfLink": "/api/v1/namespaces/default/services/ambassadoridtest",
-                    "uid": "565b8c5f-536e-11ea-85dd-167682b5c255"
+                    "uid": "deb6c425-58af-11ea-86d6-0e674b3ff44f"
                 },
                 "spec": {
-                    "clusterIP": "10.107.139.134",
+                    "clusterIP": "10.108.229.115",
                     "externalTrafficPolicy": "Cluster",
                     "ports": [
                         {
                             "name": "http",
-                            "nodePort": 31458,
+                            "nodePort": 30563,
                             "port": 80,
                             "protocol": "TCP",
                             "targetPort": 8080
                         },
                         {
                             "name": "https",
-                            "nodePort": 31259,
+                            "nodePort": 32739,
                             "port": 443,
                             "protocol": "TCP",
                             "targetPort": 8443
@@ -71,7 +71,7 @@
                     "annotations": {
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"ambassadoridtest\",\"scope\":\"AmbassadorTest\",\"service\":\"ambassadoridtest-admin\"},\"name\":\"ambassadoridtest-admin\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"ambassadoridtest-admin\",\"port\":8877,\"targetPort\":8877}],\"selector\":{\"service\":\"ambassadoridtest\"},\"type\":\"NodePort\"}}\n"
                     },
-                    "creationTimestamp": "2020-02-19T23:19:54Z",
+                    "creationTimestamp": "2020-02-26T15:51:36Z",
                     "labels": {
                         "kat-ambassador-id": "ambassadoridtest",
                         "scope": "AmbassadorTest",
@@ -79,17 +79,17 @@
                     },
                     "name": "ambassadoridtest-admin",
                     "namespace": "default",
-                    "resourceVersion": "55126",
+                    "resourceVersion": "65800",
                     "selfLink": "/api/v1/namespaces/default/services/ambassadoridtest-admin",
-                    "uid": "56624b2d-536e-11ea-85dd-167682b5c255"
+                    "uid": "debfdad8-58af-11ea-86d6-0e674b3ff44f"
                 },
                 "spec": {
-                    "clusterIP": "10.104.68.34",
+                    "clusterIP": "10.99.26.6",
                     "externalTrafficPolicy": "Cluster",
                     "ports": [
                         {
                             "name": "ambassadoridtest-admin",
-                            "nodePort": 32385,
+                            "nodePort": 32535,
                             "port": 8877,
                             "protocol": "TCP",
                             "targetPort": 8877
@@ -113,19 +113,19 @@
                         "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: ambassadoridtest-findme\nprefix: /findme/\nservice: ambassadoridtest-http\nambassador_id: ambassadoridtest\n\n---\napiVersion: ambassador/v0\nkind: Mapping\nname: ambassadoridtest-findme-array\nprefix: /findme-array/\nservice: ambassadoridtest-http\nambassador_id: [ambassadoridtest, missme]\n\n---\napiVersion: ambassador/v0\nkind: Mapping\nname: ambassadoridtest-findme-array2\nprefix: /findme-array2/\nservice: ambassadoridtest-http\nambassador_id: [missme, ambassadoridtest]\n\n---\napiVersion: ambassador/v0\nkind: Mapping\nname: ambassadoridtest-missme\nprefix: /missme/\nservice: ambassadoridtest-http\nambassador_id: missme\n\n---\napiVersion: ambassador/v0\nkind: Mapping\nname: ambassadoridtest-missme-array\nprefix: /missme-array/\nservice: ambassadoridtest-http\nambassador_id: [missme1, missme2]\n",
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: ambassadoridtest-findme\\nprefix: /findme/\\nservice: ambassadoridtest-http\\nambassador_id: ambassadoridtest\\n\\n---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: ambassadoridtest-findme-array\\nprefix: /findme-array/\\nservice: ambassadoridtest-http\\nambassador_id: [ambassadoridtest, missme]\\n\\n---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: ambassadoridtest-findme-array2\\nprefix: /findme-array2/\\nservice: ambassadoridtest-http\\nambassador_id: [missme, ambassadoridtest]\\n\\n---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: ambassadoridtest-missme\\nprefix: /missme/\\nservice: ambassadoridtest-http\\nambassador_id: missme\\n\\n---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: ambassadoridtest-missme-array\\nprefix: /missme-array/\\nservice: ambassadoridtest-http\\nambassador_id: [missme1, missme2]\\n\"},\"labels\":{\"kat-ambassador-id\":\"ambassadoridtest\",\"scope\":\"AmbassadorTest\"},\"name\":\"ambassadoridtest-http\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8080},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8443}],\"selector\":{\"backend\":\"superpod-default\"}}}\n"
                     },
-                    "creationTimestamp": "2020-02-19T23:19:54Z",
+                    "creationTimestamp": "2020-02-26T15:51:36Z",
                     "labels": {
                         "kat-ambassador-id": "ambassadoridtest",
                         "scope": "AmbassadorTest"
                     },
                     "name": "ambassadoridtest-http",
                     "namespace": "default",
-                    "resourceVersion": "55133",
+                    "resourceVersion": "65807",
                     "selfLink": "/api/v1/namespaces/default/services/ambassadoridtest-http",
-                    "uid": "566f229b-536e-11ea-85dd-167682b5c255"
+                    "uid": "ded0bdb7-58af-11ea-86d6-0e674b3ff44f"
                 },
                 "spec": {
-                    "clusterIP": "10.102.211.236",
+                    "clusterIP": "10.104.62.206",
                     "ports": [
                         {
                             "name": "http",

--- a/python/tests/gold/authenticationgrpctest/snapshots/econf.json
+++ b/python/tests/gold/authenticationgrpctest/snapshots/econf.json
@@ -342,8 +342,7 @@
                                     "xff_num_trusted_hops": 0
                                 }
                             }
-                        ],
-                        "use_proxy_proto": false
+                        ]
                     }
                 ],
                 "listener_filters": [],

--- a/python/tests/gold/authenticationgrpctest/snapshots/snapshot.yaml
+++ b/python/tests/gold/authenticationgrpctest/snapshots/snapshot.yaml
@@ -20,106 +20,21 @@
                 "kind": "Service",
                 "metadata": {
                     "annotations": {
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"authenticationgrpctest\",\"scope\":\"AmbassadorTest\",\"service\":\"authenticationgrpctest-admin\"},\"name\":\"authenticationgrpctest-admin\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"authenticationgrpctest-admin\",\"port\":8877,\"targetPort\":8877}],\"selector\":{\"service\":\"authenticationgrpctest\"},\"type\":\"NodePort\"}}\n"
-                    },
-                    "creationTimestamp": "2020-02-19T23:19:56Z",
-                    "labels": {
-                        "kat-ambassador-id": "authenticationgrpctest",
-                        "scope": "AmbassadorTest",
-                        "service": "authenticationgrpctest-admin"
-                    },
-                    "name": "authenticationgrpctest-admin",
-                    "namespace": "default",
-                    "resourceVersion": "55250",
-                    "selfLink": "/api/v1/namespaces/default/services/authenticationgrpctest-admin",
-                    "uid": "576a2836-536e-11ea-85dd-167682b5c255"
-                },
-                "spec": {
-                    "clusterIP": "10.99.110.91",
-                    "externalTrafficPolicy": "Cluster",
-                    "ports": [
-                        {
-                            "name": "authenticationgrpctest-admin",
-                            "nodePort": 32326,
-                            "port": 8877,
-                            "protocol": "TCP",
-                            "targetPort": 8877
-                        }
-                    ],
-                    "selector": {
-                        "service": "authenticationgrpctest"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "NodePort"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"authenticationgrpctest\",\"scope\":\"AmbassadorTest\"},\"name\":\"authenticationgrpctest-agrpc-auth\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8080},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8443}],\"selector\":{\"backend\":\"authenticationgrpctest-agrpc-auth\"}}}\n"
-                    },
-                    "creationTimestamp": "2020-02-19T23:19:56Z",
-                    "labels": {
-                        "kat-ambassador-id": "authenticationgrpctest",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "authenticationgrpctest-agrpc-auth",
-                    "namespace": "default",
-                    "resourceVersion": "55261",
-                    "selfLink": "/api/v1/namespaces/default/services/authenticationgrpctest-agrpc-auth",
-                    "uid": "578570b4-536e-11ea-85dd-167682b5c255"
-                },
-                "spec": {
-                    "clusterIP": "10.108.253.215",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8080
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8443
-                        }
-                    ],
-                    "selector": {
-                        "backend": "authenticationgrpctest-agrpc-auth"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"authenticationgrpctest\",\"scope\":\"AmbassadorTest\"},\"name\":\"authenticationgrpctest-http\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8085},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8448}],\"selector\":{\"backend\":\"superpod-default\"}}}\n"
                     },
-                    "creationTimestamp": "2020-02-19T23:19:56Z",
+                    "creationTimestamp": "2020-02-26T15:51:39Z",
                     "labels": {
                         "kat-ambassador-id": "authenticationgrpctest",
                         "scope": "AmbassadorTest"
                     },
                     "name": "authenticationgrpctest-http",
                     "namespace": "default",
-                    "resourceVersion": "55258",
+                    "resourceVersion": "65937",
                     "selfLink": "/api/v1/namespaces/default/services/authenticationgrpctest-http",
-                    "uid": "5779deb3-536e-11ea-85dd-167682b5c255"
+                    "uid": "e047cc8a-58af-11ea-86d6-0e674b3ff44f"
                 },
                 "spec": {
-                    "clusterIP": "10.100.30.53",
+                    "clusterIP": "10.104.74.66",
                     "ports": [
                         {
                             "name": "http",
@@ -152,7 +67,7 @@
                         "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: AuthService\nname: authenticationgrpctest-agrpc-auth\nauth_service: \"authenticationgrpctest-agrpc-auth\"\ntimeout_ms: 5000\nproto: grpc\nambassador_id: authenticationgrpctest\n\n---\napiVersion: ambassador/v0\nkind: Mapping\nname: authenticationgrpctest-http\nprefix: /target/\nservice: authenticationgrpctest-http\nambassador_id: authenticationgrpctest\n",
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: AuthService\\nname: authenticationgrpctest-agrpc-auth\\nauth_service: \\\"authenticationgrpctest-agrpc-auth\\\"\\ntimeout_ms: 5000\\nproto: grpc\\nambassador_id: authenticationgrpctest\\n\\n---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: authenticationgrpctest-http\\nprefix: /target/\\nservice: authenticationgrpctest-http\\nambassador_id: authenticationgrpctest\\n\"},\"labels\":{\"app.kubernetes.io/component\":\"ambassador-service\",\"kat-ambassador-id\":\"authenticationgrpctest\",\"scope\":\"AmbassadorTest\"},\"name\":\"authenticationgrpctest\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8080},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8443}],\"selector\":{\"service\":\"authenticationgrpctest\"},\"type\":\"NodePort\"}}\n"
                     },
-                    "creationTimestamp": "2020-02-19T23:19:56Z",
+                    "creationTimestamp": "2020-02-26T15:51:39Z",
                     "labels": {
                         "app.kubernetes.io/component": "ambassador-service",
                         "kat-ambassador-id": "authenticationgrpctest",
@@ -160,24 +75,24 @@
                     },
                     "name": "authenticationgrpctest",
                     "namespace": "default",
-                    "resourceVersion": "55246",
+                    "resourceVersion": "65926",
                     "selfLink": "/api/v1/namespaces/default/services/authenticationgrpctest",
-                    "uid": "57625147-536e-11ea-85dd-167682b5c255"
+                    "uid": "e01f80c2-58af-11ea-86d6-0e674b3ff44f"
                 },
                 "spec": {
-                    "clusterIP": "10.99.10.142",
+                    "clusterIP": "10.100.222.245",
                     "externalTrafficPolicy": "Cluster",
                     "ports": [
                         {
                             "name": "http",
-                            "nodePort": 30126,
+                            "nodePort": 30613,
                             "port": 80,
                             "protocol": "TCP",
                             "targetPort": 8080
                         },
                         {
                             "name": "https",
-                            "nodePort": 30726,
+                            "nodePort": 30725,
                             "port": 443,
                             "protocol": "TCP",
                             "targetPort": 8443
@@ -188,6 +103,91 @@
                     },
                     "sessionAffinity": "None",
                     "type": "NodePort"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"authenticationgrpctest\",\"scope\":\"AmbassadorTest\",\"service\":\"authenticationgrpctest-admin\"},\"name\":\"authenticationgrpctest-admin\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"authenticationgrpctest-admin\",\"port\":8877,\"targetPort\":8877}],\"selector\":{\"service\":\"authenticationgrpctest\"},\"type\":\"NodePort\"}}\n"
+                    },
+                    "creationTimestamp": "2020-02-26T15:51:39Z",
+                    "labels": {
+                        "kat-ambassador-id": "authenticationgrpctest",
+                        "scope": "AmbassadorTest",
+                        "service": "authenticationgrpctest-admin"
+                    },
+                    "name": "authenticationgrpctest-admin",
+                    "namespace": "default",
+                    "resourceVersion": "65930",
+                    "selfLink": "/api/v1/namespaces/default/services/authenticationgrpctest-admin",
+                    "uid": "e02f04d0-58af-11ea-86d6-0e674b3ff44f"
+                },
+                "spec": {
+                    "clusterIP": "10.97.169.171",
+                    "externalTrafficPolicy": "Cluster",
+                    "ports": [
+                        {
+                            "name": "authenticationgrpctest-admin",
+                            "nodePort": 32017,
+                            "port": 8877,
+                            "protocol": "TCP",
+                            "targetPort": 8877
+                        }
+                    ],
+                    "selector": {
+                        "service": "authenticationgrpctest"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "NodePort"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"authenticationgrpctest\",\"scope\":\"AmbassadorTest\"},\"name\":\"authenticationgrpctest-agrpc-auth\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8080},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8443}],\"selector\":{\"backend\":\"authenticationgrpctest-agrpc-auth\"}}}\n"
+                    },
+                    "creationTimestamp": "2020-02-26T15:51:39Z",
+                    "labels": {
+                        "kat-ambassador-id": "authenticationgrpctest",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "authenticationgrpctest-agrpc-auth",
+                    "namespace": "default",
+                    "resourceVersion": "65940",
+                    "selfLink": "/api/v1/namespaces/default/services/authenticationgrpctest-agrpc-auth",
+                    "uid": "e052a997-58af-11ea-86d6-0e674b3ff44f"
+                },
+                "spec": {
+                    "clusterIP": "10.105.192.55",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8080
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8443
+                        }
+                    ],
+                    "selector": {
+                        "backend": "authenticationgrpctest-agrpc-auth"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
                 },
                 "status": {
                     "loadBalancer": {}

--- a/python/tests/gold/authenticationheaderrouting/snapshots/econf.json
+++ b/python/tests/gold/authenticationheaderrouting/snapshots/econf.json
@@ -506,8 +506,7 @@
                                     "xff_num_trusted_hops": 0
                                 }
                             }
-                        ],
-                        "use_proxy_proto": false
+                        ]
                     }
                 ],
                 "listener_filters": [],

--- a/python/tests/gold/authenticationheaderrouting/snapshots/snapshot.yaml
+++ b/python/tests/gold/authenticationheaderrouting/snapshots/snapshot.yaml
@@ -20,10 +20,55 @@
                 "kind": "Service",
                 "metadata": {
                     "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: AuthenticationHeaderRouting-target2\nprefix: /target/\nservice: http://authenticationheaderrouting-http-target2\nheaders:\n  X-Auth-Route: Route\nambassador_id: authenticationheaderrouting\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: AuthenticationHeaderRouting-target2\\nprefix: /target/\\nservice: http://authenticationheaderrouting-http-target2\\nheaders:\\n  X-Auth-Route: Route\\nambassador_id: authenticationheaderrouting\\n\"},\"labels\":{\"kat-ambassador-id\":\"authenticationheaderrouting\",\"scope\":\"AmbassadorTest\"},\"name\":\"authenticationheaderrouting-http-target2\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8099},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8462}],\"selector\":{\"backend\":\"superpod-default\"}}}\n"
+                    },
+                    "creationTimestamp": "2020-02-26T15:51:48Z",
+                    "labels": {
+                        "kat-ambassador-id": "authenticationheaderrouting",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "authenticationheaderrouting-http-target2",
+                    "namespace": "default",
+                    "resourceVersion": "66358",
+                    "selfLink": "/api/v1/namespaces/default/services/authenticationheaderrouting-http-target2",
+                    "uid": "e5aab579-58af-11ea-86d6-0e674b3ff44f"
+                },
+                "spec": {
+                    "clusterIP": "10.104.86.133",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8099
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8462
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-default"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
                         "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: AuthService\nname: authenticationheaderrouting-headerroutingauth\nauth_service: \"authenticationheaderrouting-headerroutingauth\"\nproto: http\npath_prefix: \"\"\ntimeout_ms: 5000\nallowed_authorization_headers:\n- X-Auth-Route\n- Extauth\nambassador_id: authenticationheaderrouting\n",
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: AuthService\\nname: authenticationheaderrouting-headerroutingauth\\nauth_service: \\\"authenticationheaderrouting-headerroutingauth\\\"\\nproto: http\\npath_prefix: \\\"\\\"\\ntimeout_ms: 5000\\nallowed_authorization_headers:\\n- X-Auth-Route\\n- Extauth\\nambassador_id: authenticationheaderrouting\\n\"},\"labels\":{\"app.kubernetes.io/component\":\"ambassador-service\",\"kat-ambassador-id\":\"authenticationheaderrouting\",\"scope\":\"AmbassadorTest\"},\"name\":\"authenticationheaderrouting\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8080},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8443}],\"selector\":{\"service\":\"authenticationheaderrouting\"},\"type\":\"NodePort\"}}\n"
                     },
-                    "creationTimestamp": "2020-02-19T23:20:05Z",
+                    "creationTimestamp": "2020-02-26T15:51:48Z",
                     "labels": {
                         "app.kubernetes.io/component": "ambassador-service",
                         "kat-ambassador-id": "authenticationheaderrouting",
@@ -31,24 +76,24 @@
                     },
                     "name": "authenticationheaderrouting",
                     "namespace": "default",
-                    "resourceVersion": "55658",
+                    "resourceVersion": "66342",
                     "selfLink": "/api/v1/namespaces/default/services/authenticationheaderrouting",
-                    "uid": "5cbf95ea-536e-11ea-85dd-167682b5c255"
+                    "uid": "e57dd50a-58af-11ea-86d6-0e674b3ff44f"
                 },
                 "spec": {
-                    "clusterIP": "10.109.51.216",
+                    "clusterIP": "10.109.179.125",
                     "externalTrafficPolicy": "Cluster",
                     "ports": [
                         {
                             "name": "http",
-                            "nodePort": 30252,
+                            "nodePort": 30356,
                             "port": 80,
                             "protocol": "TCP",
                             "targetPort": 8080
                         },
                         {
                             "name": "https",
-                            "nodePort": 32162,
+                            "nodePort": 30611,
                             "port": 443,
                             "protocol": "TCP",
                             "targetPort": 8443
@@ -71,7 +116,7 @@
                     "annotations": {
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"authenticationheaderrouting\",\"scope\":\"AmbassadorTest\",\"service\":\"authenticationheaderrouting-admin\"},\"name\":\"authenticationheaderrouting-admin\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"authenticationheaderrouting-admin\",\"port\":8877,\"targetPort\":8877}],\"selector\":{\"service\":\"authenticationheaderrouting\"},\"type\":\"NodePort\"}}\n"
                     },
-                    "creationTimestamp": "2020-02-19T23:20:05Z",
+                    "creationTimestamp": "2020-02-26T15:51:48Z",
                     "labels": {
                         "kat-ambassador-id": "authenticationheaderrouting",
                         "scope": "AmbassadorTest",
@@ -79,17 +124,17 @@
                     },
                     "name": "authenticationheaderrouting-admin",
                     "namespace": "default",
-                    "resourceVersion": "55663",
+                    "resourceVersion": "66347",
                     "selfLink": "/api/v1/namespaces/default/services/authenticationheaderrouting-admin",
-                    "uid": "5cc8aac5-536e-11ea-85dd-167682b5c255"
+                    "uid": "e58a9068-58af-11ea-86d6-0e674b3ff44f"
                 },
                 "spec": {
-                    "clusterIP": "10.103.42.212",
+                    "clusterIP": "10.110.162.64",
                     "externalTrafficPolicy": "Cluster",
                     "ports": [
                         {
                             "name": "authenticationheaderrouting-admin",
-                            "nodePort": 31771,
+                            "nodePort": 31608,
                             "port": 8877,
                             "protocol": "TCP",
                             "targetPort": 8877
@@ -112,19 +157,19 @@
                     "annotations": {
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"authenticationheaderrouting\",\"scope\":\"AmbassadorTest\"},\"name\":\"authenticationheaderrouting-headerroutingauth\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":80},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":443}],\"selector\":{\"backend\":\"authenticationheaderrouting-headerroutingauth\"}}}\n"
                     },
-                    "creationTimestamp": "2020-02-19T23:20:05Z",
+                    "creationTimestamp": "2020-02-26T15:51:48Z",
                     "labels": {
                         "kat-ambassador-id": "authenticationheaderrouting",
                         "scope": "AmbassadorTest"
                     },
                     "name": "authenticationheaderrouting-headerroutingauth",
                     "namespace": "default",
-                    "resourceVersion": "55677",
+                    "resourceVersion": "66361",
                     "selfLink": "/api/v1/namespaces/default/services/authenticationheaderrouting-headerroutingauth",
-                    "uid": "5cec61a9-536e-11ea-85dd-167682b5c255"
+                    "uid": "e5b5e371-58af-11ea-86d6-0e674b3ff44f"
                 },
                 "spec": {
-                    "clusterIP": "10.104.32.137",
+                    "clusterIP": "10.98.135.116",
                     "ports": [
                         {
                             "name": "http",
@@ -157,19 +202,19 @@
                         "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: AuthenticationHeaderRouting-target1\nprefix: /target/\nservice: http://authenticationheaderrouting-http-target1\nambassador_id: authenticationheaderrouting\n",
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: AuthenticationHeaderRouting-target1\\nprefix: /target/\\nservice: http://authenticationheaderrouting-http-target1\\nambassador_id: authenticationheaderrouting\\n\"},\"labels\":{\"kat-ambassador-id\":\"authenticationheaderrouting\",\"scope\":\"AmbassadorTest\"},\"name\":\"authenticationheaderrouting-http-target1\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8098},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8461}],\"selector\":{\"backend\":\"superpod-default\"}}}\n"
                     },
-                    "creationTimestamp": "2020-02-19T23:20:05Z",
+                    "creationTimestamp": "2020-02-26T15:51:48Z",
                     "labels": {
                         "kat-ambassador-id": "authenticationheaderrouting",
                         "scope": "AmbassadorTest"
                     },
                     "name": "authenticationheaderrouting-http-target1",
                     "namespace": "default",
-                    "resourceVersion": "55669",
+                    "resourceVersion": "66354",
                     "selfLink": "/api/v1/namespaces/default/services/authenticationheaderrouting-http-target1",
-                    "uid": "5cd80eee-536e-11ea-85dd-167682b5c255"
+                    "uid": "e59d7ea8-58af-11ea-86d6-0e674b3ff44f"
                 },
                 "spec": {
-                    "clusterIP": "10.97.105.164",
+                    "clusterIP": "10.104.68.90",
                     "ports": [
                         {
                             "name": "http",
@@ -182,51 +227,6 @@
                             "port": 443,
                             "protocol": "TCP",
                             "targetPort": 8461
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-default"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: AuthenticationHeaderRouting-target2\nprefix: /target/\nservice: http://authenticationheaderrouting-http-target2\nheaders:\n  X-Auth-Route: Route\nambassador_id: authenticationheaderrouting\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: AuthenticationHeaderRouting-target2\\nprefix: /target/\\nservice: http://authenticationheaderrouting-http-target2\\nheaders:\\n  X-Auth-Route: Route\\nambassador_id: authenticationheaderrouting\\n\"},\"labels\":{\"kat-ambassador-id\":\"authenticationheaderrouting\",\"scope\":\"AmbassadorTest\"},\"name\":\"authenticationheaderrouting-http-target2\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8099},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8462}],\"selector\":{\"backend\":\"superpod-default\"}}}\n"
-                    },
-                    "creationTimestamp": "2020-02-19T23:20:05Z",
-                    "labels": {
-                        "kat-ambassador-id": "authenticationheaderrouting",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "authenticationheaderrouting-http-target2",
-                    "namespace": "default",
-                    "resourceVersion": "55672",
-                    "selfLink": "/api/v1/namespaces/default/services/authenticationheaderrouting-http-target2",
-                    "uid": "5ce252de-536e-11ea-85dd-167682b5c255"
-                },
-                "spec": {
-                    "clusterIP": "10.100.25.224",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8099
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8462
                         }
                     ],
                     "selector": {

--- a/python/tests/gold/authenticationhttpbufferedtest/snapshots/econf.json
+++ b/python/tests/gold/authenticationhttpbufferedtest/snapshots/econf.json
@@ -542,8 +542,7 @@
                                     "xff_num_trusted_hops": 0
                                 }
                             }
-                        ],
-                        "use_proxy_proto": false
+                        ]
                     }
                 ],
                 "listener_filters": [],

--- a/python/tests/gold/authenticationhttpbufferedtest/snapshots/snapshot.yaml
+++ b/python/tests/gold/authenticationhttpbufferedtest/snapshots/snapshot.yaml
@@ -26,16 +26,16 @@
                     "annotations": {
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"data\":{\"tls.crt\":\"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURnRENDQW1pZ0F3SUJBZ0lKQUpycUl0ekY2MTBpTUEwR0NTcUdTSWIzRFFFQkN3VUFNRlV4Q3pBSkJnTlYKQkFZVEFsVlRNUXN3Q1FZRFZRUUlEQUpOUVRFUE1BMEdBMVVFQnd3R1FtOXpkRzl1TVFzd0NRWURWUVFLREFKRQpWekViTUJrR0ExVUVBd3dTZEd4ekxXTnZiblJsZUhRdGFHOXpkQzB4TUI0WERURTRNVEV3TVRFek5UTXhPRm9YCkRUSTRNVEF5T1RFek5UTXhPRm93VlRFTE1Ba0dBMVVFQmhNQ1ZWTXhDekFKQmdOVkJBZ01BazFCTVE4d0RRWUQKVlFRSERBWkNiM04wYjI0eEN6QUpCZ05WQkFvTUFrUlhNUnN3R1FZRFZRUUREQkowYkhNdFkyOXVkR1Y0ZEMxbwpiM04wTFRFd2dnRWlNQTBHQ1NxR1NJYjNEUUVCQVFVQUE0SUJEd0F3Z2dFS0FvSUJBUUM5T2dDOHd4eUlyUHpvCkdYc0xwUEt0NzJERXgyd2p3VzhuWFcyd1dieWEzYzk2bjJuU0NLUEJuODVoYnFzaHpqNWloU1RBTURJb2c5RnYKRzZSS1dVUFhUNEtJa1R2M0NESHFYc0FwSmxKNGxTeW5ReW8yWnYwbytBZjhDTG5nWVpCK3JmenRad3llRGhWcAp3WXpCVjIzNXp6NisycWJWbUNabHZCdVhiVXFUbEVZWXZ1R2xNR3o3cFBmT1dLVXBlWW9kYkcyZmIraEZGcGVvCkN4a1VYclFzT29SNUpkSEc1aldyWnVCTzQ1NVNzcnpCTDhSbGU1VUhvMDVXY0s3YkJiaVF6MTA2cEhDSllaK3AKdmxQSWNOU1g1S2gzNEZnOTZVUHg5bFFpQTN6RFRLQmZ5V2NMUStxMWNabExjV2RnUkZjTkJpckdCLzdyYTFWVApnRUplR2tQekFnTUJBQUdqVXpCUk1CMEdBMVVkRGdRV0JCUkRWVUtYWWJsRFdNTzE3MUJuWWZhYlkzM0NFVEFmCkJnTlZIU01FR0RBV2dCUkRWVUtYWWJsRFdNTzE3MUJuWWZhYlkzM0NFVEFQQmdOVkhSTUJBZjhFQlRBREFRSC8KTUEwR0NTcUdTSWIzRFFFQkN3VUFBNElCQVFBUE8vRDRUdDUyWHJsQ0NmUzZnVUVkRU5DcnBBV05YRHJvR2M2dApTVGx3aC8rUUxRYk5hZEtlaEtiZjg5clhLaituVXF0cS9OUlpQSXNBSytXVWtHOVpQb1FPOFBRaVY0V1g1clE3CjI5dUtjSmZhQlhrZHpVVzdxTlFoRTRjOEJhc0JySWVzcmtqcFQ5OVF4SktuWFFhTitTdzdvRlBVSUFOMzhHcWEKV2wvS1BNVHRicWt3eWFjS01CbXExVkx6dldKb0g1Q2l6Skp3aG5rWHh0V0tzLzY3clROblBWTXorbWVHdHZTaQpkcVg2V1NTbUdMRkVFcjJoZ1VjQVpqazNWdVFoLzc1aFh1K1UySXRzQys1cXBsaEc3Q1hzb1huS0t5MVhsT0FFCmI4a3IyZFdXRWs2STVZNm5USnpXSWxTVGtXODl4d1hyY3RtTjlzYjlxNFNuaVZsegotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==\",\"tls.key\":\"LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0tCk1JSUV2UUlCQURBTkJna3Foa2lHOXcwQkFRRUZBQVNDQktjd2dnU2pBZ0VBQW9JQkFRQzlPZ0M4d3h5SXJQem8KR1hzTHBQS3Q3MkRFeDJ3andXOG5YVzJ3V2J5YTNjOTZuMm5TQ0tQQm44NWhicXNoemo1aWhTVEFNRElvZzlGdgpHNlJLV1VQWFQ0S0lrVHYzQ0RIcVhzQXBKbEo0bFN5blF5bzJadjBvK0FmOENMbmdZWkIrcmZ6dFp3eWVEaFZwCndZekJWMjM1eno2KzJxYlZtQ1psdkJ1WGJVcVRsRVlZdnVHbE1HejdwUGZPV0tVcGVZb2RiRzJmYitoRkZwZW8KQ3hrVVhyUXNPb1I1SmRIRzVqV3JadUJPNDU1U3NyekJMOFJsZTVVSG8wNVdjSzdiQmJpUXoxMDZwSENKWVorcAp2bFBJY05TWDVLaDM0Rmc5NlVQeDlsUWlBM3pEVEtCZnlXY0xRK3ExY1psTGNXZGdSRmNOQmlyR0IvN3JhMVZUCmdFSmVHa1B6QWdNQkFBRUNnZ0VBQmFsN3BpcE1hMGFKMXNRVWEzZkhEeTlQZlBQZXAzODlQVGROZGU1cGQxVFYKeFh5SnBSQS9IaWNTL05WYjU0b05VZE5jRXlnZUNCcFJwUHAxd3dmQ3dPbVBKVmo3SzF3aWFqbmxsQldpZUJzMgpsOWFwcDdFVE9DdWJ5WTNWU2dLQldWa0piVzBjOG9uSFdEL0RYM0duUjhkTXdGYzRrTUdadkllUlo4bU1acmdHCjZPdDNKOHI2eVZsZWI2OGF1WmtneXMwR2VGc3pNdVRubHJCOEw5djI1UUtjVGtESjIvRWx1Y1p5aER0eGF0OEIKTzZOUnNubmNyOHhwUVdPci9sV3M5VVFuZEdCdHFzbXMrdGNUN1ZUNU9UanQ4WHY5NVhNSHB5Z29pTHk3czhvYwpJMGprNDJabzRKZW5JT3c2Rm0weUFEZ0E3eWlXcks0bEkzWGhqaTVSb1FLQmdRRGRqaWNkTUpYVUZWc28rNTJkCkUwT2EwcEpVMFNSaC9JQmdvRzdNakhrVWxiaXlpR1pNanA5MEo5VHFaL1ErM1pWZVdqMmxPSWF0OG5nUzB6MDAKVzA3T1ZxYXprMVNYaFZlY2tGNWFEcm5PRDNhU2VWMSthV3JUdDFXRWdqOVFxYnJZYVA5emd4UkpkRzV3WENCUApGNDNFeXE5ZEhXOWF6SSt3UHlJQ0JqNnZBd0tCZ1FEYXBTelhPR2ViMi9SMWhlWXdWV240czNGZEtYVjgzemtTCnFSWDd6d1pLdkk5OGMybDU1Y1ZNUzBoTGM0bTVPMXZCaUd5SG80eTB2SVAvR0k0Rzl4T1FhMXdpVnNmUVBiSU4KLzJPSDFnNXJLSFdCWVJUaHZGcERqdHJRU2xyRHVjWUNSRExCd1hUcDFrbVBkL09mY2FybG42MjZEamthZllieAp3dWUydlhCTVVRS0JnQm4vTmlPOHNiZ0RFWUZMbFFEN1k3RmxCL3FmMTg4UG05aTZ1b1dSN2hzMlBrZmtyV3hLClIvZVBQUEtNWkNLRVNhU2FuaVVtN3RhMlh0U0dxT1hkMk85cFI0Skd4V1JLSnkrZDJSUmtLZlU5NTBIa3I4M0gKZk50KzVhLzR3SWtzZ1ZvblorSWIvV05wSUJSYkd3ZHMwaHZIVkxCdVpjU1h3RHlFQysrRTRCSVZBb0dCQUoxUQp6eXlqWnRqYnI4NkhZeEpQd29teEF0WVhLSE9LWVJRdUdLVXZWY1djV2xrZTZUdE51V0dsb1FTNHd0VkdBa1VECmxhTWFaL2o2MHJaT3dwSDhZRlUvQ2ZHakl1MlFGbmEvMUtzOXR1NGZGRHpjenh1RVhDWFR1Vmk0eHdtZ3R2bVcKZkRhd3JTQTZrSDdydlp4eE9wY3hCdHloc3pCK05RUHFTckpQSjJlaEFvR0FkdFJKam9vU0lpYURVU25lZUcyZgpUTml1T01uazJkeFV3RVF2S1E4eWNuUnpyN0QwaEtZVWIycThHKzE2bThQUjNCcFMzZDFLbkpMVnI3TUhaWHpSCitzZHNaWGtTMWVEcEZhV0RFREFEWWI0ckRCb2RBdk8xYm03ZXdTMzhSbk1UaTlhdFZzNVNTODNpZG5HbFZiSmsKYkZKWG0rWWxJNHFkaXowTFdjWGJyREE9Ci0tLS0tRU5EIFBSSVZBVEUgS0VZLS0tLS0K\"},\"kind\":\"Secret\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"authenticationhttpbufferedtest\",\"scope\":\"AmbassadorTest\"},\"name\":\"auth-buffered-secret\",\"namespace\":\"default\"},\"type\":\"kubernetes.io/tls\"}\n"
                     },
-                    "creationTimestamp": "2020-02-19T23:19:57Z",
+                    "creationTimestamp": "2020-02-26T15:51:40Z",
                     "labels": {
                         "kat-ambassador-id": "authenticationhttpbufferedtest",
                         "scope": "AmbassadorTest"
                     },
                     "name": "auth-buffered-secret",
                     "namespace": "default",
-                    "resourceVersion": "55316",
+                    "resourceVersion": "65979",
                     "selfLink": "/api/v1/namespaces/default/secrets/auth-buffered-secret",
-                    "uid": "58146207-536e-11ea-85dd-167682b5c255"
+                    "uid": "e0d02aa2-58af-11ea-86d6-0e674b3ff44f"
                 },
                 "type": "kubernetes.io/tls"
             }
@@ -46,58 +46,9 @@
                 "kind": "Service",
                 "metadata": {
                     "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Module\nname: ambassador\nconfig:\n  add_linkerd_headers: true\n  buffer:\n    max_request_bytes: 16384\nambassador_id: authenticationhttpbufferedtest\n---\napiVersion: ambassador/v1\nkind: TLSContext\nname: AuthenticationHTTPBufferedTest-same-context-1\nsecret: auth-buffered-secret\nambassador_id: authenticationhttpbufferedtest\n---\napiVersion: ambassador/v1\nkind: AuthService\nname: authenticationhttpbufferedtest-http-auth\nauth_service: \"authenticationhttpbufferedtest-http-auth\"\npath_prefix: \"/extauth\"\ntimeout_ms: 5000\ntls: AuthenticationHTTPBufferedTest-same-context-1\nallowed_request_headers:\n- X-Foo\n- X-Bar\n- Requested-Status\n- Requested-Header\n- Requested-Cookie\n- Location\nallowed_authorization_headers:\n- X-Foo\n- Set-Cookie\ninclude_body:\n  max_bytes: 4096\n  allow_partial: true\nambassador_id: authenticationhttpbufferedtest\n\n---\napiVersion: ambassador/v0\nkind: Mapping\nname: authenticationhttpbufferedtest-http\nprefix: /target/\nservice: authenticationhttpbufferedtest-http\nambassador_id: authenticationhttpbufferedtest\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Module\\nname: ambassador\\nconfig:\\n  add_linkerd_headers: true\\n  buffer:\\n    max_request_bytes: 16384\\nambassador_id: authenticationhttpbufferedtest\\n---\\napiVersion: ambassador/v1\\nkind: TLSContext\\nname: AuthenticationHTTPBufferedTest-same-context-1\\nsecret: auth-buffered-secret\\nambassador_id: authenticationhttpbufferedtest\\n---\\napiVersion: ambassador/v1\\nkind: AuthService\\nname: authenticationhttpbufferedtest-http-auth\\nauth_service: \\\"authenticationhttpbufferedtest-http-auth\\\"\\npath_prefix: \\\"/extauth\\\"\\ntimeout_ms: 5000\\ntls: AuthenticationHTTPBufferedTest-same-context-1\\nallowed_request_headers:\\n- X-Foo\\n- X-Bar\\n- Requested-Status\\n- Requested-Header\\n- Requested-Cookie\\n- Location\\nallowed_authorization_headers:\\n- X-Foo\\n- Set-Cookie\\ninclude_body:\\n  max_bytes: 4096\\n  allow_partial: true\\nambassador_id: authenticationhttpbufferedtest\\n\\n---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: authenticationhttpbufferedtest-http\\nprefix: /target/\\nservice: authenticationhttpbufferedtest-http\\nambassador_id: authenticationhttpbufferedtest\\n\"},\"labels\":{\"app.kubernetes.io/component\":\"ambassador-service\",\"kat-ambassador-id\":\"authenticationhttpbufferedtest\",\"scope\":\"AmbassadorTest\"},\"name\":\"authenticationhttpbufferedtest\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8080},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8443}],\"selector\":{\"service\":\"authenticationhttpbufferedtest\"},\"type\":\"NodePort\"}}\n"
-                    },
-                    "creationTimestamp": "2020-02-19T23:19:57Z",
-                    "labels": {
-                        "app.kubernetes.io/component": "ambassador-service",
-                        "kat-ambassador-id": "authenticationhttpbufferedtest",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "authenticationhttpbufferedtest",
-                    "namespace": "default",
-                    "resourceVersion": "55306",
-                    "selfLink": "/api/v1/namespaces/default/services/authenticationhttpbufferedtest",
-                    "uid": "57fa319f-536e-11ea-85dd-167682b5c255"
-                },
-                "spec": {
-                    "clusterIP": "10.111.15.230",
-                    "externalTrafficPolicy": "Cluster",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "nodePort": 32210,
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8080
-                        },
-                        {
-                            "name": "https",
-                            "nodePort": 32523,
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8443
-                        }
-                    ],
-                    "selector": {
-                        "service": "authenticationhttpbufferedtest"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "NodePort"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"authenticationhttpbufferedtest\",\"scope\":\"AmbassadorTest\",\"service\":\"authenticationhttpbufferedtest-admin\"},\"name\":\"authenticationhttpbufferedtest-admin\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"authenticationhttpbufferedtest-admin\",\"port\":8877,\"targetPort\":8877}],\"selector\":{\"service\":\"authenticationhttpbufferedtest\"},\"type\":\"NodePort\"}}\n"
                     },
-                    "creationTimestamp": "2020-02-19T23:19:57Z",
+                    "creationTimestamp": "2020-02-26T15:51:40Z",
                     "labels": {
                         "kat-ambassador-id": "authenticationhttpbufferedtest",
                         "scope": "AmbassadorTest",
@@ -105,17 +56,17 @@
                     },
                     "name": "authenticationhttpbufferedtest-admin",
                     "namespace": "default",
-                    "resourceVersion": "55311",
+                    "resourceVersion": "65995",
                     "selfLink": "/api/v1/namespaces/default/services/authenticationhttpbufferedtest-admin",
-                    "uid": "5806afbc-536e-11ea-85dd-167682b5c255"
+                    "uid": "e110288a-58af-11ea-86d6-0e674b3ff44f"
                 },
                 "spec": {
-                    "clusterIP": "10.111.2.105",
+                    "clusterIP": "10.102.100.79",
                     "externalTrafficPolicy": "Cluster",
                     "ports": [
                         {
                             "name": "authenticationhttpbufferedtest-admin",
-                            "nodePort": 31721,
+                            "nodePort": 31582,
                             "port": 8877,
                             "protocol": "TCP",
                             "targetPort": 8877
@@ -138,19 +89,19 @@
                     "annotations": {
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"authenticationhttpbufferedtest\",\"scope\":\"AmbassadorTest\"},\"name\":\"authenticationhttpbufferedtest-http\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8088},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8451}],\"selector\":{\"backend\":\"superpod-default\"}}}\n"
                     },
-                    "creationTimestamp": "2020-02-19T23:19:58Z",
+                    "creationTimestamp": "2020-02-26T15:51:40Z",
                     "labels": {
                         "kat-ambassador-id": "authenticationhttpbufferedtest",
                         "scope": "AmbassadorTest"
                     },
                     "name": "authenticationhttpbufferedtest-http",
                     "namespace": "default",
-                    "resourceVersion": "55320",
+                    "resourceVersion": "66003",
                     "selfLink": "/api/v1/namespaces/default/services/authenticationhttpbufferedtest-http",
-                    "uid": "583c22f6-536e-11ea-85dd-167682b5c255"
+                    "uid": "e125d94c-58af-11ea-86d6-0e674b3ff44f"
                 },
                 "spec": {
-                    "clusterIP": "10.97.152.178",
+                    "clusterIP": "10.103.245.14",
                     "ports": [
                         {
                             "name": "http",
@@ -182,19 +133,19 @@
                     "annotations": {
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"authenticationhttpbufferedtest\",\"scope\":\"AmbassadorTest\"},\"name\":\"authenticationhttpbufferedtest-http-auth\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8089},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8452}],\"selector\":{\"backend\":\"superpod-default\"}}}\n"
                     },
-                    "creationTimestamp": "2020-02-19T23:19:58Z",
+                    "creationTimestamp": "2020-02-26T15:51:40Z",
                     "labels": {
                         "kat-ambassador-id": "authenticationhttpbufferedtest",
                         "scope": "AmbassadorTest"
                     },
                     "name": "authenticationhttpbufferedtest-http-auth",
                     "namespace": "default",
-                    "resourceVersion": "55325",
+                    "resourceVersion": "66006",
                     "selfLink": "/api/v1/namespaces/default/services/authenticationhttpbufferedtest-http-auth",
-                    "uid": "584348a0-536e-11ea-85dd-167682b5c255"
+                    "uid": "e130d608-58af-11ea-86d6-0e674b3ff44f"
                 },
                 "spec": {
-                    "clusterIP": "10.108.56.213",
+                    "clusterIP": "10.104.253.38",
                     "ports": [
                         {
                             "name": "http",
@@ -214,6 +165,55 @@
                     },
                     "sessionAffinity": "None",
                     "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Module\nname: ambassador\nconfig:\n  add_linkerd_headers: true\n  buffer:\n    max_request_bytes: 16384\nambassador_id: authenticationhttpbufferedtest\n---\napiVersion: ambassador/v1\nkind: TLSContext\nname: AuthenticationHTTPBufferedTest-same-context-1\nsecret: auth-buffered-secret\nambassador_id: authenticationhttpbufferedtest\n---\napiVersion: ambassador/v1\nkind: AuthService\nname: authenticationhttpbufferedtest-http-auth\nauth_service: \"authenticationhttpbufferedtest-http-auth\"\npath_prefix: \"/extauth\"\ntimeout_ms: 5000\ntls: AuthenticationHTTPBufferedTest-same-context-1\nallowed_request_headers:\n- X-Foo\n- X-Bar\n- Requested-Status\n- Requested-Header\n- Requested-Cookie\n- Location\nallowed_authorization_headers:\n- X-Foo\n- Set-Cookie\ninclude_body:\n  max_bytes: 4096\n  allow_partial: true\nambassador_id: authenticationhttpbufferedtest\n\n---\napiVersion: ambassador/v0\nkind: Mapping\nname: authenticationhttpbufferedtest-http\nprefix: /target/\nservice: authenticationhttpbufferedtest-http\nambassador_id: authenticationhttpbufferedtest\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Module\\nname: ambassador\\nconfig:\\n  add_linkerd_headers: true\\n  buffer:\\n    max_request_bytes: 16384\\nambassador_id: authenticationhttpbufferedtest\\n---\\napiVersion: ambassador/v1\\nkind: TLSContext\\nname: AuthenticationHTTPBufferedTest-same-context-1\\nsecret: auth-buffered-secret\\nambassador_id: authenticationhttpbufferedtest\\n---\\napiVersion: ambassador/v1\\nkind: AuthService\\nname: authenticationhttpbufferedtest-http-auth\\nauth_service: \\\"authenticationhttpbufferedtest-http-auth\\\"\\npath_prefix: \\\"/extauth\\\"\\ntimeout_ms: 5000\\ntls: AuthenticationHTTPBufferedTest-same-context-1\\nallowed_request_headers:\\n- X-Foo\\n- X-Bar\\n- Requested-Status\\n- Requested-Header\\n- Requested-Cookie\\n- Location\\nallowed_authorization_headers:\\n- X-Foo\\n- Set-Cookie\\ninclude_body:\\n  max_bytes: 4096\\n  allow_partial: true\\nambassador_id: authenticationhttpbufferedtest\\n\\n---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: authenticationhttpbufferedtest-http\\nprefix: /target/\\nservice: authenticationhttpbufferedtest-http\\nambassador_id: authenticationhttpbufferedtest\\n\"},\"labels\":{\"app.kubernetes.io/component\":\"ambassador-service\",\"kat-ambassador-id\":\"authenticationhttpbufferedtest\",\"scope\":\"AmbassadorTest\"},\"name\":\"authenticationhttpbufferedtest\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8080},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8443}],\"selector\":{\"service\":\"authenticationhttpbufferedtest\"},\"type\":\"NodePort\"}}\n"
+                    },
+                    "creationTimestamp": "2020-02-26T15:51:40Z",
+                    "labels": {
+                        "app.kubernetes.io/component": "ambassador-service",
+                        "kat-ambassador-id": "authenticationhttpbufferedtest",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "authenticationhttpbufferedtest",
+                    "namespace": "default",
+                    "resourceVersion": "65991",
+                    "selfLink": "/api/v1/namespaces/default/services/authenticationhttpbufferedtest",
+                    "uid": "e0fda549-58af-11ea-86d6-0e674b3ff44f"
+                },
+                "spec": {
+                    "clusterIP": "10.102.143.86",
+                    "externalTrafficPolicy": "Cluster",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "nodePort": 32751,
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8080
+                        },
+                        {
+                            "name": "https",
+                            "nodePort": 30855,
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8443
+                        }
+                    ],
+                    "selector": {
+                        "service": "authenticationhttpbufferedtest"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "NodePort"
                 },
                 "status": {
                     "loadBalancer": {}

--- a/python/tests/gold/authenticationhttpfailuremodeallowtest/snapshots/econf.json
+++ b/python/tests/gold/authenticationhttpfailuremodeallowtest/snapshots/econf.json
@@ -438,8 +438,7 @@
                                     "xff_num_trusted_hops": 0
                                 }
                             }
-                        ],
-                        "use_proxy_proto": false
+                        ]
                     }
                 ],
                 "listener_filters": [],

--- a/python/tests/gold/authenticationhttpfailuremodeallowtest/snapshots/snapshot.yaml
+++ b/python/tests/gold/authenticationhttpfailuremodeallowtest/snapshots/snapshot.yaml
@@ -26,16 +26,16 @@
                     "annotations": {
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"data\":{\"tls.crt\":\"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURnRENDQW1pZ0F3SUJBZ0lKQUpycUl0ekY2MTBpTUEwR0NTcUdTSWIzRFFFQkN3VUFNRlV4Q3pBSkJnTlYKQkFZVEFsVlRNUXN3Q1FZRFZRUUlEQUpOUVRFUE1BMEdBMVVFQnd3R1FtOXpkRzl1TVFzd0NRWURWUVFLREFKRQpWekViTUJrR0ExVUVBd3dTZEd4ekxXTnZiblJsZUhRdGFHOXpkQzB4TUI0WERURTRNVEV3TVRFek5UTXhPRm9YCkRUSTRNVEF5T1RFek5UTXhPRm93VlRFTE1Ba0dBMVVFQmhNQ1ZWTXhDekFKQmdOVkJBZ01BazFCTVE4d0RRWUQKVlFRSERBWkNiM04wYjI0eEN6QUpCZ05WQkFvTUFrUlhNUnN3R1FZRFZRUUREQkowYkhNdFkyOXVkR1Y0ZEMxbwpiM04wTFRFd2dnRWlNQTBHQ1NxR1NJYjNEUUVCQVFVQUE0SUJEd0F3Z2dFS0FvSUJBUUM5T2dDOHd4eUlyUHpvCkdYc0xwUEt0NzJERXgyd2p3VzhuWFcyd1dieWEzYzk2bjJuU0NLUEJuODVoYnFzaHpqNWloU1RBTURJb2c5RnYKRzZSS1dVUFhUNEtJa1R2M0NESHFYc0FwSmxKNGxTeW5ReW8yWnYwbytBZjhDTG5nWVpCK3JmenRad3llRGhWcAp3WXpCVjIzNXp6NisycWJWbUNabHZCdVhiVXFUbEVZWXZ1R2xNR3o3cFBmT1dLVXBlWW9kYkcyZmIraEZGcGVvCkN4a1VYclFzT29SNUpkSEc1aldyWnVCTzQ1NVNzcnpCTDhSbGU1VUhvMDVXY0s3YkJiaVF6MTA2cEhDSllaK3AKdmxQSWNOU1g1S2gzNEZnOTZVUHg5bFFpQTN6RFRLQmZ5V2NMUStxMWNabExjV2RnUkZjTkJpckdCLzdyYTFWVApnRUplR2tQekFnTUJBQUdqVXpCUk1CMEdBMVVkRGdRV0JCUkRWVUtYWWJsRFdNTzE3MUJuWWZhYlkzM0NFVEFmCkJnTlZIU01FR0RBV2dCUkRWVUtYWWJsRFdNTzE3MUJuWWZhYlkzM0NFVEFQQmdOVkhSTUJBZjhFQlRBREFRSC8KTUEwR0NTcUdTSWIzRFFFQkN3VUFBNElCQVFBUE8vRDRUdDUyWHJsQ0NmUzZnVUVkRU5DcnBBV05YRHJvR2M2dApTVGx3aC8rUUxRYk5hZEtlaEtiZjg5clhLaituVXF0cS9OUlpQSXNBSytXVWtHOVpQb1FPOFBRaVY0V1g1clE3CjI5dUtjSmZhQlhrZHpVVzdxTlFoRTRjOEJhc0JySWVzcmtqcFQ5OVF4SktuWFFhTitTdzdvRlBVSUFOMzhHcWEKV2wvS1BNVHRicWt3eWFjS01CbXExVkx6dldKb0g1Q2l6Skp3aG5rWHh0V0tzLzY3clROblBWTXorbWVHdHZTaQpkcVg2V1NTbUdMRkVFcjJoZ1VjQVpqazNWdVFoLzc1aFh1K1UySXRzQys1cXBsaEc3Q1hzb1huS0t5MVhsT0FFCmI4a3IyZFdXRWs2STVZNm5USnpXSWxTVGtXODl4d1hyY3RtTjlzYjlxNFNuaVZsegotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==\",\"tls.key\":\"LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0tCk1JSUV2UUlCQURBTkJna3Foa2lHOXcwQkFRRUZBQVNDQktjd2dnU2pBZ0VBQW9JQkFRQzlPZ0M4d3h5SXJQem8KR1hzTHBQS3Q3MkRFeDJ3andXOG5YVzJ3V2J5YTNjOTZuMm5TQ0tQQm44NWhicXNoemo1aWhTVEFNRElvZzlGdgpHNlJLV1VQWFQ0S0lrVHYzQ0RIcVhzQXBKbEo0bFN5blF5bzJadjBvK0FmOENMbmdZWkIrcmZ6dFp3eWVEaFZwCndZekJWMjM1eno2KzJxYlZtQ1psdkJ1WGJVcVRsRVlZdnVHbE1HejdwUGZPV0tVcGVZb2RiRzJmYitoRkZwZW8KQ3hrVVhyUXNPb1I1SmRIRzVqV3JadUJPNDU1U3NyekJMOFJsZTVVSG8wNVdjSzdiQmJpUXoxMDZwSENKWVorcAp2bFBJY05TWDVLaDM0Rmc5NlVQeDlsUWlBM3pEVEtCZnlXY0xRK3ExY1psTGNXZGdSRmNOQmlyR0IvN3JhMVZUCmdFSmVHa1B6QWdNQkFBRUNnZ0VBQmFsN3BpcE1hMGFKMXNRVWEzZkhEeTlQZlBQZXAzODlQVGROZGU1cGQxVFYKeFh5SnBSQS9IaWNTL05WYjU0b05VZE5jRXlnZUNCcFJwUHAxd3dmQ3dPbVBKVmo3SzF3aWFqbmxsQldpZUJzMgpsOWFwcDdFVE9DdWJ5WTNWU2dLQldWa0piVzBjOG9uSFdEL0RYM0duUjhkTXdGYzRrTUdadkllUlo4bU1acmdHCjZPdDNKOHI2eVZsZWI2OGF1WmtneXMwR2VGc3pNdVRubHJCOEw5djI1UUtjVGtESjIvRWx1Y1p5aER0eGF0OEIKTzZOUnNubmNyOHhwUVdPci9sV3M5VVFuZEdCdHFzbXMrdGNUN1ZUNU9UanQ4WHY5NVhNSHB5Z29pTHk3czhvYwpJMGprNDJabzRKZW5JT3c2Rm0weUFEZ0E3eWlXcks0bEkzWGhqaTVSb1FLQmdRRGRqaWNkTUpYVUZWc28rNTJkCkUwT2EwcEpVMFNSaC9JQmdvRzdNakhrVWxiaXlpR1pNanA5MEo5VHFaL1ErM1pWZVdqMmxPSWF0OG5nUzB6MDAKVzA3T1ZxYXprMVNYaFZlY2tGNWFEcm5PRDNhU2VWMSthV3JUdDFXRWdqOVFxYnJZYVA5emd4UkpkRzV3WENCUApGNDNFeXE5ZEhXOWF6SSt3UHlJQ0JqNnZBd0tCZ1FEYXBTelhPR2ViMi9SMWhlWXdWV240czNGZEtYVjgzemtTCnFSWDd6d1pLdkk5OGMybDU1Y1ZNUzBoTGM0bTVPMXZCaUd5SG80eTB2SVAvR0k0Rzl4T1FhMXdpVnNmUVBiSU4KLzJPSDFnNXJLSFdCWVJUaHZGcERqdHJRU2xyRHVjWUNSRExCd1hUcDFrbVBkL09mY2FybG42MjZEamthZllieAp3dWUydlhCTVVRS0JnQm4vTmlPOHNiZ0RFWUZMbFFEN1k3RmxCL3FmMTg4UG05aTZ1b1dSN2hzMlBrZmtyV3hLClIvZVBQUEtNWkNLRVNhU2FuaVVtN3RhMlh0U0dxT1hkMk85cFI0Skd4V1JLSnkrZDJSUmtLZlU5NTBIa3I4M0gKZk50KzVhLzR3SWtzZ1ZvblorSWIvV05wSUJSYkd3ZHMwaHZIVkxCdVpjU1h3RHlFQysrRTRCSVZBb0dCQUoxUQp6eXlqWnRqYnI4NkhZeEpQd29teEF0WVhLSE9LWVJRdUdLVXZWY1djV2xrZTZUdE51V0dsb1FTNHd0VkdBa1VECmxhTWFaL2o2MHJaT3dwSDhZRlUvQ2ZHakl1MlFGbmEvMUtzOXR1NGZGRHpjenh1RVhDWFR1Vmk0eHdtZ3R2bVcKZkRhd3JTQTZrSDdydlp4eE9wY3hCdHloc3pCK05RUHFTckpQSjJlaEFvR0FkdFJKam9vU0lpYURVU25lZUcyZgpUTml1T01uazJkeFV3RVF2S1E4eWNuUnpyN0QwaEtZVWIycThHKzE2bThQUjNCcFMzZDFLbkpMVnI3TUhaWHpSCitzZHNaWGtTMWVEcEZhV0RFREFEWWI0ckRCb2RBdk8xYm03ZXdTMzhSbk1UaTlhdFZzNVNTODNpZG5HbFZiSmsKYkZKWG0rWWxJNHFkaXowTFdjWGJyREE9Ci0tLS0tRU5EIFBSSVZBVEUgS0VZLS0tLS0K\"},\"kind\":\"Secret\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"authenticationhttpfailuremodeallowtest\",\"scope\":\"AmbassadorTest\"},\"name\":\"auth-failure-secret\",\"namespace\":\"default\"},\"type\":\"kubernetes.io/tls\"}\n"
                     },
-                    "creationTimestamp": "2020-02-19T23:19:58Z",
+                    "creationTimestamp": "2020-02-26T15:51:40Z",
                     "labels": {
                         "kat-ambassador-id": "authenticationhttpfailuremodeallowtest",
                         "scope": "AmbassadorTest"
                     },
                     "name": "auth-failure-secret",
                     "namespace": "default",
-                    "resourceVersion": "55347",
+                    "resourceVersion": "66009",
                     "selfLink": "/api/v1/namespaces/default/secrets/auth-failure-secret",
-                    "uid": "5876dd66-536e-11ea-85dd-167682b5c255"
+                    "uid": "e13b13b6-58af-11ea-86d6-0e674b3ff44f"
                 },
                 "type": "kubernetes.io/tls"
             }
@@ -49,7 +49,7 @@
                         "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: TLSContext\nname: AuthenticationHTTPFailureModeAllowTest-failure-context\nsecret: auth-failure-secret\nambassador_id: authenticationhttpfailuremodeallowtest\n---\napiVersion: ambassador/v1\nkind: AuthService\nname: authenticationhttpfailuremodeallowtest-http-auth\nauth_service: \"authenticationhttpfailuremodeallowtest-http-auth\"\npath_prefix: \"/extauth\"\ntimeout_ms: 5000\ntls: AuthenticationHTTPFailureModeAllowTest-failure-context\nallowed_request_headers:\n- Requested-Status\n- Requested-Header\nfailure_mode_allow: true\nambassador_id: authenticationhttpfailuremodeallowtest\n\n---\napiVersion: ambassador/v0\nkind: Mapping\nname: authenticationhttpfailuremodeallowtest-http\nprefix: /target/\nservice: authenticationhttpfailuremodeallowtest-http\nambassador_id: authenticationhttpfailuremodeallowtest\n",
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: TLSContext\\nname: AuthenticationHTTPFailureModeAllowTest-failure-context\\nsecret: auth-failure-secret\\nambassador_id: authenticationhttpfailuremodeallowtest\\n---\\napiVersion: ambassador/v1\\nkind: AuthService\\nname: authenticationhttpfailuremodeallowtest-http-auth\\nauth_service: \\\"authenticationhttpfailuremodeallowtest-http-auth\\\"\\npath_prefix: \\\"/extauth\\\"\\ntimeout_ms: 5000\\ntls: AuthenticationHTTPFailureModeAllowTest-failure-context\\nallowed_request_headers:\\n- Requested-Status\\n- Requested-Header\\nfailure_mode_allow: true\\nambassador_id: authenticationhttpfailuremodeallowtest\\n\\n---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: authenticationhttpfailuremodeallowtest-http\\nprefix: /target/\\nservice: authenticationhttpfailuremodeallowtest-http\\nambassador_id: authenticationhttpfailuremodeallowtest\\n\"},\"labels\":{\"app.kubernetes.io/component\":\"ambassador-service\",\"kat-ambassador-id\":\"authenticationhttpfailuremodeallowtest\",\"scope\":\"AmbassadorTest\"},\"name\":\"authenticationhttpfailuremodeallowtest\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8080},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8443}],\"selector\":{\"service\":\"authenticationhttpfailuremodeallowtest\"},\"type\":\"NodePort\"}}\n"
                     },
-                    "creationTimestamp": "2020-02-19T23:19:58Z",
+                    "creationTimestamp": "2020-02-26T15:51:41Z",
                     "labels": {
                         "app.kubernetes.io/component": "ambassador-service",
                         "kat-ambassador-id": "authenticationhttpfailuremodeallowtest",
@@ -57,24 +57,24 @@
                     },
                     "name": "authenticationhttpfailuremodeallowtest",
                     "namespace": "default",
-                    "resourceVersion": "55337",
+                    "resourceVersion": "66022",
                     "selfLink": "/api/v1/namespaces/default/services/authenticationhttpfailuremodeallowtest",
-                    "uid": "58615ed8-536e-11ea-85dd-167682b5c255"
+                    "uid": "e1642482-58af-11ea-86d6-0e674b3ff44f"
                 },
                 "spec": {
-                    "clusterIP": "10.100.47.253",
+                    "clusterIP": "10.106.233.201",
                     "externalTrafficPolicy": "Cluster",
                     "ports": [
                         {
                             "name": "http",
-                            "nodePort": 32032,
+                            "nodePort": 30166,
                             "port": 80,
                             "protocol": "TCP",
                             "targetPort": 8080
                         },
                         {
                             "name": "https",
-                            "nodePort": 32393,
+                            "nodePort": 32645,
                             "port": 443,
                             "protocol": "TCP",
                             "targetPort": 8443
@@ -97,7 +97,7 @@
                     "annotations": {
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"authenticationhttpfailuremodeallowtest\",\"scope\":\"AmbassadorTest\",\"service\":\"authenticationhttpfailuremodeallowtest-admin\"},\"name\":\"authenticationhttpfailuremodeallowtest-admin\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"authenticationhttpfailuremodeallowtest-admin\",\"port\":8877,\"targetPort\":8877}],\"selector\":{\"service\":\"authenticationhttpfailuremodeallowtest\"},\"type\":\"NodePort\"}}\n"
                     },
-                    "creationTimestamp": "2020-02-19T23:19:58Z",
+                    "creationTimestamp": "2020-02-26T15:51:41Z",
                     "labels": {
                         "kat-ambassador-id": "authenticationhttpfailuremodeallowtest",
                         "scope": "AmbassadorTest",
@@ -105,17 +105,17 @@
                     },
                     "name": "authenticationhttpfailuremodeallowtest-admin",
                     "namespace": "default",
-                    "resourceVersion": "55341",
+                    "resourceVersion": "66028",
                     "selfLink": "/api/v1/namespaces/default/services/authenticationhttpfailuremodeallowtest-admin",
-                    "uid": "586a11dd-536e-11ea-85dd-167682b5c255"
+                    "uid": "e1763f28-58af-11ea-86d6-0e674b3ff44f"
                 },
                 "spec": {
-                    "clusterIP": "10.110.3.248",
+                    "clusterIP": "10.107.181.223",
                     "externalTrafficPolicy": "Cluster",
                     "ports": [
                         {
                             "name": "authenticationhttpfailuremodeallowtest-admin",
-                            "nodePort": 30348,
+                            "nodePort": 31385,
                             "port": 8877,
                             "protocol": "TCP",
                             "targetPort": 8877
@@ -138,19 +138,19 @@
                     "annotations": {
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"authenticationhttpfailuremodeallowtest\",\"scope\":\"AmbassadorTest\"},\"name\":\"authenticationhttpfailuremodeallowtest-http\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8090},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8453}],\"selector\":{\"backend\":\"superpod-default\"}}}\n"
                     },
-                    "creationTimestamp": "2020-02-19T23:19:58Z",
+                    "creationTimestamp": "2020-02-26T15:51:41Z",
                     "labels": {
                         "kat-ambassador-id": "authenticationhttpfailuremodeallowtest",
                         "scope": "AmbassadorTest"
                     },
                     "name": "authenticationhttpfailuremodeallowtest-http",
                     "namespace": "default",
-                    "resourceVersion": "55350",
+                    "resourceVersion": "66035",
                     "selfLink": "/api/v1/namespaces/default/services/authenticationhttpfailuremodeallowtest-http",
-                    "uid": "587ea3d2-536e-11ea-85dd-167682b5c255"
+                    "uid": "e189ef13-58af-11ea-86d6-0e674b3ff44f"
                 },
                 "spec": {
-                    "clusterIP": "10.104.145.42",
+                    "clusterIP": "10.100.249.215",
                     "ports": [
                         {
                             "name": "http",
@@ -182,19 +182,19 @@
                     "annotations": {
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"authenticationhttpfailuremodeallowtest\",\"scope\":\"AmbassadorTest\"},\"name\":\"authenticationhttpfailuremodeallowtest-http-auth\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8091},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8454}],\"selector\":{\"backend\":\"superpod-default\"}}}\n"
                     },
-                    "creationTimestamp": "2020-02-19T23:19:58Z",
+                    "creationTimestamp": "2020-02-26T15:51:41Z",
                     "labels": {
                         "kat-ambassador-id": "authenticationhttpfailuremodeallowtest",
                         "scope": "AmbassadorTest"
                     },
                     "name": "authenticationhttpfailuremodeallowtest-http-auth",
                     "namespace": "default",
-                    "resourceVersion": "55354",
+                    "resourceVersion": "66039",
                     "selfLink": "/api/v1/namespaces/default/services/authenticationhttpfailuremodeallowtest-http-auth",
-                    "uid": "58911d5f-536e-11ea-85dd-167682b5c255"
+                    "uid": "e194bc29-58af-11ea-86d6-0e674b3ff44f"
                 },
                 "spec": {
-                    "clusterIP": "10.98.12.220",
+                    "clusterIP": "10.110.25.206",
                     "ports": [
                         {
                             "name": "http",

--- a/python/tests/gold/authenticationhttppartialbuffertest/snapshots/econf.json
+++ b/python/tests/gold/authenticationhttppartialbuffertest/snapshots/econf.json
@@ -447,8 +447,7 @@
                                     "xff_num_trusted_hops": 0
                                 }
                             }
-                        ],
-                        "use_proxy_proto": false
+                        ]
                     }
                 ],
                 "listener_filters": [],

--- a/python/tests/gold/authenticationhttppartialbuffertest/snapshots/snapshot.yaml
+++ b/python/tests/gold/authenticationhttppartialbuffertest/snapshots/snapshot.yaml
@@ -26,16 +26,16 @@
                     "annotations": {
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"data\":{\"tls.crt\":\"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURnRENDQW1pZ0F3SUJBZ0lKQUpycUl0ekY2MTBpTUEwR0NTcUdTSWIzRFFFQkN3VUFNRlV4Q3pBSkJnTlYKQkFZVEFsVlRNUXN3Q1FZRFZRUUlEQUpOUVRFUE1BMEdBMVVFQnd3R1FtOXpkRzl1TVFzd0NRWURWUVFLREFKRQpWekViTUJrR0ExVUVBd3dTZEd4ekxXTnZiblJsZUhRdGFHOXpkQzB4TUI0WERURTRNVEV3TVRFek5UTXhPRm9YCkRUSTRNVEF5T1RFek5UTXhPRm93VlRFTE1Ba0dBMVVFQmhNQ1ZWTXhDekFKQmdOVkJBZ01BazFCTVE4d0RRWUQKVlFRSERBWkNiM04wYjI0eEN6QUpCZ05WQkFvTUFrUlhNUnN3R1FZRFZRUUREQkowYkhNdFkyOXVkR1Y0ZEMxbwpiM04wTFRFd2dnRWlNQTBHQ1NxR1NJYjNEUUVCQVFVQUE0SUJEd0F3Z2dFS0FvSUJBUUM5T2dDOHd4eUlyUHpvCkdYc0xwUEt0NzJERXgyd2p3VzhuWFcyd1dieWEzYzk2bjJuU0NLUEJuODVoYnFzaHpqNWloU1RBTURJb2c5RnYKRzZSS1dVUFhUNEtJa1R2M0NESHFYc0FwSmxKNGxTeW5ReW8yWnYwbytBZjhDTG5nWVpCK3JmenRad3llRGhWcAp3WXpCVjIzNXp6NisycWJWbUNabHZCdVhiVXFUbEVZWXZ1R2xNR3o3cFBmT1dLVXBlWW9kYkcyZmIraEZGcGVvCkN4a1VYclFzT29SNUpkSEc1aldyWnVCTzQ1NVNzcnpCTDhSbGU1VUhvMDVXY0s3YkJiaVF6MTA2cEhDSllaK3AKdmxQSWNOU1g1S2gzNEZnOTZVUHg5bFFpQTN6RFRLQmZ5V2NMUStxMWNabExjV2RnUkZjTkJpckdCLzdyYTFWVApnRUplR2tQekFnTUJBQUdqVXpCUk1CMEdBMVVkRGdRV0JCUkRWVUtYWWJsRFdNTzE3MUJuWWZhYlkzM0NFVEFmCkJnTlZIU01FR0RBV2dCUkRWVUtYWWJsRFdNTzE3MUJuWWZhYlkzM0NFVEFQQmdOVkhSTUJBZjhFQlRBREFRSC8KTUEwR0NTcUdTSWIzRFFFQkN3VUFBNElCQVFBUE8vRDRUdDUyWHJsQ0NmUzZnVUVkRU5DcnBBV05YRHJvR2M2dApTVGx3aC8rUUxRYk5hZEtlaEtiZjg5clhLaituVXF0cS9OUlpQSXNBSytXVWtHOVpQb1FPOFBRaVY0V1g1clE3CjI5dUtjSmZhQlhrZHpVVzdxTlFoRTRjOEJhc0JySWVzcmtqcFQ5OVF4SktuWFFhTitTdzdvRlBVSUFOMzhHcWEKV2wvS1BNVHRicWt3eWFjS01CbXExVkx6dldKb0g1Q2l6Skp3aG5rWHh0V0tzLzY3clROblBWTXorbWVHdHZTaQpkcVg2V1NTbUdMRkVFcjJoZ1VjQVpqazNWdVFoLzc1aFh1K1UySXRzQys1cXBsaEc3Q1hzb1huS0t5MVhsT0FFCmI4a3IyZFdXRWs2STVZNm5USnpXSWxTVGtXODl4d1hyY3RtTjlzYjlxNFNuaVZsegotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==\",\"tls.key\":\"LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0tCk1JSUV2UUlCQURBTkJna3Foa2lHOXcwQkFRRUZBQVNDQktjd2dnU2pBZ0VBQW9JQkFRQzlPZ0M4d3h5SXJQem8KR1hzTHBQS3Q3MkRFeDJ3andXOG5YVzJ3V2J5YTNjOTZuMm5TQ0tQQm44NWhicXNoemo1aWhTVEFNRElvZzlGdgpHNlJLV1VQWFQ0S0lrVHYzQ0RIcVhzQXBKbEo0bFN5blF5bzJadjBvK0FmOENMbmdZWkIrcmZ6dFp3eWVEaFZwCndZekJWMjM1eno2KzJxYlZtQ1psdkJ1WGJVcVRsRVlZdnVHbE1HejdwUGZPV0tVcGVZb2RiRzJmYitoRkZwZW8KQ3hrVVhyUXNPb1I1SmRIRzVqV3JadUJPNDU1U3NyekJMOFJsZTVVSG8wNVdjSzdiQmJpUXoxMDZwSENKWVorcAp2bFBJY05TWDVLaDM0Rmc5NlVQeDlsUWlBM3pEVEtCZnlXY0xRK3ExY1psTGNXZGdSRmNOQmlyR0IvN3JhMVZUCmdFSmVHa1B6QWdNQkFBRUNnZ0VBQmFsN3BpcE1hMGFKMXNRVWEzZkhEeTlQZlBQZXAzODlQVGROZGU1cGQxVFYKeFh5SnBSQS9IaWNTL05WYjU0b05VZE5jRXlnZUNCcFJwUHAxd3dmQ3dPbVBKVmo3SzF3aWFqbmxsQldpZUJzMgpsOWFwcDdFVE9DdWJ5WTNWU2dLQldWa0piVzBjOG9uSFdEL0RYM0duUjhkTXdGYzRrTUdadkllUlo4bU1acmdHCjZPdDNKOHI2eVZsZWI2OGF1WmtneXMwR2VGc3pNdVRubHJCOEw5djI1UUtjVGtESjIvRWx1Y1p5aER0eGF0OEIKTzZOUnNubmNyOHhwUVdPci9sV3M5VVFuZEdCdHFzbXMrdGNUN1ZUNU9UanQ4WHY5NVhNSHB5Z29pTHk3czhvYwpJMGprNDJabzRKZW5JT3c2Rm0weUFEZ0E3eWlXcks0bEkzWGhqaTVSb1FLQmdRRGRqaWNkTUpYVUZWc28rNTJkCkUwT2EwcEpVMFNSaC9JQmdvRzdNakhrVWxiaXlpR1pNanA5MEo5VHFaL1ErM1pWZVdqMmxPSWF0OG5nUzB6MDAKVzA3T1ZxYXprMVNYaFZlY2tGNWFEcm5PRDNhU2VWMSthV3JUdDFXRWdqOVFxYnJZYVA5emd4UkpkRzV3WENCUApGNDNFeXE5ZEhXOWF6SSt3UHlJQ0JqNnZBd0tCZ1FEYXBTelhPR2ViMi9SMWhlWXdWV240czNGZEtYVjgzemtTCnFSWDd6d1pLdkk5OGMybDU1Y1ZNUzBoTGM0bTVPMXZCaUd5SG80eTB2SVAvR0k0Rzl4T1FhMXdpVnNmUVBiSU4KLzJPSDFnNXJLSFdCWVJUaHZGcERqdHJRU2xyRHVjWUNSRExCd1hUcDFrbVBkL09mY2FybG42MjZEamthZllieAp3dWUydlhCTVVRS0JnQm4vTmlPOHNiZ0RFWUZMbFFEN1k3RmxCL3FmMTg4UG05aTZ1b1dSN2hzMlBrZmtyV3hLClIvZVBQUEtNWkNLRVNhU2FuaVVtN3RhMlh0U0dxT1hkMk85cFI0Skd4V1JLSnkrZDJSUmtLZlU5NTBIa3I4M0gKZk50KzVhLzR3SWtzZ1ZvblorSWIvV05wSUJSYkd3ZHMwaHZIVkxCdVpjU1h3RHlFQysrRTRCSVZBb0dCQUoxUQp6eXlqWnRqYnI4NkhZeEpQd29teEF0WVhLSE9LWVJRdUdLVXZWY1djV2xrZTZUdE51V0dsb1FTNHd0VkdBa1VECmxhTWFaL2o2MHJaT3dwSDhZRlUvQ2ZHakl1MlFGbmEvMUtzOXR1NGZGRHpjenh1RVhDWFR1Vmk0eHdtZ3R2bVcKZkRhd3JTQTZrSDdydlp4eE9wY3hCdHloc3pCK05RUHFTckpQSjJlaEFvR0FkdFJKam9vU0lpYURVU25lZUcyZgpUTml1T01uazJkeFV3RVF2S1E4eWNuUnpyN0QwaEtZVWIycThHKzE2bThQUjNCcFMzZDFLbkpMVnI3TUhaWHpSCitzZHNaWGtTMWVEcEZhV0RFREFEWWI0ckRCb2RBdk8xYm03ZXdTMzhSbk1UaTlhdFZzNVNTODNpZG5HbFZiSmsKYkZKWG0rWWxJNHFkaXowTFdjWGJyREE9Ci0tLS0tRU5EIFBSSVZBVEUgS0VZLS0tLS0K\"},\"kind\":\"Secret\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"authenticationhttppartialbuffertest\",\"scope\":\"AmbassadorTest\"},\"name\":\"auth-partial-secret\",\"namespace\":\"default\"},\"type\":\"kubernetes.io/tls\"}\n"
                     },
-                    "creationTimestamp": "2020-02-19T23:19:57Z",
+                    "creationTimestamp": "2020-02-26T15:51:39Z",
                     "labels": {
                         "kat-ambassador-id": "authenticationhttppartialbuffertest",
                         "scope": "AmbassadorTest"
                     },
                     "name": "auth-partial-secret",
                     "namespace": "default",
-                    "resourceVersion": "55288",
+                    "resourceVersion": "65949",
                     "selfLink": "/api/v1/namespaces/default/secrets/auth-partial-secret",
-                    "uid": "57c8d793-536e-11ea-85dd-167682b5c255"
+                    "uid": "e065edc7-58af-11ea-86d6-0e674b3ff44f"
                 },
                 "type": "kubernetes.io/tls"
             }
@@ -46,10 +46,54 @@
                 "kind": "Service",
                 "metadata": {
                     "annotations": {
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"authenticationhttppartialbuffertest\",\"scope\":\"AmbassadorTest\"},\"name\":\"authenticationhttppartialbuffertest-http-auth\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8087},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8450}],\"selector\":{\"backend\":\"superpod-default\"}}}\n"
+                    },
+                    "creationTimestamp": "2020-02-26T15:51:40Z",
+                    "labels": {
+                        "kat-ambassador-id": "authenticationhttppartialbuffertest",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "authenticationhttppartialbuffertest-http-auth",
+                    "namespace": "default",
+                    "resourceVersion": "65975",
+                    "selfLink": "/api/v1/namespaces/default/services/authenticationhttppartialbuffertest-http-auth",
+                    "uid": "e0c60471-58af-11ea-86d6-0e674b3ff44f"
+                },
+                "spec": {
+                    "clusterIP": "10.111.198.245",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8087
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8450
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-default"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
                         "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: TLSContext\nname: AuthenticationHTTPPartialBufferTest-same-context-1\nsecret: auth-partial-secret\nambassador_id: authenticationhttppartialbuffertest\n---\napiVersion: ambassador/v2\nkind: AuthService\nname: authenticationhttppartialbuffertest-http-auth\nauth_service: \"authenticationhttppartialbuffertest-http-auth\"\npath_prefix: \"/extauth\"\ntimeout_ms: 5000\ntls: AuthenticationHTTPPartialBufferTest-same-context-1\nallowed_request_headers:\n- Requested-Status\n- Requested-Header\nallowed_authorization_headers:\n- Auth-Request-Body\ninclude_body:\n  max_bytes: 7\n  allow_partial: true\nambassador_id: authenticationhttppartialbuffertest\n\n---\napiVersion: ambassador/v0\nkind: Mapping\nname: authenticationhttppartialbuffertest-http\nprefix: /target/\nservice: authenticationhttppartialbuffertest-http\nambassador_id: authenticationhttppartialbuffertest\n",
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: TLSContext\\nname: AuthenticationHTTPPartialBufferTest-same-context-1\\nsecret: auth-partial-secret\\nambassador_id: authenticationhttppartialbuffertest\\n---\\napiVersion: ambassador/v2\\nkind: AuthService\\nname: authenticationhttppartialbuffertest-http-auth\\nauth_service: \\\"authenticationhttppartialbuffertest-http-auth\\\"\\npath_prefix: \\\"/extauth\\\"\\ntimeout_ms: 5000\\ntls: AuthenticationHTTPPartialBufferTest-same-context-1\\nallowed_request_headers:\\n- Requested-Status\\n- Requested-Header\\nallowed_authorization_headers:\\n- Auth-Request-Body\\ninclude_body:\\n  max_bytes: 7\\n  allow_partial: true\\nambassador_id: authenticationhttppartialbuffertest\\n\\n---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: authenticationhttppartialbuffertest-http\\nprefix: /target/\\nservice: authenticationhttppartialbuffertest-http\\nambassador_id: authenticationhttppartialbuffertest\\n\"},\"labels\":{\"app.kubernetes.io/component\":\"ambassador-service\",\"kat-ambassador-id\":\"authenticationhttppartialbuffertest\",\"scope\":\"AmbassadorTest\"},\"name\":\"authenticationhttppartialbuffertest\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8080},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8443}],\"selector\":{\"service\":\"authenticationhttppartialbuffertest\"},\"type\":\"NodePort\"}}\n"
                     },
-                    "creationTimestamp": "2020-02-19T23:19:57Z",
+                    "creationTimestamp": "2020-02-26T15:51:39Z",
                     "labels": {
                         "app.kubernetes.io/component": "ambassador-service",
                         "kat-ambassador-id": "authenticationhttppartialbuffertest",
@@ -57,24 +101,24 @@
                     },
                     "name": "authenticationhttppartialbuffertest",
                     "namespace": "default",
-                    "resourceVersion": "55278",
+                    "resourceVersion": "65961",
                     "selfLink": "/api/v1/namespaces/default/services/authenticationhttppartialbuffertest",
-                    "uid": "57b261fa-536e-11ea-85dd-167682b5c255"
+                    "uid": "e09ca5f7-58af-11ea-86d6-0e674b3ff44f"
                 },
                 "spec": {
-                    "clusterIP": "10.98.55.199",
+                    "clusterIP": "10.109.202.90",
                     "externalTrafficPolicy": "Cluster",
                     "ports": [
                         {
                             "name": "http",
-                            "nodePort": 32110,
+                            "nodePort": 31508,
                             "port": 80,
                             "protocol": "TCP",
                             "targetPort": 8080
                         },
                         {
                             "name": "https",
-                            "nodePort": 32608,
+                            "nodePort": 32382,
                             "port": 443,
                             "protocol": "TCP",
                             "targetPort": 8443
@@ -97,7 +141,7 @@
                     "annotations": {
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"authenticationhttppartialbuffertest\",\"scope\":\"AmbassadorTest\",\"service\":\"authenticationhttppartialbuffertest-admin\"},\"name\":\"authenticationhttppartialbuffertest-admin\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"authenticationhttppartialbuffertest-admin\",\"port\":8877,\"targetPort\":8877}],\"selector\":{\"service\":\"authenticationhttppartialbuffertest\"},\"type\":\"NodePort\"}}\n"
                     },
-                    "creationTimestamp": "2020-02-19T23:19:57Z",
+                    "creationTimestamp": "2020-02-26T15:51:39Z",
                     "labels": {
                         "kat-ambassador-id": "authenticationhttppartialbuffertest",
                         "scope": "AmbassadorTest",
@@ -105,17 +149,17 @@
                     },
                     "name": "authenticationhttppartialbuffertest-admin",
                     "namespace": "default",
-                    "resourceVersion": "55282",
+                    "resourceVersion": "65965",
                     "selfLink": "/api/v1/namespaces/default/services/authenticationhttppartialbuffertest-admin",
-                    "uid": "57bae12d-536e-11ea-85dd-167682b5c255"
+                    "uid": "e0a6e339-58af-11ea-86d6-0e674b3ff44f"
                 },
                 "spec": {
-                    "clusterIP": "10.104.178.1",
+                    "clusterIP": "10.107.100.236",
                     "externalTrafficPolicy": "Cluster",
                     "ports": [
                         {
                             "name": "authenticationhttppartialbuffertest-admin",
-                            "nodePort": 30213,
+                            "nodePort": 31406,
                             "port": 8877,
                             "protocol": "TCP",
                             "targetPort": 8877
@@ -138,19 +182,19 @@
                     "annotations": {
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"authenticationhttppartialbuffertest\",\"scope\":\"AmbassadorTest\"},\"name\":\"authenticationhttppartialbuffertest-http\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8086},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8449}],\"selector\":{\"backend\":\"superpod-default\"}}}\n"
                     },
-                    "creationTimestamp": "2020-02-19T23:19:57Z",
+                    "creationTimestamp": "2020-02-26T15:51:40Z",
                     "labels": {
                         "kat-ambassador-id": "authenticationhttppartialbuffertest",
                         "scope": "AmbassadorTest"
                     },
                     "name": "authenticationhttppartialbuffertest-http",
                     "namespace": "default",
-                    "resourceVersion": "55290",
+                    "resourceVersion": "65972",
                     "selfLink": "/api/v1/namespaces/default/services/authenticationhttppartialbuffertest-http",
-                    "uid": "57d01d46-536e-11ea-85dd-167682b5c255"
+                    "uid": "e0bad89d-58af-11ea-86d6-0e674b3ff44f"
                 },
                 "spec": {
-                    "clusterIP": "10.99.110.62",
+                    "clusterIP": "10.100.207.17",
                     "ports": [
                         {
                             "name": "http",
@@ -163,50 +207,6 @@
                             "port": 443,
                             "protocol": "TCP",
                             "targetPort": 8449
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-default"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"authenticationhttppartialbuffertest\",\"scope\":\"AmbassadorTest\"},\"name\":\"authenticationhttppartialbuffertest-http-auth\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8087},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8450}],\"selector\":{\"backend\":\"superpod-default\"}}}\n"
-                    },
-                    "creationTimestamp": "2020-02-19T23:19:57Z",
-                    "labels": {
-                        "kat-ambassador-id": "authenticationhttppartialbuffertest",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "authenticationhttppartialbuffertest-http-auth",
-                    "namespace": "default",
-                    "resourceVersion": "55293",
-                    "selfLink": "/api/v1/namespaces/default/services/authenticationhttppartialbuffertest-http-auth",
-                    "uid": "57dabb38-536e-11ea-85dd-167682b5c255"
-                },
-                "spec": {
-                    "clusterIP": "10.108.126.206",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8087
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8450
                         }
                     ],
                     "selector": {

--- a/python/tests/gold/authenticationtest/snapshots/econf.json
+++ b/python/tests/gold/authenticationtest/snapshots/econf.json
@@ -502,8 +502,7 @@
                                     "xff_num_trusted_hops": 0
                                 }
                             }
-                        ],
-                        "use_proxy_proto": false
+                        ]
                     }
                 ],
                 "listener_filters": [],

--- a/python/tests/gold/authenticationtest/snapshots/snapshot.yaml
+++ b/python/tests/gold/authenticationtest/snapshots/snapshot.yaml
@@ -20,58 +20,9 @@
                 "kind": "Service",
                 "metadata": {
                     "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: AuthService\nname: authenticationtest-ahttp-auth\nauth_service: \"authenticationtest-ahttp-auth\"\npath_prefix: \"/extauth\"\nallowed_headers:\n- X-Foo\n- X-Bar\n- Requested-Location\n- Requested-Status\n- Requested-Header\n- X-Foo\n- Extauth\nambassador_id: authenticationtest\n\n---\napiVersion: ambassador/v0\nkind: Mapping\nname: authenticationtest-http\nprefix: /target/\nservice: authenticationtest-http\nambassador_id: authenticationtest\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: AuthService\\nname: authenticationtest-ahttp-auth\\nauth_service: \\\"authenticationtest-ahttp-auth\\\"\\npath_prefix: \\\"/extauth\\\"\\nallowed_headers:\\n- X-Foo\\n- X-Bar\\n- Requested-Location\\n- Requested-Status\\n- Requested-Header\\n- X-Foo\\n- Extauth\\nambassador_id: authenticationtest\\n\\n---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: authenticationtest-http\\nprefix: /target/\\nservice: authenticationtest-http\\nambassador_id: authenticationtest\\n\"},\"labels\":{\"app.kubernetes.io/component\":\"ambassador-service\",\"kat-ambassador-id\":\"authenticationtest\",\"scope\":\"AmbassadorTest\"},\"name\":\"authenticationtest\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8080},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8443}],\"selector\":{\"service\":\"authenticationtest\"},\"type\":\"NodePort\"}}\n"
-                    },
-                    "creationTimestamp": "2020-02-19T23:19:59Z",
-                    "labels": {
-                        "app.kubernetes.io/component": "ambassador-service",
-                        "kat-ambassador-id": "authenticationtest",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "authenticationtest",
-                    "namespace": "default",
-                    "resourceVersion": "55404",
-                    "selfLink": "/api/v1/namespaces/default/services/authenticationtest",
-                    "uid": "5913d6aa-536e-11ea-85dd-167682b5c255"
-                },
-                "spec": {
-                    "clusterIP": "10.103.212.225",
-                    "externalTrafficPolicy": "Cluster",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "nodePort": 31556,
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8080
-                        },
-                        {
-                            "name": "https",
-                            "nodePort": 31027,
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8443
-                        }
-                    ],
-                    "selector": {
-                        "service": "authenticationtest"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "NodePort"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"authenticationtest\",\"scope\":\"AmbassadorTest\",\"service\":\"authenticationtest-admin\"},\"name\":\"authenticationtest-admin\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"authenticationtest-admin\",\"port\":8877,\"targetPort\":8877}],\"selector\":{\"service\":\"authenticationtest\"},\"type\":\"NodePort\"}}\n"
                     },
-                    "creationTimestamp": "2020-02-19T23:19:59Z",
+                    "creationTimestamp": "2020-02-26T15:51:42Z",
                     "labels": {
                         "kat-ambassador-id": "authenticationtest",
                         "scope": "AmbassadorTest",
@@ -79,17 +30,17 @@
                     },
                     "name": "authenticationtest-admin",
                     "namespace": "default",
-                    "resourceVersion": "55409",
+                    "resourceVersion": "66094",
                     "selfLink": "/api/v1/namespaces/default/services/authenticationtest-admin",
-                    "uid": "591c8387-536e-11ea-85dd-167682b5c255"
+                    "uid": "e23ae67d-58af-11ea-86d6-0e674b3ff44f"
                 },
                 "spec": {
-                    "clusterIP": "10.98.235.227",
+                    "clusterIP": "10.106.44.87",
                     "externalTrafficPolicy": "Cluster",
                     "ports": [
                         {
                             "name": "authenticationtest-admin",
-                            "nodePort": 31232,
+                            "nodePort": 32114,
                             "port": 8877,
                             "protocol": "TCP",
                             "targetPort": 8877
@@ -112,19 +63,19 @@
                     "annotations": {
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"authenticationtest\",\"scope\":\"AmbassadorTest\"},\"name\":\"authenticationtest-ahttp-auth\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8080},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8443}],\"selector\":{\"backend\":\"authenticationtest-ahttp-auth\"}}}\n"
                     },
-                    "creationTimestamp": "2020-02-19T23:19:59Z",
+                    "creationTimestamp": "2020-02-26T15:51:42Z",
                     "labels": {
                         "kat-ambassador-id": "authenticationtest",
                         "scope": "AmbassadorTest"
                     },
                     "name": "authenticationtest-ahttp-auth",
                     "namespace": "default",
-                    "resourceVersion": "55419",
+                    "resourceVersion": "66106",
                     "selfLink": "/api/v1/namespaces/default/services/authenticationtest-ahttp-auth",
-                    "uid": "593391e1-536e-11ea-85dd-167682b5c255"
+                    "uid": "e25e003d-58af-11ea-86d6-0e674b3ff44f"
                 },
                 "spec": {
-                    "clusterIP": "10.101.118.95",
+                    "clusterIP": "10.101.95.38",
                     "ports": [
                         {
                             "name": "http",
@@ -156,19 +107,19 @@
                     "annotations": {
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"authenticationtest\",\"scope\":\"AmbassadorTest\"},\"name\":\"authenticationtest-http\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8093},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8456}],\"selector\":{\"backend\":\"superpod-default\"}}}\n"
                     },
-                    "creationTimestamp": "2020-02-19T23:19:59Z",
+                    "creationTimestamp": "2020-02-26T15:51:42Z",
                     "labels": {
                         "kat-ambassador-id": "authenticationtest",
                         "scope": "AmbassadorTest"
                     },
                     "name": "authenticationtest-http",
                     "namespace": "default",
-                    "resourceVersion": "55416",
+                    "resourceVersion": "66101",
                     "selfLink": "/api/v1/namespaces/default/services/authenticationtest-http",
-                    "uid": "592b2fbb-536e-11ea-85dd-167682b5c255"
+                    "uid": "e253881f-58af-11ea-86d6-0e674b3ff44f"
                 },
                 "spec": {
-                    "clusterIP": "10.96.182.46",
+                    "clusterIP": "10.109.173.77",
                     "ports": [
                         {
                             "name": "http",
@@ -188,6 +139,55 @@
                     },
                     "sessionAffinity": "None",
                     "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: AuthService\nname: authenticationtest-ahttp-auth\nauth_service: \"authenticationtest-ahttp-auth\"\npath_prefix: \"/extauth\"\nallowed_headers:\n- X-Foo\n- X-Bar\n- Requested-Location\n- Requested-Status\n- Requested-Header\n- X-Foo\n- Extauth\nambassador_id: authenticationtest\n\n---\napiVersion: ambassador/v0\nkind: Mapping\nname: authenticationtest-http\nprefix: /target/\nservice: authenticationtest-http\nambassador_id: authenticationtest\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: AuthService\\nname: authenticationtest-ahttp-auth\\nauth_service: \\\"authenticationtest-ahttp-auth\\\"\\npath_prefix: \\\"/extauth\\\"\\nallowed_headers:\\n- X-Foo\\n- X-Bar\\n- Requested-Location\\n- Requested-Status\\n- Requested-Header\\n- X-Foo\\n- Extauth\\nambassador_id: authenticationtest\\n\\n---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: authenticationtest-http\\nprefix: /target/\\nservice: authenticationtest-http\\nambassador_id: authenticationtest\\n\"},\"labels\":{\"app.kubernetes.io/component\":\"ambassador-service\",\"kat-ambassador-id\":\"authenticationtest\",\"scope\":\"AmbassadorTest\"},\"name\":\"authenticationtest\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8080},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8443}],\"selector\":{\"service\":\"authenticationtest\"},\"type\":\"NodePort\"}}\n"
+                    },
+                    "creationTimestamp": "2020-02-26T15:51:42Z",
+                    "labels": {
+                        "app.kubernetes.io/component": "ambassador-service",
+                        "kat-ambassador-id": "authenticationtest",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "authenticationtest",
+                    "namespace": "default",
+                    "resourceVersion": "66090",
+                    "selfLink": "/api/v1/namespaces/default/services/authenticationtest",
+                    "uid": "e23103aa-58af-11ea-86d6-0e674b3ff44f"
+                },
+                "spec": {
+                    "clusterIP": "10.106.36.38",
+                    "externalTrafficPolicy": "Cluster",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "nodePort": 32054,
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8080
+                        },
+                        {
+                            "name": "https",
+                            "nodePort": 30172,
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8443
+                        }
+                    ],
+                    "selector": {
+                        "service": "authenticationtest"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "NodePort"
                 },
                 "status": {
                     "loadBalancer": {}

--- a/python/tests/gold/authenticationtestv1/snapshots/econf.json
+++ b/python/tests/gold/authenticationtestv1/snapshots/econf.json
@@ -513,8 +513,7 @@
                                     "xff_num_trusted_hops": 0
                                 }
                             }
-                        ],
-                        "use_proxy_proto": false
+                        ]
                     }
                 ],
                 "listener_filters": [],

--- a/python/tests/gold/authenticationtestv1/snapshots/snapshot.yaml
+++ b/python/tests/gold/authenticationtestv1/snapshots/snapshot.yaml
@@ -23,7 +23,7 @@
                         "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: AuthService\nname: authenticationtestv1-ahttp-auth1\nauth_service: \"authenticationtestv1-ahttp-auth1\"\nproto: http\npath_prefix: \"/extauth\"\ntimeout_ms: 5000\nallowed_request_headers:\n- X-Foo\n- X-Bar\n- Requested-Status\n- Requested-Header\n- Location\nallowed_authorization_headers:\n- X-Foo\n- Extauth\nstatus_on_error:\n  code: 503\nambassador_id: authenticationtestv1\n---\napiVersion: ambassador/v1\nkind: AuthService\nname: authenticationtestv1-ahttp-auth2\nauth_service: \"authenticationtestv1-ahttp-auth2\"\nproto: http\npath_prefix: \"/extauth\"\ntimeout_ms: 5000\nadd_linkerd_headers: true\nallowed_request_headers:\n- X-Foo\n- X-Bar\n- Requested-Status\n- Requested-Header\n- Location\nallowed_authorization_headers:\n- X-Foo\n- Extauth\nstatus_on_error:\n  code: 503\nambassador_id: authenticationtestv1\n\n---\napiVersion: ambassador/v0\nkind: Mapping\nname: authenticationtestv1-http\nprefix: /target/\nservice: authenticationtestv1-http\nambassador_id: authenticationtestv1\n---\napiVersion: ambassador/v1\nkind: Mapping\nname: authenticationtestv1-http-unauthed\nprefix: /target/unauthed/\nservice: authenticationtestv1-http\nbypass_auth: true\nambassador_id: authenticationtestv1\n",
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: AuthService\\nname: authenticationtestv1-ahttp-auth1\\nauth_service: \\\"authenticationtestv1-ahttp-auth1\\\"\\nproto: http\\npath_prefix: \\\"/extauth\\\"\\ntimeout_ms: 5000\\nallowed_request_headers:\\n- X-Foo\\n- X-Bar\\n- Requested-Status\\n- Requested-Header\\n- Location\\nallowed_authorization_headers:\\n- X-Foo\\n- Extauth\\nstatus_on_error:\\n  code: 503\\nambassador_id: authenticationtestv1\\n---\\napiVersion: ambassador/v1\\nkind: AuthService\\nname: authenticationtestv1-ahttp-auth2\\nauth_service: \\\"authenticationtestv1-ahttp-auth2\\\"\\nproto: http\\npath_prefix: \\\"/extauth\\\"\\ntimeout_ms: 5000\\nadd_linkerd_headers: true\\nallowed_request_headers:\\n- X-Foo\\n- X-Bar\\n- Requested-Status\\n- Requested-Header\\n- Location\\nallowed_authorization_headers:\\n- X-Foo\\n- Extauth\\nstatus_on_error:\\n  code: 503\\nambassador_id: authenticationtestv1\\n\\n---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: authenticationtestv1-http\\nprefix: /target/\\nservice: authenticationtestv1-http\\nambassador_id: authenticationtestv1\\n---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: authenticationtestv1-http-unauthed\\nprefix: /target/unauthed/\\nservice: authenticationtestv1-http\\nbypass_auth: true\\nambassador_id: authenticationtestv1\\n\"},\"labels\":{\"app.kubernetes.io/component\":\"ambassador-service\",\"kat-ambassador-id\":\"authenticationtestv1\",\"scope\":\"AmbassadorTest\"},\"name\":\"authenticationtestv1\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8080},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8443}],\"selector\":{\"service\":\"authenticationtestv1\"},\"type\":\"NodePort\"}}\n"
                     },
-                    "creationTimestamp": "2020-02-19T23:19:58Z",
+                    "creationTimestamp": "2020-02-26T15:51:41Z",
                     "labels": {
                         "app.kubernetes.io/component": "ambassador-service",
                         "kat-ambassador-id": "authenticationtestv1",
@@ -31,24 +31,24 @@
                     },
                     "name": "authenticationtestv1",
                     "namespace": "default",
-                    "resourceVersion": "55367",
+                    "resourceVersion": "66051",
                     "selfLink": "/api/v1/namespaces/default/services/authenticationtestv1",
-                    "uid": "58bc740c-536e-11ea-85dd-167682b5c255"
+                    "uid": "e1bbaf1d-58af-11ea-86d6-0e674b3ff44f"
                 },
                 "spec": {
-                    "clusterIP": "10.100.214.240",
+                    "clusterIP": "10.101.187.161",
                     "externalTrafficPolicy": "Cluster",
                     "ports": [
                         {
                             "name": "http",
-                            "nodePort": 32215,
+                            "nodePort": 31818,
                             "port": 80,
                             "protocol": "TCP",
                             "targetPort": 8080
                         },
                         {
                             "name": "https",
-                            "nodePort": 31640,
+                            "nodePort": 31524,
                             "port": 443,
                             "protocol": "TCP",
                             "targetPort": 8443
@@ -71,7 +71,7 @@
                     "annotations": {
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"authenticationtestv1\",\"scope\":\"AmbassadorTest\",\"service\":\"authenticationtestv1-admin\"},\"name\":\"authenticationtestv1-admin\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"authenticationtestv1-admin\",\"port\":8877,\"targetPort\":8877}],\"selector\":{\"service\":\"authenticationtestv1\"},\"type\":\"NodePort\"}}\n"
                     },
-                    "creationTimestamp": "2020-02-19T23:19:58Z",
+                    "creationTimestamp": "2020-02-26T15:51:41Z",
                     "labels": {
                         "kat-ambassador-id": "authenticationtestv1",
                         "scope": "AmbassadorTest",
@@ -79,17 +79,17 @@
                     },
                     "name": "authenticationtestv1-admin",
                     "namespace": "default",
-                    "resourceVersion": "55371",
+                    "resourceVersion": "66055",
                     "selfLink": "/api/v1/namespaces/default/services/authenticationtestv1-admin",
-                    "uid": "58c903ba-536e-11ea-85dd-167682b5c255"
+                    "uid": "e1c801d4-58af-11ea-86d6-0e674b3ff44f"
                 },
                 "spec": {
-                    "clusterIP": "10.96.208.65",
+                    "clusterIP": "10.106.162.78",
                     "externalTrafficPolicy": "Cluster",
                     "ports": [
                         {
                             "name": "authenticationtestv1-admin",
-                            "nodePort": 30992,
+                            "nodePort": 30858,
                             "port": 8877,
                             "protocol": "TCP",
                             "targetPort": 8877
@@ -112,19 +112,19 @@
                     "annotations": {
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"authenticationtestv1\",\"scope\":\"AmbassadorTest\"},\"name\":\"authenticationtestv1-ahttp-auth1\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8080},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8443}],\"selector\":{\"backend\":\"authenticationtestv1-ahttp-auth1\"}}}\n"
                     },
-                    "creationTimestamp": "2020-02-19T23:19:59Z",
+                    "creationTimestamp": "2020-02-26T15:51:42Z",
                     "labels": {
                         "kat-ambassador-id": "authenticationtestv1",
                         "scope": "AmbassadorTest"
                     },
                     "name": "authenticationtestv1-ahttp-auth1",
                     "namespace": "default",
-                    "resourceVersion": "55381",
+                    "resourceVersion": "66066",
                     "selfLink": "/api/v1/namespaces/default/services/authenticationtestv1-ahttp-auth1",
-                    "uid": "58dff3af-536e-11ea-85dd-167682b5c255"
+                    "uid": "e1e210c2-58af-11ea-86d6-0e674b3ff44f"
                 },
                 "spec": {
-                    "clusterIP": "10.108.197.99",
+                    "clusterIP": "10.98.241.75",
                     "ports": [
                         {
                             "name": "http",
@@ -156,19 +156,19 @@
                     "annotations": {
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"authenticationtestv1\",\"scope\":\"AmbassadorTest\"},\"name\":\"authenticationtestv1-ahttp-auth2\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8080},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8443}],\"selector\":{\"backend\":\"authenticationtestv1-ahttp-auth2\"}}}\n"
                     },
-                    "creationTimestamp": "2020-02-19T23:19:59Z",
+                    "creationTimestamp": "2020-02-26T15:51:42Z",
                     "labels": {
                         "kat-ambassador-id": "authenticationtestv1",
                         "scope": "AmbassadorTest"
                     },
                     "name": "authenticationtestv1-ahttp-auth2",
                     "namespace": "default",
-                    "resourceVersion": "55389",
+                    "resourceVersion": "66074",
                     "selfLink": "/api/v1/namespaces/default/services/authenticationtestv1-ahttp-auth2",
-                    "uid": "58ef5eb3-536e-11ea-85dd-167682b5c255"
+                    "uid": "e1fbad10-58af-11ea-86d6-0e674b3ff44f"
                 },
                 "spec": {
-                    "clusterIP": "10.106.144.47",
+                    "clusterIP": "10.105.144.149",
                     "ports": [
                         {
                             "name": "http",
@@ -200,19 +200,19 @@
                     "annotations": {
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"authenticationtestv1\",\"scope\":\"AmbassadorTest\"},\"name\":\"authenticationtestv1-http\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8092},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8455}],\"selector\":{\"backend\":\"superpod-default\"}}}\n"
                     },
-                    "creationTimestamp": "2020-02-19T23:19:59Z",
+                    "creationTimestamp": "2020-02-26T15:51:41Z",
                     "labels": {
                         "kat-ambassador-id": "authenticationtestv1",
                         "scope": "AmbassadorTest"
                     },
                     "name": "authenticationtestv1-http",
                     "namespace": "default",
-                    "resourceVersion": "55377",
+                    "resourceVersion": "66063",
                     "selfLink": "/api/v1/namespaces/default/services/authenticationtestv1-http",
-                    "uid": "58d7cf48-536e-11ea-85dd-167682b5c255"
+                    "uid": "e1d97d34-58af-11ea-86d6-0e674b3ff44f"
                 },
                 "spec": {
-                    "clusterIP": "10.103.14.42",
+                    "clusterIP": "10.102.7.200",
                     "ports": [
                         {
                             "name": "http",

--- a/python/tests/gold/authenticationwebsockettest/snapshots/econf.json
+++ b/python/tests/gold/authenticationwebsockettest/snapshots/econf.json
@@ -427,8 +427,7 @@
                                     "xff_num_trusted_hops": 0
                                 }
                             }
-                        ],
-                        "use_proxy_proto": false
+                        ]
                     }
                 ],
                 "listener_filters": [],

--- a/python/tests/gold/authenticationwebsockettest/snapshots/snapshot.yaml
+++ b/python/tests/gold/authenticationwebsockettest/snapshots/snapshot.yaml
@@ -20,58 +20,9 @@
                 "kind": "Service",
                 "metadata": {
                     "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: AuthService\nname: authenticationwebsockettest-http-auth\nauth_service: \"authenticationwebsockettest-http-auth\"\npath_prefix: \"/extauth\"\ntimeout_ms: 10000\nallowed_request_headers:\n- Requested-Status\nallow_request_body: true\nambassador_id: authenticationwebsockettest\n---\napiVersion: ambassador/v0\nkind: Mapping\nname: AuthenticationWebsocketTest\nprefix: /AuthenticationWebsocketTest/\nservice: http://echo.websocket.org\nhost_rewrite: echo.websocket.org\nuse_websocket: true\nambassador_id: authenticationwebsockettest\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: AuthService\\nname: authenticationwebsockettest-http-auth\\nauth_service: \\\"authenticationwebsockettest-http-auth\\\"\\npath_prefix: \\\"/extauth\\\"\\ntimeout_ms: 10000\\nallowed_request_headers:\\n- Requested-Status\\nallow_request_body: true\\nambassador_id: authenticationwebsockettest\\n---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: AuthenticationWebsocketTest\\nprefix: /AuthenticationWebsocketTest/\\nservice: http://echo.websocket.org\\nhost_rewrite: echo.websocket.org\\nuse_websocket: true\\nambassador_id: authenticationwebsockettest\\n\"},\"labels\":{\"app.kubernetes.io/component\":\"ambassador-service\",\"kat-ambassador-id\":\"authenticationwebsockettest\",\"scope\":\"AmbassadorTest\"},\"name\":\"authenticationwebsockettest\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8080},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8443}],\"selector\":{\"service\":\"authenticationwebsockettest\"},\"type\":\"NodePort\"}}\n"
-                    },
-                    "creationTimestamp": "2020-02-19T23:19:59Z",
-                    "labels": {
-                        "app.kubernetes.io/component": "ambassador-service",
-                        "kat-ambassador-id": "authenticationwebsockettest",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "authenticationwebsockettest",
-                    "namespace": "default",
-                    "resourceVersion": "55434",
-                    "selfLink": "/api/v1/namespaces/default/services/authenticationwebsockettest",
-                    "uid": "59595791-536e-11ea-85dd-167682b5c255"
-                },
-                "spec": {
-                    "clusterIP": "10.105.246.154",
-                    "externalTrafficPolicy": "Cluster",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "nodePort": 31774,
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8080
-                        },
-                        {
-                            "name": "https",
-                            "nodePort": 32480,
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8443
-                        }
-                    ],
-                    "selector": {
-                        "service": "authenticationwebsockettest"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "NodePort"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"authenticationwebsockettest\",\"scope\":\"AmbassadorTest\",\"service\":\"authenticationwebsockettest-admin\"},\"name\":\"authenticationwebsockettest-admin\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"authenticationwebsockettest-admin\",\"port\":8877,\"targetPort\":8877}],\"selector\":{\"service\":\"authenticationwebsockettest\"},\"type\":\"NodePort\"}}\n"
                     },
-                    "creationTimestamp": "2020-02-19T23:19:59Z",
+                    "creationTimestamp": "2020-02-26T15:51:43Z",
                     "labels": {
                         "kat-ambassador-id": "authenticationwebsockettest",
                         "scope": "AmbassadorTest",
@@ -79,17 +30,17 @@
                     },
                     "name": "authenticationwebsockettest-admin",
                     "namespace": "default",
-                    "resourceVersion": "55438",
+                    "resourceVersion": "66129",
                     "selfLink": "/api/v1/namespaces/default/services/authenticationwebsockettest-admin",
-                    "uid": "5963b37c-536e-11ea-85dd-167682b5c255"
+                    "uid": "e2a68961-58af-11ea-86d6-0e674b3ff44f"
                 },
                 "spec": {
-                    "clusterIP": "10.108.245.79",
+                    "clusterIP": "10.103.130.166",
                     "externalTrafficPolicy": "Cluster",
                     "ports": [
                         {
                             "name": "authenticationwebsockettest-admin",
-                            "nodePort": 31865,
+                            "nodePort": 32234,
                             "port": 8877,
                             "protocol": "TCP",
                             "targetPort": 8877
@@ -112,19 +63,19 @@
                     "annotations": {
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"authenticationwebsockettest\",\"scope\":\"AmbassadorTest\"},\"name\":\"authenticationwebsockettest-http-auth\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8094},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8457}],\"selector\":{\"backend\":\"superpod-default\"}}}\n"
                     },
-                    "creationTimestamp": "2020-02-19T23:20:00Z",
+                    "creationTimestamp": "2020-02-26T15:51:43Z",
                     "labels": {
                         "kat-ambassador-id": "authenticationwebsockettest",
                         "scope": "AmbassadorTest"
                     },
                     "name": "authenticationwebsockettest-http-auth",
                     "namespace": "default",
-                    "resourceVersion": "55446",
+                    "resourceVersion": "66135",
                     "selfLink": "/api/v1/namespaces/default/services/authenticationwebsockettest-http-auth",
-                    "uid": "59765cdc-536e-11ea-85dd-167682b5c255"
+                    "uid": "e2bb26b5-58af-11ea-86d6-0e674b3ff44f"
                 },
                 "spec": {
-                    "clusterIP": "10.106.66.56",
+                    "clusterIP": "10.109.55.3",
                     "ports": [
                         {
                             "name": "http",
@@ -144,6 +95,55 @@
                     },
                     "sessionAffinity": "None",
                     "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: AuthService\nname: authenticationwebsockettest-http-auth\nauth_service: \"authenticationwebsockettest-http-auth\"\npath_prefix: \"/extauth\"\ntimeout_ms: 10000\nallowed_request_headers:\n- Requested-Status\nallow_request_body: true\nambassador_id: authenticationwebsockettest\n---\napiVersion: ambassador/v0\nkind: Mapping\nname: AuthenticationWebsocketTest\nprefix: /AuthenticationWebsocketTest/\nservice: http://echo.websocket.org\nhost_rewrite: echo.websocket.org\nuse_websocket: true\nambassador_id: authenticationwebsockettest\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: AuthService\\nname: authenticationwebsockettest-http-auth\\nauth_service: \\\"authenticationwebsockettest-http-auth\\\"\\npath_prefix: \\\"/extauth\\\"\\ntimeout_ms: 10000\\nallowed_request_headers:\\n- Requested-Status\\nallow_request_body: true\\nambassador_id: authenticationwebsockettest\\n---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: AuthenticationWebsocketTest\\nprefix: /AuthenticationWebsocketTest/\\nservice: http://echo.websocket.org\\nhost_rewrite: echo.websocket.org\\nuse_websocket: true\\nambassador_id: authenticationwebsockettest\\n\"},\"labels\":{\"app.kubernetes.io/component\":\"ambassador-service\",\"kat-ambassador-id\":\"authenticationwebsockettest\",\"scope\":\"AmbassadorTest\"},\"name\":\"authenticationwebsockettest\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8080},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8443}],\"selector\":{\"service\":\"authenticationwebsockettest\"},\"type\":\"NodePort\"}}\n"
+                    },
+                    "creationTimestamp": "2020-02-26T15:51:43Z",
+                    "labels": {
+                        "app.kubernetes.io/component": "ambassador-service",
+                        "kat-ambassador-id": "authenticationwebsockettest",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "authenticationwebsockettest",
+                    "namespace": "default",
+                    "resourceVersion": "66124",
+                    "selfLink": "/api/v1/namespaces/default/services/authenticationwebsockettest",
+                    "uid": "e298b00e-58af-11ea-86d6-0e674b3ff44f"
+                },
+                "spec": {
+                    "clusterIP": "10.110.114.159",
+                    "externalTrafficPolicy": "Cluster",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "nodePort": 30920,
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8080
+                        },
+                        {
+                            "name": "https",
+                            "nodePort": 31854,
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8443
+                        }
+                    ],
+                    "selector": {
+                        "service": "authenticationwebsockettest"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "NodePort"
                 },
                 "status": {
                     "loadBalancer": {}

--- a/python/tests/gold/clientcertificateauthentication/snapshots/econf.json
+++ b/python/tests/gold/clientcertificateauthentication/snapshots/econf.json
@@ -248,8 +248,7 @@
                                 }
                             },
                             "require_client_certificate": true
-                        },
-                        "use_proxy_proto": false
+                        }
                     }
                 ],
                 "listener_filters": [

--- a/python/tests/gold/clientcertificateauthentication/snapshots/snapshot.yaml
+++ b/python/tests/gold/clientcertificateauthentication/snapshots/snapshot.yaml
@@ -18,6 +18,29 @@
             {
                 "apiVersion": "v1",
                 "data": {
+                    "tls.crt": "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUR1RENDQXFDZ0F3SUJBZ0lKQUowWDU3ZXlwQk5UTUEwR0NTcUdTSWIzRFFFQkN3VUFNSEV4Q3pBSkJnTlYKQkFZVEFsVlRNUXN3Q1FZRFZRUUlEQUpOUVRFUE1BMEdBMVVFQnd3R1FtOXpkRzl1TVJFd0R3WURWUVFLREFoRQpZWFJoZDJseVpURVVNQklHQTFVRUN3d0xSVzVuYVc1bFpYSnBibWN4R3pBWkJnTlZCQU1NRW0xaGMzUmxjaTVrCllYUmhkMmx5WlM1cGJ6QWVGdzB4T1RBeE1UQXhPVEF6TXpCYUZ3MHlOREF4TURreE9UQXpNekJhTUhFeEN6QUoKQmdOVkJBWVRBbFZUTVFzd0NRWURWUVFJREFKTlFURVBNQTBHQTFVRUJ3d0dRbTl6ZEc5dU1SRXdEd1lEVlFRSwpEQWhFWVhSaGQybHlaVEVVTUJJR0ExVUVDd3dMUlc1bmFXNWxaWEpwYm1jeEd6QVpCZ05WQkFNTUVtMWhjM1JsCmNpNWtZWFJoZDJseVpTNXBiekNDQVNJd0RRWUpLb1pJaHZjTkFRRUJCUUFEZ2dFUEFEQ0NBUW9DZ2dFQkFPdlEKVjVad1NmcmQ1Vndtelo5SmNoOTdyUW40OXA2b1FiNkVIWjF5T2EyZXZBNzE2NWpkMHFqS1BPMlgyRk80MVg4QgpwQWFLZExnMmltaC9wL2NXN2JncjNHNnRHVEZVMVZHanllTE1EV0Q1MGV2TTYydnpYOFRuYVV6ZFRHTjFOdTM2CnJaM2JnK0VLcjhFYjI1b2RabEpyMm1mNktSeDdTcjZzT1N4NlE1VHhSb3NycmZ0d0tjejI5cHZlMGQ4b0NiZGkKRFJPVlZjNXpBaW0zc2Nmd3VwRUJrQzYxdlpKMzhmaXYwRENYOVpna3BMdEZKUTllTEVQSEdKUGp5ZmV3alNTeQovbk52L21Sc2J6aUNtQ3R3Z3BmbFRtODljK3EzSWhvbUE1YXhZQVFjQ0NqOXBvNUhVZHJtSUJKR0xBTVZ5OWJ5CkZnZE50aFdBeHZCNHZmQXl4OXNDQXdFQUFhTlRNRkV3SFFZRFZSME9CQllFRkdUOVAvOHBQeGI3UVJVeFcvV2gKaXpkMnNnbEtNQjhHQTFVZEl3UVlNQmFBRkdUOVAvOHBQeGI3UVJVeFcvV2hpemQyc2dsS01BOEdBMVVkRXdFQgovd1FGTUFNQkFmOHdEUVlKS29aSWh2Y05BUUVMQlFBRGdnRUJBS3NWT2Fyc01aSXhLOUpLUzBHVHNnRXNjYThqCllhTDg1YmFsbndBbnBxMllSMGNIMlhvd2dLYjNyM3VmbVRCNERzWS9RMGllaENKeTMzOUJyNjVQMVBKMGgvemYKZEZOcnZKNGlvWDVMWnc5YkowQVFORCtZUTBFK010dFppbE9DbHNPOVBCdm1tUEp1dWFlYVdvS2pWZnNOL1RjMAoycUxVM1pVMHo5bmhYeDZlOWJxYUZLSU1jYnFiVk9nS2p3V0ZpbDlkRG4vQ29KbGFUUzRJWjlOaHFjUzhYMXd0ClQybWQvSUtaaEtKc3A3VlBGeDU5ZWhuZ0VPakZocGhzd20xdDhnQWVxL1A3SkhaUXlBUGZYbDNyZDFSQVJuRVIKQUpmVUxET2tzWFNFb2RTZittR0NrVWh1b2QvaDhMTUdXTFh6Q2d0SHBKMndaVHA5a1ZWVWtKdkpqSVU9Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K"
+                },
+                "kind": "Secret",
+                "metadata": {
+                    "annotations": {
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"data\":{\"tls.crt\":\"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUR1RENDQXFDZ0F3SUJBZ0lKQUowWDU3ZXlwQk5UTUEwR0NTcUdTSWIzRFFFQkN3VUFNSEV4Q3pBSkJnTlYKQkFZVEFsVlRNUXN3Q1FZRFZRUUlEQUpOUVRFUE1BMEdBMVVFQnd3R1FtOXpkRzl1TVJFd0R3WURWUVFLREFoRQpZWFJoZDJseVpURVVNQklHQTFVRUN3d0xSVzVuYVc1bFpYSnBibWN4R3pBWkJnTlZCQU1NRW0xaGMzUmxjaTVrCllYUmhkMmx5WlM1cGJ6QWVGdzB4T1RBeE1UQXhPVEF6TXpCYUZ3MHlOREF4TURreE9UQXpNekJhTUhFeEN6QUoKQmdOVkJBWVRBbFZUTVFzd0NRWURWUVFJREFKTlFURVBNQTBHQTFVRUJ3d0dRbTl6ZEc5dU1SRXdEd1lEVlFRSwpEQWhFWVhSaGQybHlaVEVVTUJJR0ExVUVDd3dMUlc1bmFXNWxaWEpwYm1jeEd6QVpCZ05WQkFNTUVtMWhjM1JsCmNpNWtZWFJoZDJseVpTNXBiekNDQVNJd0RRWUpLb1pJaHZjTkFRRUJCUUFEZ2dFUEFEQ0NBUW9DZ2dFQkFPdlEKVjVad1NmcmQ1Vndtelo5SmNoOTdyUW40OXA2b1FiNkVIWjF5T2EyZXZBNzE2NWpkMHFqS1BPMlgyRk80MVg4QgpwQWFLZExnMmltaC9wL2NXN2JncjNHNnRHVEZVMVZHanllTE1EV0Q1MGV2TTYydnpYOFRuYVV6ZFRHTjFOdTM2CnJaM2JnK0VLcjhFYjI1b2RabEpyMm1mNktSeDdTcjZzT1N4NlE1VHhSb3NycmZ0d0tjejI5cHZlMGQ4b0NiZGkKRFJPVlZjNXpBaW0zc2Nmd3VwRUJrQzYxdlpKMzhmaXYwRENYOVpna3BMdEZKUTllTEVQSEdKUGp5ZmV3alNTeQovbk52L21Sc2J6aUNtQ3R3Z3BmbFRtODljK3EzSWhvbUE1YXhZQVFjQ0NqOXBvNUhVZHJtSUJKR0xBTVZ5OWJ5CkZnZE50aFdBeHZCNHZmQXl4OXNDQXdFQUFhTlRNRkV3SFFZRFZSME9CQllFRkdUOVAvOHBQeGI3UVJVeFcvV2gKaXpkMnNnbEtNQjhHQTFVZEl3UVlNQmFBRkdUOVAvOHBQeGI3UVJVeFcvV2hpemQyc2dsS01BOEdBMVVkRXdFQgovd1FGTUFNQkFmOHdEUVlKS29aSWh2Y05BUUVMQlFBRGdnRUJBS3NWT2Fyc01aSXhLOUpLUzBHVHNnRXNjYThqCllhTDg1YmFsbndBbnBxMllSMGNIMlhvd2dLYjNyM3VmbVRCNERzWS9RMGllaENKeTMzOUJyNjVQMVBKMGgvemYKZEZOcnZKNGlvWDVMWnc5YkowQVFORCtZUTBFK010dFppbE9DbHNPOVBCdm1tUEp1dWFlYVdvS2pWZnNOL1RjMAoycUxVM1pVMHo5bmhYeDZlOWJxYUZLSU1jYnFiVk9nS2p3V0ZpbDlkRG4vQ29KbGFUUzRJWjlOaHFjUzhYMXd0ClQybWQvSUtaaEtKc3A3VlBGeDU5ZWhuZ0VPakZocGhzd20xdDhnQWVxL1A3SkhaUXlBUGZYbDNyZDFSQVJuRVIKQUpmVUxET2tzWFNFb2RTZittR0NrVWh1b2QvaDhMTUdXTFh6Q2d0SHBKMndaVHA5a1ZWVWtKdkpqSVU9Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K\"},\"kind\":\"Secret\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"clientcertificateauthentication\",\"scope\":\"AmbassadorTest\"},\"name\":\"test-clientcert-client-secret\",\"namespace\":\"default\"},\"type\":\"Opaque\"}\n"
+                    },
+                    "creationTimestamp": "2020-02-26T15:53:18Z",
+                    "labels": {
+                        "kat-ambassador-id": "clientcertificateauthentication",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "test-clientcert-client-secret",
+                    "namespace": "default",
+                    "resourceVersion": "68013",
+                    "selfLink": "/api/v1/namespaces/default/secrets/test-clientcert-client-secret",
+                    "uid": "1b86dbb2-58b0-11ea-86d6-0e674b3ff44f"
+                },
+                "type": "Opaque"
+            },
+            {
+                "apiVersion": "v1",
+                "data": {
                     "tls.crt": "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURaekNDQWs4Q0NRQ3JLNzRhM0dGaGlUQU5CZ2txaGtpRzl3MEJBUXNGQURCeE1Rc3dDUVlEVlFRR0V3SlYKVXpFTE1Ba0dBMVVFQ0F3Q1RVRXhEekFOQmdOVkJBY01Ca0p2YzNSdmJqRVJNQThHQTFVRUNnd0lSR0YwWVhkcApjbVV4RkRBU0JnTlZCQXNNQzBWdVoybHVaV1Z5YVc1bk1Sc3dHUVlEVlFRRERCSnRZWE4wWlhJdVpHRjBZWGRwCmNtVXVhVzh3SGhjTk1Ua3dNVEV3TVRrd056TTRXaGNOTWprd01UQTNNVGt3TnpNNFdqQjZNUXN3Q1FZRFZRUUcKRXdKSlRqRUxNQWtHQTFVRUNBd0NTMEV4RWpBUUJnTlZCQWNNQ1VKaGJtZGhiRzl5WlRFVE1CRUdBMVVFQ2d3SwpRVzFpWVhOellXUnZjakVVTUJJR0ExVUVDd3dMUlc1bmFXNWxaWEpwYm1jeEh6QWRCZ05WQkFNTUZtRnRZbUZ6CmMyRmtiM0l1WlhoaGJYQnNaUzVqYjIwd2dnRWlNQTBHQ1NxR1NJYjNEUUVCQVFVQUE0SUJEd0F3Z2dFS0FvSUIKQVFDN1liY3o5SkZOSHVYY3pvZERrTURvUXd0M1pmQnpjaElwTFlkeHNDZnB1UUYybGNmOGxXMEJKNnZlNU0xTAovMjNZalFYeEFsV25VZ3FZdFlEL1hiZGh3RCtyRWx3RXZWUzR1US9IT2EyUTUwVkF6SXNYa0lxWm00dVA1QzNECk8rQ0NncXJ3UUgzYS8vdlBERldYWkUyeTJvcUdZdE1Xd20zVXQrYnFWSFEzOThqcTNoaGt3MmNXL0pLTjJkR2UKRjk0OWxJWG15NHMrbGE3b21RWldWY0JFcWdQVzJDL1VrZktSbVdsVkRwK0duSk8vZHFobDlMN3d2a2hhc2JETAphbVkweXdiOG9LSjFRdmlvV1JxcjhZZnQ5NzVwaGgzazRlRVdMMUNFTmxFK09vUWNTNVRPUEdndko3WlMyaU43CllVTDRBK0gydCt1WWdUdnFSYVNqcTdnckFnTUJBQUV3RFFZSktvWklodmNOQVFFTEJRQURnZ0VCQUJURGJ4MzkKUGpoT2JpVW1Rdm9vbVhOVjJ1TG1FZkxJcGlKQUhWOTM0VTlmMnhVUS93eExkcElhVXM0WTlRSzhOR2h2U3dSSAp4Y2w4R2hGYzBXRDRoNEJTdmNhdUdVS21LRzh5ZVFhdGhGVjBzcGFHYjUvaFBqUVdDWnNYK3crbjU4WDROOHBrCmx5YkE4akZGdUZlb3R3Z1l6UUhzQUppU29DbW9OQ0ZkaE4xT05FS1FMY1gxT2NRSUFUd3JVYzRBRkw2Y0hXZ1MKb1FOc3BTMlZIbENsVkpVN0E3Mkh4R3E5RFVJOWlaMmYxVnc1Rmpod0dxalBQMDJVZms1Tk9RNFgzNWlrcjlDcApyQWtJSnh1NkZPUUgwbDBmZ3VNUDlsUFhJZndlMUowQnNLZHRtd2wvcHp0TVV5dW5TbURVWEgyR1l5YmdQTlQyCnNMVFF1RFZaR0xmbFJUdz0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=",
                     "tls.key": "LS0tLS1CRUdJTiBSU0EgUFJJVkFURSBLRVktLS0tLQpNSUlFcEFJQkFBS0NBUUVBdTJHM00vU1JUUjdsM002SFE1REE2RU1MZDJYd2MzSVNLUzJIY2JBbjZia0JkcFhICi9KVnRBU2VyM3VUTlMvOXQySTBGOFFKVnAxSUttTFdBLzEyM1ljQS9xeEpjQkwxVXVMa1B4em10a09kRlFNeUwKRjVDS21adUxqK1F0d3p2Z2dvS3E4RUI5MnYvN3p3eFZsMlJOc3RxS2htTFRGc0p0MUxmbTZsUjBOL2ZJNnQ0WQpaTU5uRnZ5U2pkblJuaGZlUFpTRjVzdUxQcFd1NkprR1ZsWEFSS29EMXRndjFKSHlrWmxwVlE2ZmhweVR2M2FvClpmUys4TDVJV3JHd3kycG1OTXNHL0tDaWRVTDRxRmthcS9HSDdmZSthWVlkNU9IaEZpOVFoRFpSUGpxRUhFdVUKemp4b0x5ZTJVdG9qZTJGQytBUGg5cmZybUlFNzZrV2tvNnU0S3dJREFRQUJBb0lCQVFDbmZrZjViQko1Z2pYcgpzcnliKzRkRDFiSXBMdmpJNk4wczY2S1hUK1BOZW03QlprOVdDdWRkMGUxQ2x2aWZoeG5VS1BKM3BTT1ZKYk9OCkh5aklteWV4ZTl3dGVZTEJSYysyTXMzVXdrelFLcm52bXlaMWtPRWpQek40RW5tSmV6dEt6YXdvaHkwNGxmcXEKNzVhT2RiMHlNMEVCc05LSkZKQ0NSVVJtajhrMndJQXIwbHFhV0ZNcGlYT3FzTXBvWTZMY3plaGlMZHU0bUFaSQpRRHhCM3dLVGpmdGNIdzcxTmFKZlg5V2t2OFI4ZWlqeWpNOUl2Y1cwZmRQem9YVTBPZEFTa09ZRlFIZHlCUFNiCjllNWhDSGFJczZia1hBOEs4YmZRazBSL0d6STcyVXArd0JrbnJnTlhZTXFudHJSa0ljNURER1g0b3VOc2lqUkoKSWtrWER2TjVBb0dCQU8veFQrNTYyQ2hwc3R2NUpvMi9ycFdGb05tZ3ZJT0RMRGxiamhHZEpqKytwNk1BdjFQWgo2d042WnozMmppUG1OYzdCK2hrQm40RFQvVkFpU3NLRG1SK09tUkg1TVNzQXh6aWRxU3lNcldxdG1lMDNBVzd6Cklja0FNTGdwWHhDdW1HMzRCM2Jxb3VUdGVRdm5WcmRlR2hvdUJ5OUJSMVpXbnRtWHVscVhyNUFmQW9HQkFNZnIKN29NVGwzdUVVeml5a0IzYmkxb0RYdUNjN01Qc3h0c1IwdElqZXc3RStwTGoyaUxXZUZuMGVhdnJYaHQ1ODRJbwpDZG90a1ZMMHhrZ1g3M2ZremxEd1hobTJVTXBaQmxzSzBnR09SaUYzd0ZMU0hJNmxRUmJkaXRIb0JqcDRGTEZzCitlanZKUDZ1ZitBekZ5cjBLTnc3TnpyaCthbFhFQ09RS2NqUXJlWjFBb0dBQXRLZzhScEszcmJYbnRUZ2lqeGUKRG01REJTeHA2MVlvdUFnR3ROaFhjZHFKV0ZhUzZhYWZxQ3ZSZVI0a2IvR3VZbDlQMU9sNitlWUVqZVBKWTE1dQo5N3NTdSs1bGtLN3lxUXpaeDZka0J1UkI4bE42VmRiUVorL3pvc2NCMGsxcmg2ZXFWdEROMThtZmFlOXZ5cnAxCnJpY3FlSGpaSVAvbDRJTnpjc3RrQ2xzQ2dZQmh5TVZkZVZ5emZuS1NIY3lkdmY5MzVJUW9pcmpIeiswbnc1MEIKU1hkc0x1NThvRlBXakY1TGFXZUZybGJXUzV6T1FiVW44UGZPd29pbFJJZk5kYTF3SzFGcmRDQXFDTWN5Q3FYVApPdnFVYmhVMHJTNW9tdTJ1T0dnbzZUcjZxRGMrM1JXVFdEMFpFTkxkSDBBcXMwZTFDSVdvR0ZWYi9ZaVlUSEFUCmwvWW03UUtCZ1FEcFYvSjRMakY5VzBlUlNXenFBaDN1TStCdzNNN2NEMUxnUlZ6ZWxGS2w2ZzRBMWNvdU8wbHAKalpkMkVMZDlzTHhBVENVeFhQZ0dDTjY0RVNZSi92ZUozUmJzMTMrU2xqdjRleTVKck1ieEhNRC9CU1ovY2VjaAp4aFNWNkJsMHVKb2tlMTRPMEJ3OHJzSUlxZTVZSUxqSlMwL2E2eTllSlJtaGZJVG9PZU5PTUE9PQotLS0tLUVORCBSU0EgUFJJVkFURSBLRVktLS0tLQo="
                 },
@@ -26,41 +49,18 @@
                     "annotations": {
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"data\":{\"tls.crt\":\"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURaekNDQWs4Q0NRQ3JLNzRhM0dGaGlUQU5CZ2txaGtpRzl3MEJBUXNGQURCeE1Rc3dDUVlEVlFRR0V3SlYKVXpFTE1Ba0dBMVVFQ0F3Q1RVRXhEekFOQmdOVkJBY01Ca0p2YzNSdmJqRVJNQThHQTFVRUNnd0lSR0YwWVhkcApjbVV4RkRBU0JnTlZCQXNNQzBWdVoybHVaV1Z5YVc1bk1Sc3dHUVlEVlFRRERCSnRZWE4wWlhJdVpHRjBZWGRwCmNtVXVhVzh3SGhjTk1Ua3dNVEV3TVRrd056TTRXaGNOTWprd01UQTNNVGt3TnpNNFdqQjZNUXN3Q1FZRFZRUUcKRXdKSlRqRUxNQWtHQTFVRUNBd0NTMEV4RWpBUUJnTlZCQWNNQ1VKaGJtZGhiRzl5WlRFVE1CRUdBMVVFQ2d3SwpRVzFpWVhOellXUnZjakVVTUJJR0ExVUVDd3dMUlc1bmFXNWxaWEpwYm1jeEh6QWRCZ05WQkFNTUZtRnRZbUZ6CmMyRmtiM0l1WlhoaGJYQnNaUzVqYjIwd2dnRWlNQTBHQ1NxR1NJYjNEUUVCQVFVQUE0SUJEd0F3Z2dFS0FvSUIKQVFDN1liY3o5SkZOSHVYY3pvZERrTURvUXd0M1pmQnpjaElwTFlkeHNDZnB1UUYybGNmOGxXMEJKNnZlNU0xTAovMjNZalFYeEFsV25VZ3FZdFlEL1hiZGh3RCtyRWx3RXZWUzR1US9IT2EyUTUwVkF6SXNYa0lxWm00dVA1QzNECk8rQ0NncXJ3UUgzYS8vdlBERldYWkUyeTJvcUdZdE1Xd20zVXQrYnFWSFEzOThqcTNoaGt3MmNXL0pLTjJkR2UKRjk0OWxJWG15NHMrbGE3b21RWldWY0JFcWdQVzJDL1VrZktSbVdsVkRwK0duSk8vZHFobDlMN3d2a2hhc2JETAphbVkweXdiOG9LSjFRdmlvV1JxcjhZZnQ5NzVwaGgzazRlRVdMMUNFTmxFK09vUWNTNVRPUEdndko3WlMyaU43CllVTDRBK0gydCt1WWdUdnFSYVNqcTdnckFnTUJBQUV3RFFZSktvWklodmNOQVFFTEJRQURnZ0VCQUJURGJ4MzkKUGpoT2JpVW1Rdm9vbVhOVjJ1TG1FZkxJcGlKQUhWOTM0VTlmMnhVUS93eExkcElhVXM0WTlRSzhOR2h2U3dSSAp4Y2w4R2hGYzBXRDRoNEJTdmNhdUdVS21LRzh5ZVFhdGhGVjBzcGFHYjUvaFBqUVdDWnNYK3crbjU4WDROOHBrCmx5YkE4akZGdUZlb3R3Z1l6UUhzQUppU29DbW9OQ0ZkaE4xT05FS1FMY1gxT2NRSUFUd3JVYzRBRkw2Y0hXZ1MKb1FOc3BTMlZIbENsVkpVN0E3Mkh4R3E5RFVJOWlaMmYxVnc1Rmpod0dxalBQMDJVZms1Tk9RNFgzNWlrcjlDcApyQWtJSnh1NkZPUUgwbDBmZ3VNUDlsUFhJZndlMUowQnNLZHRtd2wvcHp0TVV5dW5TbURVWEgyR1l5YmdQTlQyCnNMVFF1RFZaR0xmbFJUdz0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=\",\"tls.key\":\"LS0tLS1CRUdJTiBSU0EgUFJJVkFURSBLRVktLS0tLQpNSUlFcEFJQkFBS0NBUUVBdTJHM00vU1JUUjdsM002SFE1REE2RU1MZDJYd2MzSVNLUzJIY2JBbjZia0JkcFhICi9KVnRBU2VyM3VUTlMvOXQySTBGOFFKVnAxSUttTFdBLzEyM1ljQS9xeEpjQkwxVXVMa1B4em10a09kRlFNeUwKRjVDS21adUxqK1F0d3p2Z2dvS3E4RUI5MnYvN3p3eFZsMlJOc3RxS2htTFRGc0p0MUxmbTZsUjBOL2ZJNnQ0WQpaTU5uRnZ5U2pkblJuaGZlUFpTRjVzdUxQcFd1NkprR1ZsWEFSS29EMXRndjFKSHlrWmxwVlE2ZmhweVR2M2FvClpmUys4TDVJV3JHd3kycG1OTXNHL0tDaWRVTDRxRmthcS9HSDdmZSthWVlkNU9IaEZpOVFoRFpSUGpxRUhFdVUKemp4b0x5ZTJVdG9qZTJGQytBUGg5cmZybUlFNzZrV2tvNnU0S3dJREFRQUJBb0lCQVFDbmZrZjViQko1Z2pYcgpzcnliKzRkRDFiSXBMdmpJNk4wczY2S1hUK1BOZW03QlprOVdDdWRkMGUxQ2x2aWZoeG5VS1BKM3BTT1ZKYk9OCkh5aklteWV4ZTl3dGVZTEJSYysyTXMzVXdrelFLcm52bXlaMWtPRWpQek40RW5tSmV6dEt6YXdvaHkwNGxmcXEKNzVhT2RiMHlNMEVCc05LSkZKQ0NSVVJtajhrMndJQXIwbHFhV0ZNcGlYT3FzTXBvWTZMY3plaGlMZHU0bUFaSQpRRHhCM3dLVGpmdGNIdzcxTmFKZlg5V2t2OFI4ZWlqeWpNOUl2Y1cwZmRQem9YVTBPZEFTa09ZRlFIZHlCUFNiCjllNWhDSGFJczZia1hBOEs4YmZRazBSL0d6STcyVXArd0JrbnJnTlhZTXFudHJSa0ljNURER1g0b3VOc2lqUkoKSWtrWER2TjVBb0dCQU8veFQrNTYyQ2hwc3R2NUpvMi9ycFdGb05tZ3ZJT0RMRGxiamhHZEpqKytwNk1BdjFQWgo2d042WnozMmppUG1OYzdCK2hrQm40RFQvVkFpU3NLRG1SK09tUkg1TVNzQXh6aWRxU3lNcldxdG1lMDNBVzd6Cklja0FNTGdwWHhDdW1HMzRCM2Jxb3VUdGVRdm5WcmRlR2hvdUJ5OUJSMVpXbnRtWHVscVhyNUFmQW9HQkFNZnIKN29NVGwzdUVVeml5a0IzYmkxb0RYdUNjN01Qc3h0c1IwdElqZXc3RStwTGoyaUxXZUZuMGVhdnJYaHQ1ODRJbwpDZG90a1ZMMHhrZ1g3M2ZremxEd1hobTJVTXBaQmxzSzBnR09SaUYzd0ZMU0hJNmxRUmJkaXRIb0JqcDRGTEZzCitlanZKUDZ1ZitBekZ5cjBLTnc3TnpyaCthbFhFQ09RS2NqUXJlWjFBb0dBQXRLZzhScEszcmJYbnRUZ2lqeGUKRG01REJTeHA2MVlvdUFnR3ROaFhjZHFKV0ZhUzZhYWZxQ3ZSZVI0a2IvR3VZbDlQMU9sNitlWUVqZVBKWTE1dQo5N3NTdSs1bGtLN3lxUXpaeDZka0J1UkI4bE42VmRiUVorL3pvc2NCMGsxcmg2ZXFWdEROMThtZmFlOXZ5cnAxCnJpY3FlSGpaSVAvbDRJTnpjc3RrQ2xzQ2dZQmh5TVZkZVZ5emZuS1NIY3lkdmY5MzVJUW9pcmpIeiswbnc1MEIKU1hkc0x1NThvRlBXakY1TGFXZUZybGJXUzV6T1FiVW44UGZPd29pbFJJZk5kYTF3SzFGcmRDQXFDTWN5Q3FYVApPdnFVYmhVMHJTNW9tdTJ1T0dnbzZUcjZxRGMrM1JXVFdEMFpFTkxkSDBBcXMwZTFDSVdvR0ZWYi9ZaVlUSEFUCmwvWW03UUtCZ1FEcFYvSjRMakY5VzBlUlNXenFBaDN1TStCdzNNN2NEMUxnUlZ6ZWxGS2w2ZzRBMWNvdU8wbHAKalpkMkVMZDlzTHhBVENVeFhQZ0dDTjY0RVNZSi92ZUozUmJzMTMrU2xqdjRleTVKck1ieEhNRC9CU1ovY2VjaAp4aFNWNkJsMHVKb2tlMTRPMEJ3OHJzSUlxZTVZSUxqSlMwL2E2eTllSlJtaGZJVG9PZU5PTUE9PQotLS0tLUVORCBSU0EgUFJJVkFURSBLRVktLS0tLQo=\"},\"kind\":\"Secret\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"clientcertificateauthentication\",\"scope\":\"AmbassadorTest\"},\"name\":\"test-clientcert-server-secret\",\"namespace\":\"default\"},\"type\":\"kubernetes.io/tls\"}\n"
                     },
-                    "creationTimestamp": "2020-02-19T23:20:45Z",
+                    "creationTimestamp": "2020-02-26T15:53:19Z",
                     "labels": {
                         "kat-ambassador-id": "clientcertificateauthentication",
                         "scope": "AmbassadorTest"
                     },
                     "name": "test-clientcert-server-secret",
                     "namespace": "default",
-                    "resourceVersion": "56947",
+                    "resourceVersion": "68015",
                     "selfLink": "/api/v1/namespaces/default/secrets/test-clientcert-server-secret",
-                    "uid": "749eac0c-536e-11ea-85dd-167682b5c255"
+                    "uid": "1bb9e003-58b0-11ea-86d6-0e674b3ff44f"
                 },
                 "type": "kubernetes.io/tls"
-            },
-            {
-                "apiVersion": "v1",
-                "data": {
-                    "tls.crt": "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUR1RENDQXFDZ0F3SUJBZ0lKQUowWDU3ZXlwQk5UTUEwR0NTcUdTSWIzRFFFQkN3VUFNSEV4Q3pBSkJnTlYKQkFZVEFsVlRNUXN3Q1FZRFZRUUlEQUpOUVRFUE1BMEdBMVVFQnd3R1FtOXpkRzl1TVJFd0R3WURWUVFLREFoRQpZWFJoZDJseVpURVVNQklHQTFVRUN3d0xSVzVuYVc1bFpYSnBibWN4R3pBWkJnTlZCQU1NRW0xaGMzUmxjaTVrCllYUmhkMmx5WlM1cGJ6QWVGdzB4T1RBeE1UQXhPVEF6TXpCYUZ3MHlOREF4TURreE9UQXpNekJhTUhFeEN6QUoKQmdOVkJBWVRBbFZUTVFzd0NRWURWUVFJREFKTlFURVBNQTBHQTFVRUJ3d0dRbTl6ZEc5dU1SRXdEd1lEVlFRSwpEQWhFWVhSaGQybHlaVEVVTUJJR0ExVUVDd3dMUlc1bmFXNWxaWEpwYm1jeEd6QVpCZ05WQkFNTUVtMWhjM1JsCmNpNWtZWFJoZDJseVpTNXBiekNDQVNJd0RRWUpLb1pJaHZjTkFRRUJCUUFEZ2dFUEFEQ0NBUW9DZ2dFQkFPdlEKVjVad1NmcmQ1Vndtelo5SmNoOTdyUW40OXA2b1FiNkVIWjF5T2EyZXZBNzE2NWpkMHFqS1BPMlgyRk80MVg4QgpwQWFLZExnMmltaC9wL2NXN2JncjNHNnRHVEZVMVZHanllTE1EV0Q1MGV2TTYydnpYOFRuYVV6ZFRHTjFOdTM2CnJaM2JnK0VLcjhFYjI1b2RabEpyMm1mNktSeDdTcjZzT1N4NlE1VHhSb3NycmZ0d0tjejI5cHZlMGQ4b0NiZGkKRFJPVlZjNXpBaW0zc2Nmd3VwRUJrQzYxdlpKMzhmaXYwRENYOVpna3BMdEZKUTllTEVQSEdKUGp5ZmV3alNTeQovbk52L21Sc2J6aUNtQ3R3Z3BmbFRtODljK3EzSWhvbUE1YXhZQVFjQ0NqOXBvNUhVZHJtSUJKR0xBTVZ5OWJ5CkZnZE50aFdBeHZCNHZmQXl4OXNDQXdFQUFhTlRNRkV3SFFZRFZSME9CQllFRkdUOVAvOHBQeGI3UVJVeFcvV2gKaXpkMnNnbEtNQjhHQTFVZEl3UVlNQmFBRkdUOVAvOHBQeGI3UVJVeFcvV2hpemQyc2dsS01BOEdBMVVkRXdFQgovd1FGTUFNQkFmOHdEUVlKS29aSWh2Y05BUUVMQlFBRGdnRUJBS3NWT2Fyc01aSXhLOUpLUzBHVHNnRXNjYThqCllhTDg1YmFsbndBbnBxMllSMGNIMlhvd2dLYjNyM3VmbVRCNERzWS9RMGllaENKeTMzOUJyNjVQMVBKMGgvemYKZEZOcnZKNGlvWDVMWnc5YkowQVFORCtZUTBFK010dFppbE9DbHNPOVBCdm1tUEp1dWFlYVdvS2pWZnNOL1RjMAoycUxVM1pVMHo5bmhYeDZlOWJxYUZLSU1jYnFiVk9nS2p3V0ZpbDlkRG4vQ29KbGFUUzRJWjlOaHFjUzhYMXd0ClQybWQvSUtaaEtKc3A3VlBGeDU5ZWhuZ0VPakZocGhzd20xdDhnQWVxL1A3SkhaUXlBUGZYbDNyZDFSQVJuRVIKQUpmVUxET2tzWFNFb2RTZittR0NrVWh1b2QvaDhMTUdXTFh6Q2d0SHBKMndaVHA5a1ZWVWtKdkpqSVU9Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K"
-                },
-                "kind": "Secret",
-                "metadata": {
-                    "annotations": {
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"data\":{\"tls.crt\":\"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUR1RENDQXFDZ0F3SUJBZ0lKQUowWDU3ZXlwQk5UTUEwR0NTcUdTSWIzRFFFQkN3VUFNSEV4Q3pBSkJnTlYKQkFZVEFsVlRNUXN3Q1FZRFZRUUlEQUpOUVRFUE1BMEdBMVVFQnd3R1FtOXpkRzl1TVJFd0R3WURWUVFLREFoRQpZWFJoZDJseVpURVVNQklHQTFVRUN3d0xSVzVuYVc1bFpYSnBibWN4R3pBWkJnTlZCQU1NRW0xaGMzUmxjaTVrCllYUmhkMmx5WlM1cGJ6QWVGdzB4T1RBeE1UQXhPVEF6TXpCYUZ3MHlOREF4TURreE9UQXpNekJhTUhFeEN6QUoKQmdOVkJBWVRBbFZUTVFzd0NRWURWUVFJREFKTlFURVBNQTBHQTFVRUJ3d0dRbTl6ZEc5dU1SRXdEd1lEVlFRSwpEQWhFWVhSaGQybHlaVEVVTUJJR0ExVUVDd3dMUlc1bmFXNWxaWEpwYm1jeEd6QVpCZ05WQkFNTUVtMWhjM1JsCmNpNWtZWFJoZDJseVpTNXBiekNDQVNJd0RRWUpLb1pJaHZjTkFRRUJCUUFEZ2dFUEFEQ0NBUW9DZ2dFQkFPdlEKVjVad1NmcmQ1Vndtelo5SmNoOTdyUW40OXA2b1FiNkVIWjF5T2EyZXZBNzE2NWpkMHFqS1BPMlgyRk80MVg4QgpwQWFLZExnMmltaC9wL2NXN2JncjNHNnRHVEZVMVZHanllTE1EV0Q1MGV2TTYydnpYOFRuYVV6ZFRHTjFOdTM2CnJaM2JnK0VLcjhFYjI1b2RabEpyMm1mNktSeDdTcjZzT1N4NlE1VHhSb3NycmZ0d0tjejI5cHZlMGQ4b0NiZGkKRFJPVlZjNXpBaW0zc2Nmd3VwRUJrQzYxdlpKMzhmaXYwRENYOVpna3BMdEZKUTllTEVQSEdKUGp5ZmV3alNTeQovbk52L21Sc2J6aUNtQ3R3Z3BmbFRtODljK3EzSWhvbUE1YXhZQVFjQ0NqOXBvNUhVZHJtSUJKR0xBTVZ5OWJ5CkZnZE50aFdBeHZCNHZmQXl4OXNDQXdFQUFhTlRNRkV3SFFZRFZSME9CQllFRkdUOVAvOHBQeGI3UVJVeFcvV2gKaXpkMnNnbEtNQjhHQTFVZEl3UVlNQmFBRkdUOVAvOHBQeGI3UVJVeFcvV2hpemQyc2dsS01BOEdBMVVkRXdFQgovd1FGTUFNQkFmOHdEUVlKS29aSWh2Y05BUUVMQlFBRGdnRUJBS3NWT2Fyc01aSXhLOUpLUzBHVHNnRXNjYThqCllhTDg1YmFsbndBbnBxMllSMGNIMlhvd2dLYjNyM3VmbVRCNERzWS9RMGllaENKeTMzOUJyNjVQMVBKMGgvemYKZEZOcnZKNGlvWDVMWnc5YkowQVFORCtZUTBFK010dFppbE9DbHNPOVBCdm1tUEp1dWFlYVdvS2pWZnNOL1RjMAoycUxVM1pVMHo5bmhYeDZlOWJxYUZLSU1jYnFiVk9nS2p3V0ZpbDlkRG4vQ29KbGFUUzRJWjlOaHFjUzhYMXd0ClQybWQvSUtaaEtKc3A3VlBGeDU5ZWhuZ0VPakZocGhzd20xdDhnQWVxL1A3SkhaUXlBUGZYbDNyZDFSQVJuRVIKQUpmVUxET2tzWFNFb2RTZittR0NrVWh1b2QvaDhMTUdXTFh6Q2d0SHBKMndaVHA5a1ZWVWtKdkpqSVU9Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K\"},\"kind\":\"Secret\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"clientcertificateauthentication\",\"scope\":\"AmbassadorTest\"},\"name\":\"test-clientcert-client-secret\",\"namespace\":\"default\"},\"type\":\"Opaque\"}\n"
-                    },
-                    "creationTimestamp": "2020-02-19T23:20:45Z",
-                    "labels": {
-                        "kat-ambassador-id": "clientcertificateauthentication",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "test-clientcert-client-secret",
-                    "namespace": "default",
-                    "resourceVersion": "56942",
-                    "selfLink": "/api/v1/namespaces/default/secrets/test-clientcert-client-secret",
-                    "uid": "748522e2-536e-11ea-85dd-167682b5c255"
-                },
-                "type": "Opaque"
             }
         ],
         "service": [
@@ -69,10 +69,54 @@
                 "kind": "Service",
                 "metadata": {
                     "annotations": {
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"clientcertificateauthentication\",\"scope\":\"AmbassadorTest\"},\"name\":\"clientcertificateauthentication-http\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8123},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8486}],\"selector\":{\"backend\":\"superpod-default\"}}}\n"
+                    },
+                    "creationTimestamp": "2020-02-26T15:53:20Z",
+                    "labels": {
+                        "kat-ambassador-id": "clientcertificateauthentication",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "clientcertificateauthentication-http",
+                    "namespace": "default",
+                    "resourceVersion": "68044",
+                    "selfLink": "/api/v1/namespaces/default/services/clientcertificateauthentication-http",
+                    "uid": "1c8c46db-58b0-11ea-86d6-0e674b3ff44f"
+                },
+                "spec": {
+                    "clusterIP": "10.106.216.116",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8123
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8486
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-default"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
                         "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Module\nambassador_id: clientcertificateauthentication\nname: tls\nconfig:\n  server:\n    enabled: True\n    secret: test-clientcert-server-secret\n  client:\n    enabled: True\n    secret: test-clientcert-client-secret\n    cert_required: True\n\n---\napiVersion: ambassador/v0\nkind: Mapping\nname: clientcertificateauthentication-http\nprefix: /ClientCertificateAuthentication/\nservice: clientcertificateauthentication-http\nambassador_id: clientcertificateauthentication\n",
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Module\\nambassador_id: clientcertificateauthentication\\nname: tls\\nconfig:\\n  server:\\n    enabled: True\\n    secret: test-clientcert-server-secret\\n  client:\\n    enabled: True\\n    secret: test-clientcert-client-secret\\n    cert_required: True\\n\\n---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: clientcertificateauthentication-http\\nprefix: /ClientCertificateAuthentication/\\nservice: clientcertificateauthentication-http\\nambassador_id: clientcertificateauthentication\\n\"},\"labels\":{\"app.kubernetes.io/component\":\"ambassador-service\",\"kat-ambassador-id\":\"clientcertificateauthentication\",\"scope\":\"AmbassadorTest\"},\"name\":\"clientcertificateauthentication\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8080},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8443}],\"selector\":{\"service\":\"clientcertificateauthentication\"},\"type\":\"NodePort\"}}\n"
                     },
-                    "creationTimestamp": "2020-02-19T23:20:44Z",
+                    "creationTimestamp": "2020-02-26T15:53:20Z",
                     "labels": {
                         "app.kubernetes.io/component": "ambassador-service",
                         "kat-ambassador-id": "clientcertificateauthentication",
@@ -80,24 +124,24 @@
                     },
                     "name": "clientcertificateauthentication",
                     "namespace": "default",
-                    "resourceVersion": "56926",
+                    "resourceVersion": "68032",
                     "selfLink": "/api/v1/namespaces/default/services/clientcertificateauthentication",
-                    "uid": "743dfbb3-536e-11ea-85dd-167682b5c255"
+                    "uid": "1c518fed-58b0-11ea-86d6-0e674b3ff44f"
                 },
                 "spec": {
-                    "clusterIP": "10.97.117.114",
+                    "clusterIP": "10.99.121.155",
                     "externalTrafficPolicy": "Cluster",
                     "ports": [
                         {
                             "name": "http",
-                            "nodePort": 32482,
+                            "nodePort": 31225,
                             "port": 80,
                             "protocol": "TCP",
                             "targetPort": 8080
                         },
                         {
                             "name": "https",
-                            "nodePort": 32396,
+                            "nodePort": 31882,
                             "port": 443,
                             "protocol": "TCP",
                             "targetPort": 8443
@@ -120,7 +164,7 @@
                     "annotations": {
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"clientcertificateauthentication\",\"scope\":\"AmbassadorTest\",\"service\":\"clientcertificateauthentication-admin\"},\"name\":\"clientcertificateauthentication-admin\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"clientcertificateauthentication-admin\",\"port\":8877,\"targetPort\":8877}],\"selector\":{\"service\":\"clientcertificateauthentication\"},\"type\":\"NodePort\"}}\n"
                     },
-                    "creationTimestamp": "2020-02-19T23:20:45Z",
+                    "creationTimestamp": "2020-02-26T15:53:20Z",
                     "labels": {
                         "kat-ambassador-id": "clientcertificateauthentication",
                         "scope": "AmbassadorTest",
@@ -128,17 +172,17 @@
                     },
                     "name": "clientcertificateauthentication-admin",
                     "namespace": "default",
-                    "resourceVersion": "56935",
+                    "resourceVersion": "68036",
                     "selfLink": "/api/v1/namespaces/default/services/clientcertificateauthentication-admin",
-                    "uid": "746ffc1c-536e-11ea-85dd-167682b5c255"
+                    "uid": "1c656365-58b0-11ea-86d6-0e674b3ff44f"
                 },
                 "spec": {
-                    "clusterIP": "10.105.62.26",
+                    "clusterIP": "10.96.95.75",
                     "externalTrafficPolicy": "Cluster",
                     "ports": [
                         {
                             "name": "clientcertificateauthentication-admin",
-                            "nodePort": 30921,
+                            "nodePort": 30478,
                             "port": 8877,
                             "protocol": "TCP",
                             "targetPort": 8877
@@ -149,50 +193,6 @@
                     },
                     "sessionAffinity": "None",
                     "type": "NodePort"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"clientcertificateauthentication\",\"scope\":\"AmbassadorTest\"},\"name\":\"clientcertificateauthentication-http\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8123},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8486}],\"selector\":{\"backend\":\"superpod-default\"}}}\n"
-                    },
-                    "creationTimestamp": "2020-02-19T23:20:45Z",
-                    "labels": {
-                        "kat-ambassador-id": "clientcertificateauthentication",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "clientcertificateauthentication-http",
-                    "namespace": "default",
-                    "resourceVersion": "56950",
-                    "selfLink": "/api/v1/namespaces/default/services/clientcertificateauthentication-http",
-                    "uid": "74b12ad7-536e-11ea-85dd-167682b5c255"
-                },
-                "spec": {
-                    "clusterIP": "10.101.110.29",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8123
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8486
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-default"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
                 },
                 "status": {
                     "loadBalancer": {}

--- a/python/tests/gold/empty/snapshots/aconf.json
+++ b/python/tests/gold/empty/snapshots/aconf.json
@@ -5,25 +5,25 @@
                 "error": "Ambassador could not find core CRD definitions. Please visit https://www.getambassador.io/reference/core/crds/ for more information. You can continue using Ambassador via Kubernetes annotations, any configuration via CRDs will be ignored...",
                 "hostname": "empty",
                 "ok": false,
-                "version": "1.1.1-161-g310bb7bf0"
+                "version": "1.2.0-4-g8f507fdcf-dirty"
             },
             {
                 "error": "Ambassador could not find Resolver type CRD definitions. Please visit https://www.getambassador.io/reference/core/crds/ for more information. You can continue using Ambassador via Kubernetes annotations, any configuration via CRDs will be ignored...",
                 "hostname": "empty",
                 "ok": false,
-                "version": "1.1.1-161-g310bb7bf0"
+                "version": "1.2.0-4-g8f507fdcf-dirty"
             },
             {
                 "error": "Ambassador could not find the Host CRD definition. Please visit https://www.getambassador.io/reference/core/crds/ for more information. You can continue using Ambassador via Kubernetes annotations, any configuration via CRDs will be ignored...",
                 "hostname": "empty",
                 "ok": false,
-                "version": "1.1.1-161-g310bb7bf0"
+                "version": "1.2.0-4-g8f507fdcf-dirty"
             },
             {
                 "error": "Ambassador could not find the LogService CRD definition. Please visit https://www.getambassador.io/reference/core/crds/ for more information. You can continue using Ambassador via Kubernetes annotations, any configuration via CRDs will be ignored...",
                 "hostname": "empty",
                 "ok": false,
-                "version": "1.1.1-161-g310bb7bf0"
+                "version": "1.2.0-4-g8f507fdcf-dirty"
             }
         ]
     },

--- a/python/tests/gold/empty/snapshots/econf.json
+++ b/python/tests/gold/empty/snapshots/econf.json
@@ -231,8 +231,7 @@
                                     "xff_num_trusted_hops": 0
                                 }
                             }
-                        ],
-                        "use_proxy_proto": false
+                        ]
                     }
                 ],
                 "listener_filters": [],

--- a/python/tests/gold/empty/snapshots/snapshot.yaml
+++ b/python/tests/gold/empty/snapshots/snapshot.yaml
@@ -10,7 +10,7 @@
                     "annotations": {
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"app.kubernetes.io/component\":\"ambassador-service\",\"kat-ambassador-id\":\"empty\",\"scope\":\"AmbassadorTest\"},\"name\":\"empty\",\"namespace\":\"empty-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8080},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8443}],\"selector\":{\"service\":\"empty\"},\"type\":\"NodePort\"}}\n"
                     },
-                    "creationTimestamp": "2020-02-19T23:19:54Z",
+                    "creationTimestamp": "2020-02-26T15:51:36Z",
                     "labels": {
                         "app.kubernetes.io/component": "ambassador-service",
                         "kat-ambassador-id": "empty",
@@ -18,24 +18,24 @@
                     },
                     "name": "empty",
                     "namespace": "empty-namespace",
-                    "resourceVersion": "55101",
+                    "resourceVersion": "65775",
                     "selfLink": "/api/v1/namespaces/empty-namespace/services/empty",
-                    "uid": "56320af5-536e-11ea-85dd-167682b5c255"
+                    "uid": "de7d5714-58af-11ea-86d6-0e674b3ff44f"
                 },
                 "spec": {
-                    "clusterIP": "10.103.229.209",
+                    "clusterIP": "10.105.87.98",
                     "externalTrafficPolicy": "Cluster",
                     "ports": [
                         {
                             "name": "http",
-                            "nodePort": 31945,
+                            "nodePort": 32547,
                             "port": 80,
                             "protocol": "TCP",
                             "targetPort": 8080
                         },
                         {
                             "name": "https",
-                            "nodePort": 30329,
+                            "nodePort": 31652,
                             "port": 443,
                             "protocol": "TCP",
                             "targetPort": 8443
@@ -58,7 +58,7 @@
                     "annotations": {
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"empty\",\"scope\":\"AmbassadorTest\",\"service\":\"empty-admin\"},\"name\":\"empty-admin\",\"namespace\":\"empty-namespace\"},\"spec\":{\"ports\":[{\"name\":\"empty-admin\",\"port\":8877,\"targetPort\":8877}],\"selector\":{\"service\":\"empty\"},\"type\":\"NodePort\"}}\n"
                     },
-                    "creationTimestamp": "2020-02-19T23:19:54Z",
+                    "creationTimestamp": "2020-02-26T15:51:36Z",
                     "labels": {
                         "kat-ambassador-id": "empty",
                         "scope": "AmbassadorTest",
@@ -66,17 +66,17 @@
                     },
                     "name": "empty-admin",
                     "namespace": "empty-namespace",
-                    "resourceVersion": "55105",
+                    "resourceVersion": "65779",
                     "selfLink": "/api/v1/namespaces/empty-namespace/services/empty-admin",
-                    "uid": "563a5ab4-536e-11ea-85dd-167682b5c255"
+                    "uid": "de8a43e9-58af-11ea-86d6-0e674b3ff44f"
                 },
                 "spec": {
-                    "clusterIP": "10.105.120.111",
+                    "clusterIP": "10.109.33.49",
                     "externalTrafficPolicy": "Cluster",
                     "ports": [
                         {
                             "name": "empty-admin",
-                            "nodePort": 31999,
+                            "nodePort": 32162,
                             "port": 8877,
                             "protocol": "TCP",
                             "targetPort": 8877

--- a/python/tests/gold/envoylogtest/snapshots/econf.json
+++ b/python/tests/gold/envoylogtest/snapshots/econf.json
@@ -231,8 +231,7 @@
                                     "xff_num_trusted_hops": 0
                                 }
                             }
-                        ],
-                        "use_proxy_proto": false
+                        ]
                     }
                 ],
                 "listener_filters": [],

--- a/python/tests/gold/envoylogtest/snapshots/snapshot.yaml
+++ b/python/tests/gold/envoylogtest/snapshots/snapshot.yaml
@@ -23,7 +23,7 @@
                         "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Module\nname: ambassador\nambassador_id: envoylogtest\nconfig:\n  envoy_log_path: /tmp/ambassador/ambassador.log\n  envoy_log_format: MY_REQUEST %RESPONSE_CODE% \"%REQ(:AUTHORITY)%\" \"%REQ(USER-AGENT)%\"\n    \"%REQ(X-REQUEST-ID)%\" \"%UPSTREAM_HOST%\"\n",
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Module\\nname: ambassador\\nambassador_id: envoylogtest\\nconfig:\\n  envoy_log_path: /tmp/ambassador/ambassador.log\\n  envoy_log_format: MY_REQUEST %RESPONSE_CODE% \\\"%REQ(:AUTHORITY)%\\\" \\\"%REQ(USER-AGENT)%\\\"\\n    \\\"%REQ(X-REQUEST-ID)%\\\" \\\"%UPSTREAM_HOST%\\\"\\n\"},\"labels\":{\"app.kubernetes.io/component\":\"ambassador-service\",\"kat-ambassador-id\":\"envoylogtest\",\"scope\":\"AmbassadorTest\"},\"name\":\"envoylogtest\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8080},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8443}],\"selector\":{\"service\":\"envoylogtest\"},\"type\":\"NodePort\"}}\n"
                     },
-                    "creationTimestamp": "2020-02-19T23:22:01Z",
+                    "creationTimestamp": "2020-02-26T15:54:11Z",
                     "labels": {
                         "app.kubernetes.io/component": "ambassador-service",
                         "kat-ambassador-id": "envoylogtest",
@@ -31,24 +31,24 @@
                     },
                     "name": "envoylogtest",
                     "namespace": "default",
-                    "resourceVersion": "57900",
+                    "resourceVersion": "68869",
                     "selfLink": "/api/v1/namespaces/default/services/envoylogtest",
-                    "uid": "a1c94f04-536e-11ea-85dd-167682b5c255"
+                    "uid": "3b17b103-58b0-11ea-86d6-0e674b3ff44f"
                 },
                 "spec": {
-                    "clusterIP": "10.100.18.157",
+                    "clusterIP": "10.100.90.219",
                     "externalTrafficPolicy": "Cluster",
                     "ports": [
                         {
                             "name": "http",
-                            "nodePort": 31178,
+                            "nodePort": 30720,
                             "port": 80,
                             "protocol": "TCP",
                             "targetPort": 8080
                         },
                         {
                             "name": "https",
-                            "nodePort": 32456,
+                            "nodePort": 32196,
                             "port": 443,
                             "protocol": "TCP",
                             "targetPort": 8443
@@ -71,7 +71,7 @@
                     "annotations": {
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"envoylogtest\",\"scope\":\"AmbassadorTest\",\"service\":\"envoylogtest-admin\"},\"name\":\"envoylogtest-admin\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"envoylogtest-admin\",\"port\":8877,\"targetPort\":8877}],\"selector\":{\"service\":\"envoylogtest\"},\"type\":\"NodePort\"}}\n"
                     },
-                    "creationTimestamp": "2020-02-19T23:22:03Z",
+                    "creationTimestamp": "2020-02-26T15:54:13Z",
                     "labels": {
                         "kat-ambassador-id": "envoylogtest",
                         "scope": "AmbassadorTest",
@@ -79,17 +79,17 @@
                     },
                     "name": "envoylogtest-admin",
                     "namespace": "default",
-                    "resourceVersion": "57911",
+                    "resourceVersion": "68882",
                     "selfLink": "/api/v1/namespaces/default/services/envoylogtest-admin",
-                    "uid": "a2e3b310-536e-11ea-85dd-167682b5c255"
+                    "uid": "3bebcab2-58b0-11ea-86d6-0e674b3ff44f"
                 },
                 "spec": {
-                    "clusterIP": "10.110.160.237",
+                    "clusterIP": "10.106.95.236",
                     "externalTrafficPolicy": "Cluster",
                     "ports": [
                         {
                             "name": "envoylogtest-admin",
-                            "nodePort": 32360,
+                            "nodePort": 30347,
                             "port": 8877,
                             "protocol": "TCP",
                             "targetPort": 8877
@@ -112,19 +112,19 @@
                     "annotations": {
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"envoylogtest\",\"scope\":\"AmbassadorTest\"},\"name\":\"envoylogtest-http\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8138},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8501}],\"selector\":{\"backend\":\"superpod-default\"}}}\n"
                     },
-                    "creationTimestamp": "2020-02-19T23:22:05Z",
+                    "creationTimestamp": "2020-02-26T15:54:14Z",
                     "labels": {
                         "kat-ambassador-id": "envoylogtest",
                         "scope": "AmbassadorTest"
                     },
                     "name": "envoylogtest-http",
                     "namespace": "default",
-                    "resourceVersion": "57931",
+                    "resourceVersion": "68889",
                     "selfLink": "/api/v1/namespaces/default/services/envoylogtest-http",
-                    "uid": "a401a100-536e-11ea-85dd-167682b5c255"
+                    "uid": "3c87e9bc-58b0-11ea-86d6-0e674b3ff44f"
                 },
                 "spec": {
-                    "clusterIP": "10.108.153.45",
+                    "clusterIP": "10.104.209.18",
                     "ports": [
                         {
                             "name": "http",

--- a/python/tests/gold/globalcorstest/snapshots/econf.json
+++ b/python/tests/gold/globalcorstest/snapshots/econf.json
@@ -496,8 +496,7 @@
                                     "xff_num_trusted_hops": 0
                                 }
                             }
-                        ],
-                        "use_proxy_proto": false
+                        ]
                     }
                 ],
                 "listener_filters": [],

--- a/python/tests/gold/globalcorstest/snapshots/snapshot.yaml
+++ b/python/tests/gold/globalcorstest/snapshots/snapshot.yaml
@@ -20,9 +20,58 @@
                 "kind": "Service",
                 "metadata": {
                     "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Module\nname: ambassador\nconfig:\n  cors:\n    origins: http://foo.example.com\n    methods: POST, GET, OPTIONS\nambassador_id: globalcorstest\n---\napiVersion: ambassador/v1\nkind: Mapping\nname: globalcorstest-http-foo\nprefix: /foo/\nservice: globalcorstest-http\nambassador_id: globalcorstest\n---\napiVersion: ambassador/v1\nkind: Mapping\nname: globalcorstest-http-bar\nprefix: /bar/\nservice: globalcorstest-http\ncors:\n  origins: http://bar.example.com\n  methods: POST, GET, OPTIONS\nambassador_id: globalcorstest\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Module\\nname: ambassador\\nconfig:\\n  cors:\\n    origins: http://foo.example.com\\n    methods: POST, GET, OPTIONS\\nambassador_id: globalcorstest\\n---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: globalcorstest-http-foo\\nprefix: /foo/\\nservice: globalcorstest-http\\nambassador_id: globalcorstest\\n---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: globalcorstest-http-bar\\nprefix: /bar/\\nservice: globalcorstest-http\\ncors:\\n  origins: http://bar.example.com\\n  methods: POST, GET, OPTIONS\\nambassador_id: globalcorstest\\n\"},\"labels\":{\"app.kubernetes.io/component\":\"ambassador-service\",\"kat-ambassador-id\":\"globalcorstest\",\"scope\":\"AmbassadorTest\"},\"name\":\"globalcorstest\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8080},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8443}],\"selector\":{\"service\":\"globalcorstest\"},\"type\":\"NodePort\"}}\n"
+                    },
+                    "creationTimestamp": "2020-02-26T15:51:38Z",
+                    "labels": {
+                        "app.kubernetes.io/component": "ambassador-service",
+                        "kat-ambassador-id": "globalcorstest",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "globalcorstest",
+                    "namespace": "default",
+                    "resourceVersion": "65898",
+                    "selfLink": "/api/v1/namespaces/default/services/globalcorstest",
+                    "uid": "dfce12d0-58af-11ea-86d6-0e674b3ff44f"
+                },
+                "spec": {
+                    "clusterIP": "10.104.70.148",
+                    "externalTrafficPolicy": "Cluster",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "nodePort": 30616,
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8080
+                        },
+                        {
+                            "name": "https",
+                            "nodePort": 30913,
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8443
+                        }
+                    ],
+                    "selector": {
+                        "service": "globalcorstest"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "NodePort"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"globalcorstest\",\"scope\":\"AmbassadorTest\",\"service\":\"globalcorstest-admin\"},\"name\":\"globalcorstest-admin\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"globalcorstest-admin\",\"port\":8877,\"targetPort\":8877}],\"selector\":{\"service\":\"globalcorstest\"},\"type\":\"NodePort\"}}\n"
                     },
-                    "creationTimestamp": "2020-02-19T23:19:56Z",
+                    "creationTimestamp": "2020-02-26T15:51:38Z",
                     "labels": {
                         "kat-ambassador-id": "globalcorstest",
                         "scope": "AmbassadorTest",
@@ -30,17 +79,17 @@
                     },
                     "name": "globalcorstest-admin",
                     "namespace": "default",
-                    "resourceVersion": "55223",
+                    "resourceVersion": "65902",
                     "selfLink": "/api/v1/namespaces/default/services/globalcorstest-admin",
-                    "uid": "57301d71-536e-11ea-85dd-167682b5c255"
+                    "uid": "dfd8d0e8-58af-11ea-86d6-0e674b3ff44f"
                 },
                 "spec": {
-                    "clusterIP": "10.105.131.166",
+                    "clusterIP": "10.97.215.206",
                     "externalTrafficPolicy": "Cluster",
                     "ports": [
                         {
                             "name": "globalcorstest-admin",
-                            "nodePort": 32252,
+                            "nodePort": 32326,
                             "port": 8877,
                             "protocol": "TCP",
                             "targetPort": 8877
@@ -63,19 +112,19 @@
                     "annotations": {
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"globalcorstest\",\"scope\":\"AmbassadorTest\"},\"name\":\"globalcorstest-http\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8084},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8447}],\"selector\":{\"backend\":\"superpod-default\"}}}\n"
                     },
-                    "creationTimestamp": "2020-02-19T23:19:56Z",
+                    "creationTimestamp": "2020-02-26T15:51:38Z",
                     "labels": {
                         "kat-ambassador-id": "globalcorstest",
                         "scope": "AmbassadorTest"
                     },
                     "name": "globalcorstest-http",
                     "namespace": "default",
-                    "resourceVersion": "55232",
+                    "resourceVersion": "65909",
                     "selfLink": "/api/v1/namespaces/default/services/globalcorstest-http",
-                    "uid": "573e6fdd-536e-11ea-85dd-167682b5c255"
+                    "uid": "dff41f4d-58af-11ea-86d6-0e674b3ff44f"
                 },
                 "spec": {
-                    "clusterIP": "10.99.173.184",
+                    "clusterIP": "10.103.99.200",
                     "ports": [
                         {
                             "name": "http",
@@ -95,55 +144,6 @@
                     },
                     "sessionAffinity": "None",
                     "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Module\nname: ambassador\nconfig:\n  cors:\n    origins: http://foo.example.com\n    methods: POST, GET, OPTIONS\nambassador_id: globalcorstest\n---\napiVersion: ambassador/v1\nkind: Mapping\nname: globalcorstest-http-foo\nprefix: /foo/\nservice: globalcorstest-http\nambassador_id: globalcorstest\n---\napiVersion: ambassador/v1\nkind: Mapping\nname: globalcorstest-http-bar\nprefix: /bar/\nservice: globalcorstest-http\ncors:\n  origins: http://bar.example.com\n  methods: POST, GET, OPTIONS\nambassador_id: globalcorstest\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Module\\nname: ambassador\\nconfig:\\n  cors:\\n    origins: http://foo.example.com\\n    methods: POST, GET, OPTIONS\\nambassador_id: globalcorstest\\n---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: globalcorstest-http-foo\\nprefix: /foo/\\nservice: globalcorstest-http\\nambassador_id: globalcorstest\\n---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: globalcorstest-http-bar\\nprefix: /bar/\\nservice: globalcorstest-http\\ncors:\\n  origins: http://bar.example.com\\n  methods: POST, GET, OPTIONS\\nambassador_id: globalcorstest\\n\"},\"labels\":{\"app.kubernetes.io/component\":\"ambassador-service\",\"kat-ambassador-id\":\"globalcorstest\",\"scope\":\"AmbassadorTest\"},\"name\":\"globalcorstest\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8080},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8443}],\"selector\":{\"service\":\"globalcorstest\"},\"type\":\"NodePort\"}}\n"
-                    },
-                    "creationTimestamp": "2020-02-19T23:19:56Z",
-                    "labels": {
-                        "app.kubernetes.io/component": "ambassador-service",
-                        "kat-ambassador-id": "globalcorstest",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "globalcorstest",
-                    "namespace": "default",
-                    "resourceVersion": "55219",
-                    "selfLink": "/api/v1/namespaces/default/services/globalcorstest",
-                    "uid": "57277b49-536e-11ea-85dd-167682b5c255"
-                },
-                "spec": {
-                    "clusterIP": "10.105.86.54",
-                    "externalTrafficPolicy": "Cluster",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "nodePort": 30615,
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8080
-                        },
-                        {
-                            "name": "https",
-                            "nodePort": 31797,
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8443
-                        }
-                    ],
-                    "selector": {
-                        "service": "globalcorstest"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "NodePort"
                 },
                 "status": {
                     "loadBalancer": {}

--- a/python/tests/gold/gzipminimumconfigtest/snapshots/econf.json
+++ b/python/tests/gold/gzipminimumconfigtest/snapshots/econf.json
@@ -315,8 +315,7 @@
                                     "xff_num_trusted_hops": 0
                                 }
                             }
-                        ],
-                        "use_proxy_proto": false
+                        ]
                     }
                 ],
                 "listener_filters": [],

--- a/python/tests/gold/gzipminimumconfigtest/snapshots/snapshot.yaml
+++ b/python/tests/gold/gzipminimumconfigtest/snapshots/snapshot.yaml
@@ -20,9 +20,58 @@
                 "kind": "Service",
                 "metadata": {
                     "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Module\nname: ambassador\nconfig:\n  gzip:\n    enabled: true\nambassador_id: gzipminimumconfigtest\n\n---\napiVersion: ambassador/v0\nkind: Mapping\nname: gzipminimumconfigtest-http\nprefix: /target/\nservice: gzipminimumconfigtest-http\nambassador_id: gzipminimumconfigtest\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Module\\nname: ambassador\\nconfig:\\n  gzip:\\n    enabled: true\\nambassador_id: gzipminimumconfigtest\\n\\n---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: gzipminimumconfigtest-http\\nprefix: /target/\\nservice: gzipminimumconfigtest-http\\nambassador_id: gzipminimumconfigtest\\n\"},\"labels\":{\"app.kubernetes.io/component\":\"ambassador-service\",\"kat-ambassador-id\":\"gzipminimumconfigtest\",\"scope\":\"AmbassadorTest\"},\"name\":\"gzipminimumconfigtest\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8080},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8443}],\"selector\":{\"service\":\"gzipminimumconfigtest\"},\"type\":\"NodePort\"}}\n"
+                    },
+                    "creationTimestamp": "2020-02-26T15:51:46Z",
+                    "labels": {
+                        "app.kubernetes.io/component": "ambassador-service",
+                        "kat-ambassador-id": "gzipminimumconfigtest",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "gzipminimumconfigtest",
+                    "namespace": "default",
+                    "resourceVersion": "66267",
+                    "selfLink": "/api/v1/namespaces/default/services/gzipminimumconfigtest",
+                    "uid": "e490b5a0-58af-11ea-86d6-0e674b3ff44f"
+                },
+                "spec": {
+                    "clusterIP": "10.108.94.175",
+                    "externalTrafficPolicy": "Cluster",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "nodePort": 30197,
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8080
+                        },
+                        {
+                            "name": "https",
+                            "nodePort": 31164,
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8443
+                        }
+                    ],
+                    "selector": {
+                        "service": "gzipminimumconfigtest"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "NodePort"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"gzipminimumconfigtest\",\"scope\":\"AmbassadorTest\",\"service\":\"gzipminimumconfigtest-admin\"},\"name\":\"gzipminimumconfigtest-admin\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"gzipminimumconfigtest-admin\",\"port\":8877,\"targetPort\":8877}],\"selector\":{\"service\":\"gzipminimumconfigtest\"},\"type\":\"NodePort\"}}\n"
                     },
-                    "creationTimestamp": "2020-02-19T23:20:04Z",
+                    "creationTimestamp": "2020-02-26T15:51:46Z",
                     "labels": {
                         "kat-ambassador-id": "gzipminimumconfigtest",
                         "scope": "AmbassadorTest",
@@ -30,17 +79,17 @@
                     },
                     "name": "gzipminimumconfigtest-admin",
                     "namespace": "default",
-                    "resourceVersion": "55595",
+                    "resourceVersion": "66271",
                     "selfLink": "/api/v1/namespaces/default/services/gzipminimumconfigtest-admin",
-                    "uid": "5c24b7bc-536e-11ea-85dd-167682b5c255"
+                    "uid": "e49b827f-58af-11ea-86d6-0e674b3ff44f"
                 },
                 "spec": {
-                    "clusterIP": "10.98.52.125",
+                    "clusterIP": "10.103.66.132",
                     "externalTrafficPolicy": "Cluster",
                     "ports": [
                         {
                             "name": "gzipminimumconfigtest-admin",
-                            "nodePort": 30425,
+                            "nodePort": 31483,
                             "port": 8877,
                             "protocol": "TCP",
                             "targetPort": 8877
@@ -63,19 +112,19 @@
                     "annotations": {
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"gzipminimumconfigtest\",\"scope\":\"AmbassadorTest\"},\"name\":\"gzipminimumconfigtest-http\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8095},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8458}],\"selector\":{\"backend\":\"superpod-default\"}}}\n"
                     },
-                    "creationTimestamp": "2020-02-19T23:20:04Z",
+                    "creationTimestamp": "2020-02-26T15:51:46Z",
                     "labels": {
                         "kat-ambassador-id": "gzipminimumconfigtest",
                         "scope": "AmbassadorTest"
                     },
                     "name": "gzipminimumconfigtest-http",
                     "namespace": "default",
-                    "resourceVersion": "55602",
+                    "resourceVersion": "66278",
                     "selfLink": "/api/v1/namespaces/default/services/gzipminimumconfigtest-http",
-                    "uid": "5c31f048-536e-11ea-85dd-167682b5c255"
+                    "uid": "e4b371f5-58af-11ea-86d6-0e674b3ff44f"
                 },
                 "spec": {
-                    "clusterIP": "10.99.50.253",
+                    "clusterIP": "10.107.159.41",
                     "ports": [
                         {
                             "name": "http",
@@ -95,55 +144,6 @@
                     },
                     "sessionAffinity": "None",
                     "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Module\nname: ambassador\nconfig:\n  gzip:\n    enabled: true\nambassador_id: gzipminimumconfigtest\n\n---\napiVersion: ambassador/v0\nkind: Mapping\nname: gzipminimumconfigtest-http\nprefix: /target/\nservice: gzipminimumconfigtest-http\nambassador_id: gzipminimumconfigtest\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Module\\nname: ambassador\\nconfig:\\n  gzip:\\n    enabled: true\\nambassador_id: gzipminimumconfigtest\\n\\n---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: gzipminimumconfigtest-http\\nprefix: /target/\\nservice: gzipminimumconfigtest-http\\nambassador_id: gzipminimumconfigtest\\n\"},\"labels\":{\"app.kubernetes.io/component\":\"ambassador-service\",\"kat-ambassador-id\":\"gzipminimumconfigtest\",\"scope\":\"AmbassadorTest\"},\"name\":\"gzipminimumconfigtest\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8080},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8443}],\"selector\":{\"service\":\"gzipminimumconfigtest\"},\"type\":\"NodePort\"}}\n"
-                    },
-                    "creationTimestamp": "2020-02-19T23:20:04Z",
-                    "labels": {
-                        "app.kubernetes.io/component": "ambassador-service",
-                        "kat-ambassador-id": "gzipminimumconfigtest",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "gzipminimumconfigtest",
-                    "namespace": "default",
-                    "resourceVersion": "55591",
-                    "selfLink": "/api/v1/namespaces/default/services/gzipminimumconfigtest",
-                    "uid": "5c1bbba3-536e-11ea-85dd-167682b5c255"
-                },
-                "spec": {
-                    "clusterIP": "10.104.158.21",
-                    "externalTrafficPolicy": "Cluster",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "nodePort": 32412,
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8080
-                        },
-                        {
-                            "name": "https",
-                            "nodePort": 31429,
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8443
-                        }
-                    ],
-                    "selector": {
-                        "service": "gzipminimumconfigtest"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "NodePort"
                 },
                 "status": {
                     "loadBalancer": {}

--- a/python/tests/gold/gzipnotsupportedcontenttypetest/snapshots/econf.json
+++ b/python/tests/gold/gzipnotsupportedcontenttypetest/snapshots/econf.json
@@ -317,8 +317,7 @@
                                     "xff_num_trusted_hops": 0
                                 }
                             }
-                        ],
-                        "use_proxy_proto": false
+                        ]
                     }
                 ],
                 "listener_filters": [],

--- a/python/tests/gold/gzipnotsupportedcontenttypetest/snapshots/snapshot.yaml
+++ b/python/tests/gold/gzipnotsupportedcontenttypetest/snapshots/snapshot.yaml
@@ -20,58 +20,9 @@
                 "kind": "Service",
                 "metadata": {
                     "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Module\nname: ambassador\nconfig:\n  gzip:\n    min_content_length: 32\n    content_type:\n    - application/json\nambassador_id: gzipnotsupportedcontenttypetest\n\n---\napiVersion: ambassador/v0\nkind: Mapping\nname: gzipnotsupportedcontenttypetest-http\nprefix: /target/\nservice: gzipnotsupportedcontenttypetest-http\nambassador_id: gzipnotsupportedcontenttypetest\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Module\\nname: ambassador\\nconfig:\\n  gzip:\\n    min_content_length: 32\\n    content_type:\\n    - application/json\\nambassador_id: gzipnotsupportedcontenttypetest\\n\\n---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: gzipnotsupportedcontenttypetest-http\\nprefix: /target/\\nservice: gzipnotsupportedcontenttypetest-http\\nambassador_id: gzipnotsupportedcontenttypetest\\n\"},\"labels\":{\"app.kubernetes.io/component\":\"ambassador-service\",\"kat-ambassador-id\":\"gzipnotsupportedcontenttypetest\",\"scope\":\"AmbassadorTest\"},\"name\":\"gzipnotsupportedcontenttypetest\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8080},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8443}],\"selector\":{\"service\":\"gzipnotsupportedcontenttypetest\"},\"type\":\"NodePort\"}}\n"
-                    },
-                    "creationTimestamp": "2020-02-19T23:20:05Z",
-                    "labels": {
-                        "app.kubernetes.io/component": "ambassador-service",
-                        "kat-ambassador-id": "gzipnotsupportedcontenttypetest",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "gzipnotsupportedcontenttypetest",
-                    "namespace": "default",
-                    "resourceVersion": "55635",
-                    "selfLink": "/api/v1/namespaces/default/services/gzipnotsupportedcontenttypetest",
-                    "uid": "5c8531c9-536e-11ea-85dd-167682b5c255"
-                },
-                "spec": {
-                    "clusterIP": "10.107.143.148",
-                    "externalTrafficPolicy": "Cluster",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "nodePort": 30096,
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8080
-                        },
-                        {
-                            "name": "https",
-                            "nodePort": 30035,
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8443
-                        }
-                    ],
-                    "selector": {
-                        "service": "gzipnotsupportedcontenttypetest"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "NodePort"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"gzipnotsupportedcontenttypetest\",\"scope\":\"AmbassadorTest\",\"service\":\"gzipnotsupportedcontenttypetest-admin\"},\"name\":\"gzipnotsupportedcontenttypetest-admin\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"gzipnotsupportedcontenttypetest-admin\",\"port\":8877,\"targetPort\":8877}],\"selector\":{\"service\":\"gzipnotsupportedcontenttypetest\"},\"type\":\"NodePort\"}}\n"
                     },
-                    "creationTimestamp": "2020-02-19T23:20:05Z",
+                    "creationTimestamp": "2020-02-26T15:51:47Z",
                     "labels": {
                         "kat-ambassador-id": "gzipnotsupportedcontenttypetest",
                         "scope": "AmbassadorTest",
@@ -79,17 +30,17 @@
                     },
                     "name": "gzipnotsupportedcontenttypetest-admin",
                     "namespace": "default",
-                    "resourceVersion": "55640",
+                    "resourceVersion": "66322",
                     "selfLink": "/api/v1/namespaces/default/services/gzipnotsupportedcontenttypetest-admin",
-                    "uid": "5c8fe371-536e-11ea-85dd-167682b5c255"
+                    "uid": "e53b191b-58af-11ea-86d6-0e674b3ff44f"
                 },
                 "spec": {
-                    "clusterIP": "10.97.214.216",
+                    "clusterIP": "10.101.64.175",
                     "externalTrafficPolicy": "Cluster",
                     "ports": [
                         {
                             "name": "gzipnotsupportedcontenttypetest-admin",
-                            "nodePort": 30591,
+                            "nodePort": 32176,
                             "port": 8877,
                             "protocol": "TCP",
                             "targetPort": 8877
@@ -112,19 +63,19 @@
                     "annotations": {
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"gzipnotsupportedcontenttypetest\",\"scope\":\"AmbassadorTest\"},\"name\":\"gzipnotsupportedcontenttypetest-http\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8097},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8460}],\"selector\":{\"backend\":\"superpod-default\"}}}\n"
                     },
-                    "creationTimestamp": "2020-02-19T23:20:05Z",
+                    "creationTimestamp": "2020-02-26T15:51:47Z",
                     "labels": {
                         "kat-ambassador-id": "gzipnotsupportedcontenttypetest",
                         "scope": "AmbassadorTest"
                     },
                     "name": "gzipnotsupportedcontenttypetest-http",
                     "namespace": "default",
-                    "resourceVersion": "55647",
+                    "resourceVersion": "66329",
                     "selfLink": "/api/v1/namespaces/default/services/gzipnotsupportedcontenttypetest-http",
-                    "uid": "5c9fff87-536e-11ea-85dd-167682b5c255"
+                    "uid": "e54feb45-58af-11ea-86d6-0e674b3ff44f"
                 },
                 "spec": {
-                    "clusterIP": "10.111.144.63",
+                    "clusterIP": "10.106.176.130",
                     "ports": [
                         {
                             "name": "http",
@@ -144,6 +95,55 @@
                     },
                     "sessionAffinity": "None",
                     "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Module\nname: ambassador\nconfig:\n  gzip:\n    min_content_length: 32\n    content_type:\n    - application/json\nambassador_id: gzipnotsupportedcontenttypetest\n\n---\napiVersion: ambassador/v0\nkind: Mapping\nname: gzipnotsupportedcontenttypetest-http\nprefix: /target/\nservice: gzipnotsupportedcontenttypetest-http\nambassador_id: gzipnotsupportedcontenttypetest\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Module\\nname: ambassador\\nconfig:\\n  gzip:\\n    min_content_length: 32\\n    content_type:\\n    - application/json\\nambassador_id: gzipnotsupportedcontenttypetest\\n\\n---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: gzipnotsupportedcontenttypetest-http\\nprefix: /target/\\nservice: gzipnotsupportedcontenttypetest-http\\nambassador_id: gzipnotsupportedcontenttypetest\\n\"},\"labels\":{\"app.kubernetes.io/component\":\"ambassador-service\",\"kat-ambassador-id\":\"gzipnotsupportedcontenttypetest\",\"scope\":\"AmbassadorTest\"},\"name\":\"gzipnotsupportedcontenttypetest\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8080},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8443}],\"selector\":{\"service\":\"gzipnotsupportedcontenttypetest\"},\"type\":\"NodePort\"}}\n"
+                    },
+                    "creationTimestamp": "2020-02-26T15:51:47Z",
+                    "labels": {
+                        "app.kubernetes.io/component": "ambassador-service",
+                        "kat-ambassador-id": "gzipnotsupportedcontenttypetest",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "gzipnotsupportedcontenttypetest",
+                    "namespace": "default",
+                    "resourceVersion": "66317",
+                    "selfLink": "/api/v1/namespaces/default/services/gzipnotsupportedcontenttypetest",
+                    "uid": "e5291b30-58af-11ea-86d6-0e674b3ff44f"
+                },
+                "spec": {
+                    "clusterIP": "10.103.109.56",
+                    "externalTrafficPolicy": "Cluster",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "nodePort": 30351,
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8080
+                        },
+                        {
+                            "name": "https",
+                            "nodePort": 31108,
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8443
+                        }
+                    ],
+                    "selector": {
+                        "service": "gzipnotsupportedcontenttypetest"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "NodePort"
                 },
                 "status": {
                     "loadBalancer": {}

--- a/python/tests/gold/gziptest/snapshots/econf.json
+++ b/python/tests/gold/gziptest/snapshots/econf.json
@@ -317,8 +317,7 @@
                                     "xff_num_trusted_hops": 0
                                 }
                             }
-                        ],
-                        "use_proxy_proto": false
+                        ]
                     }
                 ],
                 "listener_filters": [],

--- a/python/tests/gold/gziptest/snapshots/snapshot.yaml
+++ b/python/tests/gold/gziptest/snapshots/snapshot.yaml
@@ -20,58 +20,9 @@
                 "kind": "Service",
                 "metadata": {
                     "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Module\nname: ambassador\nconfig:\n  gzip:\n    min_content_length: 32\n    window_bits: 15\n    content_type:\n    - text/plain\nambassador_id: gziptest\n\n---\napiVersion: ambassador/v0\nkind: Mapping\nname: gziptest-http\nprefix: /target/\nservice: gziptest-http\nambassador_id: gziptest\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Module\\nname: ambassador\\nconfig:\\n  gzip:\\n    min_content_length: 32\\n    window_bits: 15\\n    content_type:\\n    - text/plain\\nambassador_id: gziptest\\n\\n---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: gziptest-http\\nprefix: /target/\\nservice: gziptest-http\\nambassador_id: gziptest\\n\"},\"labels\":{\"app.kubernetes.io/component\":\"ambassador-service\",\"kat-ambassador-id\":\"gziptest\",\"scope\":\"AmbassadorTest\"},\"name\":\"gziptest\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8080},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8443}],\"selector\":{\"service\":\"gziptest\"},\"type\":\"NodePort\"}}\n"
-                    },
-                    "creationTimestamp": "2020-02-19T23:20:04Z",
-                    "labels": {
-                        "app.kubernetes.io/component": "ambassador-service",
-                        "kat-ambassador-id": "gziptest",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "gziptest",
-                    "namespace": "default",
-                    "resourceVersion": "55613",
-                    "selfLink": "/api/v1/namespaces/default/services/gziptest",
-                    "uid": "5c4e8886-536e-11ea-85dd-167682b5c255"
-                },
-                "spec": {
-                    "clusterIP": "10.106.178.66",
-                    "externalTrafficPolicy": "Cluster",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "nodePort": 31013,
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8080
-                        },
-                        {
-                            "name": "https",
-                            "nodePort": 31067,
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8443
-                        }
-                    ],
-                    "selector": {
-                        "service": "gziptest"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "NodePort"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"gziptest\",\"scope\":\"AmbassadorTest\",\"service\":\"gziptest-admin\"},\"name\":\"gziptest-admin\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"gziptest-admin\",\"port\":8877,\"targetPort\":8877}],\"selector\":{\"service\":\"gziptest\"},\"type\":\"NodePort\"}}\n"
                     },
-                    "creationTimestamp": "2020-02-19T23:20:04Z",
+                    "creationTimestamp": "2020-02-26T15:51:47Z",
                     "labels": {
                         "kat-ambassador-id": "gziptest",
                         "scope": "AmbassadorTest",
@@ -79,17 +30,17 @@
                     },
                     "name": "gziptest-admin",
                     "namespace": "default",
-                    "resourceVersion": "55617",
+                    "resourceVersion": "66297",
                     "selfLink": "/api/v1/namespaces/default/services/gziptest-admin",
-                    "uid": "5c56c49d-536e-11ea-85dd-167682b5c255"
+                    "uid": "e4e7e464-58af-11ea-86d6-0e674b3ff44f"
                 },
                 "spec": {
-                    "clusterIP": "10.100.122.170",
+                    "clusterIP": "10.105.92.41",
                     "externalTrafficPolicy": "Cluster",
                     "ports": [
                         {
                             "name": "gziptest-admin",
-                            "nodePort": 30471,
+                            "nodePort": 30846,
                             "port": 8877,
                             "protocol": "TCP",
                             "targetPort": 8877
@@ -112,19 +63,19 @@
                     "annotations": {
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"gziptest\",\"scope\":\"AmbassadorTest\"},\"name\":\"gziptest-http\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8096},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8459}],\"selector\":{\"backend\":\"superpod-default\"}}}\n"
                     },
-                    "creationTimestamp": "2020-02-19T23:20:04Z",
+                    "creationTimestamp": "2020-02-26T15:51:47Z",
                     "labels": {
                         "kat-ambassador-id": "gziptest",
                         "scope": "AmbassadorTest"
                     },
                     "name": "gziptest-http",
                     "namespace": "default",
-                    "resourceVersion": "55623",
+                    "resourceVersion": "66304",
                     "selfLink": "/api/v1/namespaces/default/services/gziptest-http",
-                    "uid": "5c649116-536e-11ea-85dd-167682b5c255"
+                    "uid": "e4faf214-58af-11ea-86d6-0e674b3ff44f"
                 },
                 "spec": {
-                    "clusterIP": "10.107.166.146",
+                    "clusterIP": "10.101.51.201",
                     "ports": [
                         {
                             "name": "http",
@@ -144,6 +95,55 @@
                     },
                     "sessionAffinity": "None",
                     "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Module\nname: ambassador\nconfig:\n  gzip:\n    min_content_length: 32\n    window_bits: 15\n    content_type:\n    - text/plain\nambassador_id: gziptest\n\n---\napiVersion: ambassador/v0\nkind: Mapping\nname: gziptest-http\nprefix: /target/\nservice: gziptest-http\nambassador_id: gziptest\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Module\\nname: ambassador\\nconfig:\\n  gzip:\\n    min_content_length: 32\\n    window_bits: 15\\n    content_type:\\n    - text/plain\\nambassador_id: gziptest\\n\\n---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: gziptest-http\\nprefix: /target/\\nservice: gziptest-http\\nambassador_id: gziptest\\n\"},\"labels\":{\"app.kubernetes.io/component\":\"ambassador-service\",\"kat-ambassador-id\":\"gziptest\",\"scope\":\"AmbassadorTest\"},\"name\":\"gziptest\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8080},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8443}],\"selector\":{\"service\":\"gziptest\"},\"type\":\"NodePort\"}}\n"
+                    },
+                    "creationTimestamp": "2020-02-26T15:51:47Z",
+                    "labels": {
+                        "app.kubernetes.io/component": "ambassador-service",
+                        "kat-ambassador-id": "gziptest",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "gziptest",
+                    "namespace": "default",
+                    "resourceVersion": "66290",
+                    "selfLink": "/api/v1/namespaces/default/services/gziptest",
+                    "uid": "e4db0762-58af-11ea-86d6-0e674b3ff44f"
+                },
+                "spec": {
+                    "clusterIP": "10.109.116.106",
+                    "externalTrafficPolicy": "Cluster",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "nodePort": 30056,
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8080
+                        },
+                        {
+                            "name": "https",
+                            "nodePort": 31247,
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8443
+                        }
+                    ],
+                    "selector": {
+                        "service": "gziptest"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "NodePort"
                 },
                 "status": {
                     "loadBalancer": {}

--- a/python/tests/gold/hostcrdcleartext/snapshots/econf.json
+++ b/python/tests/gold/hostcrdcleartext/snapshots/econf.json
@@ -302,8 +302,7 @@
                                     "xff_num_trusted_hops": 0
                                 }
                             }
-                        ],
-                        "use_proxy_proto": false
+                        ]
                     }
                 ],
                 "listener_filters": [],

--- a/python/tests/gold/hostcrdcleartext/snapshots/snapshot.yaml
+++ b/python/tests/gold/hostcrdcleartext/snapshots/snapshot.yaml
@@ -12,7 +12,7 @@
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"getambassador.io/v2\",\"kind\":\"Host\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"hostcrdcleartext\",\"scope\":\"AmbassadorTest\"},\"name\":\"cleartext-host\",\"namespace\":\"default\"},\"spec\":{\"acmeProvider\":{\"authority\":\"none\"},\"ambassador_id\":[\"hostcrdcleartext\"],\"hostname\":\"hostcrdcleartext\",\"requestPolicy\":{\"insecure\":{\"action\":\"Route\"}},\"selector\":{\"matchLabels\":{\"hostname\":\"host-cleartext\"}}}}\n"
                     },
                     "clusterName": "",
-                    "creationTimestamp": "2020-02-19T23:20:08Z",
+                    "creationTimestamp": "2020-02-26T15:51:51Z",
                     "generation": 1,
                     "labels": {
                         "kat-ambassador-id": "hostcrdcleartext",
@@ -20,9 +20,9 @@
                     },
                     "name": "cleartext-host",
                     "namespace": "default",
-                    "resourceVersion": "55787",
+                    "resourceVersion": "66463",
                     "selfLink": "/apis/getambassador.io/v2/namespaces/default/hosts/cleartext-host",
-                    "uid": "5e33bc3a-536e-11ea-85dd-167682b5c255"
+                    "uid": "e73f94fc-58af-11ea-86d6-0e674b3ff44f"
                 },
                 "spec": {
                     "acmeProvider": {
@@ -57,7 +57,7 @@
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"getambassador.io/v2\",\"kind\":\"Mapping\",\"metadata\":{\"annotations\":{},\"labels\":{\"hostname\":\"host-cleartext\",\"kat-ambassador-id\":\"hostcrdcleartext\",\"scope\":\"AmbassadorTest\"},\"name\":\"cleartext-target-mapping\",\"namespace\":\"default\"},\"spec\":{\"ambassador_id\":[\"hostcrdcleartext\"],\"prefix\":\"/target/\",\"service\":\"hostcrdcleartext-http\"}}\n"
                     },
                     "clusterName": "",
-                    "creationTimestamp": "2020-02-19T23:20:08Z",
+                    "creationTimestamp": "2020-02-26T15:51:51Z",
                     "generation": 1,
                     "labels": {
                         "hostname": "host-cleartext",
@@ -66,9 +66,9 @@
                     },
                     "name": "cleartext-target-mapping",
                     "namespace": "default",
-                    "resourceVersion": "55790",
+                    "resourceVersion": "66465",
                     "selfLink": "/apis/getambassador.io/v2/namespaces/default/mappings/cleartext-target-mapping",
-                    "uid": "5e3bd151-536e-11ea-85dd-167682b5c255"
+                    "uid": "e747da48-58af-11ea-86d6-0e674b3ff44f"
                 },
                 "spec": {
                     "ambassador_id": [
@@ -94,7 +94,7 @@
                     "annotations": {
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"app.kubernetes.io/component\":\"ambassador-service\",\"kat-ambassador-id\":\"hostcrdcleartext\",\"scope\":\"AmbassadorTest\"},\"name\":\"hostcrdcleartext\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8080},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8443}],\"selector\":{\"service\":\"hostcrdcleartext\"},\"type\":\"NodePort\"}}\n"
                     },
-                    "creationTimestamp": "2020-02-19T23:20:07Z",
+                    "creationTimestamp": "2020-02-26T15:51:51Z",
                     "labels": {
                         "app.kubernetes.io/component": "ambassador-service",
                         "kat-ambassador-id": "hostcrdcleartext",
@@ -102,24 +102,24 @@
                     },
                     "name": "hostcrdcleartext",
                     "namespace": "default",
-                    "resourceVersion": "55778",
+                    "resourceVersion": "66478",
                     "selfLink": "/api/v1/namespaces/default/services/hostcrdcleartext",
-                    "uid": "5e1ccc08-536e-11ea-85dd-167682b5c255"
+                    "uid": "e76b7208-58af-11ea-86d6-0e674b3ff44f"
                 },
                 "spec": {
-                    "clusterIP": "10.104.65.218",
+                    "clusterIP": "10.98.172.23",
                     "externalTrafficPolicy": "Cluster",
                     "ports": [
                         {
                             "name": "http",
-                            "nodePort": 30478,
+                            "nodePort": 32596,
                             "port": 80,
                             "protocol": "TCP",
                             "targetPort": 8080
                         },
                         {
                             "name": "https",
-                            "nodePort": 32337,
+                            "nodePort": 31819,
                             "port": 443,
                             "protocol": "TCP",
                             "targetPort": 8443
@@ -142,7 +142,7 @@
                     "annotations": {
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"hostcrdcleartext\",\"scope\":\"AmbassadorTest\",\"service\":\"hostcrdcleartext-admin\"},\"name\":\"hostcrdcleartext-admin\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"hostcrdcleartext-admin\",\"port\":8877,\"targetPort\":8877}],\"selector\":{\"service\":\"hostcrdcleartext\"},\"type\":\"NodePort\"}}\n"
                     },
-                    "creationTimestamp": "2020-02-19T23:20:07Z",
+                    "creationTimestamp": "2020-02-26T15:51:51Z",
                     "labels": {
                         "kat-ambassador-id": "hostcrdcleartext",
                         "scope": "AmbassadorTest",
@@ -150,17 +150,17 @@
                     },
                     "name": "hostcrdcleartext-admin",
                     "namespace": "default",
-                    "resourceVersion": "55782",
+                    "resourceVersion": "66482",
                     "selfLink": "/api/v1/namespaces/default/services/hostcrdcleartext-admin",
-                    "uid": "5e25e92f-536e-11ea-85dd-167682b5c255"
+                    "uid": "e77517f4-58af-11ea-86d6-0e674b3ff44f"
                 },
                 "spec": {
-                    "clusterIP": "10.101.101.233",
+                    "clusterIP": "10.102.71.187",
                     "externalTrafficPolicy": "Cluster",
                     "ports": [
                         {
                             "name": "hostcrdcleartext-admin",
-                            "nodePort": 31881,
+                            "nodePort": 31735,
                             "port": 8877,
                             "protocol": "TCP",
                             "targetPort": 8877
@@ -183,19 +183,19 @@
                     "annotations": {
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"hostcrdcleartext\",\"scope\":\"AmbassadorTest\"},\"name\":\"hostcrdcleartext-http\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8103},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8466}],\"selector\":{\"backend\":\"superpod-default\"}}}\n"
                     },
-                    "creationTimestamp": "2020-02-19T23:20:08Z",
+                    "creationTimestamp": "2020-02-26T15:51:51Z",
                     "labels": {
                         "kat-ambassador-id": "hostcrdcleartext",
                         "scope": "AmbassadorTest"
                     },
                     "name": "hostcrdcleartext-http",
                     "namespace": "default",
-                    "resourceVersion": "55794",
+                    "resourceVersion": "66489",
                     "selfLink": "/api/v1/namespaces/default/services/hostcrdcleartext-http",
-                    "uid": "5e4849a9-536e-11ea-85dd-167682b5c255"
+                    "uid": "e78ab7f0-58af-11ea-86d6-0e674b3ff44f"
                 },
                 "spec": {
-                    "clusterIP": "10.99.204.164",
+                    "clusterIP": "10.106.29.55",
                     "ports": [
                         {
                             "name": "http",

--- a/python/tests/gold/hostcrddouble/snapshots/econf.json
+++ b/python/tests/gold/hostcrddouble/snapshots/econf.json
@@ -394,8 +394,7 @@
                                     }
                                 ]
                             }
-                        },
-                        "use_proxy_proto": false
+                        }
                     },
                     {
                         "filter_chain_match": {
@@ -637,8 +636,7 @@
                                     }
                                 ]
                             }
-                        },
-                        "use_proxy_proto": false
+                        }
                     }
                 ],
                 "listener_filters": [
@@ -798,8 +796,7 @@
                                     "xff_num_trusted_hops": 0
                                 }
                             }
-                        ],
-                        "use_proxy_proto": false
+                        ]
                     },
                     {
                         "filter_chain_match": {
@@ -922,8 +919,7 @@
                                     "xff_num_trusted_hops": 0
                                 }
                             }
-                        ],
-                        "use_proxy_proto": false
+                        ]
                     }
                 ],
                 "listener_filters": [],

--- a/python/tests/gold/hostcrddouble/snapshots/snapshot.yaml
+++ b/python/tests/gold/hostcrddouble/snapshots/snapshot.yaml
@@ -9,48 +9,10 @@
                 "kind": "Host",
                 "metadata": {
                     "annotations": {
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"getambassador.io/v2\",\"kind\":\"Host\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"hostcrddouble\",\"scope\":\"AmbassadorTest\"},\"name\":\"host-2\",\"namespace\":\"default\"},\"spec\":{\"acmeProvider\":{\"authority\":\"none\"},\"ambassador_id\":[\"hostcrddouble\"],\"hostname\":\"tls-context-host-2\",\"selector\":{\"matchLabels\":{\"hostname\":\"tls-context-host-2\"}},\"tlsSecret\":{\"name\":\"test-tlscontext-secret-2\"}}}\n"
-                    },
-                    "clusterName": "",
-                    "creationTimestamp": "2020-02-19T23:20:08Z",
-                    "generation": 1,
-                    "labels": {
-                        "kat-ambassador-id": "hostcrddouble",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "host-2",
-                    "namespace": "default",
-                    "resourceVersion": "55822",
-                    "selfLink": "/apis/getambassador.io/v2/namespaces/default/hosts/host-2",
-                    "uid": "5e981f04-536e-11ea-85dd-167682b5c255"
-                },
-                "spec": {
-                    "acmeProvider": {
-                        "authority": "none"
-                    },
-                    "ambassador_id": [
-                        "hostcrddouble"
-                    ],
-                    "hostname": "tls-context-host-2",
-                    "selector": {
-                        "matchLabels": {
-                            "hostname": "tls-context-host-2"
-                        }
-                    },
-                    "tlsSecret": {
-                        "name": "test-tlscontext-secret-2"
-                    }
-                }
-            },
-            {
-                "apiVersion": "getambassador.io/v2",
-                "kind": "Host",
-                "metadata": {
-                    "annotations": {
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"getambassador.io/v2\",\"kind\":\"Host\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"hostcrddouble\",\"scope\":\"AmbassadorTest\"},\"name\":\"host-1\",\"namespace\":\"default\"},\"spec\":{\"acmeProvider\":{\"authority\":\"none\"},\"ambassador_id\":[\"hostcrddouble\"],\"hostname\":\"tls-context-host-1\",\"selector\":{\"matchLabels\":{\"hostname\":\"tls-context-host-1\"}},\"tlsSecret\":{\"name\":\"test-tlscontext-secret-1\"}}}\n"
                     },
                     "clusterName": "",
-                    "creationTimestamp": "2020-02-19T23:20:08Z",
+                    "creationTimestamp": "2020-02-26T15:51:51Z",
                     "generation": 1,
                     "labels": {
                         "kat-ambassador-id": "hostcrddouble",
@@ -58,9 +20,9 @@
                     },
                     "name": "host-1",
                     "namespace": "default",
-                    "resourceVersion": "55820",
+                    "resourceVersion": "66497",
                     "selfLink": "/apis/getambassador.io/v2/namespaces/default/hosts/host-1",
-                    "uid": "5e924a48-536e-11ea-85dd-167682b5c255"
+                    "uid": "e7c5d6c6-58af-11ea-86d6-0e674b3ff44f"
                 },
                 "spec": {
                     "acmeProvider": {
@@ -79,6 +41,44 @@
                         "name": "test-tlscontext-secret-1"
                     }
                 }
+            },
+            {
+                "apiVersion": "getambassador.io/v2",
+                "kind": "Host",
+                "metadata": {
+                    "annotations": {
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"getambassador.io/v2\",\"kind\":\"Host\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"hostcrddouble\",\"scope\":\"AmbassadorTest\"},\"name\":\"host-2\",\"namespace\":\"default\"},\"spec\":{\"acmeProvider\":{\"authority\":\"none\"},\"ambassador_id\":[\"hostcrddouble\"],\"hostname\":\"tls-context-host-2\",\"selector\":{\"matchLabels\":{\"hostname\":\"tls-context-host-2\"}},\"tlsSecret\":{\"name\":\"test-tlscontext-secret-2\"}}}\n"
+                    },
+                    "clusterName": "",
+                    "creationTimestamp": "2020-02-26T15:51:51Z",
+                    "generation": 1,
+                    "labels": {
+                        "kat-ambassador-id": "hostcrddouble",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "host-2",
+                    "namespace": "default",
+                    "resourceVersion": "66498",
+                    "selfLink": "/apis/getambassador.io/v2/namespaces/default/hosts/host-2",
+                    "uid": "e7d0cb24-58af-11ea-86d6-0e674b3ff44f"
+                },
+                "spec": {
+                    "acmeProvider": {
+                        "authority": "none"
+                    },
+                    "ambassador_id": [
+                        "hostcrddouble"
+                    ],
+                    "hostname": "tls-context-host-2",
+                    "selector": {
+                        "matchLabels": {
+                            "hostname": "tls-context-host-2"
+                        }
+                    },
+                    "tlsSecret": {
+                        "name": "test-tlscontext-secret-2"
+                    }
+                }
             }
         ],
         "KubernetesEndpointResolver": null,
@@ -90,40 +90,10 @@
                 "kind": "Mapping",
                 "metadata": {
                     "annotations": {
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"getambassador.io/v2\",\"kind\":\"Mapping\",\"metadata\":{\"annotations\":{},\"labels\":{\"hostname\":\"tls-context-host-2\",\"kat-ambassador-id\":\"hostcrddouble\",\"scope\":\"AmbassadorTest\"},\"name\":\"host-2-mapping\",\"namespace\":\"default\"},\"spec\":{\"ambassador_id\":[\"hostcrddouble\"],\"host\":\"tls-context-host-2\",\"prefix\":\"/target/\",\"service\":\"hostcrddouble-http-target2\"}}\n"
-                    },
-                    "clusterName": "",
-                    "creationTimestamp": "2020-02-19T23:20:08Z",
-                    "generation": 1,
-                    "labels": {
-                        "hostname": "tls-context-host-2",
-                        "kat-ambassador-id": "hostcrddouble",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "host-2-mapping",
-                    "namespace": "default",
-                    "resourceVersion": "55826",
-                    "selfLink": "/apis/getambassador.io/v2/namespaces/default/mappings/host-2-mapping",
-                    "uid": "5ea4953c-536e-11ea-85dd-167682b5c255"
-                },
-                "spec": {
-                    "ambassador_id": [
-                        "hostcrddouble"
-                    ],
-                    "host": "tls-context-host-2",
-                    "prefix": "/target/",
-                    "service": "hostcrddouble-http-target2"
-                }
-            },
-            {
-                "apiVersion": "getambassador.io/v2",
-                "kind": "Mapping",
-                "metadata": {
-                    "annotations": {
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"getambassador.io/v2\",\"kind\":\"Mapping\",\"metadata\":{\"annotations\":{},\"labels\":{\"hostname\":\"tls-context-host-1\",\"kat-ambassador-id\":\"hostcrddouble\",\"scope\":\"AmbassadorTest\"},\"name\":\"host-1-mapping\",\"namespace\":\"default\"},\"spec\":{\"ambassador_id\":[\"hostcrddouble\"],\"host\":\"tls-context-host-1\",\"prefix\":\"/target/\",\"service\":\"hostcrddouble-http-target1\"}}\n"
                     },
                     "clusterName": "",
-                    "creationTimestamp": "2020-02-19T23:20:08Z",
+                    "creationTimestamp": "2020-02-26T15:51:52Z",
                     "generation": 1,
                     "labels": {
                         "hostname": "tls-context-host-1",
@@ -132,9 +102,9 @@
                     },
                     "name": "host-1-mapping",
                     "namespace": "default",
-                    "resourceVersion": "55824",
+                    "resourceVersion": "66499",
                     "selfLink": "/apis/getambassador.io/v2/namespaces/default/mappings/host-1-mapping",
-                    "uid": "5e9e4053-536e-11ea-85dd-167682b5c255"
+                    "uid": "e7d8e780-58af-11ea-86d6-0e674b3ff44f"
                 },
                 "spec": {
                     "ambassador_id": [
@@ -143,6 +113,36 @@
                     "host": "tls-context-host-1",
                     "prefix": "/target/",
                     "service": "hostcrddouble-http-target1"
+                }
+            },
+            {
+                "apiVersion": "getambassador.io/v2",
+                "kind": "Mapping",
+                "metadata": {
+                    "annotations": {
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"getambassador.io/v2\",\"kind\":\"Mapping\",\"metadata\":{\"annotations\":{},\"labels\":{\"hostname\":\"tls-context-host-2\",\"kat-ambassador-id\":\"hostcrddouble\",\"scope\":\"AmbassadorTest\"},\"name\":\"host-2-mapping\",\"namespace\":\"default\"},\"spec\":{\"ambassador_id\":[\"hostcrddouble\"],\"host\":\"tls-context-host-2\",\"prefix\":\"/target/\",\"service\":\"hostcrddouble-http-target2\"}}\n"
+                    },
+                    "clusterName": "",
+                    "creationTimestamp": "2020-02-26T15:51:52Z",
+                    "generation": 1,
+                    "labels": {
+                        "hostname": "tls-context-host-2",
+                        "kat-ambassador-id": "hostcrddouble",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "host-2-mapping",
+                    "namespace": "default",
+                    "resourceVersion": "66501",
+                    "selfLink": "/apis/getambassador.io/v2/namespaces/default/mappings/host-2-mapping",
+                    "uid": "e7e08377-58af-11ea-86d6-0e674b3ff44f"
+                },
+                "spec": {
+                    "ambassador_id": [
+                        "hostcrddouble"
+                    ],
+                    "host": "tls-context-host-2",
+                    "prefix": "/target/",
+                    "service": "hostcrddouble-http-target2"
                 }
             }
         ],
@@ -156,30 +156,6 @@
             {
                 "apiVersion": "v1",
                 "data": {
-                    "tls.crt": "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURnRENDQW1pZ0F3SUJBZ0lKQUlIWTY3cFNoZ3NyTUEwR0NTcUdTSWIzRFFFQkN3VUFNRlV4Q3pBSkJnTlYKQkFZVEFsVlRNUXN3Q1FZRFZRUUlEQUpOUVRFUE1BMEdBMVVFQnd3R1FtOXpkRzl1TVFzd0NRWURWUVFLREFKRQpWekViTUJrR0ExVUVBd3dTZEd4ekxXTnZiblJsZUhRdGFHOXpkQzB5TUI0WERURTRNVEV3TVRFME1EUXhObG9YCkRUSTRNVEF5T1RFME1EUXhObG93VlRFTE1Ba0dBMVVFQmhNQ1ZWTXhDekFKQmdOVkJBZ01BazFCTVE4d0RRWUQKVlFRSERBWkNiM04wYjI0eEN6QUpCZ05WQkFvTUFrUlhNUnN3R1FZRFZRUUREQkowYkhNdFkyOXVkR1Y0ZEMxbwpiM04wTFRJd2dnRWlNQTBHQ1NxR1NJYjNEUUVCQVFVQUE0SUJEd0F3Z2dFS0FvSUJBUURjQThZdGgvUFdhT0dTCm9ObXZFSFoyNGpRN1BLTitENG93TEhXZWl1UmRtaEEwWU92VTN3cUczVnFZNFpwbFpBVjBQS2xELysyWlNGMTQKejh3MWVGNFFUelphWXh3eTkrd2ZITmtUREVwTWpQOEpNMk9FYnlrVVJ4VVJ2VzQrN0QzMEUyRXo1T1BseG1jMApNWU0vL0pINUVEUWhjaURybFlxZTFTUk1SQUxaZVZta2FBeXU2TkhKVEJ1ajBTSVB1ZExUY2grOTBxK3Jkd255CmZrVDF4M09UYW5iV2pub21FSmU3TXZ5NG12dnFxSUh1NDhTOUM4WmQxQkdWUGJ1OFYvVURyU1dROXpZQ1g0U0cKT2FzbDhDMFhtSDZrZW1oUERsRC9UdjB4dnlINXE1TVVjSGk0bUp0Titnem9iNTREd3pWR0VqZWY1TGVTMVY1RgowVEFQMGQrWEFnTUJBQUdqVXpCUk1CMEdBMVVkRGdRV0JCUWRGMEdRSGRxbHRoZG5RWXFWaXVtRXJsUk9mREFmCkJnTlZIU01FR0RBV2dCUWRGMEdRSGRxbHRoZG5RWXFWaXVtRXJsUk9mREFQQmdOVkhSTUJBZjhFQlRBREFRSC8KTUEwR0NTcUdTSWIzRFFFQkN3VUFBNElCQVFBbUFLYkNsdUhFZS9JRmJ1QWJneDBNenV6aTkwd2xtQVBiOGdtTwpxdmJwMjl1T1ZzVlNtUUFkZFBuZEZhTVhWcDFaaG1UVjVDU1F0ZFgyQ1ZNVyswVzQ3Qy9DT0Jkb1NFUTl5akJmCmlGRGNseG04QU4yUG1hR1FhK3hvT1hnWkxYZXJDaE5LV0JTWlIrWktYTEpTTTlVYUVTbEhmNXVuQkxFcENqK2oKZEJpSXFGY2E3eElGUGtyKzBSRW9BVmMveFBubnNhS2pMMlV5Z0dqUWZGTnhjT042Y3VjYjZMS0pYT1pFSVRiNQpINjhKdWFSQ0tyZWZZK0l5aFFWVk5taWk3dE1wY1UyS2pXNXBrVktxVTNkS0l0RXEyVmtTZHpNVUtqTnhZd3FGCll6YnozNFQ1MENXbm9HbU5SQVdKc0xlVmlPWVUyNmR3YkFXZDlVYitWMDFRam43OAotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==",
-                    "tls.key": "LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0tCk1JSUV2d0lCQURBTkJna3Foa2lHOXcwQkFRRUZBQVNDQktrd2dnU2xBZ0VBQW9JQkFRRGNBOFl0aC9QV2FPR1MKb05tdkVIWjI0alE3UEtOK0Q0b3dMSFdlaXVSZG1oQTBZT3ZVM3dxRzNWcVk0WnBsWkFWMFBLbEQvKzJaU0YxNAp6OHcxZUY0UVR6WmFZeHd5OSt3ZkhOa1RERXBNalA4Sk0yT0VieWtVUnhVUnZXNCs3RDMwRTJFejVPUGx4bWMwCk1ZTS8vSkg1RURRaGNpRHJsWXFlMVNSTVJBTFplVm1rYUF5dTZOSEpUQnVqMFNJUHVkTFRjaCs5MHErcmR3bnkKZmtUMXgzT1RhbmJXam5vbUVKZTdNdnk0bXZ2cXFJSHU0OFM5QzhaZDFCR1ZQYnU4Vi9VRHJTV1E5ellDWDRTRwpPYXNsOEMwWG1INmtlbWhQRGxEL1R2MHh2eUg1cTVNVWNIaTRtSnROK2d6b2I1NER3elZHRWplZjVMZVMxVjVGCjBUQVAwZCtYQWdNQkFBRUNnZ0VCQUk2U3I0anYwZForanJhN0gzVnZ3S1RYZnl0bjV6YVlrVjhZWUh3RjIyakEKbm9HaTBSQllIUFU2V2l3NS9oaDRFWVM2anFHdkptUXZYY3NkTldMdEJsK2hSVUtiZVRtYUtWd2NFSnRrV24xeQozUTQwUytnVk5OU2NINDRvYUZuRU0zMklWWFFRZnBKMjJJZ2RFY1dVUVcvWnpUNWpPK3dPTXc4c1plSTZMSEtLCkdoOENsVDkrRGUvdXFqbjNCRnQwelZ3cnFLbllKSU1DSWFrb2lDRmtIcGhVTURFNVkyU1NLaGFGWndxMWtLd0sKdHFvWFpKQnlzYXhnUTFRa21mS1RnRkx5WlpXT01mRzVzb1VrU1RTeURFRzFsYnVYcHpUbTlVSTlKU2lsK01yaAp1LzVTeXBLOHBCSHhBdFg5VXdiTjFiRGw3Sng1SWJyMnNoM0F1UDF4OUpFQ2dZRUE4dGNTM09URXNOUFpQZlptCk9jaUduOW9STTdHVmVGdjMrL05iL3JodHp1L1RQUWJBSzhWZ3FrS0dPazNGN1krY2txS1NTWjFnUkF2SHBsZEIKaTY0Y0daT1dpK01jMWZVcEdVV2sxdnZXbG1nTUlQVjVtbFpvOHowMlNTdXhLZTI1Y2VNb09oenFlay9vRmFtdgoyTmxFeTh0dEhOMUxMS3grZllhMkpGcWVycThDZ1lFQTUvQUxHSXVrU3J0K0dkektJLzV5cjdSREpTVzIzUTJ4CkM5ZklUTUFSL1Q4dzNsWGhyUnRXcmlHL3l0QkVPNXdTMVIwdDkydW1nVkhIRTA5eFFXbzZ0Tm16QVBNb1RSekMKd08yYnJqQktBdUJkQ0RISjZsMlFnOEhPQWovUncrK2x4bEN0VEI2YS8xWEZIZnNHUGhqMEQrWlJiWVZzaE00UgpnSVVmdmpmQ1Y1a0NnWUVBMzdzL2FieHJhdThEaTQ3a0NBQ3o1N3FsZHBiNk92V2d0OFF5MGE5aG0vSmhFQ3lVCkNML0VtNWpHeWhpMWJuV05yNXVRWTdwVzR0cG5pdDJCU2d1VFlBMFYrck8zOFhmNThZcTBvRTFPR3l5cFlBUkoKa09SanRSYUVXVTJqNEJsaGJZZjNtL0xnSk9oUnp3T1RPNXFSUTZHY1dhZVlod1ExVmJrelByTXUxNGtDZ1lCbwp4dEhjWnNqelVidm5wd3hTTWxKUStaZ1RvZlAzN0lWOG1pQk1POEJrclRWQVczKzFtZElRbkFKdWRxTThZb2RICmF3VW03cVNyYXV3SjF5dU1wNWFadUhiYkNQMjl5QzVheFh3OHRtZlk0TTVtTTBmSjdqYW9ydGFId1pqYmNObHMKdTJsdUo2MVJoOGVpZ1pJU1gyZHgvMVB0ckFhWUFCZDcvYWVYWU0wVWtRS0JnUUNVbkFIdmRQUGhIVnJDWU1rTgpOOFBEK0t0YmhPRks2S3MvdlgyUkcyRnFmQkJPQWV3bEo1d0xWeFBLT1RpdytKS2FSeHhYMkcvREZVNzduOEQvCkR5V2RjM2ZCQWQ0a1lJamZVaGRGa1hHNEFMUDZBNVFIZVN4NzNScTFLNWxMVWhPbEZqc3VPZ0NKS28wVlFmRC8KT05paDB6SzN5Wmc3aDVQamZ1TUdGb09OQWc9PQotLS0tLUVORCBQUklWQVRFIEtFWS0tLS0tCg=="
-                },
-                "kind": "Secret",
-                "metadata": {
-                    "annotations": {
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"data\":{\"tls.crt\":\"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURnRENDQW1pZ0F3SUJBZ0lKQUlIWTY3cFNoZ3NyTUEwR0NTcUdTSWIzRFFFQkN3VUFNRlV4Q3pBSkJnTlYKQkFZVEFsVlRNUXN3Q1FZRFZRUUlEQUpOUVRFUE1BMEdBMVVFQnd3R1FtOXpkRzl1TVFzd0NRWURWUVFLREFKRQpWekViTUJrR0ExVUVBd3dTZEd4ekxXTnZiblJsZUhRdGFHOXpkQzB5TUI0WERURTRNVEV3TVRFME1EUXhObG9YCkRUSTRNVEF5T1RFME1EUXhObG93VlRFTE1Ba0dBMVVFQmhNQ1ZWTXhDekFKQmdOVkJBZ01BazFCTVE4d0RRWUQKVlFRSERBWkNiM04wYjI0eEN6QUpCZ05WQkFvTUFrUlhNUnN3R1FZRFZRUUREQkowYkhNdFkyOXVkR1Y0ZEMxbwpiM04wTFRJd2dnRWlNQTBHQ1NxR1NJYjNEUUVCQVFVQUE0SUJEd0F3Z2dFS0FvSUJBUURjQThZdGgvUFdhT0dTCm9ObXZFSFoyNGpRN1BLTitENG93TEhXZWl1UmRtaEEwWU92VTN3cUczVnFZNFpwbFpBVjBQS2xELysyWlNGMTQKejh3MWVGNFFUelphWXh3eTkrd2ZITmtUREVwTWpQOEpNMk9FYnlrVVJ4VVJ2VzQrN0QzMEUyRXo1T1BseG1jMApNWU0vL0pINUVEUWhjaURybFlxZTFTUk1SQUxaZVZta2FBeXU2TkhKVEJ1ajBTSVB1ZExUY2grOTBxK3Jkd255CmZrVDF4M09UYW5iV2pub21FSmU3TXZ5NG12dnFxSUh1NDhTOUM4WmQxQkdWUGJ1OFYvVURyU1dROXpZQ1g0U0cKT2FzbDhDMFhtSDZrZW1oUERsRC9UdjB4dnlINXE1TVVjSGk0bUp0Titnem9iNTREd3pWR0VqZWY1TGVTMVY1RgowVEFQMGQrWEFnTUJBQUdqVXpCUk1CMEdBMVVkRGdRV0JCUWRGMEdRSGRxbHRoZG5RWXFWaXVtRXJsUk9mREFmCkJnTlZIU01FR0RBV2dCUWRGMEdRSGRxbHRoZG5RWXFWaXVtRXJsUk9mREFQQmdOVkhSTUJBZjhFQlRBREFRSC8KTUEwR0NTcUdTSWIzRFFFQkN3VUFBNElCQVFBbUFLYkNsdUhFZS9JRmJ1QWJneDBNenV6aTkwd2xtQVBiOGdtTwpxdmJwMjl1T1ZzVlNtUUFkZFBuZEZhTVhWcDFaaG1UVjVDU1F0ZFgyQ1ZNVyswVzQ3Qy9DT0Jkb1NFUTl5akJmCmlGRGNseG04QU4yUG1hR1FhK3hvT1hnWkxYZXJDaE5LV0JTWlIrWktYTEpTTTlVYUVTbEhmNXVuQkxFcENqK2oKZEJpSXFGY2E3eElGUGtyKzBSRW9BVmMveFBubnNhS2pMMlV5Z0dqUWZGTnhjT042Y3VjYjZMS0pYT1pFSVRiNQpINjhKdWFSQ0tyZWZZK0l5aFFWVk5taWk3dE1wY1UyS2pXNXBrVktxVTNkS0l0RXEyVmtTZHpNVUtqTnhZd3FGCll6YnozNFQ1MENXbm9HbU5SQVdKc0xlVmlPWVUyNmR3YkFXZDlVYitWMDFRam43OAotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==\",\"tls.key\":\"LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0tCk1JSUV2d0lCQURBTkJna3Foa2lHOXcwQkFRRUZBQVNDQktrd2dnU2xBZ0VBQW9JQkFRRGNBOFl0aC9QV2FPR1MKb05tdkVIWjI0alE3UEtOK0Q0b3dMSFdlaXVSZG1oQTBZT3ZVM3dxRzNWcVk0WnBsWkFWMFBLbEQvKzJaU0YxNAp6OHcxZUY0UVR6WmFZeHd5OSt3ZkhOa1RERXBNalA4Sk0yT0VieWtVUnhVUnZXNCs3RDMwRTJFejVPUGx4bWMwCk1ZTS8vSkg1RURRaGNpRHJsWXFlMVNSTVJBTFplVm1rYUF5dTZOSEpUQnVqMFNJUHVkTFRjaCs5MHErcmR3bnkKZmtUMXgzT1RhbmJXam5vbUVKZTdNdnk0bXZ2cXFJSHU0OFM5QzhaZDFCR1ZQYnU4Vi9VRHJTV1E5ellDWDRTRwpPYXNsOEMwWG1INmtlbWhQRGxEL1R2MHh2eUg1cTVNVWNIaTRtSnROK2d6b2I1NER3elZHRWplZjVMZVMxVjVGCjBUQVAwZCtYQWdNQkFBRUNnZ0VCQUk2U3I0anYwZForanJhN0gzVnZ3S1RYZnl0bjV6YVlrVjhZWUh3RjIyakEKbm9HaTBSQllIUFU2V2l3NS9oaDRFWVM2anFHdkptUXZYY3NkTldMdEJsK2hSVUtiZVRtYUtWd2NFSnRrV24xeQozUTQwUytnVk5OU2NINDRvYUZuRU0zMklWWFFRZnBKMjJJZ2RFY1dVUVcvWnpUNWpPK3dPTXc4c1plSTZMSEtLCkdoOENsVDkrRGUvdXFqbjNCRnQwelZ3cnFLbllKSU1DSWFrb2lDRmtIcGhVTURFNVkyU1NLaGFGWndxMWtLd0sKdHFvWFpKQnlzYXhnUTFRa21mS1RnRkx5WlpXT01mRzVzb1VrU1RTeURFRzFsYnVYcHpUbTlVSTlKU2lsK01yaAp1LzVTeXBLOHBCSHhBdFg5VXdiTjFiRGw3Sng1SWJyMnNoM0F1UDF4OUpFQ2dZRUE4dGNTM09URXNOUFpQZlptCk9jaUduOW9STTdHVmVGdjMrL05iL3JodHp1L1RQUWJBSzhWZ3FrS0dPazNGN1krY2txS1NTWjFnUkF2SHBsZEIKaTY0Y0daT1dpK01jMWZVcEdVV2sxdnZXbG1nTUlQVjVtbFpvOHowMlNTdXhLZTI1Y2VNb09oenFlay9vRmFtdgoyTmxFeTh0dEhOMUxMS3grZllhMkpGcWVycThDZ1lFQTUvQUxHSXVrU3J0K0dkektJLzV5cjdSREpTVzIzUTJ4CkM5ZklUTUFSL1Q4dzNsWGhyUnRXcmlHL3l0QkVPNXdTMVIwdDkydW1nVkhIRTA5eFFXbzZ0Tm16QVBNb1RSekMKd08yYnJqQktBdUJkQ0RISjZsMlFnOEhPQWovUncrK2x4bEN0VEI2YS8xWEZIZnNHUGhqMEQrWlJiWVZzaE00UgpnSVVmdmpmQ1Y1a0NnWUVBMzdzL2FieHJhdThEaTQ3a0NBQ3o1N3FsZHBiNk92V2d0OFF5MGE5aG0vSmhFQ3lVCkNML0VtNWpHeWhpMWJuV05yNXVRWTdwVzR0cG5pdDJCU2d1VFlBMFYrck8zOFhmNThZcTBvRTFPR3l5cFlBUkoKa09SanRSYUVXVTJqNEJsaGJZZjNtL0xnSk9oUnp3T1RPNXFSUTZHY1dhZVlod1ExVmJrelByTXUxNGtDZ1lCbwp4dEhjWnNqelVidm5wd3hTTWxKUStaZ1RvZlAzN0lWOG1pQk1POEJrclRWQVczKzFtZElRbkFKdWRxTThZb2RICmF3VW03cVNyYXV3SjF5dU1wNWFadUhiYkNQMjl5QzVheFh3OHRtZlk0TTVtTTBmSjdqYW9ydGFId1pqYmNObHMKdTJsdUo2MVJoOGVpZ1pJU1gyZHgvMVB0ckFhWUFCZDcvYWVYWU0wVWtRS0JnUUNVbkFIdmRQUGhIVnJDWU1rTgpOOFBEK0t0YmhPRks2S3MvdlgyUkcyRnFmQkJPQWV3bEo1d0xWeFBLT1RpdytKS2FSeHhYMkcvREZVNzduOEQvCkR5V2RjM2ZCQWQ0a1lJamZVaGRGa1hHNEFMUDZBNVFIZVN4NzNScTFLNWxMVWhPbEZqc3VPZ0NKS28wVlFmRC8KT05paDB6SzN5Wmc3aDVQamZ1TUdGb09OQWc9PQotLS0tLUVORCBQUklWQVRFIEtFWS0tLS0tCg==\"},\"kind\":\"Secret\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"tlscontexttest\",\"scope\":\"AmbassadorTest\"},\"name\":\"test-tlscontext-secret-2\",\"namespace\":\"default\"},\"type\":\"kubernetes.io/tls\"}\n"
-                    },
-                    "creationTimestamp": "2020-02-19T23:20:08Z",
-                    "labels": {
-                        "kat-ambassador-id": "tlscontexttest",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "test-tlscontext-secret-2",
-                    "namespace": "default",
-                    "resourceVersion": "60447",
-                    "selfLink": "/api/v1/namespaces/default/secrets/test-tlscontext-secret-2",
-                    "uid": "5e8c3f1f-536e-11ea-85dd-167682b5c255"
-                },
-                "type": "kubernetes.io/tls"
-            },
-            {
-                "apiVersion": "v1",
-                "data": {
                     "tls.crt": "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURnRENDQW1pZ0F3SUJBZ0lKQUpycUl0ekY2MTBpTUEwR0NTcUdTSWIzRFFFQkN3VUFNRlV4Q3pBSkJnTlYKQkFZVEFsVlRNUXN3Q1FZRFZRUUlEQUpOUVRFUE1BMEdBMVVFQnd3R1FtOXpkRzl1TVFzd0NRWURWUVFLREFKRQpWekViTUJrR0ExVUVBd3dTZEd4ekxXTnZiblJsZUhRdGFHOXpkQzB4TUI0WERURTRNVEV3TVRFek5UTXhPRm9YCkRUSTRNVEF5T1RFek5UTXhPRm93VlRFTE1Ba0dBMVVFQmhNQ1ZWTXhDekFKQmdOVkJBZ01BazFCTVE4d0RRWUQKVlFRSERBWkNiM04wYjI0eEN6QUpCZ05WQkFvTUFrUlhNUnN3R1FZRFZRUUREQkowYkhNdFkyOXVkR1Y0ZEMxbwpiM04wTFRFd2dnRWlNQTBHQ1NxR1NJYjNEUUVCQVFVQUE0SUJEd0F3Z2dFS0FvSUJBUUM5T2dDOHd4eUlyUHpvCkdYc0xwUEt0NzJERXgyd2p3VzhuWFcyd1dieWEzYzk2bjJuU0NLUEJuODVoYnFzaHpqNWloU1RBTURJb2c5RnYKRzZSS1dVUFhUNEtJa1R2M0NESHFYc0FwSmxKNGxTeW5ReW8yWnYwbytBZjhDTG5nWVpCK3JmenRad3llRGhWcAp3WXpCVjIzNXp6NisycWJWbUNabHZCdVhiVXFUbEVZWXZ1R2xNR3o3cFBmT1dLVXBlWW9kYkcyZmIraEZGcGVvCkN4a1VYclFzT29SNUpkSEc1aldyWnVCTzQ1NVNzcnpCTDhSbGU1VUhvMDVXY0s3YkJiaVF6MTA2cEhDSllaK3AKdmxQSWNOU1g1S2gzNEZnOTZVUHg5bFFpQTN6RFRLQmZ5V2NMUStxMWNabExjV2RnUkZjTkJpckdCLzdyYTFWVApnRUplR2tQekFnTUJBQUdqVXpCUk1CMEdBMVVkRGdRV0JCUkRWVUtYWWJsRFdNTzE3MUJuWWZhYlkzM0NFVEFmCkJnTlZIU01FR0RBV2dCUkRWVUtYWWJsRFdNTzE3MUJuWWZhYlkzM0NFVEFQQmdOVkhSTUJBZjhFQlRBREFRSC8KTUEwR0NTcUdTSWIzRFFFQkN3VUFBNElCQVFBUE8vRDRUdDUyWHJsQ0NmUzZnVUVkRU5DcnBBV05YRHJvR2M2dApTVGx3aC8rUUxRYk5hZEtlaEtiZjg5clhLaituVXF0cS9OUlpQSXNBSytXVWtHOVpQb1FPOFBRaVY0V1g1clE3CjI5dUtjSmZhQlhrZHpVVzdxTlFoRTRjOEJhc0JySWVzcmtqcFQ5OVF4SktuWFFhTitTdzdvRlBVSUFOMzhHcWEKV2wvS1BNVHRicWt3eWFjS01CbXExVkx6dldKb0g1Q2l6Skp3aG5rWHh0V0tzLzY3clROblBWTXorbWVHdHZTaQpkcVg2V1NTbUdMRkVFcjJoZ1VjQVpqazNWdVFoLzc1aFh1K1UySXRzQys1cXBsaEc3Q1hzb1huS0t5MVhsT0FFCmI4a3IyZFdXRWs2STVZNm5USnpXSWxTVGtXODl4d1hyY3RtTjlzYjlxNFNuaVZsegotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==",
                     "tls.key": "LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0tCk1JSUV2UUlCQURBTkJna3Foa2lHOXcwQkFRRUZBQVNDQktjd2dnU2pBZ0VBQW9JQkFRQzlPZ0M4d3h5SXJQem8KR1hzTHBQS3Q3MkRFeDJ3andXOG5YVzJ3V2J5YTNjOTZuMm5TQ0tQQm44NWhicXNoemo1aWhTVEFNRElvZzlGdgpHNlJLV1VQWFQ0S0lrVHYzQ0RIcVhzQXBKbEo0bFN5blF5bzJadjBvK0FmOENMbmdZWkIrcmZ6dFp3eWVEaFZwCndZekJWMjM1eno2KzJxYlZtQ1psdkJ1WGJVcVRsRVlZdnVHbE1HejdwUGZPV0tVcGVZb2RiRzJmYitoRkZwZW8KQ3hrVVhyUXNPb1I1SmRIRzVqV3JadUJPNDU1U3NyekJMOFJsZTVVSG8wNVdjSzdiQmJpUXoxMDZwSENKWVorcAp2bFBJY05TWDVLaDM0Rmc5NlVQeDlsUWlBM3pEVEtCZnlXY0xRK3ExY1psTGNXZGdSRmNOQmlyR0IvN3JhMVZUCmdFSmVHa1B6QWdNQkFBRUNnZ0VBQmFsN3BpcE1hMGFKMXNRVWEzZkhEeTlQZlBQZXAzODlQVGROZGU1cGQxVFYKeFh5SnBSQS9IaWNTL05WYjU0b05VZE5jRXlnZUNCcFJwUHAxd3dmQ3dPbVBKVmo3SzF3aWFqbmxsQldpZUJzMgpsOWFwcDdFVE9DdWJ5WTNWU2dLQldWa0piVzBjOG9uSFdEL0RYM0duUjhkTXdGYzRrTUdadkllUlo4bU1acmdHCjZPdDNKOHI2eVZsZWI2OGF1WmtneXMwR2VGc3pNdVRubHJCOEw5djI1UUtjVGtESjIvRWx1Y1p5aER0eGF0OEIKTzZOUnNubmNyOHhwUVdPci9sV3M5VVFuZEdCdHFzbXMrdGNUN1ZUNU9UanQ4WHY5NVhNSHB5Z29pTHk3czhvYwpJMGprNDJabzRKZW5JT3c2Rm0weUFEZ0E3eWlXcks0bEkzWGhqaTVSb1FLQmdRRGRqaWNkTUpYVUZWc28rNTJkCkUwT2EwcEpVMFNSaC9JQmdvRzdNakhrVWxiaXlpR1pNanA5MEo5VHFaL1ErM1pWZVdqMmxPSWF0OG5nUzB6MDAKVzA3T1ZxYXprMVNYaFZlY2tGNWFEcm5PRDNhU2VWMSthV3JUdDFXRWdqOVFxYnJZYVA5emd4UkpkRzV3WENCUApGNDNFeXE5ZEhXOWF6SSt3UHlJQ0JqNnZBd0tCZ1FEYXBTelhPR2ViMi9SMWhlWXdWV240czNGZEtYVjgzemtTCnFSWDd6d1pLdkk5OGMybDU1Y1ZNUzBoTGM0bTVPMXZCaUd5SG80eTB2SVAvR0k0Rzl4T1FhMXdpVnNmUVBiSU4KLzJPSDFnNXJLSFdCWVJUaHZGcERqdHJRU2xyRHVjWUNSRExCd1hUcDFrbVBkL09mY2FybG42MjZEamthZllieAp3dWUydlhCTVVRS0JnQm4vTmlPOHNiZ0RFWUZMbFFEN1k3RmxCL3FmMTg4UG05aTZ1b1dSN2hzMlBrZmtyV3hLClIvZVBQUEtNWkNLRVNhU2FuaVVtN3RhMlh0U0dxT1hkMk85cFI0Skd4V1JLSnkrZDJSUmtLZlU5NTBIa3I4M0gKZk50KzVhLzR3SWtzZ1ZvblorSWIvV05wSUJSYkd3ZHMwaHZIVkxCdVpjU1h3RHlFQysrRTRCSVZBb0dCQUoxUQp6eXlqWnRqYnI4NkhZeEpQd29teEF0WVhLSE9LWVJRdUdLVXZWY1djV2xrZTZUdE51V0dsb1FTNHd0VkdBa1VECmxhTWFaL2o2MHJaT3dwSDhZRlUvQ2ZHakl1MlFGbmEvMUtzOXR1NGZGRHpjenh1RVhDWFR1Vmk0eHdtZ3R2bVcKZkRhd3JTQTZrSDdydlp4eE9wY3hCdHloc3pCK05RUHFTckpQSjJlaEFvR0FkdFJKam9vU0lpYURVU25lZUcyZgpUTml1T01uazJkeFV3RVF2S1E4eWNuUnpyN0QwaEtZVWIycThHKzE2bThQUjNCcFMzZDFLbkpMVnI3TUhaWHpSCitzZHNaWGtTMWVEcEZhV0RFREFEWWI0ckRCb2RBdk8xYm03ZXdTMzhSbk1UaTlhdFZzNVNTODNpZG5HbFZiSmsKYkZKWG0rWWxJNHFkaXowTFdjWGJyREE9Ci0tLS0tRU5EIFBSSVZBVEUgS0VZLS0tLS0K"
                 },
@@ -188,16 +164,40 @@
                     "annotations": {
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"data\":{\"tls.crt\":\"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURnRENDQW1pZ0F3SUJBZ0lKQUpycUl0ekY2MTBpTUEwR0NTcUdTSWIzRFFFQkN3VUFNRlV4Q3pBSkJnTlYKQkFZVEFsVlRNUXN3Q1FZRFZRUUlEQUpOUVRFUE1BMEdBMVVFQnd3R1FtOXpkRzl1TVFzd0NRWURWUVFLREFKRQpWekViTUJrR0ExVUVBd3dTZEd4ekxXTnZiblJsZUhRdGFHOXpkQzB4TUI0WERURTRNVEV3TVRFek5UTXhPRm9YCkRUSTRNVEF5T1RFek5UTXhPRm93VlRFTE1Ba0dBMVVFQmhNQ1ZWTXhDekFKQmdOVkJBZ01BazFCTVE4d0RRWUQKVlFRSERBWkNiM04wYjI0eEN6QUpCZ05WQkFvTUFrUlhNUnN3R1FZRFZRUUREQkowYkhNdFkyOXVkR1Y0ZEMxbwpiM04wTFRFd2dnRWlNQTBHQ1NxR1NJYjNEUUVCQVFVQUE0SUJEd0F3Z2dFS0FvSUJBUUM5T2dDOHd4eUlyUHpvCkdYc0xwUEt0NzJERXgyd2p3VzhuWFcyd1dieWEzYzk2bjJuU0NLUEJuODVoYnFzaHpqNWloU1RBTURJb2c5RnYKRzZSS1dVUFhUNEtJa1R2M0NESHFYc0FwSmxKNGxTeW5ReW8yWnYwbytBZjhDTG5nWVpCK3JmenRad3llRGhWcAp3WXpCVjIzNXp6NisycWJWbUNabHZCdVhiVXFUbEVZWXZ1R2xNR3o3cFBmT1dLVXBlWW9kYkcyZmIraEZGcGVvCkN4a1VYclFzT29SNUpkSEc1aldyWnVCTzQ1NVNzcnpCTDhSbGU1VUhvMDVXY0s3YkJiaVF6MTA2cEhDSllaK3AKdmxQSWNOU1g1S2gzNEZnOTZVUHg5bFFpQTN6RFRLQmZ5V2NMUStxMWNabExjV2RnUkZjTkJpckdCLzdyYTFWVApnRUplR2tQekFnTUJBQUdqVXpCUk1CMEdBMVVkRGdRV0JCUkRWVUtYWWJsRFdNTzE3MUJuWWZhYlkzM0NFVEFmCkJnTlZIU01FR0RBV2dCUkRWVUtYWWJsRFdNTzE3MUJuWWZhYlkzM0NFVEFQQmdOVkhSTUJBZjhFQlRBREFRSC8KTUEwR0NTcUdTSWIzRFFFQkN3VUFBNElCQVFBUE8vRDRUdDUyWHJsQ0NmUzZnVUVkRU5DcnBBV05YRHJvR2M2dApTVGx3aC8rUUxRYk5hZEtlaEtiZjg5clhLaituVXF0cS9OUlpQSXNBSytXVWtHOVpQb1FPOFBRaVY0V1g1clE3CjI5dUtjSmZhQlhrZHpVVzdxTlFoRTRjOEJhc0JySWVzcmtqcFQ5OVF4SktuWFFhTitTdzdvRlBVSUFOMzhHcWEKV2wvS1BNVHRicWt3eWFjS01CbXExVkx6dldKb0g1Q2l6Skp3aG5rWHh0V0tzLzY3clROblBWTXorbWVHdHZTaQpkcVg2V1NTbUdMRkVFcjJoZ1VjQVpqazNWdVFoLzc1aFh1K1UySXRzQys1cXBsaEc3Q1hzb1huS0t5MVhsT0FFCmI4a3IyZFdXRWs2STVZNm5USnpXSWxTVGtXODl4d1hyY3RtTjlzYjlxNFNuaVZsegotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==\",\"tls.key\":\"LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0tCk1JSUV2UUlCQURBTkJna3Foa2lHOXcwQkFRRUZBQVNDQktjd2dnU2pBZ0VBQW9JQkFRQzlPZ0M4d3h5SXJQem8KR1hzTHBQS3Q3MkRFeDJ3andXOG5YVzJ3V2J5YTNjOTZuMm5TQ0tQQm44NWhicXNoemo1aWhTVEFNRElvZzlGdgpHNlJLV1VQWFQ0S0lrVHYzQ0RIcVhzQXBKbEo0bFN5blF5bzJadjBvK0FmOENMbmdZWkIrcmZ6dFp3eWVEaFZwCndZekJWMjM1eno2KzJxYlZtQ1psdkJ1WGJVcVRsRVlZdnVHbE1HejdwUGZPV0tVcGVZb2RiRzJmYitoRkZwZW8KQ3hrVVhyUXNPb1I1SmRIRzVqV3JadUJPNDU1U3NyekJMOFJsZTVVSG8wNVdjSzdiQmJpUXoxMDZwSENKWVorcAp2bFBJY05TWDVLaDM0Rmc5NlVQeDlsUWlBM3pEVEtCZnlXY0xRK3ExY1psTGNXZGdSRmNOQmlyR0IvN3JhMVZUCmdFSmVHa1B6QWdNQkFBRUNnZ0VBQmFsN3BpcE1hMGFKMXNRVWEzZkhEeTlQZlBQZXAzODlQVGROZGU1cGQxVFYKeFh5SnBSQS9IaWNTL05WYjU0b05VZE5jRXlnZUNCcFJwUHAxd3dmQ3dPbVBKVmo3SzF3aWFqbmxsQldpZUJzMgpsOWFwcDdFVE9DdWJ5WTNWU2dLQldWa0piVzBjOG9uSFdEL0RYM0duUjhkTXdGYzRrTUdadkllUlo4bU1acmdHCjZPdDNKOHI2eVZsZWI2OGF1WmtneXMwR2VGc3pNdVRubHJCOEw5djI1UUtjVGtESjIvRWx1Y1p5aER0eGF0OEIKTzZOUnNubmNyOHhwUVdPci9sV3M5VVFuZEdCdHFzbXMrdGNUN1ZUNU9UanQ4WHY5NVhNSHB5Z29pTHk3czhvYwpJMGprNDJabzRKZW5JT3c2Rm0weUFEZ0E3eWlXcks0bEkzWGhqaTVSb1FLQmdRRGRqaWNkTUpYVUZWc28rNTJkCkUwT2EwcEpVMFNSaC9JQmdvRzdNakhrVWxiaXlpR1pNanA5MEo5VHFaL1ErM1pWZVdqMmxPSWF0OG5nUzB6MDAKVzA3T1ZxYXprMVNYaFZlY2tGNWFEcm5PRDNhU2VWMSthV3JUdDFXRWdqOVFxYnJZYVA5emd4UkpkRzV3WENCUApGNDNFeXE5ZEhXOWF6SSt3UHlJQ0JqNnZBd0tCZ1FEYXBTelhPR2ViMi9SMWhlWXdWV240czNGZEtYVjgzemtTCnFSWDd6d1pLdkk5OGMybDU1Y1ZNUzBoTGM0bTVPMXZCaUd5SG80eTB2SVAvR0k0Rzl4T1FhMXdpVnNmUVBiSU4KLzJPSDFnNXJLSFdCWVJUaHZGcERqdHJRU2xyRHVjWUNSRExCd1hUcDFrbVBkL09mY2FybG42MjZEamthZllieAp3dWUydlhCTVVRS0JnQm4vTmlPOHNiZ0RFWUZMbFFEN1k3RmxCL3FmMTg4UG05aTZ1b1dSN2hzMlBrZmtyV3hLClIvZVBQUEtNWkNLRVNhU2FuaVVtN3RhMlh0U0dxT1hkMk85cFI0Skd4V1JLSnkrZDJSUmtLZlU5NTBIa3I4M0gKZk50KzVhLzR3SWtzZ1ZvblorSWIvV05wSUJSYkd3ZHMwaHZIVkxCdVpjU1h3RHlFQysrRTRCSVZBb0dCQUoxUQp6eXlqWnRqYnI4NkhZeEpQd29teEF0WVhLSE9LWVJRdUdLVXZWY1djV2xrZTZUdE51V0dsb1FTNHd0VkdBa1VECmxhTWFaL2o2MHJaT3dwSDhZRlUvQ2ZHakl1MlFGbmEvMUtzOXR1NGZGRHpjenh1RVhDWFR1Vmk0eHdtZ3R2bVcKZkRhd3JTQTZrSDdydlp4eE9wY3hCdHloc3pCK05RUHFTckpQSjJlaEFvR0FkdFJKam9vU0lpYURVU25lZUcyZgpUTml1T01uazJkeFV3RVF2S1E4eWNuUnpyN0QwaEtZVWIycThHKzE2bThQUjNCcFMzZDFLbkpMVnI3TUhaWHpSCitzZHNaWGtTMWVEcEZhV0RFREFEWWI0ckRCb2RBdk8xYm03ZXdTMzhSbk1UaTlhdFZzNVNTODNpZG5HbFZiSmsKYkZKWG0rWWxJNHFkaXowTFdjWGJyREE9Ci0tLS0tRU5EIFBSSVZBVEUgS0VZLS0tLS0K\"},\"kind\":\"Secret\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"hostcrddouble\",\"scope\":\"AmbassadorTest\"},\"name\":\"test-tlscontext-secret-1\",\"namespace\":\"default\"},\"type\":\"kubernetes.io/tls\"}\n"
                     },
-                    "creationTimestamp": "2020-02-19T23:20:08Z",
+                    "creationTimestamp": "2020-02-26T15:51:51Z",
                     "labels": {
                         "kat-ambassador-id": "hostcrddouble",
                         "scope": "AmbassadorTest"
                     },
                     "name": "test-tlscontext-secret-1",
                     "namespace": "default",
-                    "resourceVersion": "55818",
+                    "resourceVersion": "66493",
                     "selfLink": "/api/v1/namespaces/default/secrets/test-tlscontext-secret-1",
-                    "uid": "5e84b13a-536e-11ea-85dd-167682b5c255"
+                    "uid": "e7b12ea4-58af-11ea-86d6-0e674b3ff44f"
+                },
+                "type": "kubernetes.io/tls"
+            },
+            {
+                "apiVersion": "v1",
+                "data": {
+                    "tls.crt": "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURnRENDQW1pZ0F3SUJBZ0lKQUlIWTY3cFNoZ3NyTUEwR0NTcUdTSWIzRFFFQkN3VUFNRlV4Q3pBSkJnTlYKQkFZVEFsVlRNUXN3Q1FZRFZRUUlEQUpOUVRFUE1BMEdBMVVFQnd3R1FtOXpkRzl1TVFzd0NRWURWUVFLREFKRQpWekViTUJrR0ExVUVBd3dTZEd4ekxXTnZiblJsZUhRdGFHOXpkQzB5TUI0WERURTRNVEV3TVRFME1EUXhObG9YCkRUSTRNVEF5T1RFME1EUXhObG93VlRFTE1Ba0dBMVVFQmhNQ1ZWTXhDekFKQmdOVkJBZ01BazFCTVE4d0RRWUQKVlFRSERBWkNiM04wYjI0eEN6QUpCZ05WQkFvTUFrUlhNUnN3R1FZRFZRUUREQkowYkhNdFkyOXVkR1Y0ZEMxbwpiM04wTFRJd2dnRWlNQTBHQ1NxR1NJYjNEUUVCQVFVQUE0SUJEd0F3Z2dFS0FvSUJBUURjQThZdGgvUFdhT0dTCm9ObXZFSFoyNGpRN1BLTitENG93TEhXZWl1UmRtaEEwWU92VTN3cUczVnFZNFpwbFpBVjBQS2xELysyWlNGMTQKejh3MWVGNFFUelphWXh3eTkrd2ZITmtUREVwTWpQOEpNMk9FYnlrVVJ4VVJ2VzQrN0QzMEUyRXo1T1BseG1jMApNWU0vL0pINUVEUWhjaURybFlxZTFTUk1SQUxaZVZta2FBeXU2TkhKVEJ1ajBTSVB1ZExUY2grOTBxK3Jkd255CmZrVDF4M09UYW5iV2pub21FSmU3TXZ5NG12dnFxSUh1NDhTOUM4WmQxQkdWUGJ1OFYvVURyU1dROXpZQ1g0U0cKT2FzbDhDMFhtSDZrZW1oUERsRC9UdjB4dnlINXE1TVVjSGk0bUp0Titnem9iNTREd3pWR0VqZWY1TGVTMVY1RgowVEFQMGQrWEFnTUJBQUdqVXpCUk1CMEdBMVVkRGdRV0JCUWRGMEdRSGRxbHRoZG5RWXFWaXVtRXJsUk9mREFmCkJnTlZIU01FR0RBV2dCUWRGMEdRSGRxbHRoZG5RWXFWaXVtRXJsUk9mREFQQmdOVkhSTUJBZjhFQlRBREFRSC8KTUEwR0NTcUdTSWIzRFFFQkN3VUFBNElCQVFBbUFLYkNsdUhFZS9JRmJ1QWJneDBNenV6aTkwd2xtQVBiOGdtTwpxdmJwMjl1T1ZzVlNtUUFkZFBuZEZhTVhWcDFaaG1UVjVDU1F0ZFgyQ1ZNVyswVzQ3Qy9DT0Jkb1NFUTl5akJmCmlGRGNseG04QU4yUG1hR1FhK3hvT1hnWkxYZXJDaE5LV0JTWlIrWktYTEpTTTlVYUVTbEhmNXVuQkxFcENqK2oKZEJpSXFGY2E3eElGUGtyKzBSRW9BVmMveFBubnNhS2pMMlV5Z0dqUWZGTnhjT042Y3VjYjZMS0pYT1pFSVRiNQpINjhKdWFSQ0tyZWZZK0l5aFFWVk5taWk3dE1wY1UyS2pXNXBrVktxVTNkS0l0RXEyVmtTZHpNVUtqTnhZd3FGCll6YnozNFQ1MENXbm9HbU5SQVdKc0xlVmlPWVUyNmR3YkFXZDlVYitWMDFRam43OAotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==",
+                    "tls.key": "LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0tCk1JSUV2d0lCQURBTkJna3Foa2lHOXcwQkFRRUZBQVNDQktrd2dnU2xBZ0VBQW9JQkFRRGNBOFl0aC9QV2FPR1MKb05tdkVIWjI0alE3UEtOK0Q0b3dMSFdlaXVSZG1oQTBZT3ZVM3dxRzNWcVk0WnBsWkFWMFBLbEQvKzJaU0YxNAp6OHcxZUY0UVR6WmFZeHd5OSt3ZkhOa1RERXBNalA4Sk0yT0VieWtVUnhVUnZXNCs3RDMwRTJFejVPUGx4bWMwCk1ZTS8vSkg1RURRaGNpRHJsWXFlMVNSTVJBTFplVm1rYUF5dTZOSEpUQnVqMFNJUHVkTFRjaCs5MHErcmR3bnkKZmtUMXgzT1RhbmJXam5vbUVKZTdNdnk0bXZ2cXFJSHU0OFM5QzhaZDFCR1ZQYnU4Vi9VRHJTV1E5ellDWDRTRwpPYXNsOEMwWG1INmtlbWhQRGxEL1R2MHh2eUg1cTVNVWNIaTRtSnROK2d6b2I1NER3elZHRWplZjVMZVMxVjVGCjBUQVAwZCtYQWdNQkFBRUNnZ0VCQUk2U3I0anYwZForanJhN0gzVnZ3S1RYZnl0bjV6YVlrVjhZWUh3RjIyakEKbm9HaTBSQllIUFU2V2l3NS9oaDRFWVM2anFHdkptUXZYY3NkTldMdEJsK2hSVUtiZVRtYUtWd2NFSnRrV24xeQozUTQwUytnVk5OU2NINDRvYUZuRU0zMklWWFFRZnBKMjJJZ2RFY1dVUVcvWnpUNWpPK3dPTXc4c1plSTZMSEtLCkdoOENsVDkrRGUvdXFqbjNCRnQwelZ3cnFLbllKSU1DSWFrb2lDRmtIcGhVTURFNVkyU1NLaGFGWndxMWtLd0sKdHFvWFpKQnlzYXhnUTFRa21mS1RnRkx5WlpXT01mRzVzb1VrU1RTeURFRzFsYnVYcHpUbTlVSTlKU2lsK01yaAp1LzVTeXBLOHBCSHhBdFg5VXdiTjFiRGw3Sng1SWJyMnNoM0F1UDF4OUpFQ2dZRUE4dGNTM09URXNOUFpQZlptCk9jaUduOW9STTdHVmVGdjMrL05iL3JodHp1L1RQUWJBSzhWZ3FrS0dPazNGN1krY2txS1NTWjFnUkF2SHBsZEIKaTY0Y0daT1dpK01jMWZVcEdVV2sxdnZXbG1nTUlQVjVtbFpvOHowMlNTdXhLZTI1Y2VNb09oenFlay9vRmFtdgoyTmxFeTh0dEhOMUxMS3grZllhMkpGcWVycThDZ1lFQTUvQUxHSXVrU3J0K0dkektJLzV5cjdSREpTVzIzUTJ4CkM5ZklUTUFSL1Q4dzNsWGhyUnRXcmlHL3l0QkVPNXdTMVIwdDkydW1nVkhIRTA5eFFXbzZ0Tm16QVBNb1RSekMKd08yYnJqQktBdUJkQ0RISjZsMlFnOEhPQWovUncrK2x4bEN0VEI2YS8xWEZIZnNHUGhqMEQrWlJiWVZzaE00UgpnSVVmdmpmQ1Y1a0NnWUVBMzdzL2FieHJhdThEaTQ3a0NBQ3o1N3FsZHBiNk92V2d0OFF5MGE5aG0vSmhFQ3lVCkNML0VtNWpHeWhpMWJuV05yNXVRWTdwVzR0cG5pdDJCU2d1VFlBMFYrck8zOFhmNThZcTBvRTFPR3l5cFlBUkoKa09SanRSYUVXVTJqNEJsaGJZZjNtL0xnSk9oUnp3T1RPNXFSUTZHY1dhZVlod1ExVmJrelByTXUxNGtDZ1lCbwp4dEhjWnNqelVidm5wd3hTTWxKUStaZ1RvZlAzN0lWOG1pQk1POEJrclRWQVczKzFtZElRbkFKdWRxTThZb2RICmF3VW03cVNyYXV3SjF5dU1wNWFadUhiYkNQMjl5QzVheFh3OHRtZlk0TTVtTTBmSjdqYW9ydGFId1pqYmNObHMKdTJsdUo2MVJoOGVpZ1pJU1gyZHgvMVB0ckFhWUFCZDcvYWVYWU0wVWtRS0JnUUNVbkFIdmRQUGhIVnJDWU1rTgpOOFBEK0t0YmhPRks2S3MvdlgyUkcyRnFmQkJPQWV3bEo1d0xWeFBLT1RpdytKS2FSeHhYMkcvREZVNzduOEQvCkR5V2RjM2ZCQWQ0a1lJamZVaGRGa1hHNEFMUDZBNVFIZVN4NzNScTFLNWxMVWhPbEZqc3VPZ0NKS28wVlFmRC8KT05paDB6SzN5Wmc3aDVQamZ1TUdGb09OQWc9PQotLS0tLUVORCBQUklWQVRFIEtFWS0tLS0tCg=="
+                },
+                "kind": "Secret",
+                "metadata": {
+                    "annotations": {
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"data\":{\"tls.crt\":\"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURnRENDQW1pZ0F3SUJBZ0lKQUlIWTY3cFNoZ3NyTUEwR0NTcUdTSWIzRFFFQkN3VUFNRlV4Q3pBSkJnTlYKQkFZVEFsVlRNUXN3Q1FZRFZRUUlEQUpOUVRFUE1BMEdBMVVFQnd3R1FtOXpkRzl1TVFzd0NRWURWUVFLREFKRQpWekViTUJrR0ExVUVBd3dTZEd4ekxXTnZiblJsZUhRdGFHOXpkQzB5TUI0WERURTRNVEV3TVRFME1EUXhObG9YCkRUSTRNVEF5T1RFME1EUXhObG93VlRFTE1Ba0dBMVVFQmhNQ1ZWTXhDekFKQmdOVkJBZ01BazFCTVE4d0RRWUQKVlFRSERBWkNiM04wYjI0eEN6QUpCZ05WQkFvTUFrUlhNUnN3R1FZRFZRUUREQkowYkhNdFkyOXVkR1Y0ZEMxbwpiM04wTFRJd2dnRWlNQTBHQ1NxR1NJYjNEUUVCQVFVQUE0SUJEd0F3Z2dFS0FvSUJBUURjQThZdGgvUFdhT0dTCm9ObXZFSFoyNGpRN1BLTitENG93TEhXZWl1UmRtaEEwWU92VTN3cUczVnFZNFpwbFpBVjBQS2xELysyWlNGMTQKejh3MWVGNFFUelphWXh3eTkrd2ZITmtUREVwTWpQOEpNMk9FYnlrVVJ4VVJ2VzQrN0QzMEUyRXo1T1BseG1jMApNWU0vL0pINUVEUWhjaURybFlxZTFTUk1SQUxaZVZta2FBeXU2TkhKVEJ1ajBTSVB1ZExUY2grOTBxK3Jkd255CmZrVDF4M09UYW5iV2pub21FSmU3TXZ5NG12dnFxSUh1NDhTOUM4WmQxQkdWUGJ1OFYvVURyU1dROXpZQ1g0U0cKT2FzbDhDMFhtSDZrZW1oUERsRC9UdjB4dnlINXE1TVVjSGk0bUp0Titnem9iNTREd3pWR0VqZWY1TGVTMVY1RgowVEFQMGQrWEFnTUJBQUdqVXpCUk1CMEdBMVVkRGdRV0JCUWRGMEdRSGRxbHRoZG5RWXFWaXVtRXJsUk9mREFmCkJnTlZIU01FR0RBV2dCUWRGMEdRSGRxbHRoZG5RWXFWaXVtRXJsUk9mREFQQmdOVkhSTUJBZjhFQlRBREFRSC8KTUEwR0NTcUdTSWIzRFFFQkN3VUFBNElCQVFBbUFLYkNsdUhFZS9JRmJ1QWJneDBNenV6aTkwd2xtQVBiOGdtTwpxdmJwMjl1T1ZzVlNtUUFkZFBuZEZhTVhWcDFaaG1UVjVDU1F0ZFgyQ1ZNVyswVzQ3Qy9DT0Jkb1NFUTl5akJmCmlGRGNseG04QU4yUG1hR1FhK3hvT1hnWkxYZXJDaE5LV0JTWlIrWktYTEpTTTlVYUVTbEhmNXVuQkxFcENqK2oKZEJpSXFGY2E3eElGUGtyKzBSRW9BVmMveFBubnNhS2pMMlV5Z0dqUWZGTnhjT042Y3VjYjZMS0pYT1pFSVRiNQpINjhKdWFSQ0tyZWZZK0l5aFFWVk5taWk3dE1wY1UyS2pXNXBrVktxVTNkS0l0RXEyVmtTZHpNVUtqTnhZd3FGCll6YnozNFQ1MENXbm9HbU5SQVdKc0xlVmlPWVUyNmR3YkFXZDlVYitWMDFRam43OAotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==\",\"tls.key\":\"LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0tCk1JSUV2d0lCQURBTkJna3Foa2lHOXcwQkFRRUZBQVNDQktrd2dnU2xBZ0VBQW9JQkFRRGNBOFl0aC9QV2FPR1MKb05tdkVIWjI0alE3UEtOK0Q0b3dMSFdlaXVSZG1oQTBZT3ZVM3dxRzNWcVk0WnBsWkFWMFBLbEQvKzJaU0YxNAp6OHcxZUY0UVR6WmFZeHd5OSt3ZkhOa1RERXBNalA4Sk0yT0VieWtVUnhVUnZXNCs3RDMwRTJFejVPUGx4bWMwCk1ZTS8vSkg1RURRaGNpRHJsWXFlMVNSTVJBTFplVm1rYUF5dTZOSEpUQnVqMFNJUHVkTFRjaCs5MHErcmR3bnkKZmtUMXgzT1RhbmJXam5vbUVKZTdNdnk0bXZ2cXFJSHU0OFM5QzhaZDFCR1ZQYnU4Vi9VRHJTV1E5ellDWDRTRwpPYXNsOEMwWG1INmtlbWhQRGxEL1R2MHh2eUg1cTVNVWNIaTRtSnROK2d6b2I1NER3elZHRWplZjVMZVMxVjVGCjBUQVAwZCtYQWdNQkFBRUNnZ0VCQUk2U3I0anYwZForanJhN0gzVnZ3S1RYZnl0bjV6YVlrVjhZWUh3RjIyakEKbm9HaTBSQllIUFU2V2l3NS9oaDRFWVM2anFHdkptUXZYY3NkTldMdEJsK2hSVUtiZVRtYUtWd2NFSnRrV24xeQozUTQwUytnVk5OU2NINDRvYUZuRU0zMklWWFFRZnBKMjJJZ2RFY1dVUVcvWnpUNWpPK3dPTXc4c1plSTZMSEtLCkdoOENsVDkrRGUvdXFqbjNCRnQwelZ3cnFLbllKSU1DSWFrb2lDRmtIcGhVTURFNVkyU1NLaGFGWndxMWtLd0sKdHFvWFpKQnlzYXhnUTFRa21mS1RnRkx5WlpXT01mRzVzb1VrU1RTeURFRzFsYnVYcHpUbTlVSTlKU2lsK01yaAp1LzVTeXBLOHBCSHhBdFg5VXdiTjFiRGw3Sng1SWJyMnNoM0F1UDF4OUpFQ2dZRUE4dGNTM09URXNOUFpQZlptCk9jaUduOW9STTdHVmVGdjMrL05iL3JodHp1L1RQUWJBSzhWZ3FrS0dPazNGN1krY2txS1NTWjFnUkF2SHBsZEIKaTY0Y0daT1dpK01jMWZVcEdVV2sxdnZXbG1nTUlQVjVtbFpvOHowMlNTdXhLZTI1Y2VNb09oenFlay9vRmFtdgoyTmxFeTh0dEhOMUxMS3grZllhMkpGcWVycThDZ1lFQTUvQUxHSXVrU3J0K0dkektJLzV5cjdSREpTVzIzUTJ4CkM5ZklUTUFSL1Q4dzNsWGhyUnRXcmlHL3l0QkVPNXdTMVIwdDkydW1nVkhIRTA5eFFXbzZ0Tm16QVBNb1RSekMKd08yYnJqQktBdUJkQ0RISjZsMlFnOEhPQWovUncrK2x4bEN0VEI2YS8xWEZIZnNHUGhqMEQrWlJiWVZzaE00UgpnSVVmdmpmQ1Y1a0NnWUVBMzdzL2FieHJhdThEaTQ3a0NBQ3o1N3FsZHBiNk92V2d0OFF5MGE5aG0vSmhFQ3lVCkNML0VtNWpHeWhpMWJuV05yNXVRWTdwVzR0cG5pdDJCU2d1VFlBMFYrck8zOFhmNThZcTBvRTFPR3l5cFlBUkoKa09SanRSYUVXVTJqNEJsaGJZZjNtL0xnSk9oUnp3T1RPNXFSUTZHY1dhZVlod1ExVmJrelByTXUxNGtDZ1lCbwp4dEhjWnNqelVidm5wd3hTTWxKUStaZ1RvZlAzN0lWOG1pQk1POEJrclRWQVczKzFtZElRbkFKdWRxTThZb2RICmF3VW03cVNyYXV3SjF5dU1wNWFadUhiYkNQMjl5QzVheFh3OHRtZlk0TTVtTTBmSjdqYW9ydGFId1pqYmNObHMKdTJsdUo2MVJoOGVpZ1pJU1gyZHgvMVB0ckFhWUFCZDcvYWVYWU0wVWtRS0JnUUNVbkFIdmRQUGhIVnJDWU1rTgpOOFBEK0t0YmhPRks2S3MvdlgyUkcyRnFmQkJPQWV3bEo1d0xWeFBLT1RpdytKS2FSeHhYMkcvREZVNzduOEQvCkR5V2RjM2ZCQWQ0a1lJamZVaGRGa1hHNEFMUDZBNVFIZVN4NzNScTFLNWxMVWhPbEZqc3VPZ0NKS28wVlFmRC8KT05paDB6SzN5Wmc3aDVQamZ1TUdGb09OQWc9PQotLS0tLUVORCBQUklWQVRFIEtFWS0tLS0tCg==\"},\"kind\":\"Secret\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"tlscontexttest\",\"scope\":\"AmbassadorTest\"},\"name\":\"test-tlscontext-secret-2\",\"namespace\":\"default\"},\"type\":\"kubernetes.io/tls\"}\n"
+                    },
+                    "creationTimestamp": "2020-02-26T15:51:51Z",
+                    "labels": {
+                        "kat-ambassador-id": "tlscontexttest",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "test-tlscontext-secret-2",
+                    "namespace": "default",
+                    "resourceVersion": "68177",
+                    "selfLink": "/api/v1/namespaces/default/secrets/test-tlscontext-secret-2",
+                    "uid": "e7bbe0f5-58af-11ea-86d6-0e674b3ff44f"
                 },
                 "type": "kubernetes.io/tls"
             }
@@ -208,9 +208,57 @@
                 "kind": "Service",
                 "metadata": {
                     "annotations": {
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"app.kubernetes.io/component\":\"ambassador-service\",\"kat-ambassador-id\":\"hostcrddouble\",\"scope\":\"AmbassadorTest\"},\"name\":\"hostcrddouble\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8080},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8443}],\"selector\":{\"service\":\"hostcrddouble\"},\"type\":\"NodePort\"}}\n"
+                    },
+                    "creationTimestamp": "2020-02-26T15:51:52Z",
+                    "labels": {
+                        "app.kubernetes.io/component": "ambassador-service",
+                        "kat-ambassador-id": "hostcrddouble",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "hostcrddouble",
+                    "namespace": "default",
+                    "resourceVersion": "66512",
+                    "selfLink": "/api/v1/namespaces/default/services/hostcrddouble",
+                    "uid": "e809a302-58af-11ea-86d6-0e674b3ff44f"
+                },
+                "spec": {
+                    "clusterIP": "10.110.34.195",
+                    "externalTrafficPolicy": "Cluster",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "nodePort": 30046,
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8080
+                        },
+                        {
+                            "name": "https",
+                            "nodePort": 32697,
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8443
+                        }
+                    ],
+                    "selector": {
+                        "service": "hostcrddouble"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "NodePort"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"hostcrddouble\",\"scope\":\"AmbassadorTest\",\"service\":\"hostcrddouble-admin\"},\"name\":\"hostcrddouble-admin\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"hostcrddouble-admin\",\"port\":8877,\"targetPort\":8877}],\"selector\":{\"service\":\"hostcrddouble\"},\"type\":\"NodePort\"}}\n"
                     },
-                    "creationTimestamp": "2020-02-19T23:20:08Z",
+                    "creationTimestamp": "2020-02-26T15:51:52Z",
                     "labels": {
                         "kat-ambassador-id": "hostcrddouble",
                         "scope": "AmbassadorTest",
@@ -218,17 +266,17 @@
                     },
                     "name": "hostcrddouble-admin",
                     "namespace": "default",
-                    "resourceVersion": "55811",
+                    "resourceVersion": "66516",
                     "selfLink": "/api/v1/namespaces/default/services/hostcrddouble-admin",
-                    "uid": "5e71305a-536e-11ea-85dd-167682b5c255"
+                    "uid": "e813a435-58af-11ea-86d6-0e674b3ff44f"
                 },
                 "spec": {
-                    "clusterIP": "10.99.183.89",
+                    "clusterIP": "10.103.29.223",
                     "externalTrafficPolicy": "Cluster",
                     "ports": [
                         {
                             "name": "hostcrddouble-admin",
-                            "nodePort": 30975,
+                            "nodePort": 31938,
                             "port": 8877,
                             "protocol": "TCP",
                             "targetPort": 8877
@@ -251,19 +299,19 @@
                     "annotations": {
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"hostcrddouble\",\"scope\":\"AmbassadorTest\"},\"name\":\"hostcrddouble-http-target1\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8104},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8467}],\"selector\":{\"backend\":\"superpod-default\"}}}\n"
                     },
-                    "creationTimestamp": "2020-02-19T23:20:08Z",
+                    "creationTimestamp": "2020-02-26T15:51:52Z",
                     "labels": {
                         "kat-ambassador-id": "hostcrddouble",
                         "scope": "AmbassadorTest"
                     },
                     "name": "hostcrddouble-http-target1",
                     "namespace": "default",
-                    "resourceVersion": "55828",
+                    "resourceVersion": "66524",
                     "selfLink": "/api/v1/namespaces/default/services/hostcrddouble-http-target1",
-                    "uid": "5eadaa3d-536e-11ea-85dd-167682b5c255"
+                    "uid": "e836b09e-58af-11ea-86d6-0e674b3ff44f"
                 },
                 "spec": {
-                    "clusterIP": "10.100.36.240",
+                    "clusterIP": "10.105.94.22",
                     "ports": [
                         {
                             "name": "http",
@@ -295,19 +343,19 @@
                     "annotations": {
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"hostcrddouble\",\"scope\":\"AmbassadorTest\"},\"name\":\"hostcrddouble-http-target2\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8105},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8468}],\"selector\":{\"backend\":\"superpod-default\"}}}\n"
                     },
-                    "creationTimestamp": "2020-02-19T23:20:08Z",
+                    "creationTimestamp": "2020-02-26T15:51:52Z",
                     "labels": {
                         "kat-ambassador-id": "hostcrddouble",
                         "scope": "AmbassadorTest"
                     },
                     "name": "hostcrddouble-http-target2",
                     "namespace": "default",
-                    "resourceVersion": "55832",
+                    "resourceVersion": "66528",
                     "selfLink": "/api/v1/namespaces/default/services/hostcrddouble-http-target2",
-                    "uid": "5ebf707b-536e-11ea-85dd-167682b5c255"
+                    "uid": "e844a8e8-58af-11ea-86d6-0e674b3ff44f"
                 },
                 "spec": {
-                    "clusterIP": "10.104.36.63",
+                    "clusterIP": "10.100.119.13",
                     "ports": [
                         {
                             "name": "http",
@@ -327,54 +375,6 @@
                     },
                     "sessionAffinity": "None",
                     "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"app.kubernetes.io/component\":\"ambassador-service\",\"kat-ambassador-id\":\"hostcrddouble\",\"scope\":\"AmbassadorTest\"},\"name\":\"hostcrddouble\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8080},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8443}],\"selector\":{\"service\":\"hostcrddouble\"},\"type\":\"NodePort\"}}\n"
-                    },
-                    "creationTimestamp": "2020-02-19T23:20:08Z",
-                    "labels": {
-                        "app.kubernetes.io/component": "ambassador-service",
-                        "kat-ambassador-id": "hostcrddouble",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "hostcrddouble",
-                    "namespace": "default",
-                    "resourceVersion": "55807",
-                    "selfLink": "/api/v1/namespaces/default/services/hostcrddouble",
-                    "uid": "5e697e6d-536e-11ea-85dd-167682b5c255"
-                },
-                "spec": {
-                    "clusterIP": "10.101.223.139",
-                    "externalTrafficPolicy": "Cluster",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "nodePort": 32377,
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8080
-                        },
-                        {
-                            "name": "https",
-                            "nodePort": 30843,
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8443
-                        }
-                    ],
-                    "selector": {
-                        "service": "hostcrddouble"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "NodePort"
                 },
                 "status": {
                     "loadBalancer": {}

--- a/python/tests/gold/hostcrdmanualcontext/snapshots/econf.json
+++ b/python/tests/gold/hostcrdmanualcontext/snapshots/econf.json
@@ -310,8 +310,7 @@
                                     "tls_minimum_protocol_version": "TLSv1_2"
                                 }
                             }
-                        },
-                        "use_proxy_proto": false
+                        }
                     }
                 ],
                 "listener_filters": [

--- a/python/tests/gold/hostcrdmanualcontext/snapshots/snapshot.yaml
+++ b/python/tests/gold/hostcrdmanualcontext/snapshots/snapshot.yaml
@@ -12,7 +12,7 @@
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"getambassador.io/v2\",\"kind\":\"Host\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"hostcrdmanualcontext\",\"scope\":\"AmbassadorTest\"},\"name\":\"manual-host\",\"namespace\":\"default\"},\"spec\":{\"acmeProvider\":{\"authority\":\"none\"},\"ambassador_id\":[\"hostcrdmanualcontext\"],\"hostname\":\"hostcrdmanualcontext\",\"selector\":{\"matchLabels\":{\"hostname\":\"manual-hostname\"}},\"tlsSecret\":{\"name\":\"manual-secret\"}}}\n"
                     },
                     "clusterName": "",
-                    "creationTimestamp": "2020-02-19T23:20:07Z",
+                    "creationTimestamp": "2020-02-26T15:51:50Z",
                     "generation": 1,
                     "labels": {
                         "kat-ambassador-id": "hostcrdmanualcontext",
@@ -20,9 +20,9 @@
                     },
                     "name": "manual-host",
                     "namespace": "default",
-                    "resourceVersion": "55761",
+                    "resourceVersion": "66432",
                     "selfLink": "/apis/getambassador.io/v2/namespaces/default/hosts/manual-host",
-                    "uid": "5dde0f11-536e-11ea-85dd-167682b5c255"
+                    "uid": "e6cd6554-58af-11ea-86d6-0e674b3ff44f"
                 },
                 "spec": {
                     "acmeProvider": {
@@ -55,7 +55,7 @@
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"getambassador.io/v2\",\"kind\":\"Mapping\",\"metadata\":{\"annotations\":{},\"labels\":{\"hostname\":\"manual-hostname\",\"kat-ambassador-id\":\"hostcrdmanualcontext\",\"scope\":\"AmbassadorTest\"},\"name\":\"manual-target-mapping\",\"namespace\":\"default\"},\"spec\":{\"ambassador_id\":[\"hostcrdmanualcontext\"],\"prefix\":\"/target/\",\"service\":\"hostcrdmanualcontext-http\"}}\n"
                     },
                     "clusterName": "",
-                    "creationTimestamp": "2020-02-19T23:20:07Z",
+                    "creationTimestamp": "2020-02-26T15:51:50Z",
                     "generation": 1,
                     "labels": {
                         "hostname": "manual-hostname",
@@ -64,9 +64,9 @@
                     },
                     "name": "manual-target-mapping",
                     "namespace": "default",
-                    "resourceVersion": "55764",
+                    "resourceVersion": "66436",
                     "selfLink": "/apis/getambassador.io/v2/namespaces/default/mappings/manual-target-mapping",
-                    "uid": "5deb320a-536e-11ea-85dd-167682b5c255"
+                    "uid": "e6e19fa8-58af-11ea-86d6-0e674b3ff44f"
                 },
                 "spec": {
                     "ambassador_id": [
@@ -89,7 +89,7 @@
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"getambassador.io/v2\",\"kind\":\"TLSContext\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"hostcrdmanualcontext\",\"scope\":\"AmbassadorTest\"},\"name\":\"manual-host-context\",\"namespace\":\"default\"},\"spec\":{\"ambassador_id\":[\"hostcrdmanualcontext\"],\"hosts\":[\"hostcrdmanualcontext\"],\"max_tls_version\":\"v1.3\",\"min_tls_version\":\"v1.2\",\"secret\":\"manual-secret\"}}\n"
                     },
                     "clusterName": "",
-                    "creationTimestamp": "2020-02-19T23:20:07Z",
+                    "creationTimestamp": "2020-02-26T15:51:50Z",
                     "generation": 1,
                     "labels": {
                         "kat-ambassador-id": "hostcrdmanualcontext",
@@ -97,9 +97,9 @@
                     },
                     "name": "manual-host-context",
                     "namespace": "default",
-                    "resourceVersion": "55762",
+                    "resourceVersion": "66435",
                     "selfLink": "/apis/getambassador.io/v2/namespaces/default/tlscontexts/manual-host-context",
-                    "uid": "5de3ce1d-536e-11ea-85dd-167682b5c255"
+                    "uid": "e6d818da-58af-11ea-86d6-0e674b3ff44f"
                 },
                 "spec": {
                     "ambassador_id": [
@@ -128,16 +128,16 @@
                     "annotations": {
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"data\":{\"tls.crt\":\"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwakNDQW82Z0F3SUJBZ0lKQUpxa1Z4Y1RtQ1FITUEwR0NTcUdTSWIzRFFFQkN3VUFNR2d4Q3pBSkJnTlYKQkFZVEFsVlRNUXN3Q1FZRFZRUUlEQUpOUVRFUE1BMEdBMVVFQnd3R1FtOXpkRzl1TVJFd0R3WURWUVFLREFoRQpZWFJoZDJseVpURVVNQklHQTFVRUN3d0xSVzVuYVc1bFpYSnBibWN4RWpBUUJnTlZCQU1NQ1d4dlkyRnNhRzl6CmREQWVGdzB4T0RFd01UQXhNREk1TURKYUZ3MHlPREV3TURjeE1ESTVNREphTUdneEN6QUpCZ05WQkFZVEFsVlQKTVFzd0NRWURWUVFJREFKTlFURVBNQTBHQTFVRUJ3d0dRbTl6ZEc5dU1SRXdEd1lEVlFRS0RBaEVZWFJoZDJseQpaVEVVTUJJR0ExVUVDd3dMUlc1bmFXNWxaWEpwYm1jeEVqQVFCZ05WQkFNTUNXeHZZMkZzYUc5emREQ0NBU0l3CkRRWUpLb1pJaHZjTkFRRUJCUUFEZ2dFUEFEQ0NBUW9DZ2dFQkFMcTZtdS9FSzlQc1Q0YkR1WWg0aEZPVnZiblAKekV6MGpQcnVzdXcxT05MQk9jT2htbmNSTnE4c1FyTGxBZ3NicDBuTFZmQ1pSZHQ4UnlOcUFGeUJlR29XS3IvZAprQVEybVBucjBQRHlCTzk0UHo4VHdydDBtZEtEU1dGanNxMjlOYVJaT0JqdStLcGV6RytOZ3pLMk04M0ZtSldUCnFYdTI3ME9pOXlqb2VGQ3lPMjdwUkdvcktkQk9TcmIwd3ozdFdWUGk4NFZMdnFKRWprT0JVZjJYNVF3b25XWngKMktxVUJ6OUFSZVVUMzdwUVJZQkJMSUdvSnM4U042cjF4MSt1dTNLdTVxSkN1QmRlSHlJbHpKb2V0aEp2K3pTMgowN0pFc2ZKWkluMWNpdXhNNzNPbmVRTm1LUkpsL2NEb3BLemswSldRSnRSV1NnbktneFNYWkRrZjJMOENBd0VBCkFhTlRNRkV3SFFZRFZSME9CQllFRkJoQzdDeVRpNGFkSFVCd0wvTkZlRTZLdnFIRE1COEdBMVVkSXdRWU1CYUEKRkJoQzdDeVRpNGFkSFVCd0wvTkZlRTZLdnFIRE1BOEdBMVVkRXdFQi93UUZNQU1CQWY4d0RRWUpLb1pJaHZjTgpBUUVMQlFBRGdnRUJBSFJvb0xjcFdEa1IyMEhENEJ5d1BTUGRLV1hjWnN1U2tXYWZyekhoYUJ5MWJZcktIR1o1CmFodFF3L1gwQmRnMWtidlpZUDJSTzdGTFhBSlNTdXVJT0NHTFVwS0pkVHE1NDREUThNb1daWVZKbTc3UWxxam0KbHNIa2VlTlRNamFOVjdMd0MzalBkMERYelczbGVnWFRoYWpmZ2dtLzBJZXNGRzBVWjFEOTJHNURmc0hLekpSagpNSHZyVDNtVmJGZjkrSGJhRE4yT2g5VjIxUWhWSzF2M0F2dWNXczhUWCswZHZFZ1dtWHBRcndEd2pTMU04QkRYCldoWjVsZTZjVzhNYjhnZmRseG1JckpnQStuVVZzMU9EbkJKS1F3MUY4MVdkc25tWXdweVUrT2xVais4UGt1TVoKSU4rUlhQVnZMSWJ3czBmamJ4UXRzbTArZVBpRnN2d0NsUFk9Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K\",\"tls.key\":\"LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0tCk1JSUV2Z0lCQURBTkJna3Foa2lHOXcwQkFRRUZBQVNDQktnd2dnU2tBZ0VBQW9JQkFRQzZ1cHJ2eEN2VDdFK0cKdzdtSWVJUlRsYjI1ejh4TTlJejY3ckxzTlRqU3dUbkRvWnAzRVRhdkxFS3k1UUlMRzZkSnkxWHdtVVhiZkVjagphZ0JjZ1hocUZpcS8zWkFFTnBqNTY5RHc4Z1R2ZUQ4L0U4SzdkSm5TZzBsaFk3S3R2VFdrV1RnWTd2aXFYc3h2CmpZTXl0alBOeFppVms2bDd0dTlEb3ZjbzZIaFFzanR1NlVScUt5blFUa3EyOU1NOTdWbFQ0dk9GUzc2aVJJNUQKZ1ZIOWwrVU1LSjFtY2RpcWxBYy9RRVhsRTkrNlVFV0FRU3lCcUNiUEVqZXE5Y2RmcnJ0eXJ1YWlRcmdYWGg4aQpKY3lhSHJZU2IvczB0dE95UkxIeVdTSjlYSXJzVE85enAza0RaaWtTWmYzQTZLU3M1TkNWa0NiVVZrb0p5b01VCmwyUTVIOWkvQWdNQkFBRUNnZ0VBSVFsZzNpamNCRHViK21Eb2syK1hJZDZ0V1pHZE9NUlBxUm5RU0NCR2RHdEIKV0E1Z2NNNTMyVmhBV0x4UnR6dG1ScFVXR0dKVnpMWlpNN2ZPWm85MWlYZHdpcytkYWxGcWtWVWFlM2FtVHVQOApkS0YvWTRFR3Nnc09VWSs5RGlZYXRvQWVmN0xRQmZ5TnVQTFZrb1JQK0FrTXJQSWFHMHhMV3JFYmYzNVp3eFRuCnd5TTF3YVpQb1oxWjZFdmhHQkxNNzlXYmY2VFY0WXVzSTRNOEVQdU1GcWlYcDNlRmZ4L0tnNHhtYnZtN1JhYzcKOEJ3Z3pnVmljNXlSbkVXYjhpWUh5WGtyazNTL0VCYUNEMlQwUjM5VmlVM1I0VjBmMUtyV3NjRHowVmNiVWNhKwpzeVdyaVhKMHBnR1N0Q3FWK0dRYy9aNmJjOGt4VWpTTWxOUWtudVJRZ1FLQmdRRHpwM1ZaVmFzMTA3NThVT00rCnZUeTFNL0V6azg4cWhGb21kYVFiSFRlbStpeGpCNlg3RU9sRlkya3JwUkwvbURDSEpwR0MzYlJtUHNFaHVGSUwKRHhSQ2hUcEtTVmNsSytaaUNPaWE1ektTVUpxZnBOcW15RnNaQlhJNnRkNW9mWk42aFpJVTlJR2RUaGlYMjBONwppUW01UnZlSUx2UHVwMWZRMmRqd2F6Ykgvd0tCZ1FERU1MN21Mb2RqSjBNTXh6ZnM3MW1FNmZOUFhBMVY2ZEgrCllCVG4xS2txaHJpampRWmFNbXZ6dEZmL1F3Wkhmd3FKQUVuNGx2em5ncUNzZTMvUElZMy8zRERxd1p2NE1vdy8KRGdBeTBLQmpQYVJGNjhYT1B1d0VuSFN1UjhyZFg2UzI3TXQ2cEZIeFZ2YjlRRFJuSXc4a3grSFVreml4U0h5Ugo2NWxESklEdlFRS0JnUURpQTF3ZldoQlBCZk9VYlpQZUJydmhlaVVycXRob29BemYwQkJCOW9CQks1OHczVTloCjdQWDFuNWxYR3ZEY2x0ZXRCbUhEK3RQMFpCSFNyWit0RW5mQW5NVE5VK3E2V0ZhRWFhOGF3WXR2bmNWUWdTTXgKd25oK1pVYm9udnVJQWJSajJyTC9MUzl1TTVzc2dmKy9BQWM5RGs5ZXkrOEtXY0Jqd3pBeEU4TGxFUUtCZ0IzNwoxVEVZcTFoY0I4Tk1MeC9tOUtkN21kUG5IYUtqdVpSRzJ1c1RkVWNxajgxdklDbG95MWJUbVI5Si93dXVQczN4ClhWekF0cVlyTUtNcnZMekxSQWgyZm9OaVU1UDdKYlA5VDhwMFdBN1N2T2h5d0NobE5XeisvRlltWXJxeWcxbngKbHFlSHRYNU03REtJUFhvRndhcTlZYVk3V2M2K1pVdG4xbVNNajZnQkFvR0JBSTgwdU9iTkdhRndQTVYrUWhiZApBelkrSFNGQjBkWWZxRytzcTBmRVdIWTNHTXFmNFh0aVRqUEFjWlg3RmdtT3Q5Uit3TlFQK0dFNjZoV0JpKzBWCmVLV3prV0lXeS9sTVZCSW0zVWtlSlRCT3NudTFVaGhXbm5WVDhFeWhEY1FxcndPSGlhaUo3bFZSZmRoRWFyQysKSnpaU0czOHVZUVlyc0lITnRVZFgySmdPCi0tLS0tRU5EIFBSSVZBVEUgS0VZLS0tLS0K\"},\"kind\":\"Secret\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"hostcrdmanualcontext\",\"scope\":\"AmbassadorTest\"},\"name\":\"manual-secret\",\"namespace\":\"default\"},\"type\":\"kubernetes.io/tls\"}\n"
                     },
-                    "creationTimestamp": "2020-02-19T23:20:07Z",
+                    "creationTimestamp": "2020-02-26T15:51:50Z",
                     "labels": {
                         "kat-ambassador-id": "hostcrdmanualcontext",
                         "scope": "AmbassadorTest"
                     },
                     "name": "manual-secret",
                     "namespace": "default",
-                    "resourceVersion": "55759",
+                    "resourceVersion": "66431",
                     "selfLink": "/api/v1/namespaces/default/secrets/manual-secret",
-                    "uid": "5dd75fb9-536e-11ea-85dd-167682b5c255"
+                    "uid": "e6c44fe5-58af-11ea-86d6-0e674b3ff44f"
                 },
                 "type": "kubernetes.io/tls"
             }
@@ -150,7 +150,7 @@
                     "annotations": {
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"app.kubernetes.io/component\":\"ambassador-service\",\"kat-ambassador-id\":\"hostcrdmanualcontext\",\"scope\":\"AmbassadorTest\"},\"name\":\"hostcrdmanualcontext\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8080},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8443}],\"selector\":{\"service\":\"hostcrdmanualcontext\"},\"type\":\"NodePort\"}}\n"
                     },
-                    "creationTimestamp": "2020-02-19T23:20:07Z",
+                    "creationTimestamp": "2020-02-26T15:51:50Z",
                     "labels": {
                         "app.kubernetes.io/component": "ambassador-service",
                         "kat-ambassador-id": "hostcrdmanualcontext",
@@ -158,24 +158,24 @@
                     },
                     "name": "hostcrdmanualcontext",
                     "namespace": "default",
-                    "resourceVersion": "55749",
+                    "resourceVersion": "66447",
                     "selfLink": "/api/v1/namespaces/default/services/hostcrdmanualcontext",
-                    "uid": "5dbedb45-536e-11ea-85dd-167682b5c255"
+                    "uid": "e7057a92-58af-11ea-86d6-0e674b3ff44f"
                 },
                 "spec": {
-                    "clusterIP": "10.104.225.111",
+                    "clusterIP": "10.104.29.16",
                     "externalTrafficPolicy": "Cluster",
                     "ports": [
                         {
                             "name": "http",
-                            "nodePort": 30539,
+                            "nodePort": 31514,
                             "port": 80,
                             "protocol": "TCP",
                             "targetPort": 8080
                         },
                         {
                             "name": "https",
-                            "nodePort": 30813,
+                            "nodePort": 32251,
                             "port": 443,
                             "protocol": "TCP",
                             "targetPort": 8443
@@ -198,7 +198,7 @@
                     "annotations": {
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"hostcrdmanualcontext\",\"scope\":\"AmbassadorTest\",\"service\":\"hostcrdmanualcontext-admin\"},\"name\":\"hostcrdmanualcontext-admin\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"hostcrdmanualcontext-admin\",\"port\":8877,\"targetPort\":8877}],\"selector\":{\"service\":\"hostcrdmanualcontext\"},\"type\":\"NodePort\"}}\n"
                     },
-                    "creationTimestamp": "2020-02-19T23:20:07Z",
+                    "creationTimestamp": "2020-02-26T15:51:50Z",
                     "labels": {
                         "kat-ambassador-id": "hostcrdmanualcontext",
                         "scope": "AmbassadorTest",
@@ -206,17 +206,17 @@
                     },
                     "name": "hostcrdmanualcontext-admin",
                     "namespace": "default",
-                    "resourceVersion": "55754",
+                    "resourceVersion": "66452",
                     "selfLink": "/api/v1/namespaces/default/services/hostcrdmanualcontext-admin",
-                    "uid": "5dca74f4-536e-11ea-85dd-167682b5c255"
+                    "uid": "e716c4f3-58af-11ea-86d6-0e674b3ff44f"
                 },
                 "spec": {
-                    "clusterIP": "10.107.113.52",
+                    "clusterIP": "10.101.226.201",
                     "externalTrafficPolicy": "Cluster",
                     "ports": [
                         {
                             "name": "hostcrdmanualcontext-admin",
-                            "nodePort": 30792,
+                            "nodePort": 32199,
                             "port": 8877,
                             "protocol": "TCP",
                             "targetPort": 8877
@@ -239,19 +239,19 @@
                     "annotations": {
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"hostcrdmanualcontext\",\"scope\":\"AmbassadorTest\"},\"name\":\"hostcrdmanualcontext-http\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8102},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8465}],\"selector\":{\"backend\":\"superpod-default\"}}}\n"
                     },
-                    "creationTimestamp": "2020-02-19T23:20:07Z",
+                    "creationTimestamp": "2020-02-26T15:51:50Z",
                     "labels": {
                         "kat-ambassador-id": "hostcrdmanualcontext",
                         "scope": "AmbassadorTest"
                     },
                     "name": "hostcrdmanualcontext-http",
                     "namespace": "default",
-                    "resourceVersion": "55767",
+                    "resourceVersion": "66461",
                     "selfLink": "/api/v1/namespaces/default/services/hostcrdmanualcontext-http",
-                    "uid": "5dfc16ab-536e-11ea-85dd-167682b5c255"
+                    "uid": "e737cd36-58af-11ea-86d6-0e674b3ff44f"
                 },
                 "spec": {
-                    "clusterIP": "10.104.197.86",
+                    "clusterIP": "10.105.159.47",
                     "ports": [
                         {
                             "name": "http",

--- a/python/tests/gold/hostcrdno8080/snapshots/econf.json
+++ b/python/tests/gold/hostcrdno8080/snapshots/econf.json
@@ -306,8 +306,7 @@
                                     }
                                 ]
                             }
-                        },
-                        "use_proxy_proto": false
+                        }
                     }
                 ],
                 "listener_filters": [

--- a/python/tests/gold/hostcrdno8080/snapshots/snapshot.yaml
+++ b/python/tests/gold/hostcrdno8080/snapshots/snapshot.yaml
@@ -12,7 +12,7 @@
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"getambassador.io/v2\",\"kind\":\"Host\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"hostcrdno8080\",\"scope\":\"AmbassadorTest\"},\"name\":\"hostcrdno8080-host\",\"namespace\":\"default\"},\"spec\":{\"acmeProvider\":{\"authority\":\"none\"},\"ambassador_id\":[\"hostcrdno8080\"],\"hostname\":\"hostcrdno8080\",\"requestPolicy\":{\"insecure\":{\"additionalPort\":-1}},\"selector\":{\"matchLabels\":{\"hostname\":\"hostcrdno8080\"}},\"tlsSecret\":{\"name\":\"hostcrdno8080-secret\"}}}\n"
                     },
                     "clusterName": "",
-                    "creationTimestamp": "2020-02-19T23:20:06Z",
+                    "creationTimestamp": "2020-02-26T15:51:49Z",
                     "generation": 1,
                     "labels": {
                         "kat-ambassador-id": "hostcrdno8080",
@@ -20,9 +20,9 @@
                     },
                     "name": "hostcrdno8080-host",
                     "namespace": "default",
-                    "resourceVersion": "55732",
+                    "resourceVersion": "66402",
                     "selfLink": "/apis/getambassador.io/v2/namespaces/default/hosts/hostcrdno8080-host",
-                    "uid": "5d8b751a-536e-11ea-85dd-167682b5c255"
+                    "uid": "e64fcde9-58af-11ea-86d6-0e674b3ff44f"
                 },
                 "spec": {
                     "acmeProvider": {
@@ -60,7 +60,7 @@
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"getambassador.io/v2\",\"kind\":\"Mapping\",\"metadata\":{\"annotations\":{},\"labels\":{\"hostname\":\"hostcrdno8080\",\"kat-ambassador-id\":\"hostcrdno8080\",\"scope\":\"AmbassadorTest\"},\"name\":\"hostcrdno8080-target-mapping\",\"namespace\":\"default\"},\"spec\":{\"ambassador_id\":[\"hostcrdno8080\"],\"prefix\":\"/target/\",\"service\":\"hostcrdno8080-http\"}}\n"
                     },
                     "clusterName": "",
-                    "creationTimestamp": "2020-02-19T23:20:06Z",
+                    "creationTimestamp": "2020-02-26T15:51:49Z",
                     "generation": 1,
                     "labels": {
                         "hostname": "hostcrdno8080",
@@ -69,9 +69,9 @@
                     },
                     "name": "hostcrdno8080-target-mapping",
                     "namespace": "default",
-                    "resourceVersion": "55733",
+                    "resourceVersion": "66404",
                     "selfLink": "/apis/getambassador.io/v2/namespaces/default/mappings/hostcrdno8080-target-mapping",
-                    "uid": "5d92ff3a-536e-11ea-85dd-167682b5c255"
+                    "uid": "e657feda-58af-11ea-86d6-0e674b3ff44f"
                 },
                 "spec": {
                     "ambassador_id": [
@@ -100,16 +100,16 @@
                     "annotations": {
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"data\":{\"tls.crt\":\"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwakNDQW82Z0F3SUJBZ0lKQUpxa1Z4Y1RtQ1FITUEwR0NTcUdTSWIzRFFFQkN3VUFNR2d4Q3pBSkJnTlYKQkFZVEFsVlRNUXN3Q1FZRFZRUUlEQUpOUVRFUE1BMEdBMVVFQnd3R1FtOXpkRzl1TVJFd0R3WURWUVFLREFoRQpZWFJoZDJseVpURVVNQklHQTFVRUN3d0xSVzVuYVc1bFpYSnBibWN4RWpBUUJnTlZCQU1NQ1d4dlkyRnNhRzl6CmREQWVGdzB4T0RFd01UQXhNREk1TURKYUZ3MHlPREV3TURjeE1ESTVNREphTUdneEN6QUpCZ05WQkFZVEFsVlQKTVFzd0NRWURWUVFJREFKTlFURVBNQTBHQTFVRUJ3d0dRbTl6ZEc5dU1SRXdEd1lEVlFRS0RBaEVZWFJoZDJseQpaVEVVTUJJR0ExVUVDd3dMUlc1bmFXNWxaWEpwYm1jeEVqQVFCZ05WQkFNTUNXeHZZMkZzYUc5emREQ0NBU0l3CkRRWUpLb1pJaHZjTkFRRUJCUUFEZ2dFUEFEQ0NBUW9DZ2dFQkFMcTZtdS9FSzlQc1Q0YkR1WWg0aEZPVnZiblAKekV6MGpQcnVzdXcxT05MQk9jT2htbmNSTnE4c1FyTGxBZ3NicDBuTFZmQ1pSZHQ4UnlOcUFGeUJlR29XS3IvZAprQVEybVBucjBQRHlCTzk0UHo4VHdydDBtZEtEU1dGanNxMjlOYVJaT0JqdStLcGV6RytOZ3pLMk04M0ZtSldUCnFYdTI3ME9pOXlqb2VGQ3lPMjdwUkdvcktkQk9TcmIwd3ozdFdWUGk4NFZMdnFKRWprT0JVZjJYNVF3b25XWngKMktxVUJ6OUFSZVVUMzdwUVJZQkJMSUdvSnM4U042cjF4MSt1dTNLdTVxSkN1QmRlSHlJbHpKb2V0aEp2K3pTMgowN0pFc2ZKWkluMWNpdXhNNzNPbmVRTm1LUkpsL2NEb3BLemswSldRSnRSV1NnbktneFNYWkRrZjJMOENBd0VBCkFhTlRNRkV3SFFZRFZSME9CQllFRkJoQzdDeVRpNGFkSFVCd0wvTkZlRTZLdnFIRE1COEdBMVVkSXdRWU1CYUEKRkJoQzdDeVRpNGFkSFVCd0wvTkZlRTZLdnFIRE1BOEdBMVVkRXdFQi93UUZNQU1CQWY4d0RRWUpLb1pJaHZjTgpBUUVMQlFBRGdnRUJBSFJvb0xjcFdEa1IyMEhENEJ5d1BTUGRLV1hjWnN1U2tXYWZyekhoYUJ5MWJZcktIR1o1CmFodFF3L1gwQmRnMWtidlpZUDJSTzdGTFhBSlNTdXVJT0NHTFVwS0pkVHE1NDREUThNb1daWVZKbTc3UWxxam0KbHNIa2VlTlRNamFOVjdMd0MzalBkMERYelczbGVnWFRoYWpmZ2dtLzBJZXNGRzBVWjFEOTJHNURmc0hLekpSagpNSHZyVDNtVmJGZjkrSGJhRE4yT2g5VjIxUWhWSzF2M0F2dWNXczhUWCswZHZFZ1dtWHBRcndEd2pTMU04QkRYCldoWjVsZTZjVzhNYjhnZmRseG1JckpnQStuVVZzMU9EbkJKS1F3MUY4MVdkc25tWXdweVUrT2xVais4UGt1TVoKSU4rUlhQVnZMSWJ3czBmamJ4UXRzbTArZVBpRnN2d0NsUFk9Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K\",\"tls.key\":\"LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0tCk1JSUV2Z0lCQURBTkJna3Foa2lHOXcwQkFRRUZBQVNDQktnd2dnU2tBZ0VBQW9JQkFRQzZ1cHJ2eEN2VDdFK0cKdzdtSWVJUlRsYjI1ejh4TTlJejY3ckxzTlRqU3dUbkRvWnAzRVRhdkxFS3k1UUlMRzZkSnkxWHdtVVhiZkVjagphZ0JjZ1hocUZpcS8zWkFFTnBqNTY5RHc4Z1R2ZUQ4L0U4SzdkSm5TZzBsaFk3S3R2VFdrV1RnWTd2aXFYc3h2CmpZTXl0alBOeFppVms2bDd0dTlEb3ZjbzZIaFFzanR1NlVScUt5blFUa3EyOU1NOTdWbFQ0dk9GUzc2aVJJNUQKZ1ZIOWwrVU1LSjFtY2RpcWxBYy9RRVhsRTkrNlVFV0FRU3lCcUNiUEVqZXE5Y2RmcnJ0eXJ1YWlRcmdYWGg4aQpKY3lhSHJZU2IvczB0dE95UkxIeVdTSjlYSXJzVE85enAza0RaaWtTWmYzQTZLU3M1TkNWa0NiVVZrb0p5b01VCmwyUTVIOWkvQWdNQkFBRUNnZ0VBSVFsZzNpamNCRHViK21Eb2syK1hJZDZ0V1pHZE9NUlBxUm5RU0NCR2RHdEIKV0E1Z2NNNTMyVmhBV0x4UnR6dG1ScFVXR0dKVnpMWlpNN2ZPWm85MWlYZHdpcytkYWxGcWtWVWFlM2FtVHVQOApkS0YvWTRFR3Nnc09VWSs5RGlZYXRvQWVmN0xRQmZ5TnVQTFZrb1JQK0FrTXJQSWFHMHhMV3JFYmYzNVp3eFRuCnd5TTF3YVpQb1oxWjZFdmhHQkxNNzlXYmY2VFY0WXVzSTRNOEVQdU1GcWlYcDNlRmZ4L0tnNHhtYnZtN1JhYzcKOEJ3Z3pnVmljNXlSbkVXYjhpWUh5WGtyazNTL0VCYUNEMlQwUjM5VmlVM1I0VjBmMUtyV3NjRHowVmNiVWNhKwpzeVdyaVhKMHBnR1N0Q3FWK0dRYy9aNmJjOGt4VWpTTWxOUWtudVJRZ1FLQmdRRHpwM1ZaVmFzMTA3NThVT00rCnZUeTFNL0V6azg4cWhGb21kYVFiSFRlbStpeGpCNlg3RU9sRlkya3JwUkwvbURDSEpwR0MzYlJtUHNFaHVGSUwKRHhSQ2hUcEtTVmNsSytaaUNPaWE1ektTVUpxZnBOcW15RnNaQlhJNnRkNW9mWk42aFpJVTlJR2RUaGlYMjBONwppUW01UnZlSUx2UHVwMWZRMmRqd2F6Ykgvd0tCZ1FERU1MN21Mb2RqSjBNTXh6ZnM3MW1FNmZOUFhBMVY2ZEgrCllCVG4xS2txaHJpampRWmFNbXZ6dEZmL1F3Wkhmd3FKQUVuNGx2em5ncUNzZTMvUElZMy8zRERxd1p2NE1vdy8KRGdBeTBLQmpQYVJGNjhYT1B1d0VuSFN1UjhyZFg2UzI3TXQ2cEZIeFZ2YjlRRFJuSXc4a3grSFVreml4U0h5Ugo2NWxESklEdlFRS0JnUURpQTF3ZldoQlBCZk9VYlpQZUJydmhlaVVycXRob29BemYwQkJCOW9CQks1OHczVTloCjdQWDFuNWxYR3ZEY2x0ZXRCbUhEK3RQMFpCSFNyWit0RW5mQW5NVE5VK3E2V0ZhRWFhOGF3WXR2bmNWUWdTTXgKd25oK1pVYm9udnVJQWJSajJyTC9MUzl1TTVzc2dmKy9BQWM5RGs5ZXkrOEtXY0Jqd3pBeEU4TGxFUUtCZ0IzNwoxVEVZcTFoY0I4Tk1MeC9tOUtkN21kUG5IYUtqdVpSRzJ1c1RkVWNxajgxdklDbG95MWJUbVI5Si93dXVQczN4ClhWekF0cVlyTUtNcnZMekxSQWgyZm9OaVU1UDdKYlA5VDhwMFdBN1N2T2h5d0NobE5XeisvRlltWXJxeWcxbngKbHFlSHRYNU03REtJUFhvRndhcTlZYVk3V2M2K1pVdG4xbVNNajZnQkFvR0JBSTgwdU9iTkdhRndQTVYrUWhiZApBelkrSFNGQjBkWWZxRytzcTBmRVdIWTNHTXFmNFh0aVRqUEFjWlg3RmdtT3Q5Uit3TlFQK0dFNjZoV0JpKzBWCmVLV3prV0lXeS9sTVZCSW0zVWtlSlRCT3NudTFVaGhXbm5WVDhFeWhEY1FxcndPSGlhaUo3bFZSZmRoRWFyQysKSnpaU0czOHVZUVlyc0lITnRVZFgySmdPCi0tLS0tRU5EIFBSSVZBVEUgS0VZLS0tLS0K\"},\"kind\":\"Secret\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"hostcrdno8080\",\"scope\":\"AmbassadorTest\"},\"name\":\"hostcrdno8080-secret\",\"namespace\":\"default\"},\"type\":\"kubernetes.io/tls\"}\n"
                     },
-                    "creationTimestamp": "2020-02-19T23:20:06Z",
+                    "creationTimestamp": "2020-02-26T15:51:49Z",
                     "labels": {
                         "kat-ambassador-id": "hostcrdno8080",
                         "scope": "AmbassadorTest"
                     },
                     "name": "hostcrdno8080-secret",
                     "namespace": "default",
-                    "resourceVersion": "55731",
+                    "resourceVersion": "66401",
                     "selfLink": "/api/v1/namespaces/default/secrets/hostcrdno8080-secret",
-                    "uid": "5d85c119-536e-11ea-85dd-167682b5c255"
+                    "uid": "e63855f7-58af-11ea-86d6-0e674b3ff44f"
                 },
                 "type": "kubernetes.io/tls"
             }
@@ -120,57 +120,9 @@
                 "kind": "Service",
                 "metadata": {
                     "annotations": {
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"app.kubernetes.io/component\":\"ambassador-service\",\"kat-ambassador-id\":\"hostcrdno8080\",\"scope\":\"AmbassadorTest\"},\"name\":\"hostcrdno8080\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8080},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8443}],\"selector\":{\"service\":\"hostcrdno8080\"},\"type\":\"NodePort\"}}\n"
-                    },
-                    "creationTimestamp": "2020-02-19T23:20:06Z",
-                    "labels": {
-                        "app.kubernetes.io/component": "ambassador-service",
-                        "kat-ambassador-id": "hostcrdno8080",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "hostcrdno8080",
-                    "namespace": "default",
-                    "resourceVersion": "55719",
-                    "selfLink": "/api/v1/namespaces/default/services/hostcrdno8080",
-                    "uid": "5d5c50ff-536e-11ea-85dd-167682b5c255"
-                },
-                "spec": {
-                    "clusterIP": "10.103.211.138",
-                    "externalTrafficPolicy": "Cluster",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "nodePort": 30901,
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8080
-                        },
-                        {
-                            "name": "https",
-                            "nodePort": 32206,
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8443
-                        }
-                    ],
-                    "selector": {
-                        "service": "hostcrdno8080"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "NodePort"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"hostcrdno8080\",\"scope\":\"AmbassadorTest\",\"service\":\"hostcrdno8080-admin\"},\"name\":\"hostcrdno8080-admin\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"hostcrdno8080-admin\",\"port\":8877,\"targetPort\":8877}],\"selector\":{\"service\":\"hostcrdno8080\"},\"type\":\"NodePort\"}}\n"
                     },
-                    "creationTimestamp": "2020-02-19T23:20:06Z",
+                    "creationTimestamp": "2020-02-26T15:51:50Z",
                     "labels": {
                         "kat-ambassador-id": "hostcrdno8080",
                         "scope": "AmbassadorTest",
@@ -178,17 +130,17 @@
                     },
                     "name": "hostcrdno8080-admin",
                     "namespace": "default",
-                    "resourceVersion": "55725",
+                    "resourceVersion": "66422",
                     "selfLink": "/api/v1/namespaces/default/services/hostcrdno8080-admin",
-                    "uid": "5d720ee4-536e-11ea-85dd-167682b5c255"
+                    "uid": "e6a09175-58af-11ea-86d6-0e674b3ff44f"
                 },
                 "spec": {
-                    "clusterIP": "10.103.75.44",
+                    "clusterIP": "10.111.228.43",
                     "externalTrafficPolicy": "Cluster",
                     "ports": [
                         {
                             "name": "hostcrdno8080-admin",
-                            "nodePort": 32713,
+                            "nodePort": 30404,
                             "port": 8877,
                             "protocol": "TCP",
                             "targetPort": 8877
@@ -211,19 +163,19 @@
                     "annotations": {
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"hostcrdno8080\",\"scope\":\"AmbassadorTest\"},\"name\":\"hostcrdno8080-http\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8101},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8464}],\"selector\":{\"backend\":\"superpod-default\"}}}\n"
                     },
-                    "creationTimestamp": "2020-02-19T23:20:07Z",
+                    "creationTimestamp": "2020-02-26T15:51:50Z",
                     "labels": {
                         "kat-ambassador-id": "hostcrdno8080",
                         "scope": "AmbassadorTest"
                     },
                     "name": "hostcrdno8080-http",
                     "namespace": "default",
-                    "resourceVersion": "55735",
+                    "resourceVersion": "66429",
                     "selfLink": "/api/v1/namespaces/default/services/hostcrdno8080-http",
-                    "uid": "5d9a9e07-536e-11ea-85dd-167682b5c255"
+                    "uid": "e6b45934-58af-11ea-86d6-0e674b3ff44f"
                 },
                 "spec": {
-                    "clusterIP": "10.106.64.248",
+                    "clusterIP": "10.110.165.225",
                     "ports": [
                         {
                             "name": "http",
@@ -243,6 +195,54 @@
                     },
                     "sessionAffinity": "None",
                     "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"app.kubernetes.io/component\":\"ambassador-service\",\"kat-ambassador-id\":\"hostcrdno8080\",\"scope\":\"AmbassadorTest\"},\"name\":\"hostcrdno8080\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8080},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8443}],\"selector\":{\"service\":\"hostcrdno8080\"},\"type\":\"NodePort\"}}\n"
+                    },
+                    "creationTimestamp": "2020-02-26T15:51:49Z",
+                    "labels": {
+                        "app.kubernetes.io/component": "ambassador-service",
+                        "kat-ambassador-id": "hostcrdno8080",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "hostcrdno8080",
+                    "namespace": "default",
+                    "resourceVersion": "66415",
+                    "selfLink": "/api/v1/namespaces/default/services/hostcrdno8080",
+                    "uid": "e68f75ad-58af-11ea-86d6-0e674b3ff44f"
+                },
+                "spec": {
+                    "clusterIP": "10.104.138.113",
+                    "externalTrafficPolicy": "Cluster",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "nodePort": 32680,
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8080
+                        },
+                        {
+                            "name": "https",
+                            "nodePort": 32343,
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8443
+                        }
+                    ],
+                    "selector": {
+                        "service": "hostcrdno8080"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "NodePort"
                 },
                 "status": {
                     "loadBalancer": {}

--- a/python/tests/gold/hostcrdsingle/snapshots/econf.json
+++ b/python/tests/gold/hostcrdsingle/snapshots/econf.json
@@ -306,8 +306,7 @@
                                     }
                                 ]
                             }
-                        },
-                        "use_proxy_proto": false
+                        }
                     }
                 ],
                 "listener_filters": [
@@ -439,8 +438,7 @@
                                     "xff_num_trusted_hops": 0
                                 }
                             }
-                        ],
-                        "use_proxy_proto": false
+                        ]
                     }
                 ],
                 "listener_filters": [],

--- a/python/tests/gold/hostcrdsingle/snapshots/snapshot.yaml
+++ b/python/tests/gold/hostcrdsingle/snapshots/snapshot.yaml
@@ -12,7 +12,7 @@
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"getambassador.io/v2\",\"kind\":\"Host\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"hostcrdsingle\",\"scope\":\"AmbassadorTest\"},\"name\":\"hostcrdsingle-host\",\"namespace\":\"default\"},\"spec\":{\"acmeProvider\":{\"authority\":\"none\"},\"ambassador_id\":[\"hostcrdsingle\"],\"hostname\":\"hostcrdsingle\",\"selector\":{\"matchLabels\":{\"hostname\":\"hostcrdsingle\"}},\"tlsSecret\":{\"name\":\"hostcrdsingle-secret\"}}}\n"
                     },
                     "clusterName": "",
-                    "creationTimestamp": "2020-02-19T23:20:06Z",
+                    "creationTimestamp": "2020-02-26T15:51:48Z",
                     "generation": 1,
                     "labels": {
                         "kat-ambassador-id": "hostcrdsingle",
@@ -20,9 +20,9 @@
                     },
                     "name": "hostcrdsingle-host",
                     "namespace": "default",
-                    "resourceVersion": "55703",
+                    "resourceVersion": "66369",
                     "selfLink": "/apis/getambassador.io/v2/namespaces/default/hosts/hostcrdsingle-host",
-                    "uid": "5d2ebf6a-536e-11ea-85dd-167682b5c255"
+                    "uid": "e5d6bbef-58af-11ea-86d6-0e674b3ff44f"
                 },
                 "spec": {
                     "acmeProvider": {
@@ -55,7 +55,7 @@
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"getambassador.io/v2\",\"kind\":\"Mapping\",\"metadata\":{\"annotations\":{},\"labels\":{\"hostname\":\"hostcrdsingle\",\"kat-ambassador-id\":\"hostcrdsingle\",\"scope\":\"AmbassadorTest\"},\"name\":\"hostcrdsingle-target-mapping\",\"namespace\":\"default\"},\"spec\":{\"ambassador_id\":[\"hostcrdsingle\"],\"prefix\":\"/target/\",\"service\":\"hostcrdsingle-http\"}}\n"
                     },
                     "clusterName": "",
-                    "creationTimestamp": "2020-02-19T23:20:06Z",
+                    "creationTimestamp": "2020-02-26T15:51:48Z",
                     "generation": 1,
                     "labels": {
                         "hostname": "hostcrdsingle",
@@ -64,9 +64,9 @@
                     },
                     "name": "hostcrdsingle-target-mapping",
                     "namespace": "default",
-                    "resourceVersion": "55705",
+                    "resourceVersion": "66371",
                     "selfLink": "/apis/getambassador.io/v2/namespaces/default/mappings/hostcrdsingle-target-mapping",
-                    "uid": "5d3525bc-536e-11ea-85dd-167682b5c255"
+                    "uid": "e5deadc7-58af-11ea-86d6-0e674b3ff44f"
                 },
                 "spec": {
                     "ambassador_id": [
@@ -95,16 +95,16 @@
                     "annotations": {
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"data\":{\"tls.crt\":\"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwakNDQW82Z0F3SUJBZ0lKQUpxa1Z4Y1RtQ1FITUEwR0NTcUdTSWIzRFFFQkN3VUFNR2d4Q3pBSkJnTlYKQkFZVEFsVlRNUXN3Q1FZRFZRUUlEQUpOUVRFUE1BMEdBMVVFQnd3R1FtOXpkRzl1TVJFd0R3WURWUVFLREFoRQpZWFJoZDJseVpURVVNQklHQTFVRUN3d0xSVzVuYVc1bFpYSnBibWN4RWpBUUJnTlZCQU1NQ1d4dlkyRnNhRzl6CmREQWVGdzB4T0RFd01UQXhNREk1TURKYUZ3MHlPREV3TURjeE1ESTVNREphTUdneEN6QUpCZ05WQkFZVEFsVlQKTVFzd0NRWURWUVFJREFKTlFURVBNQTBHQTFVRUJ3d0dRbTl6ZEc5dU1SRXdEd1lEVlFRS0RBaEVZWFJoZDJseQpaVEVVTUJJR0ExVUVDd3dMUlc1bmFXNWxaWEpwYm1jeEVqQVFCZ05WQkFNTUNXeHZZMkZzYUc5emREQ0NBU0l3CkRRWUpLb1pJaHZjTkFRRUJCUUFEZ2dFUEFEQ0NBUW9DZ2dFQkFMcTZtdS9FSzlQc1Q0YkR1WWg0aEZPVnZiblAKekV6MGpQcnVzdXcxT05MQk9jT2htbmNSTnE4c1FyTGxBZ3NicDBuTFZmQ1pSZHQ4UnlOcUFGeUJlR29XS3IvZAprQVEybVBucjBQRHlCTzk0UHo4VHdydDBtZEtEU1dGanNxMjlOYVJaT0JqdStLcGV6RytOZ3pLMk04M0ZtSldUCnFYdTI3ME9pOXlqb2VGQ3lPMjdwUkdvcktkQk9TcmIwd3ozdFdWUGk4NFZMdnFKRWprT0JVZjJYNVF3b25XWngKMktxVUJ6OUFSZVVUMzdwUVJZQkJMSUdvSnM4U042cjF4MSt1dTNLdTVxSkN1QmRlSHlJbHpKb2V0aEp2K3pTMgowN0pFc2ZKWkluMWNpdXhNNzNPbmVRTm1LUkpsL2NEb3BLemswSldRSnRSV1NnbktneFNYWkRrZjJMOENBd0VBCkFhTlRNRkV3SFFZRFZSME9CQllFRkJoQzdDeVRpNGFkSFVCd0wvTkZlRTZLdnFIRE1COEdBMVVkSXdRWU1CYUEKRkJoQzdDeVRpNGFkSFVCd0wvTkZlRTZLdnFIRE1BOEdBMVVkRXdFQi93UUZNQU1CQWY4d0RRWUpLb1pJaHZjTgpBUUVMQlFBRGdnRUJBSFJvb0xjcFdEa1IyMEhENEJ5d1BTUGRLV1hjWnN1U2tXYWZyekhoYUJ5MWJZcktIR1o1CmFodFF3L1gwQmRnMWtidlpZUDJSTzdGTFhBSlNTdXVJT0NHTFVwS0pkVHE1NDREUThNb1daWVZKbTc3UWxxam0KbHNIa2VlTlRNamFOVjdMd0MzalBkMERYelczbGVnWFRoYWpmZ2dtLzBJZXNGRzBVWjFEOTJHNURmc0hLekpSagpNSHZyVDNtVmJGZjkrSGJhRE4yT2g5VjIxUWhWSzF2M0F2dWNXczhUWCswZHZFZ1dtWHBRcndEd2pTMU04QkRYCldoWjVsZTZjVzhNYjhnZmRseG1JckpnQStuVVZzMU9EbkJKS1F3MUY4MVdkc25tWXdweVUrT2xVais4UGt1TVoKSU4rUlhQVnZMSWJ3czBmamJ4UXRzbTArZVBpRnN2d0NsUFk9Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K\",\"tls.key\":\"LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0tCk1JSUV2Z0lCQURBTkJna3Foa2lHOXcwQkFRRUZBQVNDQktnd2dnU2tBZ0VBQW9JQkFRQzZ1cHJ2eEN2VDdFK0cKdzdtSWVJUlRsYjI1ejh4TTlJejY3ckxzTlRqU3dUbkRvWnAzRVRhdkxFS3k1UUlMRzZkSnkxWHdtVVhiZkVjagphZ0JjZ1hocUZpcS8zWkFFTnBqNTY5RHc4Z1R2ZUQ4L0U4SzdkSm5TZzBsaFk3S3R2VFdrV1RnWTd2aXFYc3h2CmpZTXl0alBOeFppVms2bDd0dTlEb3ZjbzZIaFFzanR1NlVScUt5blFUa3EyOU1NOTdWbFQ0dk9GUzc2aVJJNUQKZ1ZIOWwrVU1LSjFtY2RpcWxBYy9RRVhsRTkrNlVFV0FRU3lCcUNiUEVqZXE5Y2RmcnJ0eXJ1YWlRcmdYWGg4aQpKY3lhSHJZU2IvczB0dE95UkxIeVdTSjlYSXJzVE85enAza0RaaWtTWmYzQTZLU3M1TkNWa0NiVVZrb0p5b01VCmwyUTVIOWkvQWdNQkFBRUNnZ0VBSVFsZzNpamNCRHViK21Eb2syK1hJZDZ0V1pHZE9NUlBxUm5RU0NCR2RHdEIKV0E1Z2NNNTMyVmhBV0x4UnR6dG1ScFVXR0dKVnpMWlpNN2ZPWm85MWlYZHdpcytkYWxGcWtWVWFlM2FtVHVQOApkS0YvWTRFR3Nnc09VWSs5RGlZYXRvQWVmN0xRQmZ5TnVQTFZrb1JQK0FrTXJQSWFHMHhMV3JFYmYzNVp3eFRuCnd5TTF3YVpQb1oxWjZFdmhHQkxNNzlXYmY2VFY0WXVzSTRNOEVQdU1GcWlYcDNlRmZ4L0tnNHhtYnZtN1JhYzcKOEJ3Z3pnVmljNXlSbkVXYjhpWUh5WGtyazNTL0VCYUNEMlQwUjM5VmlVM1I0VjBmMUtyV3NjRHowVmNiVWNhKwpzeVdyaVhKMHBnR1N0Q3FWK0dRYy9aNmJjOGt4VWpTTWxOUWtudVJRZ1FLQmdRRHpwM1ZaVmFzMTA3NThVT00rCnZUeTFNL0V6azg4cWhGb21kYVFiSFRlbStpeGpCNlg3RU9sRlkya3JwUkwvbURDSEpwR0MzYlJtUHNFaHVGSUwKRHhSQ2hUcEtTVmNsSytaaUNPaWE1ektTVUpxZnBOcW15RnNaQlhJNnRkNW9mWk42aFpJVTlJR2RUaGlYMjBONwppUW01UnZlSUx2UHVwMWZRMmRqd2F6Ykgvd0tCZ1FERU1MN21Mb2RqSjBNTXh6ZnM3MW1FNmZOUFhBMVY2ZEgrCllCVG4xS2txaHJpampRWmFNbXZ6dEZmL1F3Wkhmd3FKQUVuNGx2em5ncUNzZTMvUElZMy8zRERxd1p2NE1vdy8KRGdBeTBLQmpQYVJGNjhYT1B1d0VuSFN1UjhyZFg2UzI3TXQ2cEZIeFZ2YjlRRFJuSXc4a3grSFVreml4U0h5Ugo2NWxESklEdlFRS0JnUURpQTF3ZldoQlBCZk9VYlpQZUJydmhlaVVycXRob29BemYwQkJCOW9CQks1OHczVTloCjdQWDFuNWxYR3ZEY2x0ZXRCbUhEK3RQMFpCSFNyWit0RW5mQW5NVE5VK3E2V0ZhRWFhOGF3WXR2bmNWUWdTTXgKd25oK1pVYm9udnVJQWJSajJyTC9MUzl1TTVzc2dmKy9BQWM5RGs5ZXkrOEtXY0Jqd3pBeEU4TGxFUUtCZ0IzNwoxVEVZcTFoY0I4Tk1MeC9tOUtkN21kUG5IYUtqdVpSRzJ1c1RkVWNxajgxdklDbG95MWJUbVI5Si93dXVQczN4ClhWekF0cVlyTUtNcnZMekxSQWgyZm9OaVU1UDdKYlA5VDhwMFdBN1N2T2h5d0NobE5XeisvRlltWXJxeWcxbngKbHFlSHRYNU03REtJUFhvRndhcTlZYVk3V2M2K1pVdG4xbVNNajZnQkFvR0JBSTgwdU9iTkdhRndQTVYrUWhiZApBelkrSFNGQjBkWWZxRytzcTBmRVdIWTNHTXFmNFh0aVRqUEFjWlg3RmdtT3Q5Uit3TlFQK0dFNjZoV0JpKzBWCmVLV3prV0lXeS9sTVZCSW0zVWtlSlRCT3NudTFVaGhXbm5WVDhFeWhEY1FxcndPSGlhaUo3bFZSZmRoRWFyQysKSnpaU0czOHVZUVlyc0lITnRVZFgySmdPCi0tLS0tRU5EIFBSSVZBVEUgS0VZLS0tLS0K\"},\"kind\":\"Secret\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"hostcrdsingle\",\"scope\":\"AmbassadorTest\"},\"name\":\"hostcrdsingle-secret\",\"namespace\":\"default\"},\"type\":\"kubernetes.io/tls\"}\n"
                     },
-                    "creationTimestamp": "2020-02-19T23:20:06Z",
+                    "creationTimestamp": "2020-02-26T15:51:48Z",
                     "labels": {
                         "kat-ambassador-id": "hostcrdsingle",
                         "scope": "AmbassadorTest"
                     },
                     "name": "hostcrdsingle-secret",
                     "namespace": "default",
-                    "resourceVersion": "55702",
+                    "resourceVersion": "66368",
                     "selfLink": "/api/v1/namespaces/default/secrets/hostcrdsingle-secret",
-                    "uid": "5d28202a-536e-11ea-85dd-167682b5c255"
+                    "uid": "e5ccccd8-58af-11ea-86d6-0e674b3ff44f"
                 },
                 "type": "kubernetes.io/tls"
             }
@@ -117,7 +117,7 @@
                     "annotations": {
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"app.kubernetes.io/component\":\"ambassador-service\",\"kat-ambassador-id\":\"hostcrdsingle\",\"scope\":\"AmbassadorTest\"},\"name\":\"hostcrdsingle\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8080},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8443}],\"selector\":{\"service\":\"hostcrdsingle\"},\"type\":\"NodePort\"}}\n"
                     },
-                    "creationTimestamp": "2020-02-19T23:20:06Z",
+                    "creationTimestamp": "2020-02-26T15:51:49Z",
                     "labels": {
                         "app.kubernetes.io/component": "ambassador-service",
                         "kat-ambassador-id": "hostcrdsingle",
@@ -125,24 +125,24 @@
                     },
                     "name": "hostcrdsingle",
                     "namespace": "default",
-                    "resourceVersion": "55691",
+                    "resourceVersion": "66382",
                     "selfLink": "/api/v1/namespaces/default/services/hostcrdsingle",
-                    "uid": "5d120bb0-536e-11ea-85dd-167682b5c255"
+                    "uid": "e609fd52-58af-11ea-86d6-0e674b3ff44f"
                 },
                 "spec": {
-                    "clusterIP": "10.101.243.208",
+                    "clusterIP": "10.101.227.192",
                     "externalTrafficPolicy": "Cluster",
                     "ports": [
                         {
                             "name": "http",
-                            "nodePort": 32074,
+                            "nodePort": 31197,
                             "port": 80,
                             "protocol": "TCP",
                             "targetPort": 8080
                         },
                         {
                             "name": "https",
-                            "nodePort": 31194,
+                            "nodePort": 30738,
                             "port": 443,
                             "protocol": "TCP",
                             "targetPort": 8443
@@ -165,7 +165,7 @@
                     "annotations": {
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"hostcrdsingle\",\"scope\":\"AmbassadorTest\",\"service\":\"hostcrdsingle-admin\"},\"name\":\"hostcrdsingle-admin\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"hostcrdsingle-admin\",\"port\":8877,\"targetPort\":8877}],\"selector\":{\"service\":\"hostcrdsingle\"},\"type\":\"NodePort\"}}\n"
                     },
-                    "creationTimestamp": "2020-02-19T23:20:06Z",
+                    "creationTimestamp": "2020-02-26T15:51:49Z",
                     "labels": {
                         "kat-ambassador-id": "hostcrdsingle",
                         "scope": "AmbassadorTest",
@@ -173,17 +173,17 @@
                     },
                     "name": "hostcrdsingle-admin",
                     "namespace": "default",
-                    "resourceVersion": "55695",
+                    "resourceVersion": "66388",
                     "selfLink": "/api/v1/namespaces/default/services/hostcrdsingle-admin",
-                    "uid": "5d19cead-536e-11ea-85dd-167682b5c255"
+                    "uid": "e61616df-58af-11ea-86d6-0e674b3ff44f"
                 },
                 "spec": {
-                    "clusterIP": "10.103.31.216",
+                    "clusterIP": "10.107.63.129",
                     "externalTrafficPolicy": "Cluster",
                     "ports": [
                         {
                             "name": "hostcrdsingle-admin",
-                            "nodePort": 31347,
+                            "nodePort": 30654,
                             "port": 8877,
                             "protocol": "TCP",
                             "targetPort": 8877
@@ -206,19 +206,19 @@
                     "annotations": {
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"hostcrdsingle\",\"scope\":\"AmbassadorTest\"},\"name\":\"hostcrdsingle-http\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8100},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8463}],\"selector\":{\"backend\":\"superpod-default\"}}}\n"
                     },
-                    "creationTimestamp": "2020-02-19T23:20:06Z",
+                    "creationTimestamp": "2020-02-26T15:51:49Z",
                     "labels": {
                         "kat-ambassador-id": "hostcrdsingle",
                         "scope": "AmbassadorTest"
                     },
                     "name": "hostcrdsingle-http",
                     "namespace": "default",
-                    "resourceVersion": "55707",
+                    "resourceVersion": "66396",
                     "selfLink": "/api/v1/namespaces/default/services/hostcrdsingle-http",
-                    "uid": "5d3ca88b-536e-11ea-85dd-167682b5c255"
+                    "uid": "e62d9c35-58af-11ea-86d6-0e674b3ff44f"
                 },
                 "spec": {
-                    "clusterIP": "10.104.69.201",
+                    "clusterIP": "10.109.22.11",
                     "ports": [
                         {
                             "name": "http",

--- a/python/tests/gold/linkerdheadermapping/snapshots/econf.json
+++ b/python/tests/gold/linkerdheadermapping/snapshots/econf.json
@@ -566,8 +566,7 @@
                                     "xff_num_trusted_hops": 0
                                 }
                             }
-                        ],
-                        "use_proxy_proto": false
+                        ]
                     }
                 ],
                 "listener_filters": [],

--- a/python/tests/gold/linkerdheadermapping/snapshots/snapshot.yaml
+++ b/python/tests/gold/linkerdheadermapping/snapshots/snapshot.yaml
@@ -20,155 +20,21 @@
                 "kind": "Service",
                 "metadata": {
                     "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Module\nname: ambassador\nconfig:\n  add_linkerd_headers: true\nambassador_id: linkerdheadermapping\n---\napiVersion: ambassador/v1\nkind: Mapping\nname: linkerdheadermapping-http-addlinkerdonly\nprefix: /target_add_linkerd_header_only/\nservice: linkerdheadermapping-http-addlinkerdonly\nambassador_id: linkerdheadermapping\n---\napiVersion: ambassador/v1\nkind: Mapping\nname: linkerdheadermapping-http-noheader\nprefix: /target_no_header/\nservice: linkerdheadermapping-http-noheader\nadd_linkerd_headers: false\nadd_request_headers:\n  fruit:\n    append: False\n    value: orange\nambassador_id: linkerdheadermapping\n---\napiVersion: ambassador/v1\nkind: Mapping\nname: linkerdheadermapping-http\nprefix: /target/\nservice: linkerdheadermapping-http\nadd_request_headers:\n  fruit:\n    append: False\n    value: banana\nambassador_id: linkerdheadermapping\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Module\\nname: ambassador\\nconfig:\\n  add_linkerd_headers: true\\nambassador_id: linkerdheadermapping\\n---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: linkerdheadermapping-http-addlinkerdonly\\nprefix: /target_add_linkerd_header_only/\\nservice: linkerdheadermapping-http-addlinkerdonly\\nambassador_id: linkerdheadermapping\\n---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: linkerdheadermapping-http-noheader\\nprefix: /target_no_header/\\nservice: linkerdheadermapping-http-noheader\\nadd_linkerd_headers: false\\nadd_request_headers:\\n  fruit:\\n    append: False\\n    value: orange\\nambassador_id: linkerdheadermapping\\n---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: linkerdheadermapping-http\\nprefix: /target/\\nservice: linkerdheadermapping-http\\nadd_request_headers:\\n  fruit:\\n    append: False\\n    value: banana\\nambassador_id: linkerdheadermapping\\n\"},\"labels\":{\"app.kubernetes.io/component\":\"ambassador-service\",\"kat-ambassador-id\":\"linkerdheadermapping\",\"scope\":\"AmbassadorTest\"},\"name\":\"linkerdheadermapping\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8080},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8443}],\"selector\":{\"service\":\"linkerdheadermapping\"},\"type\":\"NodePort\"}}\n"
-                    },
-                    "creationTimestamp": "2020-02-19T23:20:11Z",
-                    "labels": {
-                        "app.kubernetes.io/component": "ambassador-service",
-                        "kat-ambassador-id": "linkerdheadermapping",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "linkerdheadermapping",
-                    "namespace": "default",
-                    "resourceVersion": "56013",
-                    "selfLink": "/api/v1/namespaces/default/services/linkerdheadermapping",
-                    "uid": "60695dfe-536e-11ea-85dd-167682b5c255"
-                },
-                "spec": {
-                    "clusterIP": "10.109.16.39",
-                    "externalTrafficPolicy": "Cluster",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "nodePort": 32203,
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8080
-                        },
-                        {
-                            "name": "https",
-                            "nodePort": 32455,
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8443
-                        }
-                    ],
-                    "selector": {
-                        "service": "linkerdheadermapping"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "NodePort"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"linkerdheadermapping\",\"scope\":\"AmbassadorTest\",\"service\":\"linkerdheadermapping-admin\"},\"name\":\"linkerdheadermapping-admin\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"linkerdheadermapping-admin\",\"port\":8877,\"targetPort\":8877}],\"selector\":{\"service\":\"linkerdheadermapping\"},\"type\":\"NodePort\"}}\n"
-                    },
-                    "creationTimestamp": "2020-02-19T23:20:11Z",
-                    "labels": {
-                        "kat-ambassador-id": "linkerdheadermapping",
-                        "scope": "AmbassadorTest",
-                        "service": "linkerdheadermapping-admin"
-                    },
-                    "name": "linkerdheadermapping-admin",
-                    "namespace": "default",
-                    "resourceVersion": "56017",
-                    "selfLink": "/api/v1/namespaces/default/services/linkerdheadermapping-admin",
-                    "uid": "6070c2da-536e-11ea-85dd-167682b5c255"
-                },
-                "spec": {
-                    "clusterIP": "10.99.120.96",
-                    "externalTrafficPolicy": "Cluster",
-                    "ports": [
-                        {
-                            "name": "linkerdheadermapping-admin",
-                            "nodePort": 31254,
-                            "port": 8877,
-                            "protocol": "TCP",
-                            "targetPort": 8877
-                        }
-                    ],
-                    "selector": {
-                        "service": "linkerdheadermapping"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "NodePort"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"linkerdheadermapping\",\"scope\":\"AmbassadorTest\"},\"name\":\"linkerdheadermapping-http\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8111},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8474}],\"selector\":{\"backend\":\"superpod-default\"}}}\n"
-                    },
-                    "creationTimestamp": "2020-02-19T23:20:11Z",
-                    "labels": {
-                        "kat-ambassador-id": "linkerdheadermapping",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "linkerdheadermapping-http",
-                    "namespace": "default",
-                    "resourceVersion": "56024",
-                    "selfLink": "/api/v1/namespaces/default/services/linkerdheadermapping-http",
-                    "uid": "6085a8fe-536e-11ea-85dd-167682b5c255"
-                },
-                "spec": {
-                    "clusterIP": "10.101.99.46",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8111
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8474
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-default"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"linkerdheadermapping\",\"scope\":\"AmbassadorTest\"},\"name\":\"linkerdheadermapping-http-addlinkerdonly\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8113},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8476}],\"selector\":{\"backend\":\"superpod-default\"}}}\n"
                     },
-                    "creationTimestamp": "2020-02-19T23:20:12Z",
+                    "creationTimestamp": "2020-02-26T15:51:58Z",
                     "labels": {
                         "kat-ambassador-id": "linkerdheadermapping",
                         "scope": "AmbassadorTest"
                     },
                     "name": "linkerdheadermapping-http-addlinkerdonly",
                     "namespace": "default",
-                    "resourceVersion": "56030",
+                    "resourceVersion": "66747",
                     "selfLink": "/api/v1/namespaces/default/services/linkerdheadermapping-http-addlinkerdonly",
-                    "uid": "6097297e-536e-11ea-85dd-167682b5c255"
+                    "uid": "ebf86858-58af-11ea-86d6-0e674b3ff44f"
                 },
                 "spec": {
-                    "clusterIP": "10.103.57.149",
+                    "clusterIP": "10.106.67.126",
                     "ports": [
                         {
                             "name": "http",
@@ -200,19 +66,19 @@
                     "annotations": {
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"linkerdheadermapping\",\"scope\":\"AmbassadorTest\"},\"name\":\"linkerdheadermapping-http-noheader\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8112},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8475}],\"selector\":{\"backend\":\"superpod-default\"}}}\n"
                     },
-                    "creationTimestamp": "2020-02-19T23:20:11Z",
+                    "creationTimestamp": "2020-02-26T15:51:58Z",
                     "labels": {
                         "kat-ambassador-id": "linkerdheadermapping",
                         "scope": "AmbassadorTest"
                     },
                     "name": "linkerdheadermapping-http-noheader",
                     "namespace": "default",
-                    "resourceVersion": "56027",
+                    "resourceVersion": "66743",
                     "selfLink": "/api/v1/namespaces/default/services/linkerdheadermapping-http-noheader",
-                    "uid": "6090153b-536e-11ea-85dd-167682b5c255"
+                    "uid": "ebeb9322-58af-11ea-86d6-0e674b3ff44f"
                 },
                 "spec": {
-                    "clusterIP": "10.107.17.220",
+                    "clusterIP": "10.111.74.102",
                     "ports": [
                         {
                             "name": "http",
@@ -225,6 +91,140 @@
                             "port": 443,
                             "protocol": "TCP",
                             "targetPort": 8475
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-default"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Module\nname: ambassador\nconfig:\n  add_linkerd_headers: true\nambassador_id: linkerdheadermapping\n---\napiVersion: ambassador/v1\nkind: Mapping\nname: linkerdheadermapping-http-addlinkerdonly\nprefix: /target_add_linkerd_header_only/\nservice: linkerdheadermapping-http-addlinkerdonly\nambassador_id: linkerdheadermapping\n---\napiVersion: ambassador/v1\nkind: Mapping\nname: linkerdheadermapping-http-noheader\nprefix: /target_no_header/\nservice: linkerdheadermapping-http-noheader\nadd_linkerd_headers: false\nadd_request_headers:\n  fruit:\n    append: False\n    value: orange\nambassador_id: linkerdheadermapping\n---\napiVersion: ambassador/v1\nkind: Mapping\nname: linkerdheadermapping-http\nprefix: /target/\nservice: linkerdheadermapping-http\nadd_request_headers:\n  fruit:\n    append: False\n    value: banana\nambassador_id: linkerdheadermapping\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Module\\nname: ambassador\\nconfig:\\n  add_linkerd_headers: true\\nambassador_id: linkerdheadermapping\\n---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: linkerdheadermapping-http-addlinkerdonly\\nprefix: /target_add_linkerd_header_only/\\nservice: linkerdheadermapping-http-addlinkerdonly\\nambassador_id: linkerdheadermapping\\n---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: linkerdheadermapping-http-noheader\\nprefix: /target_no_header/\\nservice: linkerdheadermapping-http-noheader\\nadd_linkerd_headers: false\\nadd_request_headers:\\n  fruit:\\n    append: False\\n    value: orange\\nambassador_id: linkerdheadermapping\\n---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: linkerdheadermapping-http\\nprefix: /target/\\nservice: linkerdheadermapping-http\\nadd_request_headers:\\n  fruit:\\n    append: False\\n    value: banana\\nambassador_id: linkerdheadermapping\\n\"},\"labels\":{\"app.kubernetes.io/component\":\"ambassador-service\",\"kat-ambassador-id\":\"linkerdheadermapping\",\"scope\":\"AmbassadorTest\"},\"name\":\"linkerdheadermapping\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8080},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8443}],\"selector\":{\"service\":\"linkerdheadermapping\"},\"type\":\"NodePort\"}}\n"
+                    },
+                    "creationTimestamp": "2020-02-26T15:51:58Z",
+                    "labels": {
+                        "app.kubernetes.io/component": "ambassador-service",
+                        "kat-ambassador-id": "linkerdheadermapping",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "linkerdheadermapping",
+                    "namespace": "default",
+                    "resourceVersion": "66728",
+                    "selfLink": "/api/v1/namespaces/default/services/linkerdheadermapping",
+                    "uid": "ebab12dc-58af-11ea-86d6-0e674b3ff44f"
+                },
+                "spec": {
+                    "clusterIP": "10.106.105.72",
+                    "externalTrafficPolicy": "Cluster",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "nodePort": 31988,
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8080
+                        },
+                        {
+                            "name": "https",
+                            "nodePort": 30635,
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8443
+                        }
+                    ],
+                    "selector": {
+                        "service": "linkerdheadermapping"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "NodePort"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"linkerdheadermapping\",\"scope\":\"AmbassadorTest\",\"service\":\"linkerdheadermapping-admin\"},\"name\":\"linkerdheadermapping-admin\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"linkerdheadermapping-admin\",\"port\":8877,\"targetPort\":8877}],\"selector\":{\"service\":\"linkerdheadermapping\"},\"type\":\"NodePort\"}}\n"
+                    },
+                    "creationTimestamp": "2020-02-26T15:51:58Z",
+                    "labels": {
+                        "kat-ambassador-id": "linkerdheadermapping",
+                        "scope": "AmbassadorTest",
+                        "service": "linkerdheadermapping-admin"
+                    },
+                    "name": "linkerdheadermapping-admin",
+                    "namespace": "default",
+                    "resourceVersion": "66733",
+                    "selfLink": "/api/v1/namespaces/default/services/linkerdheadermapping-admin",
+                    "uid": "ebc3cfdc-58af-11ea-86d6-0e674b3ff44f"
+                },
+                "spec": {
+                    "clusterIP": "10.105.43.89",
+                    "externalTrafficPolicy": "Cluster",
+                    "ports": [
+                        {
+                            "name": "linkerdheadermapping-admin",
+                            "nodePort": 30849,
+                            "port": 8877,
+                            "protocol": "TCP",
+                            "targetPort": 8877
+                        }
+                    ],
+                    "selector": {
+                        "service": "linkerdheadermapping"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "NodePort"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"linkerdheadermapping\",\"scope\":\"AmbassadorTest\"},\"name\":\"linkerdheadermapping-http\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8111},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8474}],\"selector\":{\"backend\":\"superpod-default\"}}}\n"
+                    },
+                    "creationTimestamp": "2020-02-26T15:51:58Z",
+                    "labels": {
+                        "kat-ambassador-id": "linkerdheadermapping",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "linkerdheadermapping-http",
+                    "namespace": "default",
+                    "resourceVersion": "66740",
+                    "selfLink": "/api/v1/namespaces/default/services/linkerdheadermapping-http",
+                    "uid": "ebdc3011-58af-11ea-86d6-0e674b3ff44f"
+                },
+                "spec": {
+                    "clusterIP": "10.98.14.102",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8111
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8474
                         }
                     ],
                     "selector": {

--- a/python/tests/gold/logservicetest/snapshots/aconf.json
+++ b/python/tests/gold/logservicetest/snapshots/aconf.json
@@ -1,7 +1,7 @@
 {
     "_errors": {},
     "_notices": {
-        "logservicetest.default.2": [
+        "stenography.default.2": [
             "apiVersion ambassador/v0 is deprecated, consider upgrading"
         ]
     },
@@ -96,7 +96,7 @@
             "rkey": "k8s-stenography-default",
             "serialization": "ambassador_id: logservicetest\napiVersion: getambassador.io/v2\nendpoints: {}\nkind: Service\nmetadata_labels:\n  kat-ambassador-id: logservicetest\n  scope: AmbassadorTest\nname: stenography\nnamespace: default\n"
         },
-        "logservicetest.default.1": {
+        "stenography.default.1": {
             "_referenced_by": {},
             "ambassador_id": "logservicetest",
             "apiVersion": "getambassador.io/v1",
@@ -126,26 +126,24 @@
             "flush_interval_byte_size": 1,
             "flush_interval_time": 1,
             "kind": "LogService",
-            "location": "logservicetest.default.1",
+            "location": "stenography.default.1",
             "metadata_labels": {
-                "app.kubernetes.io/component": "ambassador-service",
                 "kat-ambassador-id": "logservicetest",
                 "scope": "AmbassadorTest"
             },
             "name": "custom-http-logging",
             "namespace": "default",
-            "rkey": "logservicetest.default.1",
-            "serialization": "ambassador_id: logservicetest\napiVersion: ambassador/v1\ndriver: http\ndriver_config:\n  additional_log_headers:\n  - header_name: included-on-all\n  - during_trailer: false\n    header_name: not-included-on-trailer\n  - during_response: false\n    during_trailer: false\n    header_name: not-included on resp-trail\n  - during_request: false\n    during_response: false\n    during_trailer: false\n    header_name: not-anywhere\nflush_interval_byte_size: 1\nflush_interval_time: 1\nkind: LogService\nmetadata_labels:\n  app.kubernetes.io/component: ambassador-service\n  kat-ambassador-id: logservicetest\n  scope: AmbassadorTest\nname: custom-http-logging\nnamespace: default\nservice: stenography:25565\n",
+            "rkey": "stenography.default.1",
+            "serialization": "ambassador_id: logservicetest\napiVersion: ambassador/v1\ndriver: http\ndriver_config:\n  additional_log_headers:\n  - header_name: included-on-all\n  - during_trailer: false\n    header_name: not-included-on-trailer\n  - during_response: false\n    during_trailer: false\n    header_name: not-included on resp-trail\n  - during_request: false\n    during_response: false\n    during_trailer: false\n    header_name: not-anywhere\nflush_interval_byte_size: 1\nflush_interval_time: 1\nkind: LogService\nmetadata_labels:\n  kat-ambassador-id: logservicetest\n  scope: AmbassadorTest\nname: custom-http-logging\nnamespace: default\nservice: stenography:25565\n",
             "service": "stenography:25565"
         },
-        "logservicetest.default.2": {
+        "stenography.default.2": {
             "_referenced_by": {},
             "ambassador_id": "logservicetest",
             "apiVersion": "getambassador.io/v0",
             "kind": "Mapping",
-            "location": "logservicetest.default.2",
+            "location": "stenography.default.2",
             "metadata_labels": {
-                "app.kubernetes.io/component": "ambassador-service",
                 "kat-ambassador-id": "logservicetest",
                 "scope": "AmbassadorTest"
             },
@@ -153,8 +151,8 @@
             "namespace": "default",
             "prefix": "/config_dump",
             "rewrite": "/config_dump",
-            "rkey": "logservicetest.default.2",
-            "serialization": "ambassador_id: logservicetest\napiVersion: ambassador/v0\nkind: Mapping\nmetadata_labels:\n  app.kubernetes.io/component: ambassador-service\n  kat-ambassador-id: logservicetest\n  scope: AmbassadorTest\nname: config__dump\nnamespace: default\nprefix: /config_dump\nrewrite: /config_dump\nservice: http://127.0.0.1:8001\n",
+            "rkey": "stenography.default.2",
+            "serialization": "ambassador_id: logservicetest\napiVersion: ambassador/v0\nkind: Mapping\nmetadata_labels:\n  kat-ambassador-id: logservicetest\n  scope: AmbassadorTest\nname: config__dump\nnamespace: default\nprefix: /config_dump\nrewrite: /config_dump\nservice: http://127.0.0.1:8001\n",
             "service": "http://127.0.0.1:8001"
         }
     },
@@ -189,7 +187,6 @@
             "flush_interval_time": 1,
             "kind": "LogService",
             "metadata_labels": {
-                "app.kubernetes.io/component": "ambassador-service",
                 "kat-ambassador-id": "logservicetest",
                 "scope": "AmbassadorTest"
             },
@@ -204,7 +201,6 @@
             "apiVersion": "getambassador.io/v0",
             "kind": "Mapping",
             "metadata_labels": {
-                "app.kubernetes.io/component": "ambassador-service",
                 "kat-ambassador-id": "logservicetest",
                 "scope": "AmbassadorTest"
             },

--- a/python/tests/gold/logservicetest/snapshots/econf.json
+++ b/python/tests/gold/logservicetest/snapshots/econf.json
@@ -356,8 +356,7 @@
                                     "xff_num_trusted_hops": 0
                                 }
                             }
-                        ],
-                        "use_proxy_proto": false
+                        ]
                     }
                 ],
                 "listener_filters": [],

--- a/python/tests/gold/logservicetest/snapshots/ir.json
+++ b/python/tests/gold/logservicetest/snapshots/ir.json
@@ -88,7 +88,7 @@
             "_namespace": "default",
             "_port": 8001,
             "_referenced_by": [
-                "logservicetest.default.2"
+                "stenography.default.2"
             ],
             "_resolver": "kubernetes-service",
             "_rkey": "cluster_http___127_0_0_1_8001_default",
@@ -99,7 +99,7 @@
             "ignore_cluster": false,
             "kind": "IRCluster",
             "lb_type": "round_robin",
-            "location": "logservicetest.default.2",
+            "location": "stenography.default.2",
             "name": "cluster_http___127_0_0_1_8001_default",
             "namespace": "default",
             "service": "127.0.0.1:8001",
@@ -123,7 +123,7 @@
             "_namespace": "default",
             "_port": 25565,
             "_referenced_by": [
-                "logservicetest.default.1"
+                "stenography.default.1"
             ],
             "_rkey": "cluster_logging_stenography_25565_default",
             "connect_timeout_ms": 3000,
@@ -133,7 +133,7 @@
             "ignore_cluster": false,
             "kind": "IRCluster",
             "lb_type": "round_robin",
-            "location": "logservicetest.default.1",
+            "location": "stenography.default.1",
             "name": "cluster_logging_stenography_25565_default",
             "namespace": "default",
             "service": "stenography:25565",
@@ -451,9 +451,9 @@
             "_active": true,
             "_errored": false,
             "_referenced_by": [
-                "logservicetest.default.2"
+                "stenography.default.2"
             ],
-            "_rkey": "logservicetest.default.2",
+            "_rkey": "stenography.default.2",
             "group_id": "2cc88963a98f4f1bd9ddf846f8fe7bf145757e1c",
             "group_weight": [
                 0,
@@ -464,12 +464,12 @@
             ],
             "headers": [],
             "kind": "IRHTTPMappingGroup",
-            "location": "logservicetest.default.2",
+            "location": "stenography.default.2",
             "mappings": [
                 {
                     "_active": true,
                     "_errored": false,
-                    "_rkey": "logservicetest.default.2",
+                    "_rkey": "stenography.default.2",
                     "add_request_headers": {},
                     "cluster": {
                         "_active": true,
@@ -479,7 +479,7 @@
                         "_namespace": "default",
                         "_port": 8001,
                         "_referenced_by": [
-                            "logservicetest.default.2"
+                            "stenography.default.2"
                         ],
                         "_resolver": "kubernetes-service",
                         "_rkey": "cluster_http___127_0_0_1_8001_default",
@@ -490,7 +490,7 @@
                         "ignore_cluster": false,
                         "kind": "IRCluster",
                         "lb_type": "round_robin",
-                        "location": "logservicetest.default.2",
+                        "location": "stenography.default.2",
                         "name": "cluster_http___127_0_0_1_8001_default",
                         "namespace": "default",
                         "service": "127.0.0.1:8001",
@@ -509,9 +509,8 @@
                     "group_id": "2cc88963a98f4f1bd9ddf846f8fe7bf145757e1c",
                     "headers": [],
                     "kind": "Mapping",
-                    "location": "logservicetest.default.2",
+                    "location": "stenography.default.2",
                     "metadata_labels": {
-                        "app.kubernetes.io/component": "ambassador-service",
                         "kat-ambassador-id": "logservicetest",
                         "scope": "AmbassadorTest"
                     },
@@ -528,13 +527,12 @@
                         "/config_dump",
                         "GET"
                     ],
-                    "serialization": "ambassador_id: logservicetest\napiVersion: ambassador/v0\nkind: Mapping\nmetadata_labels:\n  app.kubernetes.io/component: ambassador-service\n  kat-ambassador-id: logservicetest\n  scope: AmbassadorTest\nname: config__dump\nnamespace: default\nprefix: /config_dump\nrewrite: /config_dump\nservice: http://127.0.0.1:8001\n",
+                    "serialization": "ambassador_id: logservicetest\napiVersion: ambassador/v0\nkind: Mapping\nmetadata_labels:\n  kat-ambassador-id: logservicetest\n  scope: AmbassadorTest\nname: config__dump\nnamespace: default\nprefix: /config_dump\nrewrite: /config_dump\nservice: http://127.0.0.1:8001\n",
                     "service": "http://127.0.0.1:8001",
                     "weight": 100
                 }
             ],
             "metadata_labels": {
-                "app.kubernetes.io/component": "ambassador-service",
                 "kat-ambassador-id": "logservicetest",
                 "scope": "AmbassadorTest"
             },
@@ -543,7 +541,7 @@
             "precedence": 0,
             "prefix": "/config_dump",
             "rewrite": "/config_dump",
-            "serialization": "ambassador_id: logservicetest\napiVersion: ambassador/v0\nkind: Mapping\nmetadata_labels:\n  app.kubernetes.io/component: ambassador-service\n  kat-ambassador-id: logservicetest\n  scope: AmbassadorTest\nname: config__dump\nnamespace: default\nprefix: /config_dump\nrewrite: /config_dump\nservice: http://127.0.0.1:8001\n"
+            "serialization": "ambassador_id: logservicetest\napiVersion: ambassador/v0\nkind: Mapping\nmetadata_labels:\n  kat-ambassador-id: logservicetest\n  scope: AmbassadorTest\nname: config__dump\nnamespace: default\nprefix: /config_dump\nrewrite: /config_dump\nservice: http://127.0.0.1:8001\n"
         }
     ],
     "grpc_services": {},
@@ -576,9 +574,9 @@
             "_active": true,
             "_errored": false,
             "_referenced_by": [
-                "logservicetest.default.1"
+                "stenography.default.1"
             ],
-            "_rkey": "logservicetest.default.1",
+            "_rkey": "stenography.default.1",
             "cluster": {
                 "_active": true,
                 "_errored": false,
@@ -587,7 +585,7 @@
                 "_namespace": "default",
                 "_port": 25565,
                 "_referenced_by": [
-                    "logservicetest.default.1"
+                    "stenography.default.1"
                 ],
                 "_rkey": "cluster_logging_stenography_25565_default",
                 "connect_timeout_ms": 3000,
@@ -597,7 +595,7 @@
                 "ignore_cluster": false,
                 "kind": "IRCluster",
                 "lb_type": "round_robin",
-                "location": "logservicetest.default.1",
+                "location": "stenography.default.1",
                 "name": "cluster_logging_stenography_25565_default",
                 "namespace": "default",
                 "service": "stenography:25565",
@@ -640,7 +638,7 @@
             "flush_interval_time": 1,
             "grpc": false,
             "kind": "ir.logservice",
-            "location": "logservicetest.default.1",
+            "location": "stenography.default.1",
             "name": "logservice",
             "namespace": "default",
             "service": "stenography:25565"

--- a/python/tests/gold/logservicetest/snapshots/snapshot.yaml
+++ b/python/tests/gold/logservicetest/snapshots/snapshot.yaml
@@ -20,118 +20,21 @@
                 "kind": "Service",
                 "metadata": {
                     "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: LogService\nname: custom-http-logging\nservice: stenography:25565\ndriver: http\ndriver_config:\n  additional_log_headers:\n  - header_name: \"included-on-all\"\n  - header_name: \"not-included-on-trailer\"\n    during_trailer: false\n  - header_name: \"not-included on resp-trail\"\n    during_trailer: false\n    during_response: false\n  - header_name: \"not-anywhere\"\n    during_trailer: false\n    during_response: false\n    during_request: false\nflush_interval_time: 1\nflush_interval_byte_size: 1\nambassador_id: logservicetest\n\n---\napiVersion: ambassador/v0\nkind: Mapping\nname: config__dump\nprefix: /config_dump\nrewrite: /config_dump\nservice: http://127.0.0.1:8001\nambassador_id: logservicetest\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: LogService\\nname: custom-http-logging\\nservice: stenography:25565\\ndriver: http\\ndriver_config:\\n  additional_log_headers:\\n  - header_name: \\\"included-on-all\\\"\\n  - header_name: \\\"not-included-on-trailer\\\"\\n    during_trailer: false\\n  - header_name: \\\"not-included on resp-trail\\\"\\n    during_trailer: false\\n    during_response: false\\n  - header_name: \\\"not-anywhere\\\"\\n    during_trailer: false\\n    during_response: false\\n    during_request: false\\nflush_interval_time: 1\\nflush_interval_byte_size: 1\\nambassador_id: logservicetest\\n\\n---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: config__dump\\nprefix: /config_dump\\nrewrite: /config_dump\\nservice: http://127.0.0.1:8001\\nambassador_id: logservicetest\\n\"},\"labels\":{\"app.kubernetes.io/component\":\"ambassador-service\",\"kat-ambassador-id\":\"logservicetest\",\"scope\":\"AmbassadorTest\"},\"name\":\"logservicetest\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8080},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8443},{\"name\":\"extra-25565\",\"port\":25565,\"protocol\":\"TCP\",\"targetPort\":25565}],\"selector\":{\"service\":\"logservicetest\"},\"type\":\"NodePort\"}}\n"
-                    },
-                    "creationTimestamp": "2020-02-19T23:20:10Z",
-                    "labels": {
-                        "app.kubernetes.io/component": "ambassador-service",
-                        "kat-ambassador-id": "logservicetest",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "logservicetest",
-                    "namespace": "default",
-                    "resourceVersion": "55947",
-                    "selfLink": "/api/v1/namespaces/default/services/logservicetest",
-                    "uid": "5fd5f1bf-536e-11ea-85dd-167682b5c255"
-                },
-                "spec": {
-                    "clusterIP": "10.107.80.160",
-                    "externalTrafficPolicy": "Cluster",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "nodePort": 30536,
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8080
-                        },
-                        {
-                            "name": "https",
-                            "nodePort": 30380,
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8443
-                        },
-                        {
-                            "name": "extra-25565",
-                            "nodePort": 31241,
-                            "port": 25565,
-                            "protocol": "TCP",
-                            "targetPort": 25565
-                        }
-                    ],
-                    "selector": {
-                        "service": "logservicetest"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "NodePort"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"logservicetest\",\"scope\":\"AmbassadorTest\",\"service\":\"logservicetest-admin\"},\"name\":\"logservicetest-admin\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"logservicetest-admin\",\"port\":8877,\"targetPort\":8877}],\"selector\":{\"service\":\"logservicetest\"},\"type\":\"NodePort\"}}\n"
-                    },
-                    "creationTimestamp": "2020-02-19T23:20:10Z",
-                    "labels": {
-                        "kat-ambassador-id": "logservicetest",
-                        "scope": "AmbassadorTest",
-                        "service": "logservicetest-admin"
-                    },
-                    "name": "logservicetest-admin",
-                    "namespace": "default",
-                    "resourceVersion": "55953",
-                    "selfLink": "/api/v1/namespaces/default/services/logservicetest-admin",
-                    "uid": "5fe33488-536e-11ea-85dd-167682b5c255"
-                },
-                "spec": {
-                    "clusterIP": "10.98.65.175",
-                    "externalTrafficPolicy": "Cluster",
-                    "ports": [
-                        {
-                            "name": "logservicetest-admin",
-                            "nodePort": 30826,
-                            "port": 8877,
-                            "protocol": "TCP",
-                            "targetPort": 8877
-                        }
-                    ],
-                    "selector": {
-                        "service": "logservicetest"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "NodePort"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"logservicetest\",\"scope\":\"AmbassadorTest\"},\"name\":\"logservicetest-http\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8109},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8472}],\"selector\":{\"backend\":\"superpod-default\"}}}\n"
                     },
-                    "creationTimestamp": "2020-02-19T23:20:11Z",
+                    "creationTimestamp": "2020-02-26T15:51:56Z",
                     "labels": {
                         "kat-ambassador-id": "logservicetest",
                         "scope": "AmbassadorTest"
                     },
                     "name": "logservicetest-http",
                     "namespace": "default",
-                    "resourceVersion": "55976",
+                    "resourceVersion": "66680",
                     "selfLink": "/api/v1/namespaces/default/services/logservicetest-http",
-                    "uid": "6004574b-536e-11ea-85dd-167682b5c255"
+                    "uid": "ea66e272-58af-11ea-86d6-0e674b3ff44f"
                 },
                 "spec": {
-                    "clusterIP": "10.101.40.156",
+                    "clusterIP": "10.107.247.15",
                     "ports": [
                         {
                             "name": "http",
@@ -161,26 +64,27 @@
                 "kind": "Service",
                 "metadata": {
                     "annotations": {
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"logservicetest\",\"scope\":\"AmbassadorTest\"},\"name\":\"stenography\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":25565,\"targetPort\":\"http\"}],\"selector\":{\"app\":\"stenography\"},\"type\":\"NodePort\"}}\n"
+                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: LogService\nname: custom-http-logging\nservice: stenography:25565\ndriver: http\ndriver_config:\n  additional_log_headers:\n  - header_name: \"included-on-all\"\n  - header_name: \"not-included-on-trailer\"\n    during_trailer: false\n  - header_name: \"not-included on resp-trail\"\n    during_trailer: false\n    during_response: false\n  - header_name: \"not-anywhere\"\n    during_trailer: false\n    during_response: false\n    during_request: false\nflush_interval_time: 1\nflush_interval_byte_size: 1\nambassador_id: logservicetest\n\n---\napiVersion: ambassador/v0\nkind: Mapping\nname: config__dump\nprefix: /config_dump\nrewrite: /config_dump\nservice: http://127.0.0.1:8001\nambassador_id: logservicetest\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: LogService\\nname: custom-http-logging\\nservice: stenography:25565\\ndriver: http\\ndriver_config:\\n  additional_log_headers:\\n  - header_name: \\\"included-on-all\\\"\\n  - header_name: \\\"not-included-on-trailer\\\"\\n    during_trailer: false\\n  - header_name: \\\"not-included on resp-trail\\\"\\n    during_trailer: false\\n    during_response: false\\n  - header_name: \\\"not-anywhere\\\"\\n    during_trailer: false\\n    during_response: false\\n    during_request: false\\nflush_interval_time: 1\\nflush_interval_byte_size: 1\\nambassador_id: logservicetest\\n\\n---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: config__dump\\nprefix: /config_dump\\nrewrite: /config_dump\\nservice: http://127.0.0.1:8001\\nambassador_id: logservicetest\\n\"},\"labels\":{\"kat-ambassador-id\":\"logservicetest\",\"scope\":\"AmbassadorTest\"},\"name\":\"stenography\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":25565,\"targetPort\":\"http\"}],\"selector\":{\"app\":\"stenography\"},\"type\":\"NodePort\"}}\n"
                     },
-                    "creationTimestamp": "2020-02-19T23:20:10Z",
+                    "creationTimestamp": "2020-02-26T15:51:55Z",
                     "labels": {
                         "kat-ambassador-id": "logservicetest",
                         "scope": "AmbassadorTest"
                     },
                     "name": "stenography",
                     "namespace": "default",
-                    "resourceVersion": "55960",
+                    "resourceVersion": "66642",
                     "selfLink": "/api/v1/namespaces/default/services/stenography",
-                    "uid": "5ff29381-536e-11ea-85dd-167682b5c255"
+                    "uid": "e9f22ce3-58af-11ea-86d6-0e674b3ff44f"
                 },
                 "spec": {
-                    "clusterIP": "10.104.224.112",
+                    "clusterIP": "10.111.219.58",
                     "externalTrafficPolicy": "Cluster",
                     "ports": [
                         {
                             "name": "http",
-                            "nodePort": 30131,
+                            "nodePort": 31985,
                             "port": 25565,
                             "protocol": "TCP",
                             "targetPort": "http"
@@ -188,6 +92,102 @@
                     ],
                     "selector": {
                         "app": "stenography"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "NodePort"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"app.kubernetes.io/component\":\"ambassador-service\",\"kat-ambassador-id\":\"logservicetest\",\"scope\":\"AmbassadorTest\"},\"name\":\"logservicetest\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8080},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8443},{\"name\":\"extra-25565\",\"port\":25565,\"protocol\":\"TCP\",\"targetPort\":25565}],\"selector\":{\"service\":\"logservicetest\"},\"type\":\"NodePort\"}}\n"
+                    },
+                    "creationTimestamp": "2020-02-26T15:51:56Z",
+                    "labels": {
+                        "app.kubernetes.io/component": "ambassador-service",
+                        "kat-ambassador-id": "logservicetest",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "logservicetest",
+                    "namespace": "default",
+                    "resourceVersion": "66667",
+                    "selfLink": "/api/v1/namespaces/default/services/logservicetest",
+                    "uid": "ea3f4ef2-58af-11ea-86d6-0e674b3ff44f"
+                },
+                "spec": {
+                    "clusterIP": "10.110.8.60",
+                    "externalTrafficPolicy": "Cluster",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "nodePort": 30667,
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8080
+                        },
+                        {
+                            "name": "https",
+                            "nodePort": 32708,
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8443
+                        },
+                        {
+                            "name": "extra-25565",
+                            "nodePort": 31169,
+                            "port": 25565,
+                            "protocol": "TCP",
+                            "targetPort": 25565
+                        }
+                    ],
+                    "selector": {
+                        "service": "logservicetest"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "NodePort"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"logservicetest\",\"scope\":\"AmbassadorTest\",\"service\":\"logservicetest-admin\"},\"name\":\"logservicetest-admin\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"logservicetest-admin\",\"port\":8877,\"targetPort\":8877}],\"selector\":{\"service\":\"logservicetest\"},\"type\":\"NodePort\"}}\n"
+                    },
+                    "creationTimestamp": "2020-02-26T15:51:56Z",
+                    "labels": {
+                        "kat-ambassador-id": "logservicetest",
+                        "scope": "AmbassadorTest",
+                        "service": "logservicetest-admin"
+                    },
+                    "name": "logservicetest-admin",
+                    "namespace": "default",
+                    "resourceVersion": "66672",
+                    "selfLink": "/api/v1/namespaces/default/services/logservicetest-admin",
+                    "uid": "ea4f654a-58af-11ea-86d6-0e674b3ff44f"
+                },
+                "spec": {
+                    "clusterIP": "10.110.118.12",
+                    "externalTrafficPolicy": "Cluster",
+                    "ports": [
+                        {
+                            "name": "logservicetest-admin",
+                            "nodePort": 32624,
+                            "port": 8877,
+                            "protocol": "TCP",
+                            "targetPort": 8877
+                        }
+                    ],
+                    "selector": {
+                        "service": "logservicetest"
                     },
                     "sessionAffinity": "None",
                     "type": "NodePort"

--- a/python/tests/gold/plain/snapshots/aconf.json
+++ b/python/tests/gold/plain/snapshots/aconf.json
@@ -5,25 +5,25 @@
                 "error": "Ambassador could not find core CRD definitions. Please visit https://www.getambassador.io/reference/core/crds/ for more information. You can continue using Ambassador via Kubernetes annotations, any configuration via CRDs will be ignored...",
                 "hostname": "plain",
                 "ok": false,
-                "version": "1.1.1-161-g310bb7bf0"
+                "version": "1.2.0-4-g8f507fdcf-dirty"
             },
             {
                 "error": "Ambassador could not find Resolver type CRD definitions. Please visit https://www.getambassador.io/reference/core/crds/ for more information. You can continue using Ambassador via Kubernetes annotations, any configuration via CRDs will be ignored...",
                 "hostname": "plain",
                 "ok": false,
-                "version": "1.1.1-161-g310bb7bf0"
+                "version": "1.2.0-4-g8f507fdcf-dirty"
             },
             {
                 "error": "Ambassador could not find the Host CRD definition. Please visit https://www.getambassador.io/reference/core/crds/ for more information. You can continue using Ambassador via Kubernetes annotations, any configuration via CRDs will be ignored...",
                 "hostname": "plain",
                 "ok": false,
-                "version": "1.1.1-161-g310bb7bf0"
+                "version": "1.2.0-4-g8f507fdcf-dirty"
             },
             {
                 "error": "Ambassador could not find the LogService CRD definition. Please visit https://www.getambassador.io/reference/core/crds/ for more information. You can continue using Ambassador via Kubernetes annotations, any configuration via CRDs will be ignored...",
                 "hostname": "plain",
                 "ok": false,
-                "version": "1.1.1-161-g310bb7bf0"
+                "version": "1.2.0-4-g8f507fdcf-dirty"
             }
         ]
     },

--- a/python/tests/gold/plain/snapshots/econf.json
+++ b/python/tests/gold/plain/snapshots/econf.json
@@ -8114,8 +8114,7 @@
                                     "xff_num_trusted_hops": 0
                                 }
                             }
-                        ],
-                        "use_proxy_proto": false
+                        ]
                     }
                 ],
                 "listener_filters": [],

--- a/python/tests/gold/plain/snapshots/snapshot.yaml
+++ b/python/tests/gold/plain/snapshots/snapshot.yaml
@@ -8,94 +8,10 @@
                 "metadata": {
                     "annotations": {
                         "getambassador.io/ambassador-id": "plain",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"extensions/v1beta1\",\"kind\":\"Ingress\",\"metadata\":{\"annotations\":{\"getambassador.io/ambassador-id\":\"plain\",\"kubernetes.io/ingress.class\":\"ambassador\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"simplemappingingress-grpc\",\"namespace\":\"plain-namespace\"},\"spec\":{\"rules\":[{\"http\":{\"paths\":[{\"backend\":{\"serviceName\":\"plain-simplemappingingress-grpc-grpc\",\"servicePort\":80},\"path\":\"/SimpleMappingIngress-GRPC/\"}]}}]}}\n",
-                        "kubernetes.io/ingress.class": "ambassador"
-                    },
-                    "creationTimestamp": "2020-02-19T23:20:17Z",
-                    "generation": 1,
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "simplemappingingress-grpc",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "56273",
-                    "selfLink": "/apis/extensions/v1beta1/namespaces/plain-namespace/ingresses/simplemappingingress-grpc",
-                    "uid": "6390f182-536e-11ea-85dd-167682b5c255"
-                },
-                "spec": {
-                    "rules": [
-                        {
-                            "http": {
-                                "paths": [
-                                    {
-                                        "backend": {
-                                            "serviceName": "plain-simplemappingingress-grpc-grpc",
-                                            "servicePort": 80
-                                        },
-                                        "path": "/SimpleMappingIngress-GRPC/"
-                                    }
-                                ]
-                            }
-                        }
-                    ]
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "extensions/v1beta1",
-                "kind": "Ingress",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/ambassador-id": "plain",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"extensions/v1beta1\",\"kind\":\"Ingress\",\"metadata\":{\"annotations\":{\"getambassador.io/ambassador-id\":\"plain\",\"kubernetes.io/ingress.class\":\"ambassador\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"simplemappingingress-http\",\"namespace\":\"plain-namespace\"},\"spec\":{\"rules\":[{\"http\":{\"paths\":[{\"backend\":{\"serviceName\":\"plain-simplemappingingress-http-http\",\"servicePort\":80},\"path\":\"/SimpleMappingIngress-HTTP/\"}]}}]}}\n",
-                        "kubernetes.io/ingress.class": "ambassador"
-                    },
-                    "creationTimestamp": "2020-02-19T23:20:16Z",
-                    "generation": 1,
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "simplemappingingress-http",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "56269",
-                    "selfLink": "/apis/extensions/v1beta1/namespaces/plain-namespace/ingresses/simplemappingingress-http",
-                    "uid": "637f2cef-536e-11ea-85dd-167682b5c255"
-                },
-                "spec": {
-                    "rules": [
-                        {
-                            "http": {
-                                "paths": [
-                                    {
-                                        "backend": {
-                                            "serviceName": "plain-simplemappingingress-http-http",
-                                            "servicePort": 80
-                                        },
-                                        "path": "/SimpleMappingIngress-HTTP/"
-                                    }
-                                ]
-                            }
-                        }
-                    ]
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "extensions/v1beta1",
-                "kind": "Ingress",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/ambassador-id": "plain",
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"extensions/v1beta1\",\"kind\":\"Ingress\",\"metadata\":{\"annotations\":{\"getambassador.io/ambassador-id\":\"plain\",\"kubernetes.io/ingress.class\":\"ambassador\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"hostheadermappingingress-grpc\",\"namespace\":\"plain-namespace\"},\"spec\":{\"rules\":[{\"host\":\"inspector.external\",\"http\":{\"paths\":[{\"backend\":{\"serviceName\":\"plain-hostheadermappingingress-grpc-grpc\",\"servicePort\":80},\"path\":\"/HostHeaderMappingIngress-GRPC/\"}]}}]}}\n",
                         "kubernetes.io/ingress.class": "ambassador"
                     },
-                    "creationTimestamp": "2020-02-19T23:20:17Z",
+                    "creationTimestamp": "2020-02-26T15:52:20Z",
                     "generation": 1,
                     "labels": {
                         "kat-ambassador-id": "plain",
@@ -103,9 +19,9 @@
                     },
                     "name": "hostheadermappingingress-grpc",
                     "namespace": "plain-namespace",
-                    "resourceVersion": "56295",
+                    "resourceVersion": "67136",
                     "selfLink": "/apis/extensions/v1beta1/namespaces/plain-namespace/ingresses/hostheadermappingingress-grpc",
-                    "uid": "63dd66e8-536e-11ea-85dd-167682b5c255"
+                    "uid": "f914d580-58af-11ea-86d6-0e674b3ff44f"
                 },
                 "spec": {
                     "rules": [
@@ -138,7 +54,7 @@
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"extensions/v1beta1\",\"kind\":\"Ingress\",\"metadata\":{\"annotations\":{\"getambassador.io/ambassador-id\":\"plain\",\"kubernetes.io/ingress.class\":\"ambassador\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"hostheadermappingingress-http\",\"namespace\":\"plain-namespace\"},\"spec\":{\"rules\":[{\"host\":\"inspector.external\",\"http\":{\"paths\":[{\"backend\":{\"serviceName\":\"plain-hostheadermappingingress-http-http\",\"servicePort\":80},\"path\":\"/HostHeaderMappingIngress-HTTP/\"}]}}]}}\n",
                         "kubernetes.io/ingress.class": "ambassador"
                     },
-                    "creationTimestamp": "2020-02-19T23:20:17Z",
+                    "creationTimestamp": "2020-02-26T15:52:20Z",
                     "generation": 1,
                     "labels": {
                         "kat-ambassador-id": "plain",
@@ -146,9 +62,9 @@
                     },
                     "name": "hostheadermappingingress-http",
                     "namespace": "plain-namespace",
-                    "resourceVersion": "56289",
+                    "resourceVersion": "67127",
                     "selfLink": "/apis/extensions/v1beta1/namespaces/plain-namespace/ingresses/hostheadermappingingress-http",
-                    "uid": "63ca0e8d-536e-11ea-85dd-167682b5c255"
+                    "uid": "f8d66ea8-58af-11ea-86d6-0e674b3ff44f"
                 },
                 "spec": {
                     "rules": [
@@ -182,7 +98,7 @@
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"extensions/v1beta1\",\"kind\":\"Ingress\",\"metadata\":{\"annotations\":{\"getambassador.io/ambassador-id\":\"plain\",\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind:  Mapping\\nname:  SimpleIngressWithAnnotations-GRPC-nested\\nprefix: /SimpleIngressWithAnnotations-GRPC-nested/\\nservice: http://plain-simpleingresswithannotations-grpc-grpc.plain-namespace\\nambassador_id: plain\\n\",\"kubernetes.io/ingress.class\":\"ambassador\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"simpleingresswithannotations-grpc\",\"namespace\":\"plain-namespace\"},\"spec\":{\"rules\":[{\"http\":{\"paths\":[{\"backend\":{\"serviceName\":\"plain-simpleingresswithannotations-grpc-grpc\",\"servicePort\":80},\"path\":\"/SimpleIngressWithAnnotations-GRPC/\"}]}}]}}\n",
                         "kubernetes.io/ingress.class": "ambassador"
                     },
-                    "creationTimestamp": "2020-02-19T23:20:17Z",
+                    "creationTimestamp": "2020-02-26T15:52:19Z",
                     "generation": 1,
                     "labels": {
                         "kat-ambassador-id": "plain",
@@ -190,9 +106,9 @@
                     },
                     "name": "simpleingresswithannotations-grpc",
                     "namespace": "plain-namespace",
-                    "resourceVersion": "56285",
+                    "resourceVersion": "67116",
                     "selfLink": "/apis/extensions/v1beta1/namespaces/plain-namespace/ingresses/simpleingresswithannotations-grpc",
-                    "uid": "63b5a7c4-536e-11ea-85dd-167682b5c255"
+                    "uid": "f856562b-58af-11ea-86d6-0e674b3ff44f"
                 },
                 "spec": {
                     "rules": [
@@ -225,7 +141,7 @@
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"extensions/v1beta1\",\"kind\":\"Ingress\",\"metadata\":{\"annotations\":{\"getambassador.io/ambassador-id\":\"plain\",\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind:  Mapping\\nname:  SimpleIngressWithAnnotations-HTTP-nested\\nprefix: /SimpleIngressWithAnnotations-HTTP-nested/\\nservice: http://plain-simpleingresswithannotations-http-http.plain-namespace\\nambassador_id: plain\\n\",\"kubernetes.io/ingress.class\":\"ambassador\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"simpleingresswithannotations-http\",\"namespace\":\"plain-namespace\"},\"spec\":{\"rules\":[{\"http\":{\"paths\":[{\"backend\":{\"serviceName\":\"plain-simpleingresswithannotations-http-http\",\"servicePort\":80},\"path\":\"/SimpleIngressWithAnnotations-HTTP/\"}]}}]}}\n",
                         "kubernetes.io/ingress.class": "ambassador"
                     },
-                    "creationTimestamp": "2020-02-19T23:20:17Z",
+                    "creationTimestamp": "2020-02-26T15:52:18Z",
                     "generation": 1,
                     "labels": {
                         "kat-ambassador-id": "plain",
@@ -233,9 +149,9 @@
                     },
                     "name": "simpleingresswithannotations-http",
                     "namespace": "plain-namespace",
-                    "resourceVersion": "56279",
+                    "resourceVersion": "67104",
                     "selfLink": "/apis/extensions/v1beta1/namespaces/plain-namespace/ingresses/simpleingresswithannotations-http",
-                    "uid": "63a38602-536e-11ea-85dd-167682b5c255"
+                    "uid": "f7d8125f-58af-11ea-86d6-0e674b3ff44f"
                 },
                 "spec": {
                     "rules": [
@@ -257,6 +173,90 @@
                 "status": {
                     "loadBalancer": {}
                 }
+            },
+            {
+                "apiVersion": "extensions/v1beta1",
+                "kind": "Ingress",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/ambassador-id": "plain",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"extensions/v1beta1\",\"kind\":\"Ingress\",\"metadata\":{\"annotations\":{\"getambassador.io/ambassador-id\":\"plain\",\"kubernetes.io/ingress.class\":\"ambassador\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"simplemappingingress-grpc\",\"namespace\":\"plain-namespace\"},\"spec\":{\"rules\":[{\"http\":{\"paths\":[{\"backend\":{\"serviceName\":\"plain-simplemappingingress-grpc-grpc\",\"servicePort\":80},\"path\":\"/SimpleMappingIngress-GRPC/\"}]}}]}}\n",
+                        "kubernetes.io/ingress.class": "ambassador"
+                    },
+                    "creationTimestamp": "2020-02-26T15:52:17Z",
+                    "generation": 1,
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "simplemappingingress-grpc",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "67091",
+                    "selfLink": "/apis/extensions/v1beta1/namespaces/plain-namespace/ingresses/simplemappingingress-grpc",
+                    "uid": "f73f68af-58af-11ea-86d6-0e674b3ff44f"
+                },
+                "spec": {
+                    "rules": [
+                        {
+                            "http": {
+                                "paths": [
+                                    {
+                                        "backend": {
+                                            "serviceName": "plain-simplemappingingress-grpc-grpc",
+                                            "servicePort": 80
+                                        },
+                                        "path": "/SimpleMappingIngress-GRPC/"
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "extensions/v1beta1",
+                "kind": "Ingress",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/ambassador-id": "plain",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"extensions/v1beta1\",\"kind\":\"Ingress\",\"metadata\":{\"annotations\":{\"getambassador.io/ambassador-id\":\"plain\",\"kubernetes.io/ingress.class\":\"ambassador\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"simplemappingingress-http\",\"namespace\":\"plain-namespace\"},\"spec\":{\"rules\":[{\"http\":{\"paths\":[{\"backend\":{\"serviceName\":\"plain-simplemappingingress-http-http\",\"servicePort\":80},\"path\":\"/SimpleMappingIngress-HTTP/\"}]}}]}}\n",
+                        "kubernetes.io/ingress.class": "ambassador"
+                    },
+                    "creationTimestamp": "2020-02-26T15:52:16Z",
+                    "generation": 1,
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "simplemappingingress-http",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "67081",
+                    "selfLink": "/apis/extensions/v1beta1/namespaces/plain-namespace/ingresses/simplemappingingress-http",
+                    "uid": "f67b370c-58af-11ea-86d6-0e674b3ff44f"
+                },
+                "spec": {
+                    "rules": [
+                        {
+                            "http": {
+                                "paths": [
+                                    {
+                                        "backend": {
+                                            "serviceName": "plain-simplemappingingress-http-http",
+                                            "servicePort": 80
+                                        },
+                                        "path": "/SimpleMappingIngress-HTTP/"
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
             }
         ],
         "service": [
@@ -265,3889 +265,22 @@
                 "kind": "Service",
                 "metadata": {
                     "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: CanaryDiffMapping-GRPC-50\nprefix: /CanaryDiffMapping-GRPC-50/\nservice: http://plain-canarydiffmapping-grpc-50-grpc.plain-namespace\nhost_rewrite: canary.1.example.com\nambassador_id: plain\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: CanaryDiffMapping-GRPC-50\\nprefix: /CanaryDiffMapping-GRPC-50/\\nservice: http://plain-canarydiffmapping-grpc-50-grpc.plain-namespace\\nhost_rewrite: canary.1.example.com\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-canarydiffmapping-grpc-50-grpc\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8167},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8530}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2020-02-19T23:20:21Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-canarydiffmapping-grpc-50-grpc",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "56448",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-canarydiffmapping-grpc-50-grpc",
-                    "uid": "6665e947-536e-11ea-85dd-167682b5c255"
-                },
-                "spec": {
-                    "clusterIP": "10.108.152.228",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8167
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8530
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: HeaderRoutingTest-GRPC-target1\nprefix: /HeaderRoutingTest-GRPC/\nservice: http://plain-headerroutingtest-grpc-grpc.plain-namespace\nambassador_id: plain\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: HeaderRoutingTest-GRPC-target1\\nprefix: /HeaderRoutingTest-GRPC/\\nservice: http://plain-headerroutingtest-grpc-grpc.plain-namespace\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-headerroutingtest-grpc-grpc\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8082},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8445}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2020-02-19T23:20:13Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-headerroutingtest-grpc-grpc",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "56112",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-headerroutingtest-grpc-grpc",
-                    "uid": "618851bf-536e-11ea-85dd-167682b5c255"
-                },
-                "spec": {
-                    "clusterIP": "10.99.110.187",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8082
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8445
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: SimpleMapping-GRPC-all\nprefix: /SimpleMapping-GRPC-all/\nservice: http://plain-simplemapping-grpc-all-grpc.plain-namespace\nambassador_id: plain\nadd_request_headers: {\"foo\": \"bar\"}\nadd_response_headers: {\"foo\": \"bar\"}\nuse_websocket: true\ncors: {origins: \"*\"}\ncase_sensitive: false\nauto_host_rewrite: true\nrewrite: /foo\nremove_response_headers: x-envoy-upstream-service-time\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: SimpleMapping-GRPC-all\\nprefix: /SimpleMapping-GRPC-all/\\nservice: http://plain-simplemapping-grpc-all-grpc.plain-namespace\\nambassador_id: plain\\nadd_request_headers: {\\\"foo\\\": \\\"bar\\\"}\\nadd_response_headers: {\\\"foo\\\": \\\"bar\\\"}\\nuse_websocket: true\\ncors: {origins: \\\"*\\\"}\\ncase_sensitive: false\\nauto_host_rewrite: true\\nrewrite: /foo\\nremove_response_headers: x-envoy-upstream-service-time\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-simplemapping-grpc-all-grpc\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8121},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8484}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2020-02-19T23:20:16Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-simplemapping-grpc-all-grpc",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "56267",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-simplemapping-grpc-all-grpc",
-                    "uid": "63767285-536e-11ea-85dd-167682b5c255"
-                },
-                "spec": {
-                    "clusterIP": "10.111.59.223",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8121
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8484
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: SimpleMapping-HTTP-AddRequestHeaders-foo-bar\nprefix: /SimpleMapping-HTTP-AddRequestHeaders-foo-bar/\nservice: http://plain-simplemapping-http-addrequestheaders-foo-bar-http.plain-namespace\nambassador_id: plain\nadd_request_headers: {\"foo\": \"bar\"}\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: SimpleMapping-HTTP-AddRequestHeaders-foo-bar\\nprefix: /SimpleMapping-HTTP-AddRequestHeaders-foo-bar/\\nservice: http://plain-simplemapping-http-addrequestheaders-foo-bar-http.plain-namespace\\nambassador_id: plain\\nadd_request_headers: {\\\"foo\\\": \\\"bar\\\"}\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-simplemapping-http-addrequestheaders-foo-bar-http\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8085},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8448}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2020-02-19T23:20:13Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-simplemapping-http-addrequestheaders-foo-bar-http",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "56125",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-simplemapping-http-addrequestheaders-foo-bar-http",
-                    "uid": "61afb56d-536e-11ea-85dd-167682b5c255"
-                },
-                "spec": {
-                    "clusterIP": "10.109.127.234",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8085
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8448
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: SimpleMapping-HTTP-AddResponseHeaders-aoo-tyu\nprefix: /SimpleMapping-HTTP-AddResponseHeaders-aoo-tyu/\nservice: http://plain-simplemapping-http-addresponseheaders-aoo-tyu-http.plain-namespace\nambassador_id: plain\nadd_response_headers: {\"aoo\": {\"value\": \"tyu\"}}\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: SimpleMapping-HTTP-AddResponseHeaders-aoo-tyu\\nprefix: /SimpleMapping-HTTP-AddResponseHeaders-aoo-tyu/\\nservice: http://plain-simplemapping-http-addresponseheaders-aoo-tyu-http.plain-namespace\\nambassador_id: plain\\nadd_response_headers: {\\\"aoo\\\": {\\\"value\\\": \\\"tyu\\\"}}\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-simplemapping-http-addresponseheaders-aoo-tyu-http\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8094},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8457}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2020-02-19T23:20:14Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-simplemapping-http-addresponseheaders-aoo-tyu-http",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "56158",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-simplemapping-http-addresponseheaders-aoo-tyu-http",
-                    "uid": "6220c216-536e-11ea-85dd-167682b5c255"
-                },
-                "spec": {
-                    "clusterIP": "10.105.105.253",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8094
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8457
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: SimpleMapping-HTTP-AutoHostRewrite\nprefix: /SimpleMapping-HTTP-AutoHostRewrite/\nservice: http://plain-simplemapping-http-autohostrewrite-http.plain-namespace\nambassador_id: plain\nauto_host_rewrite: true\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: SimpleMapping-HTTP-AutoHostRewrite\\nprefix: /SimpleMapping-HTTP-AutoHostRewrite/\\nservice: http://plain-simplemapping-http-autohostrewrite-http.plain-namespace\\nambassador_id: plain\\nauto_host_rewrite: true\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-simplemapping-http-autohostrewrite-http\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8098},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8461}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2020-02-19T23:20:15Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-simplemapping-http-autohostrewrite-http",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "56175",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-simplemapping-http-autohostrewrite-http",
-                    "uid": "625f2649-536e-11ea-85dd-167682b5c255"
-                },
-                "spec": {
-                    "clusterIP": "10.109.225.20",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8098
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8461
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: RemoveReqHeadersMapping-HTTP\nprefix: /RemoveReqHeadersMapping-HTTP/\nservice: http://httpbin.org\nremove_request_headers:\n- zoo\n- aoo\nambassador_id: plain\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: RemoveReqHeadersMapping-HTTP\\nprefix: /RemoveReqHeadersMapping-HTTP/\\nservice: http://httpbin.org\\nremove_request_headers:\\n- zoo\\n- aoo\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-removereqheadersmapping-http-http\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8173},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8536}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2020-02-19T23:20:22Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-removereqheadersmapping-http-http",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "56471",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-removereqheadersmapping-http-http",
-                    "uid": "66dd44c3-536e-11ea-85dd-167682b5c255"
-                },
-                "spec": {
-                    "clusterIP": "10.96.2.65",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8173
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8536
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: AddReqHeadersMapping-HTTP\nprefix: /AddReqHeadersMapping-HTTP/\nservice: http://plain-addreqheadersmapping-http-http.plain-namespace\nadd_request_headers:\n  zoo:\n    append: False\n    value: Zoo\n  aoo:\n    append: True\n    value: aoo\n  boo:\n    value: boo\n  foo: Foo\nambassador_id: plain\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: AddReqHeadersMapping-HTTP\\nprefix: /AddReqHeadersMapping-HTTP/\\nservice: http://plain-addreqheadersmapping-http-http.plain-namespace\\nadd_request_headers:\\n  zoo:\\n    append: False\\n    value: Zoo\\n  aoo:\\n    append: True\\n    value: aoo\\n  boo:\\n    value: boo\\n  foo: Foo\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-addreqheadersmapping-http-http\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8175},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8538}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2020-02-19T23:20:22Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-addreqheadersmapping-http-http",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "56478",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-addreqheadersmapping-http-http",
-                    "uid": "6700a8a8-536e-11ea-85dd-167682b5c255"
-                },
-                "spec": {
-                    "clusterIP": "10.99.29.227",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8175
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8538
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: CanaryDiffMapping-GRPC-100-canary\nprefix: /CanaryDiffMapping-GRPC-100/\nservice: http://plain-canarydiffmapping-grpc-100-grpc-canary.plain-namespace\nhost_rewrite: canary.2.example.com\nweight: 100\nambassador_id: plain\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: CanaryDiffMapping-GRPC-100-canary\\nprefix: /CanaryDiffMapping-GRPC-100/\\nservice: http://plain-canarydiffmapping-grpc-100-grpc-canary.plain-namespace\\nhost_rewrite: canary.2.example.com\\nweight: 100\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-canarydiffmapping-grpc-100-grpc-canary\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8170},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8533}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2020-02-19T23:20:22Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-canarydiffmapping-grpc-100-grpc-canary",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "56459",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-canarydiffmapping-grpc-100-grpc-canary",
-                    "uid": "66a3f806-536e-11ea-85dd-167682b5c255"
-                },
-                "spec": {
-                    "clusterIP": "10.98.132.62",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8170
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8533
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: CanaryMapping-GRPC-50-canary\nprefix: /CanaryMapping-GRPC-50/\nservice: http://plain-canarymapping-grpc-50-grpc-canary.plain-namespace\nweight: 50\nambassador_id: plain\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: CanaryMapping-GRPC-50-canary\\nprefix: /CanaryMapping-GRPC-50/\\nservice: http://plain-canarymapping-grpc-50-grpc-canary.plain-namespace\\nweight: 50\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-canarymapping-grpc-50-grpc-canary\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8152},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8515}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2020-02-19T23:20:20Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-canarymapping-grpc-50-grpc-canary",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "56393",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-canarymapping-grpc-50-grpc-canary",
-                    "uid": "6564e030-536e-11ea-85dd-167682b5c255"
-                },
-                "spec": {
-                    "clusterIP": "10.103.16.1",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8152
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8515
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: CanaryMapping-HTTP-100\nprefix: /CanaryMapping-HTTP-100/\nservice: http://plain-canarymapping-http-100-http.plain-namespace\nambassador_id: plain\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: CanaryMapping-HTTP-100\\nprefix: /CanaryMapping-HTTP-100/\\nservice: http://plain-canarymapping-http-100-http.plain-namespace\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-canarymapping-http-100-http\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8145},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8508}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2020-02-19T23:20:19Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-canarymapping-http-100-http",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "56367",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-canarymapping-http-100-http",
-                    "uid": "64ef66b3-536e-11ea-85dd-167682b5c255"
-                },
-                "spec": {
-                    "clusterIP": "10.98.118.67",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8145
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8508
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: HeaderRoutingTest-HTTP-target1\nprefix: /HeaderRoutingTest-HTTP/\nservice: http://plain-headerroutingtest-http-http.plain-namespace\nambassador_id: plain\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: HeaderRoutingTest-HTTP-target1\\nprefix: /HeaderRoutingTest-HTTP/\\nservice: http://plain-headerroutingtest-http-http.plain-namespace\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-headerroutingtest-http-http\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8080},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8443}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2020-02-19T23:20:13Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-headerroutingtest-http-http",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "56105",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-headerroutingtest-http-http",
-                    "uid": "617167b8-536e-11ea-85dd-167682b5c255"
-                },
-                "spec": {
-                    "clusterIP": "10.105.205.4",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8080
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8443
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: HeaderRoutingTest-HTTP-target2\nprefix: /HeaderRoutingTest-HTTP/\nservice: http://plain-headerroutingtest-http-http-target2.plain-namespace\nheaders:\n  X-Route: target2\nambassador_id: plain\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: HeaderRoutingTest-HTTP-target2\\nprefix: /HeaderRoutingTest-HTTP/\\nservice: http://plain-headerroutingtest-http-http-target2.plain-namespace\\nheaders:\\n  X-Route: target2\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-headerroutingtest-http-http-target2\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8081},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8444}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2020-02-19T23:20:13Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-headerroutingtest-http-http-target2",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "56109",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-headerroutingtest-http-http-target2",
-                    "uid": "617df2f7-536e-11ea-85dd-167682b5c255"
-                },
-                "spec": {
-                    "clusterIP": "10.109.6.11",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8081
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8444
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: HostHeaderMapping-GRPC\nprefix: /HostHeaderMapping-GRPC/\nservice: http://plain-hostheadermapping-grpc-grpc.plain-namespace\nhost: inspector.external\nambassador_id: plain\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: HostHeaderMapping-GRPC\\nprefix: /HostHeaderMapping-GRPC/\\nservice: http://plain-hostheadermapping-grpc-grpc.plain-namespace\\nhost: inspector.external\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-hostheadermapping-grpc-grpc\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8129},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8492}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2020-02-19T23:20:17Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-hostheadermapping-grpc-grpc",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "56305",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-hostheadermapping-grpc-grpc",
-                    "uid": "641582ed-536e-11ea-85dd-167682b5c255"
-                },
-                "spec": {
-                    "clusterIP": "10.99.202.126",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8129
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8492
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-simpleingresswithannotations-http-http\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8124},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8487}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2020-02-19T23:20:17Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-simpleingresswithannotations-http-http",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "56281",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-simpleingresswithannotations-http-http",
-                    "uid": "63acb522-536e-11ea-85dd-167682b5c255"
-                },
-                "spec": {
-                    "clusterIP": "10.101.29.195",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8124
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8487
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: SimpleMapping-HTTP-AddResponseHeaders-xoo-dwe\nprefix: /SimpleMapping-HTTP-AddResponseHeaders-xoo-dwe/\nservice: http://plain-simplemapping-http-addresponseheaders-xoo-dwe-http.plain-namespace\nambassador_id: plain\nadd_response_headers: {\"xoo\": {\"append\": false, \"value\": \"dwe\"}}\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: SimpleMapping-HTTP-AddResponseHeaders-xoo-dwe\\nprefix: /SimpleMapping-HTTP-AddResponseHeaders-xoo-dwe/\\nservice: http://plain-simplemapping-http-addresponseheaders-xoo-dwe-http.plain-namespace\\nambassador_id: plain\\nadd_response_headers: {\\\"xoo\\\": {\\\"append\\\": false, \\\"value\\\": \\\"dwe\\\"}}\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-simplemapping-http-addresponseheaders-xoo-dwe-http\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8093},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8456}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2020-02-19T23:20:14Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-simplemapping-http-addresponseheaders-xoo-dwe-http",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "56155",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-simplemapping-http-addresponseheaders-xoo-dwe-http",
-                    "uid": "62160022-536e-11ea-85dd-167682b5c255"
-                },
-                "spec": {
-                    "clusterIP": "10.98.21.165",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8093
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8456
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-simplemappingingress-grpc-grpc\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8123},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8486}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2020-02-19T23:20:17Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-simplemappingingress-grpc-grpc",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "56276",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-simplemappingingress-grpc-grpc",
-                    "uid": "639a229b-536e-11ea-85dd-167682b5c255"
-                },
-                "spec": {
-                    "clusterIP": "10.104.13.137",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8123
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8486
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: HostHeaderMapping-HTTP\nprefix: /HostHeaderMapping-HTTP/\nservice: http://plain-hostheadermapping-http-http.plain-namespace\nhost: inspector.external\nambassador_id: plain\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: HostHeaderMapping-HTTP\\nprefix: /HostHeaderMapping-HTTP/\\nservice: http://plain-hostheadermapping-http-http.plain-namespace\\nhost: inspector.external\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-hostheadermapping-http-http\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8128},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8491}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2020-02-19T23:20:17Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-hostheadermapping-http-http",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "56301",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-hostheadermapping-http-http",
-                    "uid": "63fbf31e-536e-11ea-85dd-167682b5c255"
-                },
-                "spec": {
-                    "clusterIP": "10.109.8.86",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8128
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8491
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: RemoveReqHeadersMapping-GRPC\nprefix: /RemoveReqHeadersMapping-GRPC/\nservice: http://httpbin.org\nremove_request_headers:\n- zoo\n- aoo\nambassador_id: plain\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: RemoveReqHeadersMapping-GRPC\\nprefix: /RemoveReqHeadersMapping-GRPC/\\nservice: http://httpbin.org\\nremove_request_headers:\\n- zoo\\n- aoo\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-removereqheadersmapping-grpc-grpc\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8174},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8537}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2020-02-19T23:20:22Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-removereqheadersmapping-grpc-grpc",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "56475",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-removereqheadersmapping-grpc-grpc",
-                    "uid": "66f1e7a7-536e-11ea-85dd-167682b5c255"
-                },
-                "spec": {
-                    "clusterIP": "10.102.81.164",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8174
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8537
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: SimpleMapping-GRPC-AddRequestHeaders-aoo-tyu\nprefix: /SimpleMapping-GRPC-AddRequestHeaders-aoo-tyu/\nservice: http://plain-simplemapping-grpc-addrequestheaders-aoo-tyu-grpc.plain-namespace\nambassador_id: plain\nadd_request_headers: {\"aoo\": {\"value\": \"tyu\"}}\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: SimpleMapping-GRPC-AddRequestHeaders-aoo-tyu\\nprefix: /SimpleMapping-GRPC-AddRequestHeaders-aoo-tyu/\\nservice: http://plain-simplemapping-grpc-addrequestheaders-aoo-tyu-grpc.plain-namespace\\nambassador_id: plain\\nadd_request_headers: {\\\"aoo\\\": {\\\"value\\\": \\\"tyu\\\"}}\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-simplemapping-grpc-addrequestheaders-aoo-tyu-grpc\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8108},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8471}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2020-02-19T23:20:15Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-simplemapping-grpc-addrequestheaders-aoo-tyu-grpc",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "56216",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-simplemapping-grpc-addrequestheaders-aoo-tyu-grpc",
-                    "uid": "62dd247f-536e-11ea-85dd-167682b5c255"
-                },
-                "spec": {
-                    "clusterIP": "10.110.255.89",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8108
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8471
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: SimpleMapping-GRPC-Rewrite-foo\nprefix: /SimpleMapping-GRPC-Rewrite-foo/\nservice: http://plain-simplemapping-grpc-rewrite-foo-grpc.plain-namespace\nambassador_id: plain\nrewrite: foo\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: SimpleMapping-GRPC-Rewrite-foo\\nprefix: /SimpleMapping-GRPC-Rewrite-foo/\\nservice: http://plain-simplemapping-grpc-rewrite-foo-grpc.plain-namespace\\nambassador_id: plain\\nrewrite: foo\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-simplemapping-grpc-rewrite-foo-grpc\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8119},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8482}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2020-02-19T23:20:16Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-simplemapping-grpc-rewrite-foo-grpc",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "56260",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-simplemapping-grpc-rewrite-foo-grpc",
-                    "uid": "6362b288-536e-11ea-85dd-167682b5c255"
-                },
-                "spec": {
-                    "clusterIP": "10.111.18.180",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8119
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8482
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: SimpleMapping-GRPC-UseWebsocket\nprefix: /SimpleMapping-GRPC-UseWebsocket/\nservice: http://plain-simplemapping-grpc-usewebsocket-grpc.plain-namespace\nambassador_id: plain\nuse_websocket: true\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: SimpleMapping-GRPC-UseWebsocket\\nprefix: /SimpleMapping-GRPC-UseWebsocket/\\nservice: http://plain-simplemapping-grpc-usewebsocket-grpc.plain-namespace\\nambassador_id: plain\\nuse_websocket: true\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-simplemapping-grpc-usewebsocket-grpc\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8114},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8477}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2020-02-19T23:20:16Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-simplemapping-grpc-usewebsocket-grpc",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "56242",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-simplemapping-grpc-usewebsocket-grpc",
-                    "uid": "6330a8e6-536e-11ea-85dd-167682b5c255"
-                },
-                "spec": {
-                    "clusterIP": "10.101.88.218",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8114
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8477
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: SimpleMapping-HTTP-AddRequestHeaders-aoo-tyu\nprefix: /SimpleMapping-HTTP-AddRequestHeaders-aoo-tyu/\nservice: http://plain-simplemapping-http-addrequestheaders-aoo-tyu-http.plain-namespace\nambassador_id: plain\nadd_request_headers: {\"aoo\": {\"value\": \"tyu\"}}\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: SimpleMapping-HTTP-AddRequestHeaders-aoo-tyu\\nprefix: /SimpleMapping-HTTP-AddRequestHeaders-aoo-tyu/\\nservice: http://plain-simplemapping-http-addrequestheaders-aoo-tyu-http.plain-namespace\\nambassador_id: plain\\nadd_request_headers: {\\\"aoo\\\": {\\\"value\\\": \\\"tyu\\\"}}\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-simplemapping-http-addrequestheaders-aoo-tyu-http\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8089},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8452}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2020-02-19T23:20:14Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-simplemapping-http-addrequestheaders-aoo-tyu-http",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "56138",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-simplemapping-http-addrequestheaders-aoo-tyu-http",
-                    "uid": "61e2852e-536e-11ea-85dd-167682b5c255"
-                },
-                "spec": {
-                    "clusterIP": "10.102.172.124",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8089
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8452
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: CanaryDiffMapping-GRPC-0\nprefix: /CanaryDiffMapping-GRPC-0/\nservice: http://plain-canarydiffmapping-grpc-0-grpc.plain-namespace\nhost_rewrite: canary.1.example.com\nambassador_id: plain\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: CanaryDiffMapping-GRPC-0\\nprefix: /CanaryDiffMapping-GRPC-0/\\nservice: http://plain-canarydiffmapping-grpc-0-grpc.plain-namespace\\nhost_rewrite: canary.1.example.com\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-canarydiffmapping-grpc-0-grpc\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8163},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8526}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2020-02-19T23:20:21Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-canarydiffmapping-grpc-0-grpc",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "56434",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-canarydiffmapping-grpc-0-grpc",
-                    "uid": "662df40b-536e-11ea-85dd-167682b5c255"
-                },
-                "spec": {
-                    "clusterIP": "10.108.160.170",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8163
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8526
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: CanaryMapping-GRPC-100\nprefix: /CanaryMapping-GRPC-100/\nservice: http://plain-canarymapping-grpc-100-grpc.plain-namespace\nambassador_id: plain\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: CanaryMapping-GRPC-100\\nprefix: /CanaryMapping-GRPC-100/\\nservice: http://plain-canarymapping-grpc-100-grpc.plain-namespace\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-canarymapping-grpc-100-grpc\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8153},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8516}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2020-02-19T23:20:20Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-canarymapping-grpc-100-grpc",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "56396",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-canarymapping-grpc-100-grpc",
-                    "uid": "657c9ee7-536e-11ea-85dd-167682b5c255"
-                },
-                "spec": {
-                    "clusterIP": "10.108.68.85",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8153
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8516
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: HeaderRoutingTest-GRPC-target2\nprefix: /HeaderRoutingTest-GRPC/\nservice: http://plain-headerroutingtest-grpc-grpc-target2.plain-namespace\nheaders:\n  X-Route: target2\nambassador_id: plain\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: HeaderRoutingTest-GRPC-target2\\nprefix: /HeaderRoutingTest-GRPC/\\nservice: http://plain-headerroutingtest-grpc-grpc-target2.plain-namespace\\nheaders:\\n  X-Route: target2\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-headerroutingtest-grpc-grpc-target2\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8083},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8446}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2020-02-19T23:20:13Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-headerroutingtest-grpc-grpc-target2",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "56116",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-headerroutingtest-grpc-grpc-target2",
-                    "uid": "6194a91d-536e-11ea-85dd-167682b5c255"
-                },
-                "spec": {
-                    "clusterIP": "10.97.246.8",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8083
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8446
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: InvalidPortMapping-GRPC\nprefix: /InvalidPortMapping-GRPC/\nservice: http://plain-invalidportmapping-grpc-grpc.plain-namespace:80.invalid\nambassador_id: plain\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: InvalidPortMapping-GRPC\\nprefix: /InvalidPortMapping-GRPC/\\nservice: http://plain-invalidportmapping-grpc-grpc.plain-namespace:80.invalid\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-invalidportmapping-grpc-grpc\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8131},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8494}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2020-02-19T23:20:18Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-invalidportmapping-grpc-grpc",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "56313",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-invalidportmapping-grpc-grpc",
-                    "uid": "64327286-536e-11ea-85dd-167682b5c255"
-                },
-                "spec": {
-                    "clusterIP": "10.107.219.170",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8131
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8494
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: SimpleMapping-GRPC-Rewrite-SLASH-foo\nprefix: /SimpleMapping-GRPC-Rewrite-SLASH-foo/\nservice: http://plain-simplemapping-grpc-rewrite-slash-foo-grpc.plain-namespace\nambassador_id: plain\nrewrite: /foo\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: SimpleMapping-GRPC-Rewrite-SLASH-foo\\nprefix: /SimpleMapping-GRPC-Rewrite-SLASH-foo/\\nservice: http://plain-simplemapping-grpc-rewrite-slash-foo-grpc.plain-namespace\\nambassador_id: plain\\nrewrite: /foo\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-simplemapping-grpc-rewrite-slash-foo-grpc\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8118},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8481}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2020-02-19T23:20:16Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-simplemapping-grpc-rewrite-slash-foo-grpc",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "56256",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-simplemapping-grpc-rewrite-slash-foo-grpc",
-                    "uid": "6357d96d-536e-11ea-85dd-167682b5c255"
-                },
-                "spec": {
-                    "clusterIP": "10.109.73.56",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8118
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8481
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: SimpleMapping-HTTP\nprefix: /SimpleMapping-HTTP/\nservice: http://plain-simplemapping-http-http.plain-namespace\nambassador_id: plain\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: SimpleMapping-HTTP\\nprefix: /SimpleMapping-HTTP/\\nservice: http://plain-simplemapping-http-http.plain-namespace\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-simplemapping-http-http\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8084},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8447}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2020-02-19T23:20:13Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-simplemapping-http-http",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "56120",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-simplemapping-http-http",
-                    "uid": "61a14ee4-536e-11ea-85dd-167682b5c255"
-                },
-                "spec": {
-                    "clusterIP": "10.100.72.152",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8084
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8447
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: CanaryDiffMapping-GRPC-0-canary\nprefix: /CanaryDiffMapping-GRPC-0/\nservice: http://plain-canarydiffmapping-grpc-0-grpc-canary.plain-namespace\nhost_rewrite: canary.2.example.com\nweight: 0\nambassador_id: plain\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: CanaryDiffMapping-GRPC-0-canary\\nprefix: /CanaryDiffMapping-GRPC-0/\\nservice: http://plain-canarydiffmapping-grpc-0-grpc-canary.plain-namespace\\nhost_rewrite: canary.2.example.com\\nweight: 0\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-canarydiffmapping-grpc-0-grpc-canary\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8164},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8527}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2020-02-19T23:20:21Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-canarydiffmapping-grpc-0-grpc-canary",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "56438",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-canarydiffmapping-grpc-0-grpc-canary",
-                    "uid": "663d164e-536e-11ea-85dd-167682b5c255"
-                },
-                "spec": {
-                    "clusterIP": "10.106.152.23",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8164
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8527
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: CanaryDiffMapping-HTTP-0\nprefix: /CanaryDiffMapping-HTTP-0/\nservice: http://plain-canarydiffmapping-http-0-http.plain-namespace\nhost_rewrite: canary.1.example.com\nambassador_id: plain\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: CanaryDiffMapping-HTTP-0\\nprefix: /CanaryDiffMapping-HTTP-0/\\nservice: http://plain-canarydiffmapping-http-0-http.plain-namespace\\nhost_rewrite: canary.1.example.com\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-canarydiffmapping-http-0-http\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8155},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8518}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2020-02-19T23:20:20Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-canarydiffmapping-http-0-http",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "56405",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-canarydiffmapping-http-0-http",
-                    "uid": "65aa7257-536e-11ea-85dd-167682b5c255"
-                },
-                "spec": {
-                    "clusterIP": "10.99.116.2",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8155
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8518
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: CanaryDiffMapping-HTTP-100\nprefix: /CanaryDiffMapping-HTTP-100/\nservice: http://plain-canarydiffmapping-http-100-http.plain-namespace\nhost_rewrite: canary.1.example.com\nambassador_id: plain\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: CanaryDiffMapping-HTTP-100\\nprefix: /CanaryDiffMapping-HTTP-100/\\nservice: http://plain-canarydiffmapping-http-100-http.plain-namespace\\nhost_rewrite: canary.1.example.com\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-canarydiffmapping-http-100-http\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8161},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8524}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2020-02-19T23:20:21Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-canarydiffmapping-http-100-http",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "56426",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-canarydiffmapping-http-100-http",
-                    "uid": "660e1c6d-536e-11ea-85dd-167682b5c255"
-                },
-                "spec": {
-                    "clusterIP": "10.107.125.193",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8161
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8524
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: CanaryMapping-GRPC-100-canary\nprefix: /CanaryMapping-GRPC-100/\nservice: http://plain-canarymapping-grpc-100-grpc-canary.plain-namespace\nweight: 100\nambassador_id: plain\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: CanaryMapping-GRPC-100-canary\\nprefix: /CanaryMapping-GRPC-100/\\nservice: http://plain-canarymapping-grpc-100-grpc-canary.plain-namespace\\nweight: 100\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-canarymapping-grpc-100-grpc-canary\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8154},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8517}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2020-02-19T23:20:20Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-canarymapping-grpc-100-grpc-canary",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "56401",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-canarymapping-grpc-100-grpc-canary",
-                    "uid": "659550f8-536e-11ea-85dd-167682b5c255"
-                },
-                "spec": {
-                    "clusterIP": "10.111.108.86",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8154
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8517
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: CanaryMapping-GRPC-50\nprefix: /CanaryMapping-GRPC-50/\nservice: http://plain-canarymapping-grpc-50-grpc.plain-namespace\nambassador_id: plain\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: CanaryMapping-GRPC-50\\nprefix: /CanaryMapping-GRPC-50/\\nservice: http://plain-canarymapping-grpc-50-grpc.plain-namespace\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-canarymapping-grpc-50-grpc\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8151},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8514}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2020-02-19T23:20:19Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-canarymapping-grpc-50-grpc",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "56389",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-canarymapping-grpc-50-grpc",
-                    "uid": "65571f94-536e-11ea-85dd-167682b5c255"
-                },
-                "spec": {
-                    "clusterIP": "10.105.34.200",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8151
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8514
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: CanaryMapping-HTTP-50\nprefix: /CanaryMapping-HTTP-50/\nservice: http://plain-canarymapping-http-50-http.plain-namespace\nambassador_id: plain\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: CanaryMapping-HTTP-50\\nprefix: /CanaryMapping-HTTP-50/\\nservice: http://plain-canarymapping-http-50-http.plain-namespace\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-canarymapping-http-50-http\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8143},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8506}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2020-02-19T23:20:19Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-canarymapping-http-50-http",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "56359",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-canarymapping-http-50-http",
-                    "uid": "64d17c8a-536e-11ea-85dd-167682b5c255"
-                },
-                "spec": {
-                    "clusterIP": "10.98.92.230",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8143
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8506
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: SimpleMapping-GRPC-AddRequestHeaders-foo-bar\nprefix: /SimpleMapping-GRPC-AddRequestHeaders-foo-bar/\nservice: http://plain-simplemapping-grpc-addrequestheaders-foo-bar-grpc.plain-namespace\nambassador_id: plain\nadd_request_headers: {\"foo\": \"bar\"}\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: SimpleMapping-GRPC-AddRequestHeaders-foo-bar\\nprefix: /SimpleMapping-GRPC-AddRequestHeaders-foo-bar/\\nservice: http://plain-simplemapping-grpc-addrequestheaders-foo-bar-grpc.plain-namespace\\nambassador_id: plain\\nadd_request_headers: {\\\"foo\\\": \\\"bar\\\"}\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-simplemapping-grpc-addrequestheaders-foo-bar-grpc\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8104},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8467}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2020-02-19T23:20:15Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-simplemapping-grpc-addrequestheaders-foo-bar-grpc",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "56199",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-simplemapping-grpc-addrequestheaders-foo-bar-grpc",
-                    "uid": "62a7861c-536e-11ea-85dd-167682b5c255"
-                },
-                "spec": {
-                    "clusterIP": "10.111.208.6",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8104
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8467
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: CanaryMapping-HTTP-0\nprefix: /CanaryMapping-HTTP-0/\nservice: http://plain-canarymapping-http-0-http.plain-namespace\nambassador_id: plain\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: CanaryMapping-HTTP-0\\nprefix: /CanaryMapping-HTTP-0/\\nservice: http://plain-canarymapping-http-0-http.plain-namespace\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-canarymapping-http-0-http\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8139},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8502}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2020-02-19T23:20:18Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-canarymapping-http-0-http",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "56343",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-canarymapping-http-0-http",
-                    "uid": "64923059-536e-11ea-85dd-167682b5c255"
-                },
-                "spec": {
-                    "clusterIP": "10.102.166.87",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8139
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8502
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: CanaryMapping-HTTP-100-canary\nprefix: /CanaryMapping-HTTP-100/\nservice: http://plain-canarymapping-http-100-http-canary.plain-namespace\nweight: 100\nambassador_id: plain\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: CanaryMapping-HTTP-100-canary\\nprefix: /CanaryMapping-HTTP-100/\\nservice: http://plain-canarymapping-http-100-http-canary.plain-namespace\\nweight: 100\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-canarymapping-http-100-http-canary\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8146},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8509}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2020-02-19T23:20:19Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-canarymapping-http-100-http-canary",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "56370",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-canarymapping-http-100-http-canary",
-                    "uid": "64fe43ec-536e-11ea-85dd-167682b5c255"
-                },
-                "spec": {
-                    "clusterIP": "10.106.55.181",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8146
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8509
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: SimpleMapping-GRPC-AddResponseHeaders-zoo-bar\nprefix: /SimpleMapping-GRPC-AddResponseHeaders-zoo-bar/\nservice: http://plain-simplemapping-grpc-addresponseheaders-zoo-bar-grpc.plain-namespace\nambassador_id: plain\nadd_response_headers: {\"zoo\": {\"append\": true, \"value\": \"bar\"}}\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: SimpleMapping-GRPC-AddResponseHeaders-zoo-bar\\nprefix: /SimpleMapping-GRPC-AddResponseHeaders-zoo-bar/\\nservice: http://plain-simplemapping-grpc-addresponseheaders-zoo-bar-grpc.plain-namespace\\nambassador_id: plain\\nadd_response_headers: {\\\"zoo\\\": {\\\"append\\\": true, \\\"value\\\": \\\"bar\\\"}}\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-simplemapping-grpc-addresponseheaders-zoo-bar-grpc\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8111},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8474}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2020-02-19T23:20:16Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-simplemapping-grpc-addresponseheaders-zoo-bar-grpc",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "56229",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-simplemapping-grpc-addresponseheaders-zoo-bar-grpc",
-                    "uid": "63022a9b-536e-11ea-85dd-167682b5c255"
-                },
-                "spec": {
-                    "clusterIP": "10.101.155.164",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8111
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8474
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: SimpleMapping-GRPC-AutoHostRewrite\nprefix: /SimpleMapping-GRPC-AutoHostRewrite/\nservice: http://plain-simplemapping-grpc-autohostrewrite-grpc.plain-namespace\nambassador_id: plain\nauto_host_rewrite: true\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: SimpleMapping-GRPC-AutoHostRewrite\\nprefix: /SimpleMapping-GRPC-AutoHostRewrite/\\nservice: http://plain-simplemapping-grpc-autohostrewrite-grpc.plain-namespace\\nambassador_id: plain\\nauto_host_rewrite: true\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-simplemapping-grpc-autohostrewrite-grpc\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8117},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8480}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2020-02-19T23:20:16Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-simplemapping-grpc-autohostrewrite-grpc",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "56252",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-simplemapping-grpc-autohostrewrite-grpc",
-                    "uid": "634dce24-536e-11ea-85dd-167682b5c255"
-                },
-                "spec": {
-                    "clusterIP": "10.110.255.142",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8117
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8480
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: SimpleMapping-HTTP-CaseSensitive\nprefix: /SimpleMapping-HTTP-CaseSensitive/\nservice: http://plain-simplemapping-http-casesensitive-http.plain-namespace\nambassador_id: plain\ncase_sensitive: false\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: SimpleMapping-HTTP-CaseSensitive\\nprefix: /SimpleMapping-HTTP-CaseSensitive/\\nservice: http://plain-simplemapping-http-casesensitive-http.plain-namespace\\nambassador_id: plain\\ncase_sensitive: false\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-simplemapping-http-casesensitive-http\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8097},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8460}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2020-02-19T23:20:14Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-simplemapping-http-casesensitive-http",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "56169",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-simplemapping-http-casesensitive-http",
-                    "uid": "6241b74d-536e-11ea-85dd-167682b5c255"
-                },
-                "spec": {
-                    "clusterIP": "10.103.225.95",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8097
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8460
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: SimpleMapping-HTTP-Rewrite-foo\nprefix: /SimpleMapping-HTTP-Rewrite-foo/\nservice: http://plain-simplemapping-http-rewrite-foo-http.plain-namespace\nambassador_id: plain\nrewrite: foo\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: SimpleMapping-HTTP-Rewrite-foo\\nprefix: /SimpleMapping-HTTP-Rewrite-foo/\\nservice: http://plain-simplemapping-http-rewrite-foo-http.plain-namespace\\nambassador_id: plain\\nrewrite: foo\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-simplemapping-http-rewrite-foo-http\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8100},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8463}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2020-02-19T23:20:15Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-simplemapping-http-rewrite-foo-http",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "56183",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-simplemapping-http-rewrite-foo-http",
-                    "uid": "62761551-536e-11ea-85dd-167682b5c255"
-                },
-                "spec": {
-                    "clusterIP": "10.103.82.246",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8100
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8463
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: CanaryDiffMapping-GRPC-100\nprefix: /CanaryDiffMapping-GRPC-100/\nservice: http://plain-canarydiffmapping-grpc-100-grpc.plain-namespace\nhost_rewrite: canary.1.example.com\nambassador_id: plain\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: CanaryDiffMapping-GRPC-100\\nprefix: /CanaryDiffMapping-GRPC-100/\\nservice: http://plain-canarydiffmapping-grpc-100-grpc.plain-namespace\\nhost_rewrite: canary.1.example.com\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-canarydiffmapping-grpc-100-grpc\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8169},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8532}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2020-02-19T23:20:22Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-canarydiffmapping-grpc-100-grpc",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "56456",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-canarydiffmapping-grpc-100-grpc",
-                    "uid": "669633be-536e-11ea-85dd-167682b5c255"
-                },
-                "spec": {
-                    "clusterIP": "10.98.144.161",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8169
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8532
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: CanaryMapping-GRPC-10-canary\nprefix: /CanaryMapping-GRPC-10/\nservice: http://plain-canarymapping-grpc-10-grpc-canary.plain-namespace\nweight: 10\nambassador_id: plain\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: CanaryMapping-GRPC-10-canary\\nprefix: /CanaryMapping-GRPC-10/\\nservice: http://plain-canarymapping-grpc-10-grpc-canary.plain-namespace\\nweight: 10\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-canarymapping-grpc-10-grpc-canary\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8150},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8513}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2020-02-19T23:20:19Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-canarymapping-grpc-10-grpc-canary",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "56385",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-canarymapping-grpc-10-grpc-canary",
-                    "uid": "6546b632-536e-11ea-85dd-167682b5c255"
-                },
-                "spec": {
-                    "clusterIP": "10.106.161.96",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8150
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8513
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: CanaryMapping-HTTP-10\nprefix: /CanaryMapping-HTTP-10/\nservice: http://plain-canarymapping-http-10-http.plain-namespace\nambassador_id: plain\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: CanaryMapping-HTTP-10\\nprefix: /CanaryMapping-HTTP-10/\\nservice: http://plain-canarymapping-http-10-http.plain-namespace\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-canarymapping-http-10-http\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8141},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8504}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2020-02-19T23:20:18Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-canarymapping-http-10-http",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "56351",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-canarymapping-http-10-http",
-                    "uid": "64b1c734-536e-11ea-85dd-167682b5c255"
-                },
-                "spec": {
-                    "clusterIP": "10.103.41.125",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8141
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8504
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: SimpleMapping-GRPC-AddRequestHeaders-xoo-dwe\nprefix: /SimpleMapping-GRPC-AddRequestHeaders-xoo-dwe/\nservice: http://plain-simplemapping-grpc-addrequestheaders-xoo-dwe-grpc.plain-namespace\nambassador_id: plain\nadd_request_headers: {\"xoo\": {\"append\": false, \"value\": \"dwe\"}}\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: SimpleMapping-GRPC-AddRequestHeaders-xoo-dwe\\nprefix: /SimpleMapping-GRPC-AddRequestHeaders-xoo-dwe/\\nservice: http://plain-simplemapping-grpc-addrequestheaders-xoo-dwe-grpc.plain-namespace\\nambassador_id: plain\\nadd_request_headers: {\\\"xoo\\\": {\\\"append\\\": false, \\\"value\\\": \\\"dwe\\\"}}\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-simplemapping-grpc-addrequestheaders-xoo-dwe-grpc\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8107},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8470}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2020-02-19T23:20:15Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-simplemapping-grpc-addrequestheaders-xoo-dwe-grpc",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "56212",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-simplemapping-grpc-addrequestheaders-xoo-dwe-grpc",
-                    "uid": "62d17cc8-536e-11ea-85dd-167682b5c255"
-                },
-                "spec": {
-                    "clusterIP": "10.96.17.236",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8107
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8470
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: SimpleMapping-HTTP-AddRequestHeaders-moo-arf\nprefix: /SimpleMapping-HTTP-AddRequestHeaders-moo-arf/\nservice: http://plain-simplemapping-http-addrequestheaders-moo-arf-http.plain-namespace\nambassador_id: plain\nadd_request_headers: {\"moo\": \"arf\"}\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: SimpleMapping-HTTP-AddRequestHeaders-moo-arf\\nprefix: /SimpleMapping-HTTP-AddRequestHeaders-moo-arf/\\nservice: http://plain-simplemapping-http-addrequestheaders-moo-arf-http.plain-namespace\\nambassador_id: plain\\nadd_request_headers: {\\\"moo\\\": \\\"arf\\\"}\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-simplemapping-http-addrequestheaders-moo-arf-http\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8086},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8449}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2020-02-19T23:20:13Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-simplemapping-http-addrequestheaders-moo-arf-http",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "56128",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-simplemapping-http-addrequestheaders-moo-arf-http",
-                    "uid": "61bb643e-536e-11ea-85dd-167682b5c255"
-                },
-                "spec": {
-                    "clusterIP": "10.109.203.36",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8086
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8449
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-simplemappingingress-http-http\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8122},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8485}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2020-02-19T23:20:16Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-simplemappingingress-http-http",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "56271",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-simplemappingingress-http-http",
-                    "uid": "63887101-536e-11ea-85dd-167682b5c255"
-                },
-                "spec": {
-                    "clusterIP": "10.105.167.155",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8122
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8485
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: CanaryDiffMapping-HTTP-10-canary\nprefix: /CanaryDiffMapping-HTTP-10/\nservice: http://plain-canarydiffmapping-http-10-http-canary.plain-namespace\nhost_rewrite: canary.2.example.com\nweight: 10\nambassador_id: plain\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: CanaryDiffMapping-HTTP-10-canary\\nprefix: /CanaryDiffMapping-HTTP-10/\\nservice: http://plain-canarydiffmapping-http-10-http-canary.plain-namespace\\nhost_rewrite: canary.2.example.com\\nweight: 10\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-canarydiffmapping-http-10-http-canary\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8158},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8521}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2020-02-19T23:20:20Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-canarydiffmapping-http-10-http-canary",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "56416",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-canarydiffmapping-http-10-http-canary",
-                    "uid": "65dca479-536e-11ea-85dd-167682b5c255"
-                },
-                "spec": {
-                    "clusterIP": "10.100.145.149",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8158
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8521
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: CanaryMapping-GRPC-0-canary\nprefix: /CanaryMapping-GRPC-0/\nservice: http://plain-canarymapping-grpc-0-grpc-canary.plain-namespace\nweight: 0\nambassador_id: plain\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: CanaryMapping-GRPC-0-canary\\nprefix: /CanaryMapping-GRPC-0/\\nservice: http://plain-canarymapping-grpc-0-grpc-canary.plain-namespace\\nweight: 0\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-canarymapping-grpc-0-grpc-canary\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8148},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8511}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2020-02-19T23:20:19Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-canarymapping-grpc-0-grpc-canary",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "56378",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-canarymapping-grpc-0-grpc-canary",
-                    "uid": "6529eb09-536e-11ea-85dd-167682b5c255"
-                },
-                "spec": {
-                    "clusterIP": "10.111.92.220",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8148
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8511
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: CanaryMapping-GRPC-10\nprefix: /CanaryMapping-GRPC-10/\nservice: http://plain-canarymapping-grpc-10-grpc.plain-namespace\nambassador_id: plain\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: CanaryMapping-GRPC-10\\nprefix: /CanaryMapping-GRPC-10/\\nservice: http://plain-canarymapping-grpc-10-grpc.plain-namespace\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-canarymapping-grpc-10-grpc\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8149},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8512}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2020-02-19T23:20:19Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-canarymapping-grpc-10-grpc",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "56381",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-canarymapping-grpc-10-grpc",
-                    "uid": "653852ef-536e-11ea-85dd-167682b5c255"
-                },
-                "spec": {
-                    "clusterIP": "10.100.194.104",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8149
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8512
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: CanaryMapping-HTTP-50-canary\nprefix: /CanaryMapping-HTTP-50/\nservice: http://plain-canarymapping-http-50-http-canary.plain-namespace\nweight: 50\nambassador_id: plain\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: CanaryMapping-HTTP-50-canary\\nprefix: /CanaryMapping-HTTP-50/\\nservice: http://plain-canarymapping-http-50-http-canary.plain-namespace\\nweight: 50\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-canarymapping-http-50-http-canary\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8144},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8507}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2020-02-19T23:20:19Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-canarymapping-http-50-http-canary",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "56362",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-canarymapping-http-50-http-canary",
-                    "uid": "64e03e82-536e-11ea-85dd-167682b5c255"
-                },
-                "spec": {
-                    "clusterIP": "10.108.217.220",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8144
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8507
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: SimpleMapping-GRPC-CaseSensitive\nprefix: /SimpleMapping-GRPC-CaseSensitive/\nservice: http://plain-simplemapping-grpc-casesensitive-grpc.plain-namespace\nambassador_id: plain\ncase_sensitive: false\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: SimpleMapping-GRPC-CaseSensitive\\nprefix: /SimpleMapping-GRPC-CaseSensitive/\\nservice: http://plain-simplemapping-grpc-casesensitive-grpc.plain-namespace\\nambassador_id: plain\\ncase_sensitive: false\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-simplemapping-grpc-casesensitive-grpc\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8116},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8479}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2020-02-19T23:20:16Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-simplemapping-grpc-casesensitive-grpc",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "56249",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-simplemapping-grpc-casesensitive-grpc",
-                    "uid": "6344a6d7-536e-11ea-85dd-167682b5c255"
-                },
-                "spec": {
-                    "clusterIP": "10.99.31.183",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8116
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8479
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: SimpleMapping-GRPC\nprefix: /SimpleMapping-GRPC/\nservice: http://plain-simplemapping-grpc-grpc.plain-namespace\nambassador_id: plain\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: SimpleMapping-GRPC\\nprefix: /SimpleMapping-GRPC/\\nservice: http://plain-simplemapping-grpc-grpc.plain-namespace\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-simplemapping-grpc-grpc\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8103},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8466}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2020-02-19T23:20:15Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-simplemapping-grpc-grpc",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "56195",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-simplemapping-grpc-grpc",
-                    "uid": "62997124-536e-11ea-85dd-167682b5c255"
-                },
-                "spec": {
-                    "clusterIP": "10.97.165.65",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8103
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8466
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: SimpleMapping-HTTP-AddResponseHeaders-foo-bar\nprefix: /SimpleMapping-HTTP-AddResponseHeaders-foo-bar/\nservice: http://plain-simplemapping-http-addresponseheaders-foo-bar-http.plain-namespace\nambassador_id: plain\nadd_response_headers: {\"foo\": \"bar\"}\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: SimpleMapping-HTTP-AddResponseHeaders-foo-bar\\nprefix: /SimpleMapping-HTTP-AddResponseHeaders-foo-bar/\\nservice: http://plain-simplemapping-http-addresponseheaders-foo-bar-http.plain-namespace\\nambassador_id: plain\\nadd_response_headers: {\\\"foo\\\": \\\"bar\\\"}\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-simplemapping-http-addresponseheaders-foo-bar-http\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8090},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8453}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2020-02-19T23:20:14Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-simplemapping-http-addresponseheaders-foo-bar-http",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "56144",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-simplemapping-http-addresponseheaders-foo-bar-http",
-                    "uid": "61f1d6e5-536e-11ea-85dd-167682b5c255"
-                },
-                "spec": {
-                    "clusterIP": "10.105.244.207",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8090
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8453
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: CanaryDiffMapping-GRPC-10-canary\nprefix: /CanaryDiffMapping-GRPC-10/\nservice: http://plain-canarydiffmapping-grpc-10-grpc-canary.plain-namespace\nhost_rewrite: canary.2.example.com\nweight: 10\nambassador_id: plain\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: CanaryDiffMapping-GRPC-10-canary\\nprefix: /CanaryDiffMapping-GRPC-10/\\nservice: http://plain-canarydiffmapping-grpc-10-grpc-canary.plain-namespace\\nhost_rewrite: canary.2.example.com\\nweight: 10\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-canarydiffmapping-grpc-10-grpc-canary\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8166},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8529}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2020-02-19T23:20:21Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-canarydiffmapping-grpc-10-grpc-canary",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "56445",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-canarydiffmapping-grpc-10-grpc-canary",
-                    "uid": "6654d4cd-536e-11ea-85dd-167682b5c255"
-                },
-                "spec": {
-                    "clusterIP": "10.110.78.179",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8166
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8529
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: CanaryDiffMapping-HTTP-0-canary\nprefix: /CanaryDiffMapping-HTTP-0/\nservice: http://plain-canarydiffmapping-http-0-http-canary.plain-namespace\nhost_rewrite: canary.2.example.com\nweight: 0\nambassador_id: plain\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: CanaryDiffMapping-HTTP-0-canary\\nprefix: /CanaryDiffMapping-HTTP-0/\\nservice: http://plain-canarydiffmapping-http-0-http-canary.plain-namespace\\nhost_rewrite: canary.2.example.com\\nweight: 0\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-canarydiffmapping-http-0-http-canary\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8156},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8519}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2020-02-19T23:20:20Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-canarydiffmapping-http-0-http-canary",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "56408",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-canarydiffmapping-http-0-http-canary",
-                    "uid": "65ba7452-536e-11ea-85dd-167682b5c255"
-                },
-                "spec": {
-                    "clusterIP": "10.111.210.217",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8156
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8519
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: CanaryDiffMapping-HTTP-50-canary\nprefix: /CanaryDiffMapping-HTTP-50/\nservice: http://plain-canarydiffmapping-http-50-http-canary.plain-namespace\nhost_rewrite: canary.2.example.com\nweight: 50\nambassador_id: plain\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: CanaryDiffMapping-HTTP-50-canary\\nprefix: /CanaryDiffMapping-HTTP-50/\\nservice: http://plain-canarydiffmapping-http-50-http-canary.plain-namespace\\nhost_rewrite: canary.2.example.com\\nweight: 50\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-canarydiffmapping-http-50-http-canary\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8160},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8523}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2020-02-19T23:20:21Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-canarydiffmapping-http-50-http-canary",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "56423",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-canarydiffmapping-http-50-http-canary",
-                    "uid": "65fc8070-536e-11ea-85dd-167682b5c255"
-                },
-                "spec": {
-                    "clusterIP": "10.99.189.226",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8160
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8523
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: SimpleMapping-GRPC-RemoveResponseHeaders\nprefix: /SimpleMapping-GRPC-RemoveResponseHeaders/\nservice: http://plain-simplemapping-grpc-removeresponseheaders-grpc.plain-namespace\nambassador_id: plain\nremove_response_headers: x-envoy-upstream-service-time\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: SimpleMapping-GRPC-RemoveResponseHeaders\\nprefix: /SimpleMapping-GRPC-RemoveResponseHeaders/\\nservice: http://plain-simplemapping-grpc-removeresponseheaders-grpc.plain-namespace\\nambassador_id: plain\\nremove_response_headers: x-envoy-upstream-service-time\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-simplemapping-grpc-removeresponseheaders-grpc\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8120},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8483}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2020-02-19T23:20:16Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-simplemapping-grpc-removeresponseheaders-grpc",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "56263",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-simplemapping-grpc-removeresponseheaders-grpc",
-                    "uid": "636c5ce7-536e-11ea-85dd-167682b5c255"
-                },
-                "spec": {
-                    "clusterIP": "10.106.105.182",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8120
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8483
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: SimpleMapping-HTTP-AddRequestHeaders-xoo-dwe\nprefix: /SimpleMapping-HTTP-AddRequestHeaders-xoo-dwe/\nservice: http://plain-simplemapping-http-addrequestheaders-xoo-dwe-http.plain-namespace\nambassador_id: plain\nadd_request_headers: {\"xoo\": {\"append\": false, \"value\": \"dwe\"}}\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: SimpleMapping-HTTP-AddRequestHeaders-xoo-dwe\\nprefix: /SimpleMapping-HTTP-AddRequestHeaders-xoo-dwe/\\nservice: http://plain-simplemapping-http-addrequestheaders-xoo-dwe-http.plain-namespace\\nambassador_id: plain\\nadd_request_headers: {\\\"xoo\\\": {\\\"append\\\": false, \\\"value\\\": \\\"dwe\\\"}}\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-simplemapping-http-addrequestheaders-xoo-dwe-http\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8088},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8451}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2020-02-19T23:20:14Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-simplemapping-http-addrequestheaders-xoo-dwe-http",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "56135",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-simplemapping-http-addrequestheaders-xoo-dwe-http",
-                    "uid": "61d20cc7-536e-11ea-85dd-167682b5c255"
-                },
-                "spec": {
-                    "clusterIP": "10.97.126.76",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8088
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8451
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: SimpleMapping-HTTP-UseWebsocket\nprefix: /SimpleMapping-HTTP-UseWebsocket/\nservice: http://plain-simplemapping-http-usewebsocket-http.plain-namespace\nambassador_id: plain\nuse_websocket: true\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: SimpleMapping-HTTP-UseWebsocket\\nprefix: /SimpleMapping-HTTP-UseWebsocket/\\nservice: http://plain-simplemapping-http-usewebsocket-http.plain-namespace\\nambassador_id: plain\\nuse_websocket: true\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-simplemapping-http-usewebsocket-http\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8095},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8458}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2020-02-19T23:20:14Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-simplemapping-http-usewebsocket-http",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "56162",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-simplemapping-http-usewebsocket-http",
-                    "uid": "622b569f-536e-11ea-85dd-167682b5c255"
-                },
-                "spec": {
-                    "clusterIP": "10.102.118.252",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8095
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8458
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: TLSOrigination-HTTP-IMPLICIT\nprefix: /TLSOrigination-HTTP-IMPLICIT/\nservice: https://plain-tlsorigination-http-implicit-http.plain-namespace\nambassador_id: plain\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: TLSOrigination-HTTP-IMPLICIT\\nprefix: /TLSOrigination-HTTP-IMPLICIT/\\nservice: https://plain-tlsorigination-http-implicit-http.plain-namespace\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-tlsorigination-http-implicit-http\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8134},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8497}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2020-02-19T23:20:18Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-tlsorigination-http-implicit-http",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "56324",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-tlsorigination-http-implicit-http",
-                    "uid": "6453f0da-536e-11ea-85dd-167682b5c255"
-                },
-                "spec": {
-                    "clusterIP": "10.110.219.64",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8134
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8497
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: AddRespHeadersMapping-HTTP\nprefix: /AddRespHeadersMapping-HTTP/\nservice: http://httpbin.org\nadd_response_headers:\n  koo:\n    append: False\n    value: KooK\n  zoo:\n    append: True\n    value: ZooZ\n  test:\n    value: boo\n  foo: Foo\nambassador_id: plain\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: AddRespHeadersMapping-HTTP\\nprefix: /AddRespHeadersMapping-HTTP/\\nservice: http://httpbin.org\\nadd_response_headers:\\n  koo:\\n    append: False\\n    value: KooK\\n  zoo:\\n    append: True\\n    value: ZooZ\\n  test:\\n    value: boo\\n  foo: Foo\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-addrespheadersmapping-http-http\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8171},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8534}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2020-02-19T23:20:22Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-addrespheadersmapping-http-http",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "56463",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-addrespheadersmapping-http-http",
-                    "uid": "66afa2dd-536e-11ea-85dd-167682b5c255"
-                },
-                "spec": {
-                    "clusterIP": "10.108.212.37",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8171
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8534
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: CanaryDiffMapping-HTTP-50\nprefix: /CanaryDiffMapping-HTTP-50/\nservice: http://plain-canarydiffmapping-http-50-http.plain-namespace\nhost_rewrite: canary.1.example.com\nambassador_id: plain\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: CanaryDiffMapping-HTTP-50\\nprefix: /CanaryDiffMapping-HTTP-50/\\nservice: http://plain-canarydiffmapping-http-50-http.plain-namespace\\nhost_rewrite: canary.1.example.com\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-canarydiffmapping-http-50-http\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8159},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8522}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2020-02-19T23:20:20Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-canarydiffmapping-http-50-http",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "56419",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-canarydiffmapping-http-50-http",
-                    "uid": "65ed0c3a-536e-11ea-85dd-167682b5c255"
-                },
-                "spec": {
-                    "clusterIP": "10.108.12.140",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8159
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8522
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: CanaryMapping-HTTP-0-canary\nprefix: /CanaryMapping-HTTP-0/\nservice: http://plain-canarymapping-http-0-http-canary.plain-namespace\nweight: 0\nambassador_id: plain\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: CanaryMapping-HTTP-0-canary\\nprefix: /CanaryMapping-HTTP-0/\\nservice: http://plain-canarymapping-http-0-http-canary.plain-namespace\\nweight: 0\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-canarymapping-http-0-http-canary\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8140},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8503}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2020-02-19T23:20:18Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-canarymapping-http-0-http-canary",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "56347",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-canarymapping-http-0-http-canary",
-                    "uid": "64a1d564-536e-11ea-85dd-167682b5c255"
-                },
-                "spec": {
-                    "clusterIP": "10.99.72.0",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8140
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8503
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: SimpleMapping-GRPC-AddResponseHeaders-moo-arf\nprefix: /SimpleMapping-GRPC-AddResponseHeaders-moo-arf/\nservice: http://plain-simplemapping-grpc-addresponseheaders-moo-arf-grpc.plain-namespace\nambassador_id: plain\nadd_response_headers: {\"moo\": \"arf\"}\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: SimpleMapping-GRPC-AddResponseHeaders-moo-arf\\nprefix: /SimpleMapping-GRPC-AddResponseHeaders-moo-arf/\\nservice: http://plain-simplemapping-grpc-addresponseheaders-moo-arf-grpc.plain-namespace\\nambassador_id: plain\\nadd_response_headers: {\\\"moo\\\": \\\"arf\\\"}\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-simplemapping-grpc-addresponseheaders-moo-arf-grpc\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8110},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8473}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2020-02-19T23:20:16Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-simplemapping-grpc-addresponseheaders-moo-arf-grpc",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "56225",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-simplemapping-grpc-addresponseheaders-moo-arf-grpc",
-                    "uid": "62f77b8b-536e-11ea-85dd-167682b5c255"
-                },
-                "spec": {
-                    "clusterIP": "10.105.66.135",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8110
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8473
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: SimpleMapping-GRPC-AddResponseHeaders-xoo-dwe\nprefix: /SimpleMapping-GRPC-AddResponseHeaders-xoo-dwe/\nservice: http://plain-simplemapping-grpc-addresponseheaders-xoo-dwe-grpc.plain-namespace\nambassador_id: plain\nadd_response_headers: {\"xoo\": {\"append\": false, \"value\": \"dwe\"}}\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: SimpleMapping-GRPC-AddResponseHeaders-xoo-dwe\\nprefix: /SimpleMapping-GRPC-AddResponseHeaders-xoo-dwe/\\nservice: http://plain-simplemapping-grpc-addresponseheaders-xoo-dwe-grpc.plain-namespace\\nambassador_id: plain\\nadd_response_headers: {\\\"xoo\\\": {\\\"append\\\": false, \\\"value\\\": \\\"dwe\\\"}}\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-simplemapping-grpc-addresponseheaders-xoo-dwe-grpc\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8112},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8475}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2020-02-19T23:20:16Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-simplemapping-grpc-addresponseheaders-xoo-dwe-grpc",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "56233",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-simplemapping-grpc-addresponseheaders-xoo-dwe-grpc",
-                    "uid": "630f4486-536e-11ea-85dd-167682b5c255"
-                },
-                "spec": {
-                    "clusterIP": "10.105.159.16",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8112
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8475
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: SimpleMapping-GRPC-CORS\nprefix: /SimpleMapping-GRPC-CORS/\nservice: http://plain-simplemapping-grpc-cors-grpc.plain-namespace\nambassador_id: plain\ncors: {origins: \"*\"}\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: SimpleMapping-GRPC-CORS\\nprefix: /SimpleMapping-GRPC-CORS/\\nservice: http://plain-simplemapping-grpc-cors-grpc.plain-namespace\\nambassador_id: plain\\ncors: {origins: \\\"*\\\"}\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-simplemapping-grpc-cors-grpc\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8115},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8478}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2020-02-19T23:20:16Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-simplemapping-grpc-cors-grpc",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "56246",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-simplemapping-grpc-cors-grpc",
-                    "uid": "633aa325-536e-11ea-85dd-167682b5c255"
-                },
-                "spec": {
-                    "clusterIP": "10.99.135.149",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8115
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8478
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"app.kubernetes.io/component\":\"ambassador-service\",\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8080},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8443}],\"selector\":{\"service\":\"plain\"},\"type\":\"NodePort\"}}\n"
-                    },
-                    "creationTimestamp": "2020-02-19T23:20:13Z",
-                    "labels": {
-                        "app.kubernetes.io/component": "ambassador-service",
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "56093",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain",
-                    "uid": "61515bfd-536e-11ea-85dd-167682b5c255"
-                },
-                "spec": {
-                    "clusterIP": "10.96.216.10",
-                    "externalTrafficPolicy": "Cluster",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "nodePort": 31130,
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8080
-                        },
-                        {
-                            "name": "https",
-                            "nodePort": 30281,
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8443
-                        }
-                    ],
-                    "selector": {
-                        "service": "plain"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "NodePort"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: CanaryMapping-HTTP-10-canary\nprefix: /CanaryMapping-HTTP-10/\nservice: http://plain-canarymapping-http-10-http-canary.plain-namespace\nweight: 10\nambassador_id: plain\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: CanaryMapping-HTTP-10-canary\\nprefix: /CanaryMapping-HTTP-10/\\nservice: http://plain-canarymapping-http-10-http-canary.plain-namespace\\nweight: 10\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-canarymapping-http-10-http-canary\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8142},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8505}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2020-02-19T23:20:19Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-canarymapping-http-10-http-canary",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "56354",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-canarymapping-http-10-http-canary",
-                    "uid": "64c157c1-536e-11ea-85dd-167682b5c255"
-                },
-                "spec": {
-                    "clusterIP": "10.107.238.248",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8142
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8505
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-hostheadermappingingress-http-http\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8126},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8489}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2020-02-19T23:20:17Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-hostheadermappingingress-http-http",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "56292",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-hostheadermappingingress-http-http",
-                    "uid": "63d467dc-536e-11ea-85dd-167682b5c255"
-                },
-                "spec": {
-                    "clusterIP": "10.111.130.228",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8126
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8489
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: SimpleMapping-HTTP-AddRequestHeaders-zoo-bar\nprefix: /SimpleMapping-HTTP-AddRequestHeaders-zoo-bar/\nservice: http://plain-simplemapping-http-addrequestheaders-zoo-bar-http.plain-namespace\nambassador_id: plain\nadd_request_headers: {\"zoo\": {\"append\": true, \"value\": \"bar\"}}\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: SimpleMapping-HTTP-AddRequestHeaders-zoo-bar\\nprefix: /SimpleMapping-HTTP-AddRequestHeaders-zoo-bar/\\nservice: http://plain-simplemapping-http-addrequestheaders-zoo-bar-http.plain-namespace\\nambassador_id: plain\\nadd_request_headers: {\\\"zoo\\\": {\\\"append\\\": true, \\\"value\\\": \\\"bar\\\"}}\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-simplemapping-http-addrequestheaders-zoo-bar-http\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8087},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8450}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2020-02-19T23:20:14Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-simplemapping-http-addrequestheaders-zoo-bar-http",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "56131",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-simplemapping-http-addrequestheaders-zoo-bar-http",
-                    "uid": "61c604f3-536e-11ea-85dd-167682b5c255"
-                },
-                "spec": {
-                    "clusterIP": "10.98.191.112",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8087
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8450
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: TLSOrigination-GRPC-IMPLICIT\nprefix: /TLSOrigination-GRPC-IMPLICIT/\nservice: https://plain-tlsorigination-grpc-implicit-grpc.plain-namespace\nambassador_id: plain\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: TLSOrigination-GRPC-IMPLICIT\\nprefix: /TLSOrigination-GRPC-IMPLICIT/\\nservice: https://plain-tlsorigination-grpc-implicit-grpc.plain-namespace\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-tlsorigination-grpc-implicit-grpc\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8136},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8499}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2020-02-19T23:20:18Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-tlsorigination-grpc-implicit-grpc",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "56333",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-tlsorigination-grpc-implicit-grpc",
-                    "uid": "646c7eb3-536e-11ea-85dd-167682b5c255"
-                },
-                "spec": {
-                    "clusterIP": "10.111.156.104",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8136
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8499
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: CanaryDiffMapping-HTTP-10\nprefix: /CanaryDiffMapping-HTTP-10/\nservice: http://plain-canarydiffmapping-http-10-http.plain-namespace\nhost_rewrite: canary.1.example.com\nambassador_id: plain\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: CanaryDiffMapping-HTTP-10\\nprefix: /CanaryDiffMapping-HTTP-10/\\nservice: http://plain-canarydiffmapping-http-10-http.plain-namespace\\nhost_rewrite: canary.1.example.com\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-canarydiffmapping-http-10-http\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8157},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8520}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2020-02-19T23:20:20Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-canarydiffmapping-http-10-http",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "56412",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-canarydiffmapping-http-10-http",
-                    "uid": "65ce110c-536e-11ea-85dd-167682b5c255"
-                },
-                "spec": {
-                    "clusterIP": "10.110.176.247",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8157
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8520
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-hostheadermappingingress-grpc-grpc\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8127},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8490}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2020-02-19T23:20:17Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-hostheadermappingingress-grpc-grpc",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "56297",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-hostheadermappingingress-grpc-grpc",
-                    "uid": "63e6b4dd-536e-11ea-85dd-167682b5c255"
-                },
-                "spec": {
-                    "clusterIP": "10.106.7.192",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8127
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8490
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-simpleingresswithannotations-grpc-grpc\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8125},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8488}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2020-02-19T23:20:17Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-simpleingresswithannotations-grpc-grpc",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "56287",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-simpleingresswithannotations-grpc-grpc",
-                    "uid": "63bf17b1-536e-11ea-85dd-167682b5c255"
-                },
-                "spec": {
-                    "clusterIP": "10.98.196.72",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8125
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8488
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: CanaryDiffMapping-HTTP-100-canary\nprefix: /CanaryDiffMapping-HTTP-100/\nservice: http://plain-canarydiffmapping-http-100-http-canary.plain-namespace\nhost_rewrite: canary.2.example.com\nweight: 100\nambassador_id: plain\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: CanaryDiffMapping-HTTP-100-canary\\nprefix: /CanaryDiffMapping-HTTP-100/\\nservice: http://plain-canarydiffmapping-http-100-http-canary.plain-namespace\\nhost_rewrite: canary.2.example.com\\nweight: 100\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-canarydiffmapping-http-100-http-canary\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8162},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8525}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2020-02-19T23:20:21Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-canarydiffmapping-http-100-http-canary",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "56431",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-canarydiffmapping-http-100-http-canary",
-                    "uid": "661ce6cf-536e-11ea-85dd-167682b5c255"
-                },
-                "spec": {
-                    "clusterIP": "10.98.135.68",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8162
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8525
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: CanaryMapping-GRPC-0\nprefix: /CanaryMapping-GRPC-0/\nservice: http://plain-canarymapping-grpc-0-grpc.plain-namespace\nambassador_id: plain\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: CanaryMapping-GRPC-0\\nprefix: /CanaryMapping-GRPC-0/\\nservice: http://plain-canarymapping-grpc-0-grpc.plain-namespace\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-canarymapping-grpc-0-grpc\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8147},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8510}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2020-02-19T23:20:19Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-canarymapping-grpc-0-grpc",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "56374",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-canarymapping-grpc-0-grpc",
-                    "uid": "650dc497-536e-11ea-85dd-167682b5c255"
-                },
-                "spec": {
-                    "clusterIP": "10.97.33.195",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8147
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8510
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: WebSocketMapping-GRPC\nprefix: /WebSocketMapping-GRPC/\nservice: echo.websocket.org:80\nhost_rewrite: echo.websocket.org\nuse_websocket: true\nambassador_id: plain\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: WebSocketMapping-GRPC\\nprefix: /WebSocketMapping-GRPC/\\nservice: echo.websocket.org:80\\nhost_rewrite: echo.websocket.org\\nuse_websocket: true\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-websocketmapping-grpc-grpc\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8133},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8496}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2020-02-19T23:20:18Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-websocketmapping-grpc-grpc",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "56320",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-websocketmapping-grpc-grpc",
-                    "uid": "644954e2-536e-11ea-85dd-167682b5c255"
-                },
-                "spec": {
-                    "clusterIP": "10.106.99.216",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8133
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8496
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: CanaryDiffMapping-GRPC-10\nprefix: /CanaryDiffMapping-GRPC-10/\nservice: http://plain-canarydiffmapping-grpc-10-grpc.plain-namespace\nhost_rewrite: canary.1.example.com\nambassador_id: plain\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: CanaryDiffMapping-GRPC-10\\nprefix: /CanaryDiffMapping-GRPC-10/\\nservice: http://plain-canarydiffmapping-grpc-10-grpc.plain-namespace\\nhost_rewrite: canary.1.example.com\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-canarydiffmapping-grpc-10-grpc\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8165},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8528}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2020-02-19T23:20:21Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-canarydiffmapping-grpc-10-grpc",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "56441",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-canarydiffmapping-grpc-10-grpc",
-                    "uid": "664a1240-536e-11ea-85dd-167682b5c255"
-                },
-                "spec": {
-                    "clusterIP": "10.99.250.146",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8165
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8528
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: SimpleMapping-GRPC-AddRequestHeaders-zoo-bar\nprefix: /SimpleMapping-GRPC-AddRequestHeaders-zoo-bar/\nservice: http://plain-simplemapping-grpc-addrequestheaders-zoo-bar-grpc.plain-namespace\nambassador_id: plain\nadd_request_headers: {\"zoo\": {\"append\": true, \"value\": \"bar\"}}\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: SimpleMapping-GRPC-AddRequestHeaders-zoo-bar\\nprefix: /SimpleMapping-GRPC-AddRequestHeaders-zoo-bar/\\nservice: http://plain-simplemapping-grpc-addrequestheaders-zoo-bar-grpc.plain-namespace\\nambassador_id: plain\\nadd_request_headers: {\\\"zoo\\\": {\\\"append\\\": true, \\\"value\\\": \\\"bar\\\"}}\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-simplemapping-grpc-addrequestheaders-zoo-bar-grpc\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8106},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8469}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2020-02-19T23:20:15Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-simplemapping-grpc-addrequestheaders-zoo-bar-grpc",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "56209",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-simplemapping-grpc-addrequestheaders-zoo-bar-grpc",
-                    "uid": "62c5fb69-536e-11ea-85dd-167682b5c255"
-                },
-                "spec": {
-                    "clusterIP": "10.104.225.42",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8106
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8469
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: SimpleMapping-HTTP-all\nprefix: /SimpleMapping-HTTP-all/\nservice: http://plain-simplemapping-http-all-http.plain-namespace\nambassador_id: plain\nadd_request_headers: {\"foo\": \"bar\"}\nadd_response_headers: {\"foo\": \"bar\"}\nuse_websocket: true\ncors: {origins: \"*\"}\ncase_sensitive: false\nauto_host_rewrite: true\nrewrite: /foo\nremove_response_headers: x-envoy-upstream-service-time\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: SimpleMapping-HTTP-all\\nprefix: /SimpleMapping-HTTP-all/\\nservice: http://plain-simplemapping-http-all-http.plain-namespace\\nambassador_id: plain\\nadd_request_headers: {\\\"foo\\\": \\\"bar\\\"}\\nadd_response_headers: {\\\"foo\\\": \\\"bar\\\"}\\nuse_websocket: true\\ncors: {origins: \\\"*\\\"}\\ncase_sensitive: false\\nauto_host_rewrite: true\\nrewrite: /foo\\nremove_response_headers: x-envoy-upstream-service-time\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-simplemapping-http-all-http\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8102},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8465}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2020-02-19T23:20:15Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-simplemapping-http-all-http",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "56192",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-simplemapping-http-all-http",
-                    "uid": "628b61ec-536e-11ea-85dd-167682b5c255"
-                },
-                "spec": {
-                    "clusterIP": "10.102.89.138",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8102
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8465
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: SimpleMapping-HTTP-CORS\nprefix: /SimpleMapping-HTTP-CORS/\nservice: http://plain-simplemapping-http-cors-http.plain-namespace\nambassador_id: plain\ncors: {origins: \"*\"}\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: SimpleMapping-HTTP-CORS\\nprefix: /SimpleMapping-HTTP-CORS/\\nservice: http://plain-simplemapping-http-cors-http.plain-namespace\\nambassador_id: plain\\ncors: {origins: \\\"*\\\"}\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-simplemapping-http-cors-http\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8096},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8459}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2020-02-19T23:20:14Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-simplemapping-http-cors-http",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "56166",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-simplemapping-http-cors-http",
-                    "uid": "6235fe1b-536e-11ea-85dd-167682b5c255"
-                },
-                "spec": {
-                    "clusterIP": "10.107.235.172",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8096
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8459
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: SimpleMapping-HTTP-Rewrite-SLASH-foo\nprefix: /SimpleMapping-HTTP-Rewrite-SLASH-foo/\nservice: http://plain-simplemapping-http-rewrite-slash-foo-http.plain-namespace\nambassador_id: plain\nrewrite: /foo\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: SimpleMapping-HTTP-Rewrite-SLASH-foo\\nprefix: /SimpleMapping-HTTP-Rewrite-SLASH-foo/\\nservice: http://plain-simplemapping-http-rewrite-slash-foo-http.plain-namespace\\nambassador_id: plain\\nrewrite: /foo\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-simplemapping-http-rewrite-slash-foo-http\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8099},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8462}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2020-02-19T23:20:15Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-simplemapping-http-rewrite-slash-foo-http",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "56179",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-simplemapping-http-rewrite-slash-foo-http",
-                    "uid": "626b18c5-536e-11ea-85dd-167682b5c255"
-                },
-                "spec": {
-                    "clusterIP": "10.99.9.214",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8099
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8462
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: TLSOrigination-GRPC-EXPLICIT\nprefix: /TLSOrigination-GRPC-EXPLICIT/\nservice: plain-tlsorigination-grpc-explicit-grpc.plain-namespace\ntls: true\nambassador_id: plain\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: TLSOrigination-GRPC-EXPLICIT\\nprefix: /TLSOrigination-GRPC-EXPLICIT/\\nservice: plain-tlsorigination-grpc-explicit-grpc.plain-namespace\\ntls: true\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-tlsorigination-grpc-explicit-grpc\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8137},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8500}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2020-02-19T23:20:18Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-tlsorigination-grpc-explicit-grpc",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "56336",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-tlsorigination-grpc-explicit-grpc",
-                    "uid": "64780a67-536e-11ea-85dd-167682b5c255"
-                },
-                "spec": {
-                    "clusterIP": "10.111.13.57",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8137
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8500
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: TLSOrigination-HTTP-EXPLICIT\nprefix: /TLSOrigination-HTTP-EXPLICIT/\nservice: plain-tlsorigination-http-explicit-http.plain-namespace\ntls: true\nambassador_id: plain\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: TLSOrigination-HTTP-EXPLICIT\\nprefix: /TLSOrigination-HTTP-EXPLICIT/\\nservice: plain-tlsorigination-http-explicit-http.plain-namespace\\ntls: true\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-tlsorigination-http-explicit-http\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8135},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8498}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2020-02-19T23:20:18Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-tlsorigination-http-explicit-http",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "56329",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-tlsorigination-http-explicit-http",
-                    "uid": "645ef449-536e-11ea-85dd-167682b5c255"
-                },
-                "spec": {
-                    "clusterIP": "10.106.142.0",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8135
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8498
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
                         "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: AddReqHeadersMapping-GRPC\nprefix: /AddReqHeadersMapping-GRPC/\nservice: http://plain-addreqheadersmapping-grpc-grpc.plain-namespace\nadd_request_headers:\n  zoo:\n    append: False\n    value: Zoo\n  aoo:\n    append: True\n    value: aoo\n  boo:\n    value: boo\n  foo: Foo\nambassador_id: plain\n",
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: AddReqHeadersMapping-GRPC\\nprefix: /AddReqHeadersMapping-GRPC/\\nservice: http://plain-addreqheadersmapping-grpc-grpc.plain-namespace\\nadd_request_headers:\\n  zoo:\\n    append: False\\n    value: Zoo\\n  aoo:\\n    append: True\\n    value: aoo\\n  boo:\\n    value: boo\\n  foo: Foo\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-addreqheadersmapping-grpc-grpc\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8176},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8539}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
                     },
-                    "creationTimestamp": "2020-02-19T23:20:22Z",
+                    "creationTimestamp": "2020-02-26T15:52:47Z",
                     "labels": {
                         "kat-ambassador-id": "plain",
                         "scope": "AmbassadorTest"
                     },
                     "name": "plain-addreqheadersmapping-grpc-grpc",
                     "namespace": "plain-namespace",
-                    "resourceVersion": "56482",
+                    "resourceVersion": "67499",
                     "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-addreqheadersmapping-grpc-grpc",
-                    "uid": "67118daa-536e-11ea-85dd-167682b5c255"
+                    "uid": "0920703f-58b0-11ea-86d6-0e674b3ff44f"
                 },
                 "spec": {
-                    "clusterIP": "10.102.145.125",
+                    "clusterIP": "10.100.243.26",
                     "ports": [
                         {
                             "name": "http",
@@ -4177,34 +310,34 @@
                 "kind": "Service",
                 "metadata": {
                     "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: InvalidPortMapping-HTTP\nprefix: /InvalidPortMapping-HTTP/\nservice: http://plain-invalidportmapping-http-http.plain-namespace:80.invalid\nambassador_id: plain\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: InvalidPortMapping-HTTP\\nprefix: /InvalidPortMapping-HTTP/\\nservice: http://plain-invalidportmapping-http-http.plain-namespace:80.invalid\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-invalidportmapping-http-http\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8130},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8493}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: AddReqHeadersMapping-HTTP\nprefix: /AddReqHeadersMapping-HTTP/\nservice: http://plain-addreqheadersmapping-http-http.plain-namespace\nadd_request_headers:\n  zoo:\n    append: False\n    value: Zoo\n  aoo:\n    append: True\n    value: aoo\n  boo:\n    value: boo\n  foo: Foo\nambassador_id: plain\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: AddReqHeadersMapping-HTTP\\nprefix: /AddReqHeadersMapping-HTTP/\\nservice: http://plain-addreqheadersmapping-http-http.plain-namespace\\nadd_request_headers:\\n  zoo:\\n    append: False\\n    value: Zoo\\n  aoo:\\n    append: True\\n    value: aoo\\n  boo:\\n    value: boo\\n  foo: Foo\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-addreqheadersmapping-http-http\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8175},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8538}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
                     },
-                    "creationTimestamp": "2020-02-19T23:20:18Z",
+                    "creationTimestamp": "2020-02-26T15:52:46Z",
                     "labels": {
                         "kat-ambassador-id": "plain",
                         "scope": "AmbassadorTest"
                     },
-                    "name": "plain-invalidportmapping-http-http",
+                    "name": "plain-addreqheadersmapping-http-http",
                     "namespace": "plain-namespace",
-                    "resourceVersion": "56309",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-invalidportmapping-http-http",
-                    "uid": "6427310e-536e-11ea-85dd-167682b5c255"
+                    "resourceVersion": "67493",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-addreqheadersmapping-http-http",
+                    "uid": "089603e0-58b0-11ea-86d6-0e674b3ff44f"
                 },
                 "spec": {
-                    "clusterIP": "10.97.252.161",
+                    "clusterIP": "10.110.55.245",
                     "ports": [
                         {
                             "name": "http",
                             "port": 80,
                             "protocol": "TCP",
-                            "targetPort": 8130
+                            "targetPort": 8175
                         },
                         {
                             "name": "https",
                             "port": 443,
                             "protocol": "TCP",
-                            "targetPort": 8493
+                            "targetPort": 8538
                         }
                     ],
                     "selector": {
@@ -4222,34 +355,932 @@
                 "kind": "Service",
                 "metadata": {
                     "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: SimpleMapping-GRPC-AddRequestHeaders-moo-arf\nprefix: /SimpleMapping-GRPC-AddRequestHeaders-moo-arf/\nservice: http://plain-simplemapping-grpc-addrequestheaders-moo-arf-grpc.plain-namespace\nambassador_id: plain\nadd_request_headers: {\"moo\": \"arf\"}\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: SimpleMapping-GRPC-AddRequestHeaders-moo-arf\\nprefix: /SimpleMapping-GRPC-AddRequestHeaders-moo-arf/\\nservice: http://plain-simplemapping-grpc-addrequestheaders-moo-arf-grpc.plain-namespace\\nambassador_id: plain\\nadd_request_headers: {\\\"moo\\\": \\\"arf\\\"}\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-simplemapping-grpc-addrequestheaders-moo-arf-grpc\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8105},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8468}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: CanaryDiffMapping-HTTP-100-canary\nprefix: /CanaryDiffMapping-HTTP-100/\nservice: http://plain-canarydiffmapping-http-100-http-canary.plain-namespace\nhost_rewrite: canary.2.example.com\nweight: 100\nambassador_id: plain\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: CanaryDiffMapping-HTTP-100-canary\\nprefix: /CanaryDiffMapping-HTTP-100/\\nservice: http://plain-canarydiffmapping-http-100-http-canary.plain-namespace\\nhost_rewrite: canary.2.example.com\\nweight: 100\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-canarydiffmapping-http-100-http-canary\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8162},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8525}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
                     },
-                    "creationTimestamp": "2020-02-19T23:20:15Z",
+                    "creationTimestamp": "2020-02-26T15:52:34Z",
                     "labels": {
                         "kat-ambassador-id": "plain",
                         "scope": "AmbassadorTest"
                     },
-                    "name": "plain-simplemapping-grpc-addrequestheaders-moo-arf-grpc",
+                    "name": "plain-canarydiffmapping-http-100-http-canary",
                     "namespace": "plain-namespace",
-                    "resourceVersion": "56204",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-simplemapping-grpc-addrequestheaders-moo-arf-grpc",
-                    "uid": "62b979ee-536e-11ea-85dd-167682b5c255"
+                    "resourceVersion": "67396",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-canarydiffmapping-http-100-http-canary",
+                    "uid": "010af537-58b0-11ea-86d6-0e674b3ff44f"
                 },
                 "spec": {
-                    "clusterIP": "10.97.117.12",
+                    "clusterIP": "10.98.217.97",
                     "ports": [
                         {
                             "name": "http",
                             "port": 80,
                             "protocol": "TCP",
-                            "targetPort": 8105
+                            "targetPort": 8162
                         },
                         {
                             "name": "https",
                             "port": 443,
                             "protocol": "TCP",
-                            "targetPort": 8468
+                            "targetPort": 8525
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: CanaryMapping-HTTP-100-canary\nprefix: /CanaryMapping-HTTP-100/\nservice: http://plain-canarymapping-http-100-http-canary.plain-namespace\nweight: 100\nambassador_id: plain\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: CanaryMapping-HTTP-100-canary\\nprefix: /CanaryMapping-HTTP-100/\\nservice: http://plain-canarymapping-http-100-http-canary.plain-namespace\\nweight: 100\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-canarymapping-http-100-http-canary\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8146},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8509}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2020-02-26T15:52:29Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-canarymapping-http-100-http-canary",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "67294",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-canarymapping-http-100-http-canary",
+                    "uid": "fe2ae77d-58af-11ea-86d6-0e674b3ff44f"
+                },
+                "spec": {
+                    "clusterIP": "10.110.242.197",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8146
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8509
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: SimpleMapping-GRPC-AddRequestHeaders-aoo-tyu\nprefix: /SimpleMapping-GRPC-AddRequestHeaders-aoo-tyu/\nservice: http://plain-simplemapping-grpc-addrequestheaders-aoo-tyu-grpc.plain-namespace\nambassador_id: plain\nadd_request_headers: {\"aoo\": {\"value\": \"tyu\"}}\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: SimpleMapping-GRPC-AddRequestHeaders-aoo-tyu\\nprefix: /SimpleMapping-GRPC-AddRequestHeaders-aoo-tyu/\\nservice: http://plain-simplemapping-grpc-addrequestheaders-aoo-tyu-grpc.plain-namespace\\nambassador_id: plain\\nadd_request_headers: {\\\"aoo\\\": {\\\"value\\\": \\\"tyu\\\"}}\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-simplemapping-grpc-addrequestheaders-aoo-tyu-grpc\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8108},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8471}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2020-02-26T15:52:08Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-simplemapping-grpc-addrequestheaders-aoo-tyu-grpc",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "66988",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-simplemapping-grpc-addrequestheaders-aoo-tyu-grpc",
+                    "uid": "f1c72f3f-58af-11ea-86d6-0e674b3ff44f"
+                },
+                "spec": {
+                    "clusterIP": "10.100.84.155",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8108
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8471
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: SimpleMapping-GRPC-RemoveResponseHeaders\nprefix: /SimpleMapping-GRPC-RemoveResponseHeaders/\nservice: http://plain-simplemapping-grpc-removeresponseheaders-grpc.plain-namespace\nambassador_id: plain\nremove_response_headers: x-envoy-upstream-service-time\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: SimpleMapping-GRPC-RemoveResponseHeaders\\nprefix: /SimpleMapping-GRPC-RemoveResponseHeaders/\\nservice: http://plain-simplemapping-grpc-removeresponseheaders-grpc.plain-namespace\\nambassador_id: plain\\nremove_response_headers: x-envoy-upstream-service-time\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-simplemapping-grpc-removeresponseheaders-grpc\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8120},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8483}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2020-02-26T15:52:14Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-simplemapping-grpc-removeresponseheaders-grpc",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "67068",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-simplemapping-grpc-removeresponseheaders-grpc",
+                    "uid": "f52d9c71-58af-11ea-86d6-0e674b3ff44f"
+                },
+                "spec": {
+                    "clusterIP": "10.98.113.190",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8120
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8483
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: SimpleMapping-GRPC-UseWebsocket\nprefix: /SimpleMapping-GRPC-UseWebsocket/\nservice: http://plain-simplemapping-grpc-usewebsocket-grpc.plain-namespace\nambassador_id: plain\nuse_websocket: true\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: SimpleMapping-GRPC-UseWebsocket\\nprefix: /SimpleMapping-GRPC-UseWebsocket/\\nservice: http://plain-simplemapping-grpc-usewebsocket-grpc.plain-namespace\\nambassador_id: plain\\nuse_websocket: true\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-simplemapping-grpc-usewebsocket-grpc\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8114},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8477}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2020-02-26T15:52:11Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-simplemapping-grpc-usewebsocket-grpc",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "67031",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-simplemapping-grpc-usewebsocket-grpc",
+                    "uid": "f3a3c0ad-58af-11ea-86d6-0e674b3ff44f"
+                },
+                "spec": {
+                    "clusterIP": "10.109.122.201",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8114
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8477
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: CanaryDiffMapping-HTTP-10-canary\nprefix: /CanaryDiffMapping-HTTP-10/\nservice: http://plain-canarydiffmapping-http-10-http-canary.plain-namespace\nhost_rewrite: canary.2.example.com\nweight: 10\nambassador_id: plain\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: CanaryDiffMapping-HTTP-10-canary\\nprefix: /CanaryDiffMapping-HTTP-10/\\nservice: http://plain-canarydiffmapping-http-10-http-canary.plain-namespace\\nhost_rewrite: canary.2.example.com\\nweight: 10\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-canarydiffmapping-http-10-http-canary\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8158},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8521}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2020-02-26T15:52:32Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-canarydiffmapping-http-10-http-canary",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "67365",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-canarydiffmapping-http-10-http-canary",
+                    "uid": "00061c2a-58b0-11ea-86d6-0e674b3ff44f"
+                },
+                "spec": {
+                    "clusterIP": "10.107.116.16",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8158
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8521
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: CanaryMapping-HTTP-100\nprefix: /CanaryMapping-HTTP-100/\nservice: http://plain-canarymapping-http-100-http.plain-namespace\nambassador_id: plain\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: CanaryMapping-HTTP-100\\nprefix: /CanaryMapping-HTTP-100/\\nservice: http://plain-canarymapping-http-100-http.plain-namespace\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-canarymapping-http-100-http\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8145},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8508}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2020-02-26T15:52:29Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-canarymapping-http-100-http",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "67287",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-canarymapping-http-100-http",
+                    "uid": "fe10f3a2-58af-11ea-86d6-0e674b3ff44f"
+                },
+                "spec": {
+                    "clusterIP": "10.104.139.220",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8145
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8508
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: CanaryDiffMapping-HTTP-50-canary\nprefix: /CanaryDiffMapping-HTTP-50/\nservice: http://plain-canarydiffmapping-http-50-http-canary.plain-namespace\nhost_rewrite: canary.2.example.com\nweight: 50\nambassador_id: plain\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: CanaryDiffMapping-HTTP-50-canary\\nprefix: /CanaryDiffMapping-HTTP-50/\\nservice: http://plain-canarydiffmapping-http-50-http-canary.plain-namespace\\nhost_rewrite: canary.2.example.com\\nweight: 50\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-canarydiffmapping-http-50-http-canary\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8160},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8523}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2020-02-26T15:52:33Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-canarydiffmapping-http-50-http-canary",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "67376",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-canarydiffmapping-http-50-http-canary",
+                    "uid": "006503a1-58b0-11ea-86d6-0e674b3ff44f"
+                },
+                "spec": {
+                    "clusterIP": "10.105.179.110",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8160
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8523
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: CanaryMapping-HTTP-0\nprefix: /CanaryMapping-HTTP-0/\nservice: http://plain-canarymapping-http-0-http.plain-namespace\nambassador_id: plain\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: CanaryMapping-HTTP-0\\nprefix: /CanaryMapping-HTTP-0/\\nservice: http://plain-canarymapping-http-0-http.plain-namespace\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-canarymapping-http-0-http\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8139},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8502}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2020-02-26T15:52:26Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-canarymapping-http-0-http",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "67234",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-canarymapping-http-0-http",
+                    "uid": "fc662cef-58af-11ea-86d6-0e674b3ff44f"
+                },
+                "spec": {
+                    "clusterIP": "10.96.108.164",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8139
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8502
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: SimpleMapping-HTTP\nprefix: /SimpleMapping-HTTP/\nservice: http://plain-simplemapping-http-http.plain-namespace\nambassador_id: plain\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: SimpleMapping-HTTP\\nprefix: /SimpleMapping-HTTP/\\nservice: http://plain-simplemapping-http-http.plain-namespace\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-simplemapping-http-http\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8084},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8447}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2020-02-26T15:52:02Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-simplemapping-http-http",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "66862",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-simplemapping-http-http",
+                    "uid": "ee5cb49c-58af-11ea-86d6-0e674b3ff44f"
+                },
+                "spec": {
+                    "clusterIP": "10.109.96.226",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8084
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8447
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: TLSOrigination-GRPC-IMPLICIT\nprefix: /TLSOrigination-GRPC-IMPLICIT/\nservice: https://plain-tlsorigination-grpc-implicit-grpc.plain-namespace\nambassador_id: plain\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: TLSOrigination-GRPC-IMPLICIT\\nprefix: /TLSOrigination-GRPC-IMPLICIT/\\nservice: https://plain-tlsorigination-grpc-implicit-grpc.plain-namespace\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-tlsorigination-grpc-implicit-grpc\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8136},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8499}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2020-02-26T15:52:25Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-tlsorigination-grpc-implicit-grpc",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "67211",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-tlsorigination-grpc-implicit-grpc",
+                    "uid": "fba5a46a-58af-11ea-86d6-0e674b3ff44f"
+                },
+                "spec": {
+                    "clusterIP": "10.109.64.121",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8136
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8499
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: CanaryMapping-GRPC-50-canary\nprefix: /CanaryMapping-GRPC-50/\nservice: http://plain-canarymapping-grpc-50-grpc-canary.plain-namespace\nweight: 50\nambassador_id: plain\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: CanaryMapping-GRPC-50-canary\\nprefix: /CanaryMapping-GRPC-50/\\nservice: http://plain-canarymapping-grpc-50-grpc-canary.plain-namespace\\nweight: 50\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-canarymapping-grpc-50-grpc-canary\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8152},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8515}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2020-02-26T15:52:31Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-canarymapping-grpc-50-grpc-canary",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "67328",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-canarymapping-grpc-50-grpc-canary",
+                    "uid": "ff12ec4b-58af-11ea-86d6-0e674b3ff44f"
+                },
+                "spec": {
+                    "clusterIP": "10.102.251.141",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8152
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8515
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-hostheadermappingingress-http-http\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8126},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8489}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2020-02-26T15:52:20Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-hostheadermappingingress-http-http",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "67132",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-hostheadermappingingress-http-http",
+                    "uid": "f8f7dde5-58af-11ea-86d6-0e674b3ff44f"
+                },
+                "spec": {
+                    "clusterIP": "10.106.17.16",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8126
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8489
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: RemoveReqHeadersMapping-GRPC\nprefix: /RemoveReqHeadersMapping-GRPC/\nservice: http://httpbin.org\nremove_request_headers:\n- zoo\n- aoo\nambassador_id: plain\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: RemoveReqHeadersMapping-GRPC\\nprefix: /RemoveReqHeadersMapping-GRPC/\\nservice: http://httpbin.org\\nremove_request_headers:\\n- zoo\\n- aoo\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-removereqheadersmapping-grpc-grpc\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8174},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8537}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2020-02-26T15:52:46Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-removereqheadersmapping-grpc-grpc",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "67487",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-removereqheadersmapping-grpc-grpc",
+                    "uid": "08407578-58b0-11ea-86d6-0e674b3ff44f"
+                },
+                "spec": {
+                    "clusterIP": "10.109.178.44",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8174
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8537
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-simplemappingingress-grpc-grpc\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8123},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8486}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2020-02-26T15:52:18Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-simplemappingingress-grpc-grpc",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "67097",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-simplemappingingress-grpc-grpc",
+                    "uid": "f78f8045-58af-11ea-86d6-0e674b3ff44f"
+                },
+                "spec": {
+                    "clusterIP": "10.102.45.142",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8123
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8486
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: TLSOrigination-HTTP-EXPLICIT\nprefix: /TLSOrigination-HTTP-EXPLICIT/\nservice: plain-tlsorigination-http-explicit-http.plain-namespace\ntls: true\nambassador_id: plain\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: TLSOrigination-HTTP-EXPLICIT\\nprefix: /TLSOrigination-HTTP-EXPLICIT/\\nservice: plain-tlsorigination-http-explicit-http.plain-namespace\\ntls: true\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-tlsorigination-http-explicit-http\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8135},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8498}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2020-02-26T15:52:24Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-tlsorigination-http-explicit-http",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "67206",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-tlsorigination-http-explicit-http",
+                    "uid": "fb6fb140-58af-11ea-86d6-0e674b3ff44f"
+                },
+                "spec": {
+                    "clusterIP": "10.97.241.78",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8135
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8498
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: WebSocketMapping-GRPC\nprefix: /WebSocketMapping-GRPC/\nservice: echo.websocket.org:80\nhost_rewrite: echo.websocket.org\nuse_websocket: true\nambassador_id: plain\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: WebSocketMapping-GRPC\\nprefix: /WebSocketMapping-GRPC/\\nservice: echo.websocket.org:80\\nhost_rewrite: echo.websocket.org\\nuse_websocket: true\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-websocketmapping-grpc-grpc\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8133},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8496}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2020-02-26T15:52:24Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-websocketmapping-grpc-grpc",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "67194",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-websocketmapping-grpc-grpc",
+                    "uid": "fb1e9f26-58af-11ea-86d6-0e674b3ff44f"
+                },
+                "spec": {
+                    "clusterIP": "10.103.158.143",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8133
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8496
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: CanaryDiffMapping-GRPC-0-canary\nprefix: /CanaryDiffMapping-GRPC-0/\nservice: http://plain-canarydiffmapping-grpc-0-grpc-canary.plain-namespace\nhost_rewrite: canary.2.example.com\nweight: 0\nambassador_id: plain\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: CanaryDiffMapping-GRPC-0-canary\\nprefix: /CanaryDiffMapping-GRPC-0/\\nservice: http://plain-canarydiffmapping-grpc-0-grpc-canary.plain-namespace\\nhost_rewrite: canary.2.example.com\\nweight: 0\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-canarydiffmapping-grpc-0-grpc-canary\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8164},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8527}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2020-02-26T15:52:35Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-canarydiffmapping-grpc-0-grpc-canary",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "67414",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-canarydiffmapping-grpc-0-grpc-canary",
+                    "uid": "01ca226e-58b0-11ea-86d6-0e674b3ff44f"
+                },
+                "spec": {
+                    "clusterIP": "10.102.197.19",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8164
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8527
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: CanaryMapping-HTTP-50\nprefix: /CanaryMapping-HTTP-50/\nservice: http://plain-canarymapping-http-50-http.plain-namespace\nambassador_id: plain\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: CanaryMapping-HTTP-50\\nprefix: /CanaryMapping-HTTP-50/\\nservice: http://plain-canarymapping-http-50-http.plain-namespace\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-canarymapping-http-50-http\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8143},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8506}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2020-02-26T15:52:28Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-canarymapping-http-50-http",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "67271",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-canarymapping-http-50-http",
+                    "uid": "fd83d9d7-58af-11ea-86d6-0e674b3ff44f"
+                },
+                "spec": {
+                    "clusterIP": "10.106.9.159",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8143
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8506
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: SimpleMapping-GRPC-AddRequestHeaders-zoo-bar\nprefix: /SimpleMapping-GRPC-AddRequestHeaders-zoo-bar/\nservice: http://plain-simplemapping-grpc-addrequestheaders-zoo-bar-grpc.plain-namespace\nambassador_id: plain\nadd_request_headers: {\"zoo\": {\"append\": true, \"value\": \"bar\"}}\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: SimpleMapping-GRPC-AddRequestHeaders-zoo-bar\\nprefix: /SimpleMapping-GRPC-AddRequestHeaders-zoo-bar/\\nservice: http://plain-simplemapping-grpc-addrequestheaders-zoo-bar-grpc.plain-namespace\\nambassador_id: plain\\nadd_request_headers: {\\\"zoo\\\": {\\\"append\\\": true, \\\"value\\\": \\\"bar\\\"}}\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-simplemapping-grpc-addrequestheaders-zoo-bar-grpc\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8106},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8469}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2020-02-26T15:52:08Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-simplemapping-grpc-addrequestheaders-zoo-bar-grpc",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "66981",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-simplemapping-grpc-addrequestheaders-zoo-bar-grpc",
+                    "uid": "f19bf4ca-58af-11ea-86d6-0e674b3ff44f"
+                },
+                "spec": {
+                    "clusterIP": "10.96.204.191",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8106
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8469
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: SimpleMapping-GRPC\nprefix: /SimpleMapping-GRPC/\nservice: http://plain-simplemapping-grpc-grpc.plain-namespace\nambassador_id: plain\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: SimpleMapping-GRPC\\nprefix: /SimpleMapping-GRPC/\\nservice: http://plain-simplemapping-grpc-grpc.plain-namespace\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-simplemapping-grpc-grpc\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8103},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8466}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2020-02-26T15:52:06Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-simplemapping-grpc-grpc",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "66954",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-simplemapping-grpc-grpc",
+                    "uid": "f0b1fc1f-58af-11ea-86d6-0e674b3ff44f"
+                },
+                "spec": {
+                    "clusterIP": "10.105.134.144",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8103
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8466
                         }
                     ],
                     "selector": {
@@ -4270,19 +1301,19 @@
                         "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: SimpleMapping-HTTP-AddResponseHeaders-zoo-bar\nprefix: /SimpleMapping-HTTP-AddResponseHeaders-zoo-bar/\nservice: http://plain-simplemapping-http-addresponseheaders-zoo-bar-http.plain-namespace\nambassador_id: plain\nadd_response_headers: {\"zoo\": {\"append\": true, \"value\": \"bar\"}}\n",
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: SimpleMapping-HTTP-AddResponseHeaders-zoo-bar\\nprefix: /SimpleMapping-HTTP-AddResponseHeaders-zoo-bar/\\nservice: http://plain-simplemapping-http-addresponseheaders-zoo-bar-http.plain-namespace\\nambassador_id: plain\\nadd_response_headers: {\\\"zoo\\\": {\\\"append\\\": true, \\\"value\\\": \\\"bar\\\"}}\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-simplemapping-http-addresponseheaders-zoo-bar-http\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8092},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8455}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
                     },
-                    "creationTimestamp": "2020-02-19T23:20:14Z",
+                    "creationTimestamp": "2020-02-26T15:52:04Z",
                     "labels": {
                         "kat-ambassador-id": "plain",
                         "scope": "AmbassadorTest"
                     },
                     "name": "plain-simplemapping-http-addresponseheaders-zoo-bar-http",
                     "namespace": "plain-namespace",
-                    "resourceVersion": "56152",
+                    "resourceVersion": "66904",
                     "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-simplemapping-http-addresponseheaders-zoo-bar-http",
-                    "uid": "620a8927-536e-11ea-85dd-167682b5c255"
+                    "uid": "ef6218fa-58af-11ea-86d6-0e674b3ff44f"
                 },
                 "spec": {
-                    "clusterIP": "10.98.87.223",
+                    "clusterIP": "10.106.249.72",
                     "ports": [
                         {
                             "name": "http",
@@ -4312,34 +1343,34 @@
                 "kind": "Service",
                 "metadata": {
                     "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: SimpleMapping-HTTP-RemoveResponseHeaders\nprefix: /SimpleMapping-HTTP-RemoveResponseHeaders/\nservice: http://plain-simplemapping-http-removeresponseheaders-http.plain-namespace\nambassador_id: plain\nremove_response_headers: x-envoy-upstream-service-time\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: SimpleMapping-HTTP-RemoveResponseHeaders\\nprefix: /SimpleMapping-HTTP-RemoveResponseHeaders/\\nservice: http://plain-simplemapping-http-removeresponseheaders-http.plain-namespace\\nambassador_id: plain\\nremove_response_headers: x-envoy-upstream-service-time\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-simplemapping-http-removeresponseheaders-http\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8101},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8464}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: SimpleMapping-HTTP-UseWebsocket\nprefix: /SimpleMapping-HTTP-UseWebsocket/\nservice: http://plain-simplemapping-http-usewebsocket-http.plain-namespace\nambassador_id: plain\nuse_websocket: true\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: SimpleMapping-HTTP-UseWebsocket\\nprefix: /SimpleMapping-HTTP-UseWebsocket/\\nservice: http://plain-simplemapping-http-usewebsocket-http.plain-namespace\\nambassador_id: plain\\nuse_websocket: true\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-simplemapping-http-usewebsocket-http\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8095},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8458}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
                     },
-                    "creationTimestamp": "2020-02-19T23:20:15Z",
+                    "creationTimestamp": "2020-02-26T15:52:05Z",
                     "labels": {
                         "kat-ambassador-id": "plain",
                         "scope": "AmbassadorTest"
                     },
-                    "name": "plain-simplemapping-http-removeresponseheaders-http",
+                    "name": "plain-simplemapping-http-usewebsocket-http",
                     "namespace": "plain-namespace",
-                    "resourceVersion": "56188",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-simplemapping-http-removeresponseheaders-http",
-                    "uid": "627fdddb-536e-11ea-85dd-167682b5c255"
+                    "resourceVersion": "66916",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-simplemapping-http-usewebsocket-http",
+                    "uid": "ef9918cb-58af-11ea-86d6-0e674b3ff44f"
                 },
                 "spec": {
-                    "clusterIP": "10.102.227.103",
+                    "clusterIP": "10.100.82.214",
                     "ports": [
                         {
                             "name": "http",
                             "port": 80,
                             "protocol": "TCP",
-                            "targetPort": 8101
+                            "targetPort": 8095
                         },
                         {
                             "name": "https",
                             "port": 443,
                             "protocol": "TCP",
-                            "targetPort": 8464
+                            "targetPort": 8458
                         }
                     ],
                     "selector": {
@@ -4357,34 +1388,34 @@
                 "kind": "Service",
                 "metadata": {
                     "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: WebSocketMapping-HTTP\nprefix: /WebSocketMapping-HTTP/\nservice: echo.websocket.org:80\nhost_rewrite: echo.websocket.org\nuse_websocket: true\nambassador_id: plain\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: WebSocketMapping-HTTP\\nprefix: /WebSocketMapping-HTTP/\\nservice: echo.websocket.org:80\\nhost_rewrite: echo.websocket.org\\nuse_websocket: true\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-websocketmapping-http-http\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8132},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8495}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: CanaryDiffMapping-GRPC-10\nprefix: /CanaryDiffMapping-GRPC-10/\nservice: http://plain-canarydiffmapping-grpc-10-grpc.plain-namespace\nhost_rewrite: canary.1.example.com\nambassador_id: plain\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: CanaryDiffMapping-GRPC-10\\nprefix: /CanaryDiffMapping-GRPC-10/\\nservice: http://plain-canarydiffmapping-grpc-10-grpc.plain-namespace\\nhost_rewrite: canary.1.example.com\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-canarydiffmapping-grpc-10-grpc\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8165},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8528}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
                     },
-                    "creationTimestamp": "2020-02-19T23:20:18Z",
+                    "creationTimestamp": "2020-02-26T15:52:35Z",
                     "labels": {
                         "kat-ambassador-id": "plain",
                         "scope": "AmbassadorTest"
                     },
-                    "name": "plain-websocketmapping-http-http",
+                    "name": "plain-canarydiffmapping-grpc-10-grpc",
                     "namespace": "plain-namespace",
-                    "resourceVersion": "56317",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-websocketmapping-http-http",
-                    "uid": "643d7fba-536e-11ea-85dd-167682b5c255"
+                    "resourceVersion": "67421",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-canarydiffmapping-grpc-10-grpc",
+                    "uid": "01e5a09a-58b0-11ea-86d6-0e674b3ff44f"
                 },
                 "spec": {
-                    "clusterIP": "10.109.156.34",
+                    "clusterIP": "10.105.214.92",
                     "ports": [
                         {
                             "name": "http",
                             "port": 80,
                             "protocol": "TCP",
-                            "targetPort": 8132
+                            "targetPort": 8165
                         },
                         {
                             "name": "https",
                             "port": 443,
                             "protocol": "TCP",
-                            "targetPort": 8495
+                            "targetPort": 8528
                         }
                     ],
                     "selector": {
@@ -4402,34 +1433,34 @@
                 "kind": "Service",
                 "metadata": {
                     "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: AddRespHeadersMapping-GRPC\nprefix: /AddRespHeadersMapping-GRPC/\nservice: http://httpbin.org\nadd_response_headers:\n  koo:\n    append: False\n    value: KooK\n  zoo:\n    append: True\n    value: ZooZ\n  test:\n    value: boo\n  foo: Foo\nambassador_id: plain\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: AddRespHeadersMapping-GRPC\\nprefix: /AddRespHeadersMapping-GRPC/\\nservice: http://httpbin.org\\nadd_response_headers:\\n  koo:\\n    append: False\\n    value: KooK\\n  zoo:\\n    append: True\\n    value: ZooZ\\n  test:\\n    value: boo\\n  foo: Foo\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-addrespheadersmapping-grpc-grpc\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8172},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8535}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: CanaryDiffMapping-GRPC-10-canary\nprefix: /CanaryDiffMapping-GRPC-10/\nservice: http://plain-canarydiffmapping-grpc-10-grpc-canary.plain-namespace\nhost_rewrite: canary.2.example.com\nweight: 10\nambassador_id: plain\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: CanaryDiffMapping-GRPC-10-canary\\nprefix: /CanaryDiffMapping-GRPC-10/\\nservice: http://plain-canarydiffmapping-grpc-10-grpc-canary.plain-namespace\\nhost_rewrite: canary.2.example.com\\nweight: 10\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-canarydiffmapping-grpc-10-grpc-canary\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8166},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8529}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
                     },
-                    "creationTimestamp": "2020-02-19T23:20:22Z",
+                    "creationTimestamp": "2020-02-26T15:52:35Z",
                     "labels": {
                         "kat-ambassador-id": "plain",
                         "scope": "AmbassadorTest"
                     },
-                    "name": "plain-addrespheadersmapping-grpc-grpc",
+                    "name": "plain-canarydiffmapping-grpc-10-grpc-canary",
                     "namespace": "plain-namespace",
-                    "resourceVersion": "56466",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-addrespheadersmapping-grpc-grpc",
-                    "uid": "66bdeedc-536e-11ea-85dd-167682b5c255"
+                    "resourceVersion": "67426",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-canarydiffmapping-grpc-10-grpc-canary",
+                    "uid": "020a6cb1-58b0-11ea-86d6-0e674b3ff44f"
                 },
                 "spec": {
-                    "clusterIP": "10.111.37.22",
+                    "clusterIP": "10.98.11.27",
                     "ports": [
                         {
                             "name": "http",
                             "port": 80,
                             "protocol": "TCP",
-                            "targetPort": 8172
+                            "targetPort": 8166
                         },
                         {
                             "name": "https",
                             "port": 443,
                             "protocol": "TCP",
-                            "targetPort": 8535
+                            "targetPort": 8529
                         }
                     ],
                     "selector": {
@@ -4447,165 +1478,34 @@
                 "kind": "Service",
                 "metadata": {
                     "annotations": {
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\",\"service\":\"plain-admin\"},\"name\":\"plain-admin\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"plain-admin\",\"port\":8877,\"targetPort\":8877}],\"selector\":{\"service\":\"plain\"},\"type\":\"NodePort\"}}\n"
+                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: HostHeaderMapping-HTTP\nprefix: /HostHeaderMapping-HTTP/\nservice: http://plain-hostheadermapping-http-http.plain-namespace\nhost: inspector.external\nambassador_id: plain\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: HostHeaderMapping-HTTP\\nprefix: /HostHeaderMapping-HTTP/\\nservice: http://plain-hostheadermapping-http-http.plain-namespace\\nhost: inspector.external\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-hostheadermapping-http-http\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8128},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8491}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
                     },
-                    "creationTimestamp": "2020-02-19T23:20:13Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest",
-                        "service": "plain-admin"
-                    },
-                    "name": "plain-admin",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "56098",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-admin",
-                    "uid": "615d8ee2-536e-11ea-85dd-167682b5c255"
-                },
-                "spec": {
-                    "clusterIP": "10.109.11.77",
-                    "externalTrafficPolicy": "Cluster",
-                    "ports": [
-                        {
-                            "name": "plain-admin",
-                            "nodePort": 32654,
-                            "port": 8877,
-                            "protocol": "TCP",
-                            "targetPort": 8877
-                        }
-                    ],
-                    "selector": {
-                        "service": "plain"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "NodePort"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: CanaryDiffMapping-GRPC-50-canary\nprefix: /CanaryDiffMapping-GRPC-50/\nservice: http://plain-canarydiffmapping-grpc-50-grpc-canary.plain-namespace\nhost_rewrite: canary.2.example.com\nweight: 50\nambassador_id: plain\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: CanaryDiffMapping-GRPC-50-canary\\nprefix: /CanaryDiffMapping-GRPC-50/\\nservice: http://plain-canarydiffmapping-grpc-50-grpc-canary.plain-namespace\\nhost_rewrite: canary.2.example.com\\nweight: 50\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-canarydiffmapping-grpc-50-grpc-canary\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8168},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8531}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2020-02-19T23:20:22Z",
+                    "creationTimestamp": "2020-02-26T15:52:21Z",
                     "labels": {
                         "kat-ambassador-id": "plain",
                         "scope": "AmbassadorTest"
                     },
-                    "name": "plain-canarydiffmapping-grpc-50-grpc-canary",
+                    "name": "plain-hostheadermapping-http-http",
                     "namespace": "plain-namespace",
-                    "resourceVersion": "56452",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-canarydiffmapping-grpc-50-grpc-canary",
-                    "uid": "66894400-536e-11ea-85dd-167682b5c255"
+                    "resourceVersion": "67148",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-hostheadermapping-http-http",
+                    "uid": "f995f82a-58af-11ea-86d6-0e674b3ff44f"
                 },
                 "spec": {
-                    "clusterIP": "10.98.216.248",
+                    "clusterIP": "10.100.55.242",
                     "ports": [
                         {
                             "name": "http",
                             "port": 80,
                             "protocol": "TCP",
-                            "targetPort": 8168
+                            "targetPort": 8128
                         },
                         {
                             "name": "https",
                             "port": 443,
                             "protocol": "TCP",
-                            "targetPort": 8531
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: HostRedirectMapping\nprefix: /HostRedirectMapping/\nservice: foobar.com\nhost_redirect: true\nambassador_id: plain\n---\napiVersion: ambassador/v0\nkind: Mapping\nname: HostRedirectMapping-2\nprefix: /HostRedirectMapping-2/\ncase_sensitive: false\nservice: foobar.com\nhost_redirect: true\nambassador_id: plain\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: HostRedirectMapping\\nprefix: /HostRedirectMapping/\\nservice: foobar.com\\nhost_redirect: true\\nambassador_id: plain\\n---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: HostRedirectMapping-2\\nprefix: /HostRedirectMapping-2/\\ncase_sensitive: false\\nservice: foobar.com\\nhost_redirect: true\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-hostredirectmapping-http\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8138},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8501}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2020-02-19T23:20:18Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-hostredirectmapping-http",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "56339",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-hostredirectmapping-http",
-                    "uid": "6483160b-536e-11ea-85dd-167682b5c255"
-                },
-                "spec": {
-                    "clusterIP": "10.103.18.43",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8138
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8501
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-plain-namespace"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: SimpleMapping-GRPC-AddResponseHeaders-aoo-tyu\nprefix: /SimpleMapping-GRPC-AddResponseHeaders-aoo-tyu/\nservice: http://plain-simplemapping-grpc-addresponseheaders-aoo-tyu-grpc.plain-namespace\nambassador_id: plain\nadd_response_headers: {\"aoo\": {\"value\": \"tyu\"}}\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: SimpleMapping-GRPC-AddResponseHeaders-aoo-tyu\\nprefix: /SimpleMapping-GRPC-AddResponseHeaders-aoo-tyu/\\nservice: http://plain-simplemapping-grpc-addresponseheaders-aoo-tyu-grpc.plain-namespace\\nambassador_id: plain\\nadd_response_headers: {\\\"aoo\\\": {\\\"value\\\": \\\"tyu\\\"}}\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-simplemapping-grpc-addresponseheaders-aoo-tyu-grpc\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8113},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8476}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
-                    },
-                    "creationTimestamp": "2020-02-19T23:20:16Z",
-                    "labels": {
-                        "kat-ambassador-id": "plain",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "plain-simplemapping-grpc-addresponseheaders-aoo-tyu-grpc",
-                    "namespace": "plain-namespace",
-                    "resourceVersion": "56238",
-                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-simplemapping-grpc-addresponseheaders-aoo-tyu-grpc",
-                    "uid": "6326d2ed-536e-11ea-85dd-167682b5c255"
-                },
-                "spec": {
-                    "clusterIP": "10.103.232.56",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8113
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8476
+                            "targetPort": 8491
                         }
                     ],
                     "selector": {
@@ -4626,19 +1526,19 @@
                         "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: SimpleMapping-GRPC-AddResponseHeaders-foo-bar\nprefix: /SimpleMapping-GRPC-AddResponseHeaders-foo-bar/\nservice: http://plain-simplemapping-grpc-addresponseheaders-foo-bar-grpc.plain-namespace\nambassador_id: plain\nadd_response_headers: {\"foo\": \"bar\"}\n",
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: SimpleMapping-GRPC-AddResponseHeaders-foo-bar\\nprefix: /SimpleMapping-GRPC-AddResponseHeaders-foo-bar/\\nservice: http://plain-simplemapping-grpc-addresponseheaders-foo-bar-grpc.plain-namespace\\nambassador_id: plain\\nadd_response_headers: {\\\"foo\\\": \\\"bar\\\"}\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-simplemapping-grpc-addresponseheaders-foo-bar-grpc\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8109},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8472}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
                     },
-                    "creationTimestamp": "2020-02-19T23:20:15Z",
+                    "creationTimestamp": "2020-02-26T15:52:09Z",
                     "labels": {
                         "kat-ambassador-id": "plain",
                         "scope": "AmbassadorTest"
                     },
                     "name": "plain-simplemapping-grpc-addresponseheaders-foo-bar-grpc",
                     "namespace": "plain-namespace",
-                    "resourceVersion": "56220",
+                    "resourceVersion": "66993",
                     "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-simplemapping-grpc-addresponseheaders-foo-bar-grpc",
-                    "uid": "62e73eef-536e-11ea-85dd-167682b5c255"
+                    "uid": "f1faf66f-58af-11ea-86d6-0e674b3ff44f"
                 },
                 "spec": {
-                    "clusterIP": "10.108.93.3",
+                    "clusterIP": "10.111.67.162",
                     "ports": [
                         {
                             "name": "http",
@@ -4668,22 +1568,3078 @@
                 "kind": "Service",
                 "metadata": {
                     "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: SimpleMapping-GRPC-AutoHostRewrite\nprefix: /SimpleMapping-GRPC-AutoHostRewrite/\nservice: http://plain-simplemapping-grpc-autohostrewrite-grpc.plain-namespace\nambassador_id: plain\nauto_host_rewrite: true\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: SimpleMapping-GRPC-AutoHostRewrite\\nprefix: /SimpleMapping-GRPC-AutoHostRewrite/\\nservice: http://plain-simplemapping-grpc-autohostrewrite-grpc.plain-namespace\\nambassador_id: plain\\nauto_host_rewrite: true\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-simplemapping-grpc-autohostrewrite-grpc\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8117},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8480}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2020-02-26T15:52:12Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-simplemapping-grpc-autohostrewrite-grpc",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "67045",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-simplemapping-grpc-autohostrewrite-grpc",
+                    "uid": "f3dca3cc-58af-11ea-86d6-0e674b3ff44f"
+                },
+                "spec": {
+                    "clusterIP": "10.98.123.69",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8117
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8480
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: TLSOrigination-HTTP-IMPLICIT\nprefix: /TLSOrigination-HTTP-IMPLICIT/\nservice: https://plain-tlsorigination-http-implicit-http.plain-namespace\nambassador_id: plain\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: TLSOrigination-HTTP-IMPLICIT\\nprefix: /TLSOrigination-HTTP-IMPLICIT/\\nservice: https://plain-tlsorigination-http-implicit-http.plain-namespace\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-tlsorigination-http-implicit-http\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8134},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8497}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2020-02-26T15:52:24Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-tlsorigination-http-implicit-http",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "67200",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-tlsorigination-http-implicit-http",
+                    "uid": "fb3ce3a1-58af-11ea-86d6-0e674b3ff44f"
+                },
+                "spec": {
+                    "clusterIP": "10.101.71.247",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8134
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8497
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: CanaryDiffMapping-GRPC-100\nprefix: /CanaryDiffMapping-GRPC-100/\nservice: http://plain-canarydiffmapping-grpc-100-grpc.plain-namespace\nhost_rewrite: canary.1.example.com\nambassador_id: plain\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: CanaryDiffMapping-GRPC-100\\nprefix: /CanaryDiffMapping-GRPC-100/\\nservice: http://plain-canarydiffmapping-grpc-100-grpc.plain-namespace\\nhost_rewrite: canary.1.example.com\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-canarydiffmapping-grpc-100-grpc\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8169},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8532}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2020-02-26T15:52:37Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-canarydiffmapping-grpc-100-grpc",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "67443",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-canarydiffmapping-grpc-100-grpc",
+                    "uid": "02b91585-58b0-11ea-86d6-0e674b3ff44f"
+                },
+                "spec": {
+                    "clusterIP": "10.110.184.71",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8169
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8532
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: CanaryDiffMapping-HTTP-0-canary\nprefix: /CanaryDiffMapping-HTTP-0/\nservice: http://plain-canarydiffmapping-http-0-http-canary.plain-namespace\nhost_rewrite: canary.2.example.com\nweight: 0\nambassador_id: plain\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: CanaryDiffMapping-HTTP-0-canary\\nprefix: /CanaryDiffMapping-HTTP-0/\\nservice: http://plain-canarydiffmapping-http-0-http-canary.plain-namespace\\nhost_rewrite: canary.2.example.com\\nweight: 0\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-canarydiffmapping-http-0-http-canary\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8156},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8519}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2020-02-26T15:52:32Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-canarydiffmapping-http-0-http-canary",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "67352",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-canarydiffmapping-http-0-http-canary",
+                    "uid": "ffbd2dc7-58af-11ea-86d6-0e674b3ff44f"
+                },
+                "spec": {
+                    "clusterIP": "10.106.183.34",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8156
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8519
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: CanaryMapping-GRPC-10\nprefix: /CanaryMapping-GRPC-10/\nservice: http://plain-canarymapping-grpc-10-grpc.plain-namespace\nambassador_id: plain\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: CanaryMapping-GRPC-10\\nprefix: /CanaryMapping-GRPC-10/\\nservice: http://plain-canarymapping-grpc-10-grpc.plain-namespace\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-canarymapping-grpc-10-grpc\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8149},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8512}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2020-02-26T15:52:30Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-canarymapping-grpc-10-grpc",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "67312",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-canarymapping-grpc-10-grpc",
+                    "uid": "febb975c-58af-11ea-86d6-0e674b3ff44f"
+                },
+                "spec": {
+                    "clusterIP": "10.97.76.99",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8149
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8512
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: CanaryMapping-GRPC-100\nprefix: /CanaryMapping-GRPC-100/\nservice: http://plain-canarymapping-grpc-100-grpc.plain-namespace\nambassador_id: plain\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: CanaryMapping-GRPC-100\\nprefix: /CanaryMapping-GRPC-100/\\nservice: http://plain-canarymapping-grpc-100-grpc.plain-namespace\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-canarymapping-grpc-100-grpc\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8153},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8516}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2020-02-26T15:52:31Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-canarymapping-grpc-100-grpc",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "67332",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-canarymapping-grpc-100-grpc",
+                    "uid": "ff22ea8b-58af-11ea-86d6-0e674b3ff44f"
+                },
+                "spec": {
+                    "clusterIP": "10.101.223.113",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8153
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8516
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: SimpleMapping-GRPC-all\nprefix: /SimpleMapping-GRPC-all/\nservice: http://plain-simplemapping-grpc-all-grpc.plain-namespace\nambassador_id: plain\nadd_request_headers: {\"foo\": \"bar\"}\nadd_response_headers: {\"foo\": \"bar\"}\nuse_websocket: true\ncors: {origins: \"*\"}\ncase_sensitive: false\nauto_host_rewrite: true\nrewrite: /foo\nremove_response_headers: x-envoy-upstream-service-time\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: SimpleMapping-GRPC-all\\nprefix: /SimpleMapping-GRPC-all/\\nservice: http://plain-simplemapping-grpc-all-grpc.plain-namespace\\nambassador_id: plain\\nadd_request_headers: {\\\"foo\\\": \\\"bar\\\"}\\nadd_response_headers: {\\\"foo\\\": \\\"bar\\\"}\\nuse_websocket: true\\ncors: {origins: \\\"*\\\"}\\ncase_sensitive: false\\nauto_host_rewrite: true\\nrewrite: /foo\\nremove_response_headers: x-envoy-upstream-service-time\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-simplemapping-grpc-all-grpc\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8121},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8484}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2020-02-26T15:52:15Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-simplemapping-grpc-all-grpc",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "67073",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-simplemapping-grpc-all-grpc",
+                    "uid": "f5d58a8f-58af-11ea-86d6-0e674b3ff44f"
+                },
+                "spec": {
+                    "clusterIP": "10.110.7.183",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8121
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8484
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: SimpleMapping-GRPC-CaseSensitive\nprefix: /SimpleMapping-GRPC-CaseSensitive/\nservice: http://plain-simplemapping-grpc-casesensitive-grpc.plain-namespace\nambassador_id: plain\ncase_sensitive: false\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: SimpleMapping-GRPC-CaseSensitive\\nprefix: /SimpleMapping-GRPC-CaseSensitive/\\nservice: http://plain-simplemapping-grpc-casesensitive-grpc.plain-namespace\\nambassador_id: plain\\ncase_sensitive: false\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-simplemapping-grpc-casesensitive-grpc\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8116},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8479}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2020-02-26T15:52:12Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-simplemapping-grpc-casesensitive-grpc",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "67041",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-simplemapping-grpc-casesensitive-grpc",
+                    "uid": "f3c9c8d1-58af-11ea-86d6-0e674b3ff44f"
+                },
+                "spec": {
+                    "clusterIP": "10.98.168.107",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8116
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8479
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: SimpleMapping-HTTP-AddRequestHeaders-xoo-dwe\nprefix: /SimpleMapping-HTTP-AddRequestHeaders-xoo-dwe/\nservice: http://plain-simplemapping-http-addrequestheaders-xoo-dwe-http.plain-namespace\nambassador_id: plain\nadd_request_headers: {\"xoo\": {\"append\": false, \"value\": \"dwe\"}}\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: SimpleMapping-HTTP-AddRequestHeaders-xoo-dwe\\nprefix: /SimpleMapping-HTTP-AddRequestHeaders-xoo-dwe/\\nservice: http://plain-simplemapping-http-addrequestheaders-xoo-dwe-http.plain-namespace\\nambassador_id: plain\\nadd_request_headers: {\\\"xoo\\\": {\\\"append\\\": false, \\\"value\\\": \\\"dwe\\\"}}\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-simplemapping-http-addrequestheaders-xoo-dwe-http\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8088},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8451}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2020-02-26T15:52:03Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-simplemapping-http-addrequestheaders-xoo-dwe-http",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "66883",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-simplemapping-http-addrequestheaders-xoo-dwe-http",
+                    "uid": "eec5cd7d-58af-11ea-86d6-0e674b3ff44f"
+                },
+                "spec": {
+                    "clusterIP": "10.109.128.241",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8088
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8451
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: SimpleMapping-HTTP-CORS\nprefix: /SimpleMapping-HTTP-CORS/\nservice: http://plain-simplemapping-http-cors-http.plain-namespace\nambassador_id: plain\ncors: {origins: \"*\"}\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: SimpleMapping-HTTP-CORS\\nprefix: /SimpleMapping-HTTP-CORS/\\nservice: http://plain-simplemapping-http-cors-http.plain-namespace\\nambassador_id: plain\\ncors: {origins: \\\"*\\\"}\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-simplemapping-http-cors-http\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8096},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8459}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2020-02-26T15:52:05Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-simplemapping-http-cors-http",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "66920",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-simplemapping-http-cors-http",
+                    "uid": "efaac0c0-58af-11ea-86d6-0e674b3ff44f"
+                },
+                "spec": {
+                    "clusterIP": "10.96.50.172",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8096
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8459
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: AddRespHeadersMapping-HTTP\nprefix: /AddRespHeadersMapping-HTTP/\nservice: http://httpbin.org\nadd_response_headers:\n  koo:\n    append: False\n    value: KooK\n  zoo:\n    append: True\n    value: ZooZ\n  test:\n    value: boo\n  foo: Foo\nambassador_id: plain\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: AddRespHeadersMapping-HTTP\\nprefix: /AddRespHeadersMapping-HTTP/\\nservice: http://httpbin.org\\nadd_response_headers:\\n  koo:\\n    append: False\\n    value: KooK\\n  zoo:\\n    append: True\\n    value: ZooZ\\n  test:\\n    value: boo\\n  foo: Foo\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-addrespheadersmapping-http-http\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8171},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8534}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2020-02-26T15:52:43Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-addrespheadersmapping-http-http",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "67464",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-addrespheadersmapping-http-http",
+                    "uid": "06a4e756-58b0-11ea-86d6-0e674b3ff44f"
+                },
+                "spec": {
+                    "clusterIP": "10.107.70.76",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8171
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8534
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: CanaryDiffMapping-GRPC-100-canary\nprefix: /CanaryDiffMapping-GRPC-100/\nservice: http://plain-canarydiffmapping-grpc-100-grpc-canary.plain-namespace\nhost_rewrite: canary.2.example.com\nweight: 100\nambassador_id: plain\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: CanaryDiffMapping-GRPC-100-canary\\nprefix: /CanaryDiffMapping-GRPC-100/\\nservice: http://plain-canarydiffmapping-grpc-100-grpc-canary.plain-namespace\\nhost_rewrite: canary.2.example.com\\nweight: 100\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-canarydiffmapping-grpc-100-grpc-canary\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8170},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8533}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2020-02-26T15:52:40Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-canarydiffmapping-grpc-100-grpc-canary",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "67455",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-canarydiffmapping-grpc-100-grpc-canary",
+                    "uid": "04d5cd2d-58b0-11ea-86d6-0e674b3ff44f"
+                },
+                "spec": {
+                    "clusterIP": "10.100.174.197",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8170
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8533
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: CanaryMapping-HTTP-50-canary\nprefix: /CanaryMapping-HTTP-50/\nservice: http://plain-canarymapping-http-50-http-canary.plain-namespace\nweight: 50\nambassador_id: plain\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: CanaryMapping-HTTP-50-canary\\nprefix: /CanaryMapping-HTTP-50/\\nservice: http://plain-canarymapping-http-50-http-canary.plain-namespace\\nweight: 50\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-canarymapping-http-50-http-canary\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8144},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8507}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2020-02-26T15:52:28Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-canarymapping-http-50-http-canary",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "67278",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-canarymapping-http-50-http-canary",
+                    "uid": "fdb4b71e-58af-11ea-86d6-0e674b3ff44f"
+                },
+                "spec": {
+                    "clusterIP": "10.97.39.42",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8144
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8507
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: HeaderRoutingTest-GRPC-target2\nprefix: /HeaderRoutingTest-GRPC/\nservice: http://plain-headerroutingtest-grpc-grpc-target2.plain-namespace\nheaders:\n  X-Route: target2\nambassador_id: plain\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: HeaderRoutingTest-GRPC-target2\\nprefix: /HeaderRoutingTest-GRPC/\\nservice: http://plain-headerroutingtest-grpc-grpc-target2.plain-namespace\\nheaders:\\n  X-Route: target2\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-headerroutingtest-grpc-grpc-target2\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8083},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8446}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2020-02-26T15:52:02Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-headerroutingtest-grpc-grpc-target2",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "66857",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-headerroutingtest-grpc-grpc-target2",
+                    "uid": "ee3f24b3-58af-11ea-86d6-0e674b3ff44f"
+                },
+                "spec": {
+                    "clusterIP": "10.105.113.209",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8083
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8446
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-simpleingresswithannotations-http-http\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8124},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8487}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2020-02-26T15:52:19Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-simpleingresswithannotations-http-http",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "67111",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-simpleingresswithannotations-http-http",
+                    "uid": "f802a313-58af-11ea-86d6-0e674b3ff44f"
+                },
+                "spec": {
+                    "clusterIP": "10.104.139.105",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8124
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8487
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: SimpleMapping-GRPC-AddRequestHeaders-moo-arf\nprefix: /SimpleMapping-GRPC-AddRequestHeaders-moo-arf/\nservice: http://plain-simplemapping-grpc-addrequestheaders-moo-arf-grpc.plain-namespace\nambassador_id: plain\nadd_request_headers: {\"moo\": \"arf\"}\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: SimpleMapping-GRPC-AddRequestHeaders-moo-arf\\nprefix: /SimpleMapping-GRPC-AddRequestHeaders-moo-arf/\\nservice: http://plain-simplemapping-grpc-addrequestheaders-moo-arf-grpc.plain-namespace\\nambassador_id: plain\\nadd_request_headers: {\\\"moo\\\": \\\"arf\\\"}\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-simplemapping-grpc-addrequestheaders-moo-arf-grpc\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8105},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8468}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2020-02-26T15:52:08Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-simplemapping-grpc-addrequestheaders-moo-arf-grpc",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "66976",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-simplemapping-grpc-addrequestheaders-moo-arf-grpc",
+                    "uid": "f1808fa2-58af-11ea-86d6-0e674b3ff44f"
+                },
+                "spec": {
+                    "clusterIP": "10.110.225.238",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8105
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8468
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: SimpleMapping-GRPC-Rewrite-foo\nprefix: /SimpleMapping-GRPC-Rewrite-foo/\nservice: http://plain-simplemapping-grpc-rewrite-foo-grpc.plain-namespace\nambassador_id: plain\nrewrite: foo\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: SimpleMapping-GRPC-Rewrite-foo\\nprefix: /SimpleMapping-GRPC-Rewrite-foo/\\nservice: http://plain-simplemapping-grpc-rewrite-foo-grpc.plain-namespace\\nambassador_id: plain\\nrewrite: foo\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-simplemapping-grpc-rewrite-foo-grpc\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8119},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8482}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2020-02-26T15:52:14Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-simplemapping-grpc-rewrite-foo-grpc",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "67061",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-simplemapping-grpc-rewrite-foo-grpc",
+                    "uid": "f4f383b1-58af-11ea-86d6-0e674b3ff44f"
+                },
+                "spec": {
+                    "clusterIP": "10.107.147.146",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8119
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8482
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: SimpleMapping-HTTP-AddRequestHeaders-moo-arf\nprefix: /SimpleMapping-HTTP-AddRequestHeaders-moo-arf/\nservice: http://plain-simplemapping-http-addrequestheaders-moo-arf-http.plain-namespace\nambassador_id: plain\nadd_request_headers: {\"moo\": \"arf\"}\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: SimpleMapping-HTTP-AddRequestHeaders-moo-arf\\nprefix: /SimpleMapping-HTTP-AddRequestHeaders-moo-arf/\\nservice: http://plain-simplemapping-http-addrequestheaders-moo-arf-http.plain-namespace\\nambassador_id: plain\\nadd_request_headers: {\\\"moo\\\": \\\"arf\\\"}\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-simplemapping-http-addrequestheaders-moo-arf-http\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8086},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8449}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2020-02-26T15:52:03Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-simplemapping-http-addrequestheaders-moo-arf-http",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "66871",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-simplemapping-http-addrequestheaders-moo-arf-http",
+                    "uid": "ee8f0654-58af-11ea-86d6-0e674b3ff44f"
+                },
+                "spec": {
+                    "clusterIP": "10.99.62.198",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8086
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8449
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: WebSocketMapping-HTTP\nprefix: /WebSocketMapping-HTTP/\nservice: echo.websocket.org:80\nhost_rewrite: echo.websocket.org\nuse_websocket: true\nambassador_id: plain\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: WebSocketMapping-HTTP\\nprefix: /WebSocketMapping-HTTP/\\nservice: echo.websocket.org:80\\nhost_rewrite: echo.websocket.org\\nuse_websocket: true\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-websocketmapping-http-http\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8132},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8495}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2020-02-26T15:52:24Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-websocketmapping-http-http",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "67186",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-websocketmapping-http-http",
+                    "uid": "faedff96-58af-11ea-86d6-0e674b3ff44f"
+                },
+                "spec": {
+                    "clusterIP": "10.103.6.117",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8132
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8495
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: CanaryDiffMapping-GRPC-50-canary\nprefix: /CanaryDiffMapping-GRPC-50/\nservice: http://plain-canarydiffmapping-grpc-50-grpc-canary.plain-namespace\nhost_rewrite: canary.2.example.com\nweight: 50\nambassador_id: plain\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: CanaryDiffMapping-GRPC-50-canary\\nprefix: /CanaryDiffMapping-GRPC-50/\\nservice: http://plain-canarydiffmapping-grpc-50-grpc-canary.plain-namespace\\nhost_rewrite: canary.2.example.com\\nweight: 50\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-canarydiffmapping-grpc-50-grpc-canary\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8168},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8531}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2020-02-26T15:52:36Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-canarydiffmapping-grpc-50-grpc-canary",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "67439",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-canarydiffmapping-grpc-50-grpc-canary",
+                    "uid": "02734058-58b0-11ea-86d6-0e674b3ff44f"
+                },
+                "spec": {
+                    "clusterIP": "10.103.119.166",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8168
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8531
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: HeaderRoutingTest-GRPC-target1\nprefix: /HeaderRoutingTest-GRPC/\nservice: http://plain-headerroutingtest-grpc-grpc.plain-namespace\nambassador_id: plain\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: HeaderRoutingTest-GRPC-target1\\nprefix: /HeaderRoutingTest-GRPC/\\nservice: http://plain-headerroutingtest-grpc-grpc.plain-namespace\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-headerroutingtest-grpc-grpc\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8082},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8445}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2020-02-26T15:52:02Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-headerroutingtest-grpc-grpc",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "66851",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-headerroutingtest-grpc-grpc",
+                    "uid": "ee29ec75-58af-11ea-86d6-0e674b3ff44f"
+                },
+                "spec": {
+                    "clusterIP": "10.96.250.33",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8082
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8445
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: SimpleMapping-GRPC-Rewrite-SLASH-foo\nprefix: /SimpleMapping-GRPC-Rewrite-SLASH-foo/\nservice: http://plain-simplemapping-grpc-rewrite-slash-foo-grpc.plain-namespace\nambassador_id: plain\nrewrite: /foo\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: SimpleMapping-GRPC-Rewrite-SLASH-foo\\nprefix: /SimpleMapping-GRPC-Rewrite-SLASH-foo/\\nservice: http://plain-simplemapping-grpc-rewrite-slash-foo-grpc.plain-namespace\\nambassador_id: plain\\nrewrite: /foo\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-simplemapping-grpc-rewrite-slash-foo-grpc\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8118},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8481}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2020-02-26T15:52:12Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-simplemapping-grpc-rewrite-slash-foo-grpc",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "67053",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-simplemapping-grpc-rewrite-slash-foo-grpc",
+                    "uid": "f44cc6d5-58af-11ea-86d6-0e674b3ff44f"
+                },
+                "spec": {
+                    "clusterIP": "10.98.203.205",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8118
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8481
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: SimpleMapping-HTTP-AddResponseHeaders-aoo-tyu\nprefix: /SimpleMapping-HTTP-AddResponseHeaders-aoo-tyu/\nservice: http://plain-simplemapping-http-addresponseheaders-aoo-tyu-http.plain-namespace\nambassador_id: plain\nadd_response_headers: {\"aoo\": {\"value\": \"tyu\"}}\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: SimpleMapping-HTTP-AddResponseHeaders-aoo-tyu\\nprefix: /SimpleMapping-HTTP-AddResponseHeaders-aoo-tyu/\\nservice: http://plain-simplemapping-http-addresponseheaders-aoo-tyu-http.plain-namespace\\nambassador_id: plain\\nadd_response_headers: {\\\"aoo\\\": {\\\"value\\\": \\\"tyu\\\"}}\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-simplemapping-http-addresponseheaders-aoo-tyu-http\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8094},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8457}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2020-02-26T15:52:04Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-simplemapping-http-addresponseheaders-aoo-tyu-http",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "66912",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-simplemapping-http-addresponseheaders-aoo-tyu-http",
+                    "uid": "ef850034-58af-11ea-86d6-0e674b3ff44f"
+                },
+                "spec": {
+                    "clusterIP": "10.108.194.167",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8094
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8457
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: TLSOrigination-GRPC-EXPLICIT\nprefix: /TLSOrigination-GRPC-EXPLICIT/\nservice: plain-tlsorigination-grpc-explicit-grpc.plain-namespace\ntls: true\nambassador_id: plain\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: TLSOrigination-GRPC-EXPLICIT\\nprefix: /TLSOrigination-GRPC-EXPLICIT/\\nservice: plain-tlsorigination-grpc-explicit-grpc.plain-namespace\\ntls: true\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-tlsorigination-grpc-explicit-grpc\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8137},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8500}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2020-02-26T15:52:25Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-tlsorigination-grpc-explicit-grpc",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "67218",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-tlsorigination-grpc-explicit-grpc",
+                    "uid": "fbca8113-58af-11ea-86d6-0e674b3ff44f"
+                },
+                "spec": {
+                    "clusterIP": "10.108.116.46",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8137
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8500
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: CanaryMapping-GRPC-0\nprefix: /CanaryMapping-GRPC-0/\nservice: http://plain-canarymapping-grpc-0-grpc.plain-namespace\nambassador_id: plain\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: CanaryMapping-GRPC-0\\nprefix: /CanaryMapping-GRPC-0/\\nservice: http://plain-canarymapping-grpc-0-grpc.plain-namespace\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-canarymapping-grpc-0-grpc\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8147},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8510}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2020-02-26T15:52:29Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-canarymapping-grpc-0-grpc",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "67299",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-canarymapping-grpc-0-grpc",
+                    "uid": "fe4cad38-58af-11ea-86d6-0e674b3ff44f"
+                },
+                "spec": {
+                    "clusterIP": "10.103.55.74",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8147
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8510
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: CanaryMapping-HTTP-10\nprefix: /CanaryMapping-HTTP-10/\nservice: http://plain-canarymapping-http-10-http.plain-namespace\nambassador_id: plain\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: CanaryMapping-HTTP-10\\nprefix: /CanaryMapping-HTTP-10/\\nservice: http://plain-canarymapping-http-10-http.plain-namespace\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-canarymapping-http-10-http\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8141},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8504}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2020-02-26T15:52:28Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-canarymapping-http-10-http",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "67260",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-canarymapping-http-10-http",
+                    "uid": "fd4ae577-58af-11ea-86d6-0e674b3ff44f"
+                },
+                "spec": {
+                    "clusterIP": "10.110.15.71",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8141
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8504
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: HostHeaderMapping-GRPC\nprefix: /HostHeaderMapping-GRPC/\nservice: http://plain-hostheadermapping-grpc-grpc.plain-namespace\nhost: inspector.external\nambassador_id: plain\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: HostHeaderMapping-GRPC\\nprefix: /HostHeaderMapping-GRPC/\\nservice: http://plain-hostheadermapping-grpc-grpc.plain-namespace\\nhost: inspector.external\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-hostheadermapping-grpc-grpc\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8129},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8492}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2020-02-26T15:52:22Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-hostheadermapping-grpc-grpc",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "67153",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-hostheadermapping-grpc-grpc",
+                    "uid": "f9d0e9bb-58af-11ea-86d6-0e674b3ff44f"
+                },
+                "spec": {
+                    "clusterIP": "10.97.255.7",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8129
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8492
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-simpleingresswithannotations-grpc-grpc\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8125},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8488}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2020-02-26T15:52:20Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-simpleingresswithannotations-grpc-grpc",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "67122",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-simpleingresswithannotations-grpc-grpc",
+                    "uid": "f8a71bed-58af-11ea-86d6-0e674b3ff44f"
+                },
+                "spec": {
+                    "clusterIP": "10.101.185.108",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8125
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8488
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: SimpleMapping-GRPC-AddRequestHeaders-xoo-dwe\nprefix: /SimpleMapping-GRPC-AddRequestHeaders-xoo-dwe/\nservice: http://plain-simplemapping-grpc-addrequestheaders-xoo-dwe-grpc.plain-namespace\nambassador_id: plain\nadd_request_headers: {\"xoo\": {\"append\": false, \"value\": \"dwe\"}}\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: SimpleMapping-GRPC-AddRequestHeaders-xoo-dwe\\nprefix: /SimpleMapping-GRPC-AddRequestHeaders-xoo-dwe/\\nservice: http://plain-simplemapping-grpc-addrequestheaders-xoo-dwe-grpc.plain-namespace\\nambassador_id: plain\\nadd_request_headers: {\\\"xoo\\\": {\\\"append\\\": false, \\\"value\\\": \\\"dwe\\\"}}\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-simplemapping-grpc-addrequestheaders-xoo-dwe-grpc\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8107},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8470}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2020-02-26T15:52:08Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-simplemapping-grpc-addrequestheaders-xoo-dwe-grpc",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "66985",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-simplemapping-grpc-addrequestheaders-xoo-dwe-grpc",
+                    "uid": "f1a98733-58af-11ea-86d6-0e674b3ff44f"
+                },
+                "spec": {
+                    "clusterIP": "10.97.15.146",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8107
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8470
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: SimpleMapping-GRPC-AddResponseHeaders-aoo-tyu\nprefix: /SimpleMapping-GRPC-AddResponseHeaders-aoo-tyu/\nservice: http://plain-simplemapping-grpc-addresponseheaders-aoo-tyu-grpc.plain-namespace\nambassador_id: plain\nadd_response_headers: {\"aoo\": {\"value\": \"tyu\"}}\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: SimpleMapping-GRPC-AddResponseHeaders-aoo-tyu\\nprefix: /SimpleMapping-GRPC-AddResponseHeaders-aoo-tyu/\\nservice: http://plain-simplemapping-grpc-addresponseheaders-aoo-tyu-grpc.plain-namespace\\nambassador_id: plain\\nadd_response_headers: {\\\"aoo\\\": {\\\"value\\\": \\\"tyu\\\"}}\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-simplemapping-grpc-addresponseheaders-aoo-tyu-grpc\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8113},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8476}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2020-02-26T15:52:11Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-simplemapping-grpc-addresponseheaders-aoo-tyu-grpc",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "67025",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-simplemapping-grpc-addresponseheaders-aoo-tyu-grpc",
+                    "uid": "f3290a19-58af-11ea-86d6-0e674b3ff44f"
+                },
+                "spec": {
+                    "clusterIP": "10.100.87.201",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8113
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8476
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: SimpleMapping-HTTP-AddResponseHeaders-foo-bar\nprefix: /SimpleMapping-HTTP-AddResponseHeaders-foo-bar/\nservice: http://plain-simplemapping-http-addresponseheaders-foo-bar-http.plain-namespace\nambassador_id: plain\nadd_response_headers: {\"foo\": \"bar\"}\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: SimpleMapping-HTTP-AddResponseHeaders-foo-bar\\nprefix: /SimpleMapping-HTTP-AddResponseHeaders-foo-bar/\\nservice: http://plain-simplemapping-http-addresponseheaders-foo-bar-http.plain-namespace\\nambassador_id: plain\\nadd_response_headers: {\\\"foo\\\": \\\"bar\\\"}\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-simplemapping-http-addresponseheaders-foo-bar-http\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8090},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8453}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2020-02-26T15:52:03Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-simplemapping-http-addresponseheaders-foo-bar-http",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "66892",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-simplemapping-http-addresponseheaders-foo-bar-http",
+                    "uid": "eeefcba5-58af-11ea-86d6-0e674b3ff44f"
+                },
+                "spec": {
+                    "clusterIP": "10.107.67.63",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8090
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8453
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: SimpleMapping-HTTP-AddResponseHeaders-xoo-dwe\nprefix: /SimpleMapping-HTTP-AddResponseHeaders-xoo-dwe/\nservice: http://plain-simplemapping-http-addresponseheaders-xoo-dwe-http.plain-namespace\nambassador_id: plain\nadd_response_headers: {\"xoo\": {\"append\": false, \"value\": \"dwe\"}}\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: SimpleMapping-HTTP-AddResponseHeaders-xoo-dwe\\nprefix: /SimpleMapping-HTTP-AddResponseHeaders-xoo-dwe/\\nservice: http://plain-simplemapping-http-addresponseheaders-xoo-dwe-http.plain-namespace\\nambassador_id: plain\\nadd_response_headers: {\\\"xoo\\\": {\\\"append\\\": false, \\\"value\\\": \\\"dwe\\\"}}\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-simplemapping-http-addresponseheaders-xoo-dwe-http\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8093},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8456}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2020-02-26T15:52:04Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-simplemapping-http-addresponseheaders-xoo-dwe-http",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "66908",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-simplemapping-http-addresponseheaders-xoo-dwe-http",
+                    "uid": "ef708168-58af-11ea-86d6-0e674b3ff44f"
+                },
+                "spec": {
+                    "clusterIP": "10.97.15.244",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8093
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8456
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: SimpleMapping-HTTP-Rewrite-foo\nprefix: /SimpleMapping-HTTP-Rewrite-foo/\nservice: http://plain-simplemapping-http-rewrite-foo-http.plain-namespace\nambassador_id: plain\nrewrite: foo\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: SimpleMapping-HTTP-Rewrite-foo\\nprefix: /SimpleMapping-HTTP-Rewrite-foo/\\nservice: http://plain-simplemapping-http-rewrite-foo-http.plain-namespace\\nambassador_id: plain\\nrewrite: foo\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-simplemapping-http-rewrite-foo-http\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8100},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8463}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2020-02-26T15:52:05Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-simplemapping-http-rewrite-foo-http",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "66940",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-simplemapping-http-rewrite-foo-http",
+                    "uid": "f0237ee9-58af-11ea-86d6-0e674b3ff44f"
+                },
+                "spec": {
+                    "clusterIP": "10.107.72.107",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8100
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8463
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\",\"service\":\"plain-admin\"},\"name\":\"plain-admin\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"plain-admin\",\"port\":8877,\"targetPort\":8877}],\"selector\":{\"service\":\"plain\"},\"type\":\"NodePort\"}}\n"
+                    },
+                    "creationTimestamp": "2020-02-26T15:52:01Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest",
+                        "service": "plain-admin"
+                    },
+                    "name": "plain-admin",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "66830",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-admin",
+                    "uid": "ed83d8a1-58af-11ea-86d6-0e674b3ff44f"
+                },
+                "spec": {
+                    "clusterIP": "10.107.194.2",
+                    "externalTrafficPolicy": "Cluster",
+                    "ports": [
+                        {
+                            "name": "plain-admin",
+                            "nodePort": 30674,
+                            "port": 8877,
+                            "protocol": "TCP",
+                            "targetPort": 8877
+                        }
+                    ],
+                    "selector": {
+                        "service": "plain"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "NodePort"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: CanaryDiffMapping-HTTP-10\nprefix: /CanaryDiffMapping-HTTP-10/\nservice: http://plain-canarydiffmapping-http-10-http.plain-namespace\nhost_rewrite: canary.1.example.com\nambassador_id: plain\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: CanaryDiffMapping-HTTP-10\\nprefix: /CanaryDiffMapping-HTTP-10/\\nservice: http://plain-canarydiffmapping-http-10-http.plain-namespace\\nhost_rewrite: canary.1.example.com\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-canarydiffmapping-http-10-http\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8157},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8520}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2020-02-26T15:52:32Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-canarydiffmapping-http-10-http",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "67359",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-canarydiffmapping-http-10-http",
+                    "uid": "ffcf71c5-58af-11ea-86d6-0e674b3ff44f"
+                },
+                "spec": {
+                    "clusterIP": "10.110.93.136",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8157
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8520
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: CanaryMapping-HTTP-0-canary\nprefix: /CanaryMapping-HTTP-0/\nservice: http://plain-canarymapping-http-0-http-canary.plain-namespace\nweight: 0\nambassador_id: plain\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: CanaryMapping-HTTP-0-canary\\nprefix: /CanaryMapping-HTTP-0/\\nservice: http://plain-canarymapping-http-0-http-canary.plain-namespace\\nweight: 0\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-canarymapping-http-0-http-canary\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8140},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8503}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2020-02-26T15:52:27Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-canarymapping-http-0-http-canary",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "67244",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-canarymapping-http-0-http-canary",
+                    "uid": "fcd72ee5-58af-11ea-86d6-0e674b3ff44f"
+                },
+                "spec": {
+                    "clusterIP": "10.96.79.167",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8140
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8503
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: CanaryMapping-HTTP-10-canary\nprefix: /CanaryMapping-HTTP-10/\nservice: http://plain-canarymapping-http-10-http-canary.plain-namespace\nweight: 10\nambassador_id: plain\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: CanaryMapping-HTTP-10-canary\\nprefix: /CanaryMapping-HTTP-10/\\nservice: http://plain-canarymapping-http-10-http-canary.plain-namespace\\nweight: 10\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-canarymapping-http-10-http-canary\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8142},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8505}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2020-02-26T15:52:28Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-canarymapping-http-10-http-canary",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "67267",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-canarymapping-http-10-http-canary",
+                    "uid": "fd6acc9e-58af-11ea-86d6-0e674b3ff44f"
+                },
+                "spec": {
+                    "clusterIP": "10.109.69.91",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8142
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8505
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: SimpleMapping-GRPC-AddResponseHeaders-moo-arf\nprefix: /SimpleMapping-GRPC-AddResponseHeaders-moo-arf/\nservice: http://plain-simplemapping-grpc-addresponseheaders-moo-arf-grpc.plain-namespace\nambassador_id: plain\nadd_response_headers: {\"moo\": \"arf\"}\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: SimpleMapping-GRPC-AddResponseHeaders-moo-arf\\nprefix: /SimpleMapping-GRPC-AddResponseHeaders-moo-arf/\\nservice: http://plain-simplemapping-grpc-addresponseheaders-moo-arf-grpc.plain-namespace\\nambassador_id: plain\\nadd_response_headers: {\\\"moo\\\": \\\"arf\\\"}\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-simplemapping-grpc-addresponseheaders-moo-arf-grpc\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8110},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8473}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2020-02-26T15:52:09Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-simplemapping-grpc-addresponseheaders-moo-arf-grpc",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "66999",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-simplemapping-grpc-addresponseheaders-moo-arf-grpc",
+                    "uid": "f23579d1-58af-11ea-86d6-0e674b3ff44f"
+                },
+                "spec": {
+                    "clusterIP": "10.96.255.245",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8110
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8473
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: SimpleMapping-HTTP-AutoHostRewrite\nprefix: /SimpleMapping-HTTP-AutoHostRewrite/\nservice: http://plain-simplemapping-http-autohostrewrite-http.plain-namespace\nambassador_id: plain\nauto_host_rewrite: true\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: SimpleMapping-HTTP-AutoHostRewrite\\nprefix: /SimpleMapping-HTTP-AutoHostRewrite/\\nservice: http://plain-simplemapping-http-autohostrewrite-http.plain-namespace\\nambassador_id: plain\\nauto_host_rewrite: true\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-simplemapping-http-autohostrewrite-http\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8098},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8461}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2020-02-26T15:52:05Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-simplemapping-http-autohostrewrite-http",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "66929",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-simplemapping-http-autohostrewrite-http",
+                    "uid": "efe31f5b-58af-11ea-86d6-0e674b3ff44f"
+                },
+                "spec": {
+                    "clusterIP": "10.101.110.211",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8098
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8461
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"app.kubernetes.io/component\":\"ambassador-service\",\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8080},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8443}],\"selector\":{\"service\":\"plain\"},\"type\":\"NodePort\"}}\n"
+                    },
+                    "creationTimestamp": "2020-02-26T15:52:01Z",
+                    "labels": {
+                        "app.kubernetes.io/component": "ambassador-service",
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "66820",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain",
+                    "uid": "ed6ca8b8-58af-11ea-86d6-0e674b3ff44f"
+                },
+                "spec": {
+                    "clusterIP": "10.98.69.254",
+                    "externalTrafficPolicy": "Cluster",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "nodePort": 31320,
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8080
+                        },
+                        {
+                            "name": "https",
+                            "nodePort": 30041,
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8443
+                        }
+                    ],
+                    "selector": {
+                        "service": "plain"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "NodePort"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: CanaryDiffMapping-GRPC-50\nprefix: /CanaryDiffMapping-GRPC-50/\nservice: http://plain-canarydiffmapping-grpc-50-grpc.plain-namespace\nhost_rewrite: canary.1.example.com\nambassador_id: plain\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: CanaryDiffMapping-GRPC-50\\nprefix: /CanaryDiffMapping-GRPC-50/\\nservice: http://plain-canarydiffmapping-grpc-50-grpc.plain-namespace\\nhost_rewrite: canary.1.example.com\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-canarydiffmapping-grpc-50-grpc\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8167},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8530}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2020-02-26T15:52:36Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-canarydiffmapping-grpc-50-grpc",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "67433",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-canarydiffmapping-grpc-50-grpc",
+                    "uid": "024d0ac7-58b0-11ea-86d6-0e674b3ff44f"
+                },
+                "spec": {
+                    "clusterIP": "10.103.97.34",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8167
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8530
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: CanaryMapping-GRPC-50\nprefix: /CanaryMapping-GRPC-50/\nservice: http://plain-canarymapping-grpc-50-grpc.plain-namespace\nambassador_id: plain\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: CanaryMapping-GRPC-50\\nprefix: /CanaryMapping-GRPC-50/\\nservice: http://plain-canarymapping-grpc-50-grpc.plain-namespace\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-canarymapping-grpc-50-grpc\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8151},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8514}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2020-02-26T15:52:30Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-canarymapping-grpc-50-grpc",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "67322",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-canarymapping-grpc-50-grpc",
+                    "uid": "fefab7cc-58af-11ea-86d6-0e674b3ff44f"
+                },
+                "spec": {
+                    "clusterIP": "10.104.185.233",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8151
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8514
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: SimpleMapping-HTTP-AddRequestHeaders-foo-bar\nprefix: /SimpleMapping-HTTP-AddRequestHeaders-foo-bar/\nservice: http://plain-simplemapping-http-addrequestheaders-foo-bar-http.plain-namespace\nambassador_id: plain\nadd_request_headers: {\"foo\": \"bar\"}\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: SimpleMapping-HTTP-AddRequestHeaders-foo-bar\\nprefix: /SimpleMapping-HTTP-AddRequestHeaders-foo-bar/\\nservice: http://plain-simplemapping-http-addrequestheaders-foo-bar-http.plain-namespace\\nambassador_id: plain\\nadd_request_headers: {\\\"foo\\\": \\\"bar\\\"}\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-simplemapping-http-addrequestheaders-foo-bar-http\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8085},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8448}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2020-02-26T15:52:03Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-simplemapping-http-addrequestheaders-foo-bar-http",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "66867",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-simplemapping-http-addrequestheaders-foo-bar-http",
+                    "uid": "ee71b34a-58af-11ea-86d6-0e674b3ff44f"
+                },
+                "spec": {
+                    "clusterIP": "10.101.36.230",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8085
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8448
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: SimpleMapping-HTTP-CaseSensitive\nprefix: /SimpleMapping-HTTP-CaseSensitive/\nservice: http://plain-simplemapping-http-casesensitive-http.plain-namespace\nambassador_id: plain\ncase_sensitive: false\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: SimpleMapping-HTTP-CaseSensitive\\nprefix: /SimpleMapping-HTTP-CaseSensitive/\\nservice: http://plain-simplemapping-http-casesensitive-http.plain-namespace\\nambassador_id: plain\\ncase_sensitive: false\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-simplemapping-http-casesensitive-http\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8097},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8460}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2020-02-26T15:52:05Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-simplemapping-http-casesensitive-http",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "66924",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-simplemapping-http-casesensitive-http",
+                    "uid": "efc00e3e-58af-11ea-86d6-0e674b3ff44f"
+                },
+                "spec": {
+                    "clusterIP": "10.109.118.229",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8097
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8460
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: CanaryDiffMapping-HTTP-0\nprefix: /CanaryDiffMapping-HTTP-0/\nservice: http://plain-canarydiffmapping-http-0-http.plain-namespace\nhost_rewrite: canary.1.example.com\nambassador_id: plain\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: CanaryDiffMapping-HTTP-0\\nprefix: /CanaryDiffMapping-HTTP-0/\\nservice: http://plain-canarydiffmapping-http-0-http.plain-namespace\\nhost_rewrite: canary.1.example.com\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-canarydiffmapping-http-0-http\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8155},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8518}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2020-02-26T15:52:31Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-canarydiffmapping-http-0-http",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "67346",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-canarydiffmapping-http-0-http",
+                    "uid": "ffa4d5bb-58af-11ea-86d6-0e674b3ff44f"
+                },
+                "spec": {
+                    "clusterIP": "10.101.72.40",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8155
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8518
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: CanaryMapping-GRPC-10-canary\nprefix: /CanaryMapping-GRPC-10/\nservice: http://plain-canarymapping-grpc-10-grpc-canary.plain-namespace\nweight: 10\nambassador_id: plain\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: CanaryMapping-GRPC-10-canary\\nprefix: /CanaryMapping-GRPC-10/\\nservice: http://plain-canarymapping-grpc-10-grpc-canary.plain-namespace\\nweight: 10\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-canarymapping-grpc-10-grpc-canary\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8150},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8513}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2020-02-26T15:52:30Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-canarymapping-grpc-10-grpc-canary",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "67317",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-canarymapping-grpc-10-grpc-canary",
+                    "uid": "fed94204-58af-11ea-86d6-0e674b3ff44f"
+                },
+                "spec": {
+                    "clusterIP": "10.97.162.200",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8150
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8513
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: CanaryMapping-GRPC-100-canary\nprefix: /CanaryMapping-GRPC-100/\nservice: http://plain-canarymapping-grpc-100-grpc-canary.plain-namespace\nweight: 100\nambassador_id: plain\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: CanaryMapping-GRPC-100-canary\\nprefix: /CanaryMapping-GRPC-100/\\nservice: http://plain-canarymapping-grpc-100-grpc-canary.plain-namespace\\nweight: 100\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-canarymapping-grpc-100-grpc-canary\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8154},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8517}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2020-02-26T15:52:31Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-canarymapping-grpc-100-grpc-canary",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "67338",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-canarymapping-grpc-100-grpc-canary",
+                    "uid": "ff6456b4-58af-11ea-86d6-0e674b3ff44f"
+                },
+                "spec": {
+                    "clusterIP": "10.109.142.154",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8154
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8517
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: RemoveReqHeadersMapping-HTTP\nprefix: /RemoveReqHeadersMapping-HTTP/\nservice: http://httpbin.org\nremove_request_headers:\n- zoo\n- aoo\nambassador_id: plain\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: RemoveReqHeadersMapping-HTTP\\nprefix: /RemoveReqHeadersMapping-HTTP/\\nservice: http://httpbin.org\\nremove_request_headers:\\n- zoo\\n- aoo\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-removereqheadersmapping-http-http\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8173},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8536}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2020-02-26T15:52:45Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-removereqheadersmapping-http-http",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "67477",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-removereqheadersmapping-http-http",
+                    "uid": "077e18d4-58b0-11ea-86d6-0e674b3ff44f"
+                },
+                "spec": {
+                    "clusterIP": "10.102.201.130",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8173
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8536
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: SimpleMapping-HTTP-all\nprefix: /SimpleMapping-HTTP-all/\nservice: http://plain-simplemapping-http-all-http.plain-namespace\nambassador_id: plain\nadd_request_headers: {\"foo\": \"bar\"}\nadd_response_headers: {\"foo\": \"bar\"}\nuse_websocket: true\ncors: {origins: \"*\"}\ncase_sensitive: false\nauto_host_rewrite: true\nrewrite: /foo\nremove_response_headers: x-envoy-upstream-service-time\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: SimpleMapping-HTTP-all\\nprefix: /SimpleMapping-HTTP-all/\\nservice: http://plain-simplemapping-http-all-http.plain-namespace\\nambassador_id: plain\\nadd_request_headers: {\\\"foo\\\": \\\"bar\\\"}\\nadd_response_headers: {\\\"foo\\\": \\\"bar\\\"}\\nuse_websocket: true\\ncors: {origins: \\\"*\\\"}\\ncase_sensitive: false\\nauto_host_rewrite: true\\nrewrite: /foo\\nremove_response_headers: x-envoy-upstream-service-time\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-simplemapping-http-all-http\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8102},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8465}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2020-02-26T15:52:06Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-simplemapping-http-all-http",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "66948",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-simplemapping-http-all-http",
+                    "uid": "f06bc741-58af-11ea-86d6-0e674b3ff44f"
+                },
+                "spec": {
+                    "clusterIP": "10.98.160.111",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8102
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8465
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: SimpleMapping-HTTP-RemoveResponseHeaders\nprefix: /SimpleMapping-HTTP-RemoveResponseHeaders/\nservice: http://plain-simplemapping-http-removeresponseheaders-http.plain-namespace\nambassador_id: plain\nremove_response_headers: x-envoy-upstream-service-time\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: SimpleMapping-HTTP-RemoveResponseHeaders\\nprefix: /SimpleMapping-HTTP-RemoveResponseHeaders/\\nservice: http://plain-simplemapping-http-removeresponseheaders-http.plain-namespace\\nambassador_id: plain\\nremove_response_headers: x-envoy-upstream-service-time\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-simplemapping-http-removeresponseheaders-http\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8101},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8464}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2020-02-26T15:52:06Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-simplemapping-http-removeresponseheaders-http",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "66943",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-simplemapping-http-removeresponseheaders-http",
+                    "uid": "f03605e2-58af-11ea-86d6-0e674b3ff44f"
+                },
+                "spec": {
+                    "clusterIP": "10.107.119.47",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8101
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8464
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: CanaryDiffMapping-GRPC-0\nprefix: /CanaryDiffMapping-GRPC-0/\nservice: http://plain-canarydiffmapping-grpc-0-grpc.plain-namespace\nhost_rewrite: canary.1.example.com\nambassador_id: plain\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: CanaryDiffMapping-GRPC-0\\nprefix: /CanaryDiffMapping-GRPC-0/\\nservice: http://plain-canarydiffmapping-grpc-0-grpc.plain-namespace\\nhost_rewrite: canary.1.example.com\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-canarydiffmapping-grpc-0-grpc\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8163},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8526}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2020-02-26T15:52:35Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-canarydiffmapping-grpc-0-grpc",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "67404",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-canarydiffmapping-grpc-0-grpc",
+                    "uid": "017c5893-58b0-11ea-86d6-0e674b3ff44f"
+                },
+                "spec": {
+                    "clusterIP": "10.97.38.99",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8163
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8526
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: CanaryDiffMapping-HTTP-50\nprefix: /CanaryDiffMapping-HTTP-50/\nservice: http://plain-canarydiffmapping-http-50-http.plain-namespace\nhost_rewrite: canary.1.example.com\nambassador_id: plain\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: CanaryDiffMapping-HTTP-50\\nprefix: /CanaryDiffMapping-HTTP-50/\\nservice: http://plain-canarydiffmapping-http-50-http.plain-namespace\\nhost_rewrite: canary.1.example.com\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-canarydiffmapping-http-50-http\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8159},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8522}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2020-02-26T15:52:33Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-canarydiffmapping-http-50-http",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "67373",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-canarydiffmapping-http-50-http",
+                    "uid": "004be366-58b0-11ea-86d6-0e674b3ff44f"
+                },
+                "spec": {
+                    "clusterIP": "10.109.27.16",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8159
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8522
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: HeaderRoutingTest-HTTP-target1\nprefix: /HeaderRoutingTest-HTTP/\nservice: http://plain-headerroutingtest-http-http.plain-namespace\nambassador_id: plain\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: HeaderRoutingTest-HTTP-target1\\nprefix: /HeaderRoutingTest-HTTP/\\nservice: http://plain-headerroutingtest-http-http.plain-namespace\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-headerroutingtest-http-http\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8080},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8443}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2020-02-26T15:52:01Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-headerroutingtest-http-http",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "66839",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-headerroutingtest-http-http",
+                    "uid": "edab51e8-58af-11ea-86d6-0e674b3ff44f"
+                },
+                "spec": {
+                    "clusterIP": "10.107.150.217",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8080
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8443
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-hostheadermappingingress-grpc-grpc\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8127},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8490}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2020-02-26T15:52:21Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-hostheadermappingingress-grpc-grpc",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "67140",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-hostheadermappingingress-grpc-grpc",
+                    "uid": "f94c7dca-58af-11ea-86d6-0e674b3ff44f"
+                },
+                "spec": {
+                    "clusterIP": "10.109.68.1",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8127
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8490
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: HostRedirectMapping\nprefix: /HostRedirectMapping/\nservice: foobar.com\nhost_redirect: true\nambassador_id: plain\n---\napiVersion: ambassador/v0\nkind: Mapping\nname: HostRedirectMapping-2\nprefix: /HostRedirectMapping-2/\ncase_sensitive: false\nservice: foobar.com\nhost_redirect: true\nambassador_id: plain\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: HostRedirectMapping\\nprefix: /HostRedirectMapping/\\nservice: foobar.com\\nhost_redirect: true\\nambassador_id: plain\\n---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: HostRedirectMapping-2\\nprefix: /HostRedirectMapping-2/\\ncase_sensitive: false\\nservice: foobar.com\\nhost_redirect: true\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-hostredirectmapping-http\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8138},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8501}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2020-02-26T15:52:25Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-hostredirectmapping-http",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "67224",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-hostredirectmapping-http",
+                    "uid": "fc0c8826-58af-11ea-86d6-0e674b3ff44f"
+                },
+                "spec": {
+                    "clusterIP": "10.97.193.162",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8138
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8501
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: InvalidPortMapping-GRPC\nprefix: /InvalidPortMapping-GRPC/\nservice: http://plain-invalidportmapping-grpc-grpc.plain-namespace:80.invalid\nambassador_id: plain\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: InvalidPortMapping-GRPC\\nprefix: /InvalidPortMapping-GRPC/\\nservice: http://plain-invalidportmapping-grpc-grpc.plain-namespace:80.invalid\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-invalidportmapping-grpc-grpc\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8131},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8494}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2020-02-26T15:52:23Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-invalidportmapping-grpc-grpc",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "67177",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-invalidportmapping-grpc-grpc",
+                    "uid": "fab99ca7-58af-11ea-86d6-0e674b3ff44f"
+                },
+                "spec": {
+                    "clusterIP": "10.109.160.210",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8131
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8494
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: InvalidPortMapping-HTTP\nprefix: /InvalidPortMapping-HTTP/\nservice: http://plain-invalidportmapping-http-http.plain-namespace:80.invalid\nambassador_id: plain\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: InvalidPortMapping-HTTP\\nprefix: /InvalidPortMapping-HTTP/\\nservice: http://plain-invalidportmapping-http-http.plain-namespace:80.invalid\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-invalidportmapping-http-http\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8130},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8493}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2020-02-26T15:52:22Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-invalidportmapping-http-http",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "67163",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-invalidportmapping-http-http",
+                    "uid": "fa2b84f7-58af-11ea-86d6-0e674b3ff44f"
+                },
+                "spec": {
+                    "clusterIP": "10.105.157.107",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8130
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8493
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: SimpleMapping-GRPC-AddRequestHeaders-foo-bar\nprefix: /SimpleMapping-GRPC-AddRequestHeaders-foo-bar/\nservice: http://plain-simplemapping-grpc-addrequestheaders-foo-bar-grpc.plain-namespace\nambassador_id: plain\nadd_request_headers: {\"foo\": \"bar\"}\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: SimpleMapping-GRPC-AddRequestHeaders-foo-bar\\nprefix: /SimpleMapping-GRPC-AddRequestHeaders-foo-bar/\\nservice: http://plain-simplemapping-grpc-addrequestheaders-foo-bar-grpc.plain-namespace\\nambassador_id: plain\\nadd_request_headers: {\\\"foo\\\": \\\"bar\\\"}\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-simplemapping-grpc-addrequestheaders-foo-bar-grpc\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8104},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8467}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2020-02-26T15:52:07Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-simplemapping-grpc-addrequestheaders-foo-bar-grpc",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "66964",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-simplemapping-grpc-addrequestheaders-foo-bar-grpc",
+                    "uid": "f11a6c2a-58af-11ea-86d6-0e674b3ff44f"
+                },
+                "spec": {
+                    "clusterIP": "10.106.177.61",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8104
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8467
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: SimpleMapping-GRPC-AddResponseHeaders-zoo-bar\nprefix: /SimpleMapping-GRPC-AddResponseHeaders-zoo-bar/\nservice: http://plain-simplemapping-grpc-addresponseheaders-zoo-bar-grpc.plain-namespace\nambassador_id: plain\nadd_response_headers: {\"zoo\": {\"append\": true, \"value\": \"bar\"}}\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: SimpleMapping-GRPC-AddResponseHeaders-zoo-bar\\nprefix: /SimpleMapping-GRPC-AddResponseHeaders-zoo-bar/\\nservice: http://plain-simplemapping-grpc-addresponseheaders-zoo-bar-grpc.plain-namespace\\nambassador_id: plain\\nadd_response_headers: {\\\"zoo\\\": {\\\"append\\\": true, \\\"value\\\": \\\"bar\\\"}}\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-simplemapping-grpc-addresponseheaders-zoo-bar-grpc\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8111},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8474}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2020-02-26T15:52:09Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-simplemapping-grpc-addresponseheaders-zoo-bar-grpc",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "67006",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-simplemapping-grpc-addresponseheaders-zoo-bar-grpc",
+                    "uid": "f275a0fb-58af-11ea-86d6-0e674b3ff44f"
+                },
+                "spec": {
+                    "clusterIP": "10.103.18.180",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8111
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8474
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: SimpleMapping-GRPC-CORS\nprefix: /SimpleMapping-GRPC-CORS/\nservice: http://plain-simplemapping-grpc-cors-grpc.plain-namespace\nambassador_id: plain\ncors: {origins: \"*\"}\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: SimpleMapping-GRPC-CORS\\nprefix: /SimpleMapping-GRPC-CORS/\\nservice: http://plain-simplemapping-grpc-cors-grpc.plain-namespace\\nambassador_id: plain\\ncors: {origins: \\\"*\\\"}\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-simplemapping-grpc-cors-grpc\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8115},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8478}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2020-02-26T15:52:11Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-simplemapping-grpc-cors-grpc",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "67036",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-simplemapping-grpc-cors-grpc",
+                    "uid": "f3b52790-58af-11ea-86d6-0e674b3ff44f"
+                },
+                "spec": {
+                    "clusterIP": "10.102.11.183",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8115
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8478
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: SimpleMapping-HTTP-AddRequestHeaders-aoo-tyu\nprefix: /SimpleMapping-HTTP-AddRequestHeaders-aoo-tyu/\nservice: http://plain-simplemapping-http-addrequestheaders-aoo-tyu-http.plain-namespace\nambassador_id: plain\nadd_request_headers: {\"aoo\": {\"value\": \"tyu\"}}\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: SimpleMapping-HTTP-AddRequestHeaders-aoo-tyu\\nprefix: /SimpleMapping-HTTP-AddRequestHeaders-aoo-tyu/\\nservice: http://plain-simplemapping-http-addrequestheaders-aoo-tyu-http.plain-namespace\\nambassador_id: plain\\nadd_request_headers: {\\\"aoo\\\": {\\\"value\\\": \\\"tyu\\\"}}\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-simplemapping-http-addrequestheaders-aoo-tyu-http\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8089},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8452}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2020-02-26T15:52:03Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-simplemapping-http-addrequestheaders-aoo-tyu-http",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "66887",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-simplemapping-http-addrequestheaders-aoo-tyu-http",
+                    "uid": "eed336c4-58af-11ea-86d6-0e674b3ff44f"
+                },
+                "spec": {
+                    "clusterIP": "10.100.254.232",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8089
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8452
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: SimpleMapping-HTTP-Rewrite-SLASH-foo\nprefix: /SimpleMapping-HTTP-Rewrite-SLASH-foo/\nservice: http://plain-simplemapping-http-rewrite-slash-foo-http.plain-namespace\nambassador_id: plain\nrewrite: /foo\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: SimpleMapping-HTTP-Rewrite-SLASH-foo\\nprefix: /SimpleMapping-HTTP-Rewrite-SLASH-foo/\\nservice: http://plain-simplemapping-http-rewrite-slash-foo-http.plain-namespace\\nambassador_id: plain\\nrewrite: /foo\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-simplemapping-http-rewrite-slash-foo-http\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8099},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8462}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2020-02-26T15:52:05Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-simplemapping-http-rewrite-slash-foo-http",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "66934",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-simplemapping-http-rewrite-slash-foo-http",
+                    "uid": "effeb584-58af-11ea-86d6-0e674b3ff44f"
+                },
+                "spec": {
+                    "clusterIP": "10.105.193.46",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8099
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8462
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: AddRespHeadersMapping-GRPC\nprefix: /AddRespHeadersMapping-GRPC/\nservice: http://httpbin.org\nadd_response_headers:\n  koo:\n    append: False\n    value: KooK\n  zoo:\n    append: True\n    value: ZooZ\n  test:\n    value: boo\n  foo: Foo\nambassador_id: plain\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: AddRespHeadersMapping-GRPC\\nprefix: /AddRespHeadersMapping-GRPC/\\nservice: http://httpbin.org\\nadd_response_headers:\\n  koo:\\n    append: False\\n    value: KooK\\n  zoo:\\n    append: True\\n    value: ZooZ\\n  test:\\n    value: boo\\n  foo: Foo\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-addrespheadersmapping-grpc-grpc\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8172},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8535}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2020-02-26T15:52:44Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-addrespheadersmapping-grpc-grpc",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "67472",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-addrespheadersmapping-grpc-grpc",
+                    "uid": "06fd1d17-58b0-11ea-86d6-0e674b3ff44f"
+                },
+                "spec": {
+                    "clusterIP": "10.105.190.148",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8172
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8535
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: CanaryDiffMapping-HTTP-100\nprefix: /CanaryDiffMapping-HTTP-100/\nservice: http://plain-canarydiffmapping-http-100-http.plain-namespace\nhost_rewrite: canary.1.example.com\nambassador_id: plain\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: CanaryDiffMapping-HTTP-100\\nprefix: /CanaryDiffMapping-HTTP-100/\\nservice: http://plain-canarydiffmapping-http-100-http.plain-namespace\\nhost_rewrite: canary.1.example.com\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-canarydiffmapping-http-100-http\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8161},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8524}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2020-02-26T15:52:33Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-canarydiffmapping-http-100-http",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "67389",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-canarydiffmapping-http-100-http",
+                    "uid": "00d7e027-58b0-11ea-86d6-0e674b3ff44f"
+                },
+                "spec": {
+                    "clusterIP": "10.105.160.68",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8161
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8524
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: CanaryMapping-GRPC-0-canary\nprefix: /CanaryMapping-GRPC-0/\nservice: http://plain-canarymapping-grpc-0-grpc-canary.plain-namespace\nweight: 0\nambassador_id: plain\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: CanaryMapping-GRPC-0-canary\\nprefix: /CanaryMapping-GRPC-0/\\nservice: http://plain-canarymapping-grpc-0-grpc-canary.plain-namespace\\nweight: 0\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-canarymapping-grpc-0-grpc-canary\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8148},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8511}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2020-02-26T15:52:30Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-canarymapping-grpc-0-grpc-canary",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "67305",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-canarymapping-grpc-0-grpc-canary",
+                    "uid": "fe938656-58af-11ea-86d6-0e674b3ff44f"
+                },
+                "spec": {
+                    "clusterIP": "10.98.247.216",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8148
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8511
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: HeaderRoutingTest-HTTP-target2\nprefix: /HeaderRoutingTest-HTTP/\nservice: http://plain-headerroutingtest-http-http-target2.plain-namespace\nheaders:\n  X-Route: target2\nambassador_id: plain\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: HeaderRoutingTest-HTTP-target2\\nprefix: /HeaderRoutingTest-HTTP/\\nservice: http://plain-headerroutingtest-http-http-target2.plain-namespace\\nheaders:\\n  X-Route: target2\\nambassador_id: plain\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-headerroutingtest-http-http-target2\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8081},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8444}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2020-02-26T15:52:02Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-headerroutingtest-http-http-target2",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "66845",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-headerroutingtest-http-http-target2",
+                    "uid": "edce8cca-58af-11ea-86d6-0e674b3ff44f"
+                },
+                "spec": {
+                    "clusterIP": "10.98.153.240",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8081
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8444
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: SimpleMapping-GRPC-AddResponseHeaders-xoo-dwe\nprefix: /SimpleMapping-GRPC-AddResponseHeaders-xoo-dwe/\nservice: http://plain-simplemapping-grpc-addresponseheaders-xoo-dwe-grpc.plain-namespace\nambassador_id: plain\nadd_response_headers: {\"xoo\": {\"append\": false, \"value\": \"dwe\"}}\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: SimpleMapping-GRPC-AddResponseHeaders-xoo-dwe\\nprefix: /SimpleMapping-GRPC-AddResponseHeaders-xoo-dwe/\\nservice: http://plain-simplemapping-grpc-addresponseheaders-xoo-dwe-grpc.plain-namespace\\nambassador_id: plain\\nadd_response_headers: {\\\"xoo\\\": {\\\"append\\\": false, \\\"value\\\": \\\"dwe\\\"}}\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-simplemapping-grpc-addresponseheaders-xoo-dwe-grpc\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8112},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8475}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2020-02-26T15:52:10Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-simplemapping-grpc-addresponseheaders-xoo-dwe-grpc",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "67015",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-simplemapping-grpc-addresponseheaders-xoo-dwe-grpc",
+                    "uid": "f2acfb67-58af-11ea-86d6-0e674b3ff44f"
+                },
+                "spec": {
+                    "clusterIP": "10.101.83.216",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8112
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8475
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: SimpleMapping-HTTP-AddRequestHeaders-zoo-bar\nprefix: /SimpleMapping-HTTP-AddRequestHeaders-zoo-bar/\nservice: http://plain-simplemapping-http-addrequestheaders-zoo-bar-http.plain-namespace\nambassador_id: plain\nadd_request_headers: {\"zoo\": {\"append\": true, \"value\": \"bar\"}}\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: SimpleMapping-HTTP-AddRequestHeaders-zoo-bar\\nprefix: /SimpleMapping-HTTP-AddRequestHeaders-zoo-bar/\\nservice: http://plain-simplemapping-http-addrequestheaders-zoo-bar-http.plain-namespace\\nambassador_id: plain\\nadd_request_headers: {\\\"zoo\\\": {\\\"append\\\": true, \\\"value\\\": \\\"bar\\\"}}\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-simplemapping-http-addrequestheaders-zoo-bar-http\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8087},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8450}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2020-02-26T15:52:03Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-simplemapping-http-addrequestheaders-zoo-bar-http",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "66877",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-simplemapping-http-addrequestheaders-zoo-bar-http",
+                    "uid": "eeaf57c8-58af-11ea-86d6-0e674b3ff44f"
+                },
+                "spec": {
+                    "clusterIP": "10.108.243.17",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8087
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8450
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
                         "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: SimpleMapping-HTTP-AddResponseHeaders-moo-arf\nprefix: /SimpleMapping-HTTP-AddResponseHeaders-moo-arf/\nservice: http://plain-simplemapping-http-addresponseheaders-moo-arf-http.plain-namespace\nambassador_id: plain\nadd_response_headers: {\"moo\": \"arf\"}\n",
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: SimpleMapping-HTTP-AddResponseHeaders-moo-arf\\nprefix: /SimpleMapping-HTTP-AddResponseHeaders-moo-arf/\\nservice: http://plain-simplemapping-http-addresponseheaders-moo-arf-http.plain-namespace\\nambassador_id: plain\\nadd_response_headers: {\\\"moo\\\": \\\"arf\\\"}\\n\"},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-simplemapping-http-addresponseheaders-moo-arf-http\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8091},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8454}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
                     },
-                    "creationTimestamp": "2020-02-19T23:20:14Z",
+                    "creationTimestamp": "2020-02-26T15:52:04Z",
                     "labels": {
                         "kat-ambassador-id": "plain",
                         "scope": "AmbassadorTest"
                     },
                     "name": "plain-simplemapping-http-addresponseheaders-moo-arf-http",
                     "namespace": "plain-namespace",
-                    "resourceVersion": "56148",
+                    "resourceVersion": "66898",
                     "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-simplemapping-http-addresponseheaders-moo-arf-http",
-                    "uid": "61ffde3e-536e-11ea-85dd-167682b5c255"
+                    "uid": "ef1fdfeb-58af-11ea-86d6-0e674b3ff44f"
                 },
                 "spec": {
-                    "clusterIP": "10.106.219.204",
+                    "clusterIP": "10.107.27.247",
                     "ports": [
                         {
                             "name": "http",
@@ -4696,6 +4652,50 @@
                             "port": 443,
                             "protocol": "TCP",
                             "targetPort": 8454
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-plain-namespace"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"plain\",\"scope\":\"AmbassadorTest\"},\"name\":\"plain-simplemappingingress-http-http\",\"namespace\":\"plain-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8122},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8485}],\"selector\":{\"backend\":\"superpod-plain-namespace\"}}}\n"
+                    },
+                    "creationTimestamp": "2020-02-26T15:52:17Z",
+                    "labels": {
+                        "kat-ambassador-id": "plain",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "plain-simplemappingingress-http-http",
+                    "namespace": "plain-namespace",
+                    "resourceVersion": "67086",
+                    "selfLink": "/api/v1/namespaces/plain-namespace/services/plain-simplemappingingress-http-http",
+                    "uid": "f70b8dfe-58af-11ea-86d6-0e674b3ff44f"
+                },
+                "spec": {
+                    "clusterIP": "10.107.93.169",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8122
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8485
                         }
                     ],
                     "selector": {

--- a/python/tests/gold/ratelimitv0test/snapshots/aconf.json
+++ b/python/tests/gold/ratelimitv0test/snapshots/aconf.json
@@ -1,10 +1,10 @@
 {
     "_errors": {},
     "_notices": {
-        "ratelimitv0test-http.default.1": [
+        "rate-limit-v0.default.1": [
             "apiVersion ambassador/v0 is deprecated, consider upgrading"
         ],
-        "ratelimitv0test.default.1": [
+        "ratelimitv0test-http.default.1": [
             "apiVersion ambassador/v0 is deprecated, consider upgrading"
         ]
     },
@@ -99,6 +99,23 @@
             "rkey": "k8s-ratelimitv0test-http-default",
             "serialization": "ambassador_id: ratelimitv0test\napiVersion: getambassador.io/v2\nendpoints: {}\nkind: Service\nmetadata_labels:\n  kat-ambassador-id: ratelimitv0test\n  scope: AmbassadorTest\nname: ratelimitv0test-http\nnamespace: default\n"
         },
+        "rate-limit-v0.default.1": {
+            "_referenced_by": {},
+            "ambassador_id": "ratelimitv0test",
+            "apiVersion": "getambassador.io/v0",
+            "kind": "RateLimitService",
+            "location": "rate-limit-v0.default.1",
+            "metadata_labels": {
+                "kat-ambassador-id": "ratelimitv0test",
+                "scope": "AmbassadorTest"
+            },
+            "name": "ratelimit-v0",
+            "namespace": "default",
+            "rkey": "rate-limit-v0.default.1",
+            "serialization": "ambassador_id: ratelimitv0test\napiVersion: ambassador/v0\nkind: RateLimitService\nmetadata_labels:\n  kat-ambassador-id: ratelimitv0test\n  scope: AmbassadorTest\nname: ratelimit-v0\nnamespace: default\nservice: rate-limit-v0:5000\ntimeout_ms: 500\n",
+            "service": "rate-limit-v0:5000",
+            "timeout_ms": 500
+        },
         "ratelimitv0test-http.default.1": {
             "_referenced_by": {},
             "ambassador_id": "ratelimitv0test",
@@ -170,24 +187,6 @@
             "rkey": "ratelimitv0test-http.default.2",
             "serialization": "ambassador_id: ratelimitv0test\napiVersion: ambassador/v1\nkind: Mapping\nlabels:\n  ambassador:\n  - host_and_user:\n    - custom-label:\n        header: :authority\n        omit_if_not_present: true\n    - user:\n        header: x-user\n        omit_if_not_present: true\n  - omg_header:\n    - custom-label:\n        default: OMFG!\n        header: x-omg\nmetadata_labels:\n  kat-ambassador-id: ratelimitv0test\n  scope: AmbassadorTest\nname: ratelimit_label_mapping\nnamespace: default\nprefix: /labels/\nservice: ratelimitv0test-http\n",
             "service": "ratelimitv0test-http"
-        },
-        "ratelimitv0test.default.1": {
-            "_referenced_by": {},
-            "ambassador_id": "ratelimitv0test",
-            "apiVersion": "getambassador.io/v0",
-            "kind": "RateLimitService",
-            "location": "ratelimitv0test.default.1",
-            "metadata_labels": {
-                "app.kubernetes.io/component": "ambassador-service",
-                "kat-ambassador-id": "ratelimitv0test",
-                "scope": "AmbassadorTest"
-            },
-            "name": "ratelimit-v0",
-            "namespace": "default",
-            "rkey": "ratelimitv0test.default.1",
-            "serialization": "ambassador_id: ratelimitv0test\napiVersion: ambassador/v0\nkind: RateLimitService\nmetadata_labels:\n  app.kubernetes.io/component: ambassador-service\n  kat-ambassador-id: ratelimitv0test\n  scope: AmbassadorTest\nname: ratelimit-v0\nnamespace: default\nservice: rate-limit-v0:5000\ntimeout_ms: 500\n",
-            "service": "rate-limit-v0:5000",
-            "timeout_ms": 500
         }
     },
     "mappings": {
@@ -262,7 +261,6 @@
             "apiVersion": "getambassador.io/v0",
             "kind": "RateLimitService",
             "metadata_labels": {
-                "app.kubernetes.io/component": "ambassador-service",
                 "kat-ambassador-id": "ratelimitv0test",
                 "scope": "AmbassadorTest"
             },

--- a/python/tests/gold/ratelimitv0test/snapshots/econf.json
+++ b/python/tests/gold/ratelimitv0test/snapshots/econf.json
@@ -503,8 +503,7 @@
                                     "xff_num_trusted_hops": 0
                                 }
                             }
-                        ],
-                        "use_proxy_proto": false
+                        ]
                     }
                 ],
                 "listener_filters": [],

--- a/python/tests/gold/ratelimitv0test/snapshots/ir.json
+++ b/python/tests/gold/ratelimitv0test/snapshots/ir.json
@@ -88,7 +88,7 @@
             "_namespace": "default",
             "_port": 5000,
             "_referenced_by": [
-                "ratelimitv0test.default.1"
+                "rate-limit-v0.default.1"
             ],
             "_rkey": "cluster_rate_limit_v0_5000_default",
             "connect_timeout_ms": 3000,
@@ -99,7 +99,7 @@
             "ignore_cluster": false,
             "kind": "IRCluster",
             "lb_type": "round_robin",
-            "location": "ratelimitv0test.default.1",
+            "location": "rate-limit-v0.default.1",
             "name": "cluster_rate_limit_v0_5000_default",
             "namespace": "default",
             "service": "rate-limit-v0:5000",
@@ -167,9 +167,9 @@
             "_active": true,
             "_errored": false,
             "_referenced_by": [
-                "ratelimitv0test.default.1"
+                "rate-limit-v0.default.1"
             ],
-            "_rkey": "ratelimitv0test.default.1",
+            "_rkey": "rate-limit-v0.default.1",
             "cluster": {
                 "_active": true,
                 "_errored": false,
@@ -178,7 +178,7 @@
                 "_namespace": "default",
                 "_port": 5000,
                 "_referenced_by": [
-                    "ratelimitv0test.default.1"
+                    "rate-limit-v0.default.1"
                 ],
                 "_rkey": "cluster_rate_limit_v0_5000_default",
                 "connect_timeout_ms": 3000,
@@ -189,7 +189,7 @@
                 "ignore_cluster": false,
                 "kind": "IRCluster",
                 "lb_type": "round_robin",
-                "location": "ratelimitv0test.default.1",
+                "location": "rate-limit-v0.default.1",
                 "name": "cluster_rate_limit_v0_5000_default",
                 "namespace": "default",
                 "service": "rate-limit-v0:5000",
@@ -220,7 +220,7 @@
                 "_namespace": "default",
                 "_port": 5000,
                 "_referenced_by": [
-                    "ratelimitv0test.default.1"
+                    "rate-limit-v0.default.1"
                 ],
                 "_rkey": "cluster_rate_limit_v0_5000_default",
                 "connect_timeout_ms": 3000,
@@ -231,7 +231,7 @@
                 "ignore_cluster": false,
                 "kind": "IRCluster",
                 "lb_type": "round_robin",
-                "location": "ratelimitv0test.default.1",
+                "location": "rate-limit-v0.default.1",
                 "name": "cluster_rate_limit_v0_5000_default",
                 "namespace": "default",
                 "service": "rate-limit-v0:5000",
@@ -248,7 +248,7 @@
                 ]
             },
             "kind": "IRRateLimit",
-            "location": "ratelimitv0test.default.1",
+            "location": "rate-limit-v0.default.1",
             "name": "rate_limit",
             "namespace": "default",
             "service": "rate-limit-v0:5000",
@@ -844,7 +844,7 @@
             "_namespace": "default",
             "_port": 5000,
             "_referenced_by": [
-                "ratelimitv0test.default.1"
+                "rate-limit-v0.default.1"
             ],
             "_rkey": "cluster_rate_limit_v0_5000_default",
             "connect_timeout_ms": 3000,
@@ -855,7 +855,7 @@
             "ignore_cluster": false,
             "kind": "IRCluster",
             "lb_type": "round_robin",
-            "location": "ratelimitv0test.default.1",
+            "location": "rate-limit-v0.default.1",
             "name": "cluster_rate_limit_v0_5000_default",
             "namespace": "default",
             "service": "rate-limit-v0:5000",
@@ -900,9 +900,9 @@
         "_active": true,
         "_errored": false,
         "_referenced_by": [
-            "ratelimitv0test.default.1"
+            "rate-limit-v0.default.1"
         ],
-        "_rkey": "ratelimitv0test.default.1",
+        "_rkey": "rate-limit-v0.default.1",
         "cluster": {
             "_active": true,
             "_errored": false,
@@ -911,7 +911,7 @@
             "_namespace": "default",
             "_port": 5000,
             "_referenced_by": [
-                "ratelimitv0test.default.1"
+                "rate-limit-v0.default.1"
             ],
             "_rkey": "cluster_rate_limit_v0_5000_default",
             "connect_timeout_ms": 3000,
@@ -922,7 +922,7 @@
             "ignore_cluster": false,
             "kind": "IRCluster",
             "lb_type": "round_robin",
-            "location": "ratelimitv0test.default.1",
+            "location": "rate-limit-v0.default.1",
             "name": "cluster_rate_limit_v0_5000_default",
             "namespace": "default",
             "service": "rate-limit-v0:5000",
@@ -953,7 +953,7 @@
             "_namespace": "default",
             "_port": 5000,
             "_referenced_by": [
-                "ratelimitv0test.default.1"
+                "rate-limit-v0.default.1"
             ],
             "_rkey": "cluster_rate_limit_v0_5000_default",
             "connect_timeout_ms": 3000,
@@ -964,7 +964,7 @@
             "ignore_cluster": false,
             "kind": "IRCluster",
             "lb_type": "round_robin",
-            "location": "ratelimitv0test.default.1",
+            "location": "rate-limit-v0.default.1",
             "name": "cluster_rate_limit_v0_5000_default",
             "namespace": "default",
             "service": "rate-limit-v0:5000",
@@ -981,7 +981,7 @@
             ]
         },
         "kind": "IRRateLimit",
-        "location": "ratelimitv0test.default.1",
+        "location": "rate-limit-v0.default.1",
         "name": "rate_limit",
         "namespace": "default",
         "service": "rate-limit-v0:5000",

--- a/python/tests/gold/ratelimitv0test/snapshots/snapshot.yaml
+++ b/python/tests/gold/ratelimitv0test/snapshots/snapshot.yaml
@@ -21,9 +21,47 @@
                 "metadata": {
                     "annotations": {
                         "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: RateLimitService\nname: ratelimit-v0\nservice: rate-limit-v0:5000\ntimeout_ms: 500\nambassador_id: ratelimitv0test\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: RateLimitService\\nname: ratelimit-v0\\nservice: rate-limit-v0:5000\\ntimeout_ms: 500\\nambassador_id: ratelimitv0test\\n\"},\"labels\":{\"app.kubernetes.io/component\":\"ambassador-service\",\"kat-ambassador-id\":\"ratelimitv0test\",\"scope\":\"AmbassadorTest\"},\"name\":\"ratelimitv0test\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8080},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8443}],\"selector\":{\"service\":\"ratelimitv0test\"},\"type\":\"NodePort\"}}\n"
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: RateLimitService\\nname: ratelimit-v0\\nservice: rate-limit-v0:5000\\ntimeout_ms: 500\\nambassador_id: ratelimitv0test\\n\"},\"labels\":{\"kat-ambassador-id\":\"ratelimitv0test\",\"scope\":\"AmbassadorTest\"},\"name\":\"rate-limit-v0\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"grpc\",\"port\":5000,\"targetPort\":\"grpc\"}],\"selector\":{\"app\":\"rate-limit-v0\"},\"type\":\"ClusterIP\"}}\n"
                     },
-                    "creationTimestamp": "2020-02-19T23:20:23Z",
+                    "creationTimestamp": "2020-02-26T15:52:48Z",
+                    "labels": {
+                        "kat-ambassador-id": "ratelimitv0test",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "rate-limit-v0",
+                    "namespace": "default",
+                    "resourceVersion": "67507",
+                    "selfLink": "/api/v1/namespaces/default/services/rate-limit-v0",
+                    "uid": "097aa85a-58b0-11ea-86d6-0e674b3ff44f"
+                },
+                "spec": {
+                    "clusterIP": "10.111.228.110",
+                    "ports": [
+                        {
+                            "name": "grpc",
+                            "port": 5000,
+                            "protocol": "TCP",
+                            "targetPort": "grpc"
+                        }
+                    ],
+                    "selector": {
+                        "app": "rate-limit-v0"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"app.kubernetes.io/component\":\"ambassador-service\",\"kat-ambassador-id\":\"ratelimitv0test\",\"scope\":\"AmbassadorTest\"},\"name\":\"ratelimitv0test\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8080},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8443}],\"selector\":{\"service\":\"ratelimitv0test\"},\"type\":\"NodePort\"}}\n"
+                    },
+                    "creationTimestamp": "2020-02-26T15:52:52Z",
                     "labels": {
                         "app.kubernetes.io/component": "ambassador-service",
                         "kat-ambassador-id": "ratelimitv0test",
@@ -31,24 +69,24 @@
                     },
                     "name": "ratelimitv0test",
                     "namespace": "default",
-                    "resourceVersion": "56499",
+                    "resourceVersion": "67559",
                     "selfLink": "/api/v1/namespaces/default/services/ratelimitv0test",
-                    "uid": "678a07cc-536e-11ea-85dd-167682b5c255"
+                    "uid": "0bb9fe8f-58b0-11ea-86d6-0e674b3ff44f"
                 },
                 "spec": {
-                    "clusterIP": "10.102.194.13",
+                    "clusterIP": "10.103.26.139",
                     "externalTrafficPolicy": "Cluster",
                     "ports": [
                         {
                             "name": "http",
-                            "nodePort": 30749,
+                            "nodePort": 32415,
                             "port": 80,
                             "protocol": "TCP",
                             "targetPort": 8080
                         },
                         {
                             "name": "https",
-                            "nodePort": 31650,
+                            "nodePort": 30614,
                             "port": 443,
                             "protocol": "TCP",
                             "targetPort": 8443
@@ -71,7 +109,7 @@
                     "annotations": {
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"ratelimitv0test\",\"scope\":\"AmbassadorTest\",\"service\":\"ratelimitv0test-admin\"},\"name\":\"ratelimitv0test-admin\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"ratelimitv0test-admin\",\"port\":8877,\"targetPort\":8877}],\"selector\":{\"service\":\"ratelimitv0test\"},\"type\":\"NodePort\"}}\n"
                     },
-                    "creationTimestamp": "2020-02-19T23:20:23Z",
+                    "creationTimestamp": "2020-02-26T15:52:52Z",
                     "labels": {
                         "kat-ambassador-id": "ratelimitv0test",
                         "scope": "AmbassadorTest",
@@ -79,17 +117,17 @@
                     },
                     "name": "ratelimitv0test-admin",
                     "namespace": "default",
-                    "resourceVersion": "56505",
+                    "resourceVersion": "67566",
                     "selfLink": "/api/v1/namespaces/default/services/ratelimitv0test-admin",
-                    "uid": "67ad6d2f-536e-11ea-85dd-167682b5c255"
+                    "uid": "0be6cf4c-58b0-11ea-86d6-0e674b3ff44f"
                 },
                 "spec": {
-                    "clusterIP": "10.106.16.95",
+                    "clusterIP": "10.105.82.49",
                     "externalTrafficPolicy": "Cluster",
                     "ports": [
                         {
                             "name": "ratelimitv0test-admin",
-                            "nodePort": 30838,
+                            "nodePort": 30181,
                             "port": 8877,
                             "protocol": "TCP",
                             "targetPort": 8877
@@ -113,19 +151,19 @@
                         "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: ratelimit_target_mapping\nprefix: /target/\nservice: ratelimitv0test-http\nrate_limits:\n- descriptor: A test case\n  headers:\n  - \"x-ambassador-test-allow\"\nambassador_id: ratelimitv0test\n---\napiVersion: ambassador/v1\nkind: Mapping\nname: ratelimit_label_mapping\nprefix: /labels/\nservice: ratelimitv0test-http\nlabels:\n  ambassador:\n  - host_and_user:\n    - custom-label:\n        header: \":authority\"\n        omit_if_not_present: true\n    - user:\n        header: \"x-user\"\n        omit_if_not_present: true\n  - omg_header:\n    - custom-label:\n        header: \"x-omg\"\n        default: \"OMFG!\"\nambassador_id: ratelimitv0test\n",
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: ratelimit_target_mapping\\nprefix: /target/\\nservice: ratelimitv0test-http\\nrate_limits:\\n- descriptor: A test case\\n  headers:\\n  - \\\"x-ambassador-test-allow\\\"\\nambassador_id: ratelimitv0test\\n---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: ratelimit_label_mapping\\nprefix: /labels/\\nservice: ratelimitv0test-http\\nlabels:\\n  ambassador:\\n  - host_and_user:\\n    - custom-label:\\n        header: \\\":authority\\\"\\n        omit_if_not_present: true\\n    - user:\\n        header: \\\"x-user\\\"\\n        omit_if_not_present: true\\n  - omg_header:\\n    - custom-label:\\n        header: \\\"x-omg\\\"\\n        default: \\\"OMFG!\\\"\\nambassador_id: ratelimitv0test\\n\"},\"labels\":{\"kat-ambassador-id\":\"ratelimitv0test\",\"scope\":\"AmbassadorTest\"},\"name\":\"ratelimitv0test-http\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8115},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8478}],\"selector\":{\"backend\":\"superpod-default\"}}}\n"
                     },
-                    "creationTimestamp": "2020-02-19T23:20:24Z",
+                    "creationTimestamp": "2020-02-26T15:52:53Z",
                     "labels": {
                         "kat-ambassador-id": "ratelimitv0test",
                         "scope": "AmbassadorTest"
                     },
                     "name": "ratelimitv0test-http",
                     "namespace": "default",
-                    "resourceVersion": "56529",
+                    "resourceVersion": "67583",
                     "selfLink": "/api/v1/namespaces/default/services/ratelimitv0test-http",
-                    "uid": "680780af-536e-11ea-85dd-167682b5c255"
+                    "uid": "0c55577e-58b0-11ea-86d6-0e674b3ff44f"
                 },
                 "spec": {
-                    "clusterIP": "10.107.128.16",
+                    "clusterIP": "10.99.109.52",
                     "ports": [
                         {
                             "name": "http",
@@ -142,44 +180,6 @@
                     ],
                     "selector": {
                         "backend": "superpod-default"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"ratelimitv0test\",\"scope\":\"AmbassadorTest\"},\"name\":\"rate-limit-v0\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"grpc\",\"port\":5000,\"targetPort\":\"grpc\"}],\"selector\":{\"app\":\"rate-limit-v0\"},\"type\":\"ClusterIP\"}}\n"
-                    },
-                    "creationTimestamp": "2020-02-19T23:20:24Z",
-                    "labels": {
-                        "kat-ambassador-id": "ratelimitv0test",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "rate-limit-v0",
-                    "namespace": "default",
-                    "resourceVersion": "56512",
-                    "selfLink": "/api/v1/namespaces/default/services/rate-limit-v0",
-                    "uid": "67cc7236-536e-11ea-85dd-167682b5c255"
-                },
-                "spec": {
-                    "clusterIP": "10.109.141.113",
-                    "ports": [
-                        {
-                            "name": "grpc",
-                            "port": 5000,
-                            "protocol": "TCP",
-                            "targetPort": "grpc"
-                        }
-                    ],
-                    "selector": {
-                        "app": "rate-limit-v0"
                     },
                     "sessionAffinity": "None",
                     "type": "ClusterIP"

--- a/python/tests/gold/ratelimitv1test/snapshots/aconf.json
+++ b/python/tests/gold/ratelimitv1test/snapshots/aconf.json
@@ -92,6 +92,23 @@
             "rkey": "k8s-ratelimitv1test-http-default",
             "serialization": "ambassador_id: ratelimitv1test\napiVersion: getambassador.io/v2\nendpoints: {}\nkind: Service\nmetadata_labels:\n  kat-ambassador-id: ratelimitv1test\n  scope: AmbassadorTest\nname: ratelimitv1test-http\nnamespace: default\n"
         },
+        "rate-limit-v1.default.1": {
+            "_referenced_by": {},
+            "ambassador_id": "ratelimitv1test",
+            "apiVersion": "getambassador.io/v1",
+            "kind": "RateLimitService",
+            "location": "rate-limit-v1.default.1",
+            "metadata_labels": {
+                "kat-ambassador-id": "ratelimitv1test",
+                "scope": "AmbassadorTest"
+            },
+            "name": "ratelimit-v1",
+            "namespace": "default",
+            "rkey": "rate-limit-v1.default.1",
+            "serialization": "ambassador_id: ratelimitv1test\napiVersion: ambassador/v1\nkind: RateLimitService\nmetadata_labels:\n  kat-ambassador-id: ratelimitv1test\n  scope: AmbassadorTest\nname: ratelimit-v1\nnamespace: default\nservice: rate-limit-v1:5000\ntimeout_ms: 500\n",
+            "service": "rate-limit-v1:5000",
+            "timeout_ms": 500
+        },
         "ratelimitv1test-http.default.1": {
             "_referenced_by": {},
             "ambassador_id": "ratelimitv1test",
@@ -122,24 +139,6 @@
             "rkey": "ratelimitv1test-http.default.1",
             "serialization": "ambassador_id: ratelimitv1test\napiVersion: ambassador/v1\nkind: Mapping\nlabels:\n  ambassador:\n  - request_label_group:\n    - x-ambassador-test-allow:\n        header: x-ambassador-test-allow\n        omit_if_not_present: true\nmetadata_labels:\n  kat-ambassador-id: ratelimitv1test\n  scope: AmbassadorTest\nname: ratelimit_target_mapping\nnamespace: default\nprefix: /target/\nservice: ratelimitv1test-http\n",
             "service": "ratelimitv1test-http"
-        },
-        "ratelimitv1test.default.1": {
-            "_referenced_by": {},
-            "ambassador_id": "ratelimitv1test",
-            "apiVersion": "getambassador.io/v1",
-            "kind": "RateLimitService",
-            "location": "ratelimitv1test.default.1",
-            "metadata_labels": {
-                "app.kubernetes.io/component": "ambassador-service",
-                "kat-ambassador-id": "ratelimitv1test",
-                "scope": "AmbassadorTest"
-            },
-            "name": "ratelimit-v1",
-            "namespace": "default",
-            "rkey": "ratelimitv1test.default.1",
-            "serialization": "ambassador_id: ratelimitv1test\napiVersion: ambassador/v1\nkind: RateLimitService\nmetadata_labels:\n  app.kubernetes.io/component: ambassador-service\n  kat-ambassador-id: ratelimitv1test\n  scope: AmbassadorTest\nname: ratelimit-v1\nnamespace: default\nservice: rate-limit-v1:5000\ntimeout_ms: 500\n",
-            "service": "rate-limit-v1:5000",
-            "timeout_ms": 500
         }
     },
     "mappings": {
@@ -177,7 +176,6 @@
             "apiVersion": "getambassador.io/v1",
             "kind": "RateLimitService",
             "metadata_labels": {
-                "app.kubernetes.io/component": "ambassador-service",
                 "kat-ambassador-id": "ratelimitv1test",
                 "scope": "AmbassadorTest"
             },

--- a/python/tests/gold/ratelimitv1test/snapshots/econf.json
+++ b/python/tests/gold/ratelimitv1test/snapshots/econf.json
@@ -371,8 +371,7 @@
                                     "xff_num_trusted_hops": 0
                                 }
                             }
-                        ],
-                        "use_proxy_proto": false
+                        ]
                     }
                 ],
                 "listener_filters": [],

--- a/python/tests/gold/ratelimitv1test/snapshots/ir.json
+++ b/python/tests/gold/ratelimitv1test/snapshots/ir.json
@@ -88,7 +88,7 @@
             "_namespace": "default",
             "_port": 5000,
             "_referenced_by": [
-                "ratelimitv1test.default.1"
+                "rate-limit-v1.default.1"
             ],
             "_rkey": "cluster_rate_limit_v1_5000_default",
             "connect_timeout_ms": 3000,
@@ -99,7 +99,7 @@
             "ignore_cluster": false,
             "kind": "IRCluster",
             "lb_type": "round_robin",
-            "location": "ratelimitv1test.default.1",
+            "location": "rate-limit-v1.default.1",
             "name": "cluster_rate_limit_v1_5000_default",
             "namespace": "default",
             "service": "rate-limit-v1:5000",
@@ -166,9 +166,9 @@
             "_active": true,
             "_errored": false,
             "_referenced_by": [
-                "ratelimitv1test.default.1"
+                "rate-limit-v1.default.1"
             ],
-            "_rkey": "ratelimitv1test.default.1",
+            "_rkey": "rate-limit-v1.default.1",
             "cluster": {
                 "_active": true,
                 "_errored": false,
@@ -177,7 +177,7 @@
                 "_namespace": "default",
                 "_port": 5000,
                 "_referenced_by": [
-                    "ratelimitv1test.default.1"
+                    "rate-limit-v1.default.1"
                 ],
                 "_rkey": "cluster_rate_limit_v1_5000_default",
                 "connect_timeout_ms": 3000,
@@ -188,7 +188,7 @@
                 "ignore_cluster": false,
                 "kind": "IRCluster",
                 "lb_type": "round_robin",
-                "location": "ratelimitv1test.default.1",
+                "location": "rate-limit-v1.default.1",
                 "name": "cluster_rate_limit_v1_5000_default",
                 "namespace": "default",
                 "service": "rate-limit-v1:5000",
@@ -219,7 +219,7 @@
                 "_namespace": "default",
                 "_port": 5000,
                 "_referenced_by": [
-                    "ratelimitv1test.default.1"
+                    "rate-limit-v1.default.1"
                 ],
                 "_rkey": "cluster_rate_limit_v1_5000_default",
                 "connect_timeout_ms": 3000,
@@ -230,7 +230,7 @@
                 "ignore_cluster": false,
                 "kind": "IRCluster",
                 "lb_type": "round_robin",
-                "location": "ratelimitv1test.default.1",
+                "location": "rate-limit-v1.default.1",
                 "name": "cluster_rate_limit_v1_5000_default",
                 "namespace": "default",
                 "service": "rate-limit-v1:5000",
@@ -247,7 +247,7 @@
                 ]
             },
             "kind": "IRRateLimit",
-            "location": "ratelimitv1test.default.1",
+            "location": "rate-limit-v1.default.1",
             "name": "rate_limit",
             "namespace": "default",
             "service": "rate-limit-v1:5000",
@@ -673,7 +673,7 @@
             "_namespace": "default",
             "_port": 5000,
             "_referenced_by": [
-                "ratelimitv1test.default.1"
+                "rate-limit-v1.default.1"
             ],
             "_rkey": "cluster_rate_limit_v1_5000_default",
             "connect_timeout_ms": 3000,
@@ -684,7 +684,7 @@
             "ignore_cluster": false,
             "kind": "IRCluster",
             "lb_type": "round_robin",
-            "location": "ratelimitv1test.default.1",
+            "location": "rate-limit-v1.default.1",
             "name": "cluster_rate_limit_v1_5000_default",
             "namespace": "default",
             "service": "rate-limit-v1:5000",
@@ -729,9 +729,9 @@
         "_active": true,
         "_errored": false,
         "_referenced_by": [
-            "ratelimitv1test.default.1"
+            "rate-limit-v1.default.1"
         ],
-        "_rkey": "ratelimitv1test.default.1",
+        "_rkey": "rate-limit-v1.default.1",
         "cluster": {
             "_active": true,
             "_errored": false,
@@ -740,7 +740,7 @@
             "_namespace": "default",
             "_port": 5000,
             "_referenced_by": [
-                "ratelimitv1test.default.1"
+                "rate-limit-v1.default.1"
             ],
             "_rkey": "cluster_rate_limit_v1_5000_default",
             "connect_timeout_ms": 3000,
@@ -751,7 +751,7 @@
             "ignore_cluster": false,
             "kind": "IRCluster",
             "lb_type": "round_robin",
-            "location": "ratelimitv1test.default.1",
+            "location": "rate-limit-v1.default.1",
             "name": "cluster_rate_limit_v1_5000_default",
             "namespace": "default",
             "service": "rate-limit-v1:5000",
@@ -782,7 +782,7 @@
             "_namespace": "default",
             "_port": 5000,
             "_referenced_by": [
-                "ratelimitv1test.default.1"
+                "rate-limit-v1.default.1"
             ],
             "_rkey": "cluster_rate_limit_v1_5000_default",
             "connect_timeout_ms": 3000,
@@ -793,7 +793,7 @@
             "ignore_cluster": false,
             "kind": "IRCluster",
             "lb_type": "round_robin",
-            "location": "ratelimitv1test.default.1",
+            "location": "rate-limit-v1.default.1",
             "name": "cluster_rate_limit_v1_5000_default",
             "namespace": "default",
             "service": "rate-limit-v1:5000",
@@ -810,7 +810,7 @@
             ]
         },
         "kind": "IRRateLimit",
-        "location": "ratelimitv1test.default.1",
+        "location": "rate-limit-v1.default.1",
         "name": "rate_limit",
         "namespace": "default",
         "service": "rate-limit-v1:5000",

--- a/python/tests/gold/ratelimitv1test/snapshots/snapshot.yaml
+++ b/python/tests/gold/ratelimitv1test/snapshots/snapshot.yaml
@@ -20,48 +20,9 @@
                 "kind": "Service",
                 "metadata": {
                     "annotations": {
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"ratelimitv1test\",\"scope\":\"AmbassadorTest\"},\"name\":\"rate-limit-v1\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"grpc\",\"port\":5000,\"targetPort\":\"grpc\"}],\"selector\":{\"app\":\"rate-limit-v1\"},\"type\":\"ClusterIP\"}}\n"
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"app.kubernetes.io/component\":\"ambassador-service\",\"kat-ambassador-id\":\"ratelimitv1test\",\"scope\":\"AmbassadorTest\"},\"name\":\"ratelimitv1test\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8080},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8443}],\"selector\":{\"service\":\"ratelimitv1test\"},\"type\":\"NodePort\"}}\n"
                     },
-                    "creationTimestamp": "2020-02-19T23:20:25Z",
-                    "labels": {
-                        "kat-ambassador-id": "ratelimitv1test",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "rate-limit-v1",
-                    "namespace": "default",
-                    "resourceVersion": "56555",
-                    "selfLink": "/api/v1/namespaces/default/services/rate-limit-v1",
-                    "uid": "68ae4dc6-536e-11ea-85dd-167682b5c255"
-                },
-                "spec": {
-                    "clusterIP": "10.99.82.125",
-                    "ports": [
-                        {
-                            "name": "grpc",
-                            "port": 5000,
-                            "protocol": "TCP",
-                            "targetPort": "grpc"
-                        }
-                    ],
-                    "selector": {
-                        "app": "rate-limit-v1"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: RateLimitService\nname: ratelimit-v1\nservice: rate-limit-v1:5000\ntimeout_ms: 500\nambassador_id: ratelimitv1test\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: RateLimitService\\nname: ratelimit-v1\\nservice: rate-limit-v1:5000\\ntimeout_ms: 500\\nambassador_id: ratelimitv1test\\n\"},\"labels\":{\"app.kubernetes.io/component\":\"ambassador-service\",\"kat-ambassador-id\":\"ratelimitv1test\",\"scope\":\"AmbassadorTest\"},\"name\":\"ratelimitv1test\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8080},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8443}],\"selector\":{\"service\":\"ratelimitv1test\"},\"type\":\"NodePort\"}}\n"
-                    },
-                    "creationTimestamp": "2020-02-19T23:20:25Z",
+                    "creationTimestamp": "2020-02-26T15:52:57Z",
                     "labels": {
                         "app.kubernetes.io/component": "ambassador-service",
                         "kat-ambassador-id": "ratelimitv1test",
@@ -69,24 +30,24 @@
                     },
                     "name": "ratelimitv1test",
                     "namespace": "default",
-                    "resourceVersion": "56542",
+                    "resourceVersion": "67629",
                     "selfLink": "/api/v1/namespaces/default/services/ratelimitv1test",
-                    "uid": "686505eb-536e-11ea-85dd-167682b5c255"
+                    "uid": "0e96d486-58b0-11ea-86d6-0e674b3ff44f"
                 },
                 "spec": {
-                    "clusterIP": "10.108.72.241",
+                    "clusterIP": "10.109.71.37",
                     "externalTrafficPolicy": "Cluster",
                     "ports": [
                         {
                             "name": "http",
-                            "nodePort": 30567,
+                            "nodePort": 31041,
                             "port": 80,
                             "protocol": "TCP",
                             "targetPort": 8080
                         },
                         {
                             "name": "https",
-                            "nodePort": 31012,
+                            "nodePort": 32385,
                             "port": 443,
                             "protocol": "TCP",
                             "targetPort": 8443
@@ -109,7 +70,7 @@
                     "annotations": {
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"ratelimitv1test\",\"scope\":\"AmbassadorTest\",\"service\":\"ratelimitv1test-admin\"},\"name\":\"ratelimitv1test-admin\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"ratelimitv1test-admin\",\"port\":8877,\"targetPort\":8877}],\"selector\":{\"service\":\"ratelimitv1test\"},\"type\":\"NodePort\"}}\n"
                     },
-                    "creationTimestamp": "2020-02-19T23:20:25Z",
+                    "creationTimestamp": "2020-02-26T15:52:57Z",
                     "labels": {
                         "kat-ambassador-id": "ratelimitv1test",
                         "scope": "AmbassadorTest",
@@ -117,17 +78,17 @@
                     },
                     "name": "ratelimitv1test-admin",
                     "namespace": "default",
-                    "resourceVersion": "56546",
+                    "resourceVersion": "67634",
                     "selfLink": "/api/v1/namespaces/default/services/ratelimitv1test-admin",
-                    "uid": "687bb29e-536e-11ea-85dd-167682b5c255"
+                    "uid": "0edf5156-58b0-11ea-86d6-0e674b3ff44f"
                 },
                 "spec": {
-                    "clusterIP": "10.109.152.1",
+                    "clusterIP": "10.101.168.80",
                     "externalTrafficPolicy": "Cluster",
                     "ports": [
                         {
                             "name": "ratelimitv1test-admin",
-                            "nodePort": 30732,
+                            "nodePort": 32103,
                             "port": 8877,
                             "protocol": "TCP",
                             "targetPort": 8877
@@ -151,19 +112,19 @@
                         "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: ratelimit_target_mapping\nprefix: /target/\nservice: ratelimitv1test-http\nlabels:\n  ambassador:\n  - request_label_group:\n    - x-ambassador-test-allow:\n        header: \"x-ambassador-test-allow\"\n        omit_if_not_present: true\nambassador_id: ratelimitv1test\n",
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: ratelimit_target_mapping\\nprefix: /target/\\nservice: ratelimitv1test-http\\nlabels:\\n  ambassador:\\n  - request_label_group:\\n    - x-ambassador-test-allow:\\n        header: \\\"x-ambassador-test-allow\\\"\\n        omit_if_not_present: true\\nambassador_id: ratelimitv1test\\n\"},\"labels\":{\"kat-ambassador-id\":\"ratelimitv1test\",\"scope\":\"AmbassadorTest\"},\"name\":\"ratelimitv1test-http\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8116},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8479}],\"selector\":{\"backend\":\"superpod-default\"}}}\n"
                     },
-                    "creationTimestamp": "2020-02-19T23:20:26Z",
+                    "creationTimestamp": "2020-02-26T15:52:57Z",
                     "labels": {
                         "kat-ambassador-id": "ratelimitv1test",
                         "scope": "AmbassadorTest"
                     },
                     "name": "ratelimitv1test-http",
                     "namespace": "default",
-                    "resourceVersion": "56566",
+                    "resourceVersion": "67649",
                     "selfLink": "/api/v1/namespaces/default/services/ratelimitv1test-http",
-                    "uid": "68f0fc85-536e-11ea-85dd-167682b5c255"
+                    "uid": "0f2473f5-58b0-11ea-86d6-0e674b3ff44f"
                 },
                 "spec": {
-                    "clusterIP": "10.101.168.234",
+                    "clusterIP": "10.109.82.38",
                     "ports": [
                         {
                             "name": "http",
@@ -180,6 +141,45 @@
                     ],
                     "selector": {
                         "backend": "superpod-default"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: RateLimitService\nname: ratelimit-v1\nservice: rate-limit-v1:5000\ntimeout_ms: 500\nambassador_id: ratelimitv1test\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: RateLimitService\\nname: ratelimit-v1\\nservice: rate-limit-v1:5000\\ntimeout_ms: 500\\nambassador_id: ratelimitv1test\\n\"},\"labels\":{\"kat-ambassador-id\":\"ratelimitv1test\",\"scope\":\"AmbassadorTest\"},\"name\":\"rate-limit-v1\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"grpc\",\"port\":5000,\"targetPort\":\"grpc\"}],\"selector\":{\"app\":\"rate-limit-v1\"},\"type\":\"ClusterIP\"}}\n"
+                    },
+                    "creationTimestamp": "2020-02-26T15:52:53Z",
+                    "labels": {
+                        "kat-ambassador-id": "ratelimitv1test",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "rate-limit-v1",
+                    "namespace": "default",
+                    "resourceVersion": "67590",
+                    "selfLink": "/api/v1/namespaces/default/services/rate-limit-v1",
+                    "uid": "0c79335c-58b0-11ea-86d6-0e674b3ff44f"
+                },
+                "spec": {
+                    "clusterIP": "10.98.242.200",
+                    "ports": [
+                        {
+                            "name": "grpc",
+                            "port": 5000,
+                            "protocol": "TCP",
+                            "targetPort": "grpc"
+                        }
+                    ],
+                    "selector": {
+                        "app": "rate-limit-v1"
                     },
                     "sessionAffinity": "None",
                     "type": "ClusterIP"

--- a/python/tests/gold/ratelimitv1withtlstest/snapshots/aconf.json
+++ b/python/tests/gold/ratelimitv1withtlstest/snapshots/aconf.json
@@ -92,6 +92,24 @@
             "rkey": "k8s-ratelimitv1withtlstest-http-default",
             "serialization": "ambassador_id: ratelimitv1withtlstest\napiVersion: getambassador.io/v2\nendpoints: {}\nkind: Service\nmetadata_labels:\n  kat-ambassador-id: ratelimitv1withtlstest\n  scope: AmbassadorTest\nname: ratelimitv1withtlstest-http\nnamespace: default\n"
         },
+        "rate-limit-tls.default.1": {
+            "_referenced_by": {},
+            "ambassador_id": "ratelimitv1withtlstest",
+            "apiVersion": "getambassador.io/v1",
+            "kind": "RateLimitService",
+            "location": "rate-limit-tls.default.1",
+            "metadata_labels": {
+                "kat-ambassador-id": "ratelimitv1withtlstest",
+                "scope": "AmbassadorTest"
+            },
+            "name": "ratelimit-tls",
+            "namespace": "default",
+            "rkey": "rate-limit-tls.default.1",
+            "serialization": "ambassador_id: ratelimitv1withtlstest\napiVersion: ambassador/v1\nkind: RateLimitService\nmetadata_labels:\n  kat-ambassador-id: ratelimitv1withtlstest\n  scope: AmbassadorTest\nname: ratelimit-tls\nnamespace: default\nservice: rate-limit-tls:5000\ntimeout_ms: 500\ntls: ratelimit-tls-context\n",
+            "service": "rate-limit-tls:5000",
+            "timeout_ms": 500,
+            "tls": "ratelimit-tls-context"
+        },
         "ratelimit-tls-secret.default.1": {
             "_referenced_by": {},
             "ambassador_id": "ratelimitv1withtlstest",
@@ -157,25 +175,6 @@
             "rkey": "ratelimitv1withtlstest-http.default.2",
             "serialization": "ambassador_id: ratelimitv1withtlstest\napiVersion: ambassador/v1\nkind: Mapping\nlabels:\n  ambassador:\n  - request_label_group:\n    - x-ambassador-test-allow:\n        header: x-ambassador-test-allow\n        omit_if_not_present: true\nmetadata_labels:\n  kat-ambassador-id: ratelimitv1withtlstest\n  scope: AmbassadorTest\nname: ratelimit_target_mapping\nnamespace: default\nprefix: /target/\nservice: ratelimitv1withtlstest-http\n",
             "service": "ratelimitv1withtlstest-http"
-        },
-        "ratelimitv1withtlstest.default.1": {
-            "_referenced_by": {},
-            "ambassador_id": "ratelimitv1withtlstest",
-            "apiVersion": "getambassador.io/v1",
-            "kind": "RateLimitService",
-            "location": "ratelimitv1withtlstest.default.1",
-            "metadata_labels": {
-                "app.kubernetes.io/component": "ambassador-service",
-                "kat-ambassador-id": "ratelimitv1withtlstest",
-                "scope": "AmbassadorTest"
-            },
-            "name": "ratelimit-tls",
-            "namespace": "default",
-            "rkey": "ratelimitv1withtlstest.default.1",
-            "serialization": "ambassador_id: ratelimitv1withtlstest\napiVersion: ambassador/v1\nkind: RateLimitService\nmetadata_labels:\n  app.kubernetes.io/component: ambassador-service\n  kat-ambassador-id: ratelimitv1withtlstest\n  scope: AmbassadorTest\nname: ratelimit-tls\nnamespace: default\nservice: rate-limit-tls:5000\ntimeout_ms: 500\ntls: ratelimit-tls-context\n",
-            "service": "rate-limit-tls:5000",
-            "timeout_ms": 500,
-            "tls": "ratelimit-tls-context"
         }
     },
     "mappings": {
@@ -213,7 +212,6 @@
             "apiVersion": "getambassador.io/v1",
             "kind": "RateLimitService",
             "metadata_labels": {
-                "app.kubernetes.io/component": "ambassador-service",
                 "kat-ambassador-id": "ratelimitv1withtlstest",
                 "scope": "AmbassadorTest"
             },

--- a/python/tests/gold/ratelimitv1withtlstest/snapshots/econf.json
+++ b/python/tests/gold/ratelimitv1withtlstest/snapshots/econf.json
@@ -392,8 +392,7 @@
                                     "xff_num_trusted_hops": 0
                                 }
                             }
-                        ],
-                        "use_proxy_proto": false
+                        ]
                     }
                 ],
                 "listener_filters": [],

--- a/python/tests/gold/ratelimitv1withtlstest/snapshots/ir.json
+++ b/python/tests/gold/ratelimitv1withtlstest/snapshots/ir.json
@@ -88,7 +88,7 @@
             "_namespace": "default",
             "_port": 5000,
             "_referenced_by": [
-                "ratelimitv1withtlstest.default.1"
+                "rate-limit-tls.default.1"
             ],
             "_rkey": "cluster_rate_limit_tls_5000_otls_ratelimit_tls_context_default",
             "connect_timeout_ms": 3000,
@@ -99,7 +99,7 @@
             "ignore_cluster": false,
             "kind": "IRCluster",
             "lb_type": "round_robin",
-            "location": "ratelimitv1withtlstest.default.1",
+            "location": "rate-limit-tls.default.1",
             "name": "cluster_rate_limit_tls_5000_otls_ratelim-0",
             "namespace": "default",
             "service": "rate-limit-tls:5000",
@@ -114,8 +114,8 @@
                 "_active": true,
                 "_errored": false,
                 "_referenced_by": [
-                    "ratelimitv1withtlstest-http.default.1",
-                    "ratelimitv1withtlstest.default.1"
+                    "rate-limit-tls.default.1",
+                    "ratelimitv1withtlstest-http.default.1"
                 ],
                 "_rkey": "ratelimitv1withtlstest-http.default.1",
                 "alpn_protocols": "h2",
@@ -190,9 +190,9 @@
             "_active": true,
             "_errored": false,
             "_referenced_by": [
-                "ratelimitv1withtlstest.default.1"
+                "rate-limit-tls.default.1"
             ],
-            "_rkey": "ratelimitv1withtlstest.default.1",
+            "_rkey": "rate-limit-tls.default.1",
             "cluster": {
                 "_active": true,
                 "_errored": false,
@@ -201,7 +201,7 @@
                 "_namespace": "default",
                 "_port": 5000,
                 "_referenced_by": [
-                    "ratelimitv1withtlstest.default.1"
+                    "rate-limit-tls.default.1"
                 ],
                 "_rkey": "cluster_rate_limit_tls_5000_otls_ratelimit_tls_context_default",
                 "connect_timeout_ms": 3000,
@@ -212,7 +212,7 @@
                 "ignore_cluster": false,
                 "kind": "IRCluster",
                 "lb_type": "round_robin",
-                "location": "ratelimitv1withtlstest.default.1",
+                "location": "rate-limit-tls.default.1",
                 "name": "cluster_rate_limit_tls_5000_otls_ratelim-0",
                 "namespace": "default",
                 "service": "rate-limit-tls:5000",
@@ -227,8 +227,8 @@
                     "_active": true,
                     "_errored": false,
                     "_referenced_by": [
-                        "ratelimitv1withtlstest-http.default.1",
-                        "ratelimitv1withtlstest.default.1"
+                        "rate-limit-tls.default.1",
+                        "ratelimitv1withtlstest-http.default.1"
                     ],
                     "_rkey": "ratelimitv1withtlstest-http.default.1",
                     "alpn_protocols": "h2",
@@ -268,7 +268,7 @@
                 "_namespace": "default",
                 "_port": 5000,
                 "_referenced_by": [
-                    "ratelimitv1withtlstest.default.1"
+                    "rate-limit-tls.default.1"
                 ],
                 "_rkey": "cluster_rate_limit_tls_5000_otls_ratelimit_tls_context_default",
                 "connect_timeout_ms": 3000,
@@ -279,7 +279,7 @@
                 "ignore_cluster": false,
                 "kind": "IRCluster",
                 "lb_type": "round_robin",
-                "location": "ratelimitv1withtlstest.default.1",
+                "location": "rate-limit-tls.default.1",
                 "name": "cluster_rate_limit_tls_5000_otls_ratelim-0",
                 "namespace": "default",
                 "service": "rate-limit-tls:5000",
@@ -294,8 +294,8 @@
                     "_active": true,
                     "_errored": false,
                     "_referenced_by": [
-                        "ratelimitv1withtlstest-http.default.1",
-                        "ratelimitv1withtlstest.default.1"
+                        "rate-limit-tls.default.1",
+                        "ratelimitv1withtlstest-http.default.1"
                     ],
                     "_rkey": "ratelimitv1withtlstest-http.default.1",
                     "alpn_protocols": "h2",
@@ -320,7 +320,7 @@
                 ]
             },
             "kind": "IRRateLimit",
-            "location": "ratelimitv1withtlstest.default.1",
+            "location": "rate-limit-tls.default.1",
             "name": "rate_limit",
             "namespace": "default",
             "service": "rate-limit-tls:5000",
@@ -746,7 +746,7 @@
             "_namespace": "default",
             "_port": 5000,
             "_referenced_by": [
-                "ratelimitv1withtlstest.default.1"
+                "rate-limit-tls.default.1"
             ],
             "_rkey": "cluster_rate_limit_tls_5000_otls_ratelimit_tls_context_default",
             "connect_timeout_ms": 3000,
@@ -757,7 +757,7 @@
             "ignore_cluster": false,
             "kind": "IRCluster",
             "lb_type": "round_robin",
-            "location": "ratelimitv1withtlstest.default.1",
+            "location": "rate-limit-tls.default.1",
             "name": "cluster_rate_limit_tls_5000_otls_ratelim-0",
             "namespace": "default",
             "service": "rate-limit-tls:5000",
@@ -772,8 +772,8 @@
                 "_active": true,
                 "_errored": false,
                 "_referenced_by": [
-                    "ratelimitv1withtlstest-http.default.1",
-                    "ratelimitv1withtlstest.default.1"
+                    "rate-limit-tls.default.1",
+                    "ratelimitv1withtlstest-http.default.1"
                 ],
                 "_rkey": "ratelimitv1withtlstest-http.default.1",
                 "alpn_protocols": "h2",
@@ -826,9 +826,9 @@
         "_active": true,
         "_errored": false,
         "_referenced_by": [
-            "ratelimitv1withtlstest.default.1"
+            "rate-limit-tls.default.1"
         ],
-        "_rkey": "ratelimitv1withtlstest.default.1",
+        "_rkey": "rate-limit-tls.default.1",
         "cluster": {
             "_active": true,
             "_errored": false,
@@ -837,7 +837,7 @@
             "_namespace": "default",
             "_port": 5000,
             "_referenced_by": [
-                "ratelimitv1withtlstest.default.1"
+                "rate-limit-tls.default.1"
             ],
             "_rkey": "cluster_rate_limit_tls_5000_otls_ratelimit_tls_context_default",
             "connect_timeout_ms": 3000,
@@ -848,7 +848,7 @@
             "ignore_cluster": false,
             "kind": "IRCluster",
             "lb_type": "round_robin",
-            "location": "ratelimitv1withtlstest.default.1",
+            "location": "rate-limit-tls.default.1",
             "name": "cluster_rate_limit_tls_5000_otls_ratelim-0",
             "namespace": "default",
             "service": "rate-limit-tls:5000",
@@ -863,8 +863,8 @@
                 "_active": true,
                 "_errored": false,
                 "_referenced_by": [
-                    "ratelimitv1withtlstest-http.default.1",
-                    "ratelimitv1withtlstest.default.1"
+                    "rate-limit-tls.default.1",
+                    "ratelimitv1withtlstest-http.default.1"
                 ],
                 "_rkey": "ratelimitv1withtlstest-http.default.1",
                 "alpn_protocols": "h2",
@@ -904,7 +904,7 @@
             "_namespace": "default",
             "_port": 5000,
             "_referenced_by": [
-                "ratelimitv1withtlstest.default.1"
+                "rate-limit-tls.default.1"
             ],
             "_rkey": "cluster_rate_limit_tls_5000_otls_ratelimit_tls_context_default",
             "connect_timeout_ms": 3000,
@@ -915,7 +915,7 @@
             "ignore_cluster": false,
             "kind": "IRCluster",
             "lb_type": "round_robin",
-            "location": "ratelimitv1withtlstest.default.1",
+            "location": "rate-limit-tls.default.1",
             "name": "cluster_rate_limit_tls_5000_otls_ratelim-0",
             "namespace": "default",
             "service": "rate-limit-tls:5000",
@@ -930,8 +930,8 @@
                 "_active": true,
                 "_errored": false,
                 "_referenced_by": [
-                    "ratelimitv1withtlstest-http.default.1",
-                    "ratelimitv1withtlstest.default.1"
+                    "rate-limit-tls.default.1",
+                    "ratelimitv1withtlstest-http.default.1"
                 ],
                 "_rkey": "ratelimitv1withtlstest-http.default.1",
                 "alpn_protocols": "h2",
@@ -956,7 +956,7 @@
             ]
         },
         "kind": "IRRateLimit",
-        "location": "ratelimitv1withtlstest.default.1",
+        "location": "rate-limit-tls.default.1",
         "name": "rate_limit",
         "namespace": "default",
         "service": "rate-limit-tls:5000",
@@ -1035,8 +1035,8 @@
             "_active": true,
             "_errored": false,
             "_referenced_by": [
-                "ratelimitv1withtlstest-http.default.1",
-                "ratelimitv1withtlstest.default.1"
+                "rate-limit-tls.default.1",
+                "ratelimitv1withtlstest-http.default.1"
             ],
             "_rkey": "ratelimitv1withtlstest-http.default.1",
             "alpn_protocols": "h2",

--- a/python/tests/gold/ratelimitv1withtlstest/snapshots/snapshot.yaml
+++ b/python/tests/gold/ratelimitv1withtlstest/snapshots/snapshot.yaml
@@ -26,16 +26,16 @@
                     "annotations": {
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"data\":{\"tls.crt\":\"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURDakNDQWZJQ0NRRGdYUjZ3V1Z6Wk9EQU5CZ2txaGtpRzl3MEJBUVVGQURCSE1SNHdIQVlEVlFRRERCVnkKWVhSbGJHbHRhWFF1WkdGMFlYZHBjbVV1YVc4eEpUQWpCZ2txaGtpRzl3MEJDUUVXRm1odmMzUnRZWE4wWlhKQQpaR0YwWVhkcGNtVXVhVzh3SGhjTk1Ua3dPVEU1TVRnek16QXlXaGNOTWpFd09ERTVNVGd6TXpBeVdqQkhNUjR3CkhBWURWUVFEREJWeVlYUmxiR2x0YVhRdVpHRjBZWGRwY21VdWFXOHhKVEFqQmdrcWhraUc5dzBCQ1FFV0ZtaHYKYzNSdFlYTjBaWEpBWkdGMFlYZHBjbVV1YVc4d2dnRWlNQTBHQ1NxR1NJYjNEUUVCQVFVQUE0SUJEd0F3Z2dFSwpBb0lCQVFDeWw5VkJtVjVCcFYxOHZzclNqUktyZGlEVnZZS0dxNlZVaGFTRTlZSWNRODhiSTFaeHlhUE9zUVlRCmMycmY4Q0RKdUp4M1hoUjUzMENwN3pQNmVSMjNwMkZBOSsxSWs5SHZhWUx0WDRtQTJOdjh4V1kxaEhua1BURnMKVFRwazBMREdYYjVZWnh2QkczNTNKL3NFKzFrSUUxenpKZldpQUpUMzZzMk5PRzRVQWhoVmFPS2p1K3grYXJwbQoyZnNhTldKTTFEMS9CUXVVN1Vid0p0QmIyZFo2WUtUNHE4M2doQWgybDhad1hQcFdJQmtpWGpNNXJ0WkQ3QmN4CkRxdFNtVE1ZejVjZWNwbmhiNEw4Z3hFVUJyWlRxQ3g4RVkvcDArY05mN2hScmFWbTd6Q3BaRDhvSUtLS0IvUDQKM1dHZHRHNlpHS0VFSmtXNjB5QWtxRmI3czNWdEFnTUJBQUV3RFFZSktvWklodmNOQVFFRkJRQURnZ0VCQUFJUwp2Znh1K3dQcUxicVRZV1NLTUt6S3JmNUxxWlpBZFpZZXNIR0oxNmFyVmt6eGhzcElGRGZpblZ1UmI1eERxWVVSCnFta0U1K0dCNDh5UGoxaUQvdXdPOEI0ckFnNW1Pekw1MEpUMDVQT1dyc0hjK1loLzAvUXpGNmlqNHlVNWZ6dloKRHpJdFBiNE5qWTMxUE44WkJMYTFGSHk5d2JGSzdyS2lWK2MxTzd0UHVjQTVUWnoxS0h5VUVYaWxHdmNoczB4OApzazRJR2xrVTNoSDFVWHBzTmw0NTI4VjR0L3dXOTdiYmhFeHYvYnBwR3RLbjRKei9hYkNScjA3Q3kzUytjUzc5CnlQNTZiQVZxa1R2TTVkUkhiNG9zOGYzNUJuQTdPci9YRTQ2K2VRMXNVY21IVG5OUWdFVkpWZGVwR3V4Sk5pNFMKejJ0WHhHSStTdTFlUnlQcVNGWT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=\",\"tls.key\":\"LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0tCk1JSUV2UUlCQURBTkJna3Foa2lHOXcwQkFRRUZBQVNDQktjd2dnU2pBZ0VBQW9JQkFRQ3lsOVZCbVY1QnBWMTgKdnNyU2pSS3JkaURWdllLR3E2VlVoYVNFOVlJY1E4OGJJMVp4eWFQT3NRWVFjMnJmOENESnVKeDNYaFI1MzBDcAo3elA2ZVIyM3AyRkE5KzFJazlIdmFZTHRYNG1BMk52OHhXWTFoSG5rUFRGc1RUcGswTERHWGI1WVp4dkJHMzUzCkovc0UrMWtJRTF6ekpmV2lBSlQzNnMyTk9HNFVBaGhWYU9LanUreCthcnBtMmZzYU5XSk0xRDEvQlF1VTdVYncKSnRCYjJkWjZZS1Q0cTgzZ2hBaDJsOFp3WFBwV0lCa2lYak01cnRaRDdCY3hEcXRTbVRNWXo1Y2VjcG5oYjRMOApneEVVQnJaVHFDeDhFWS9wMCtjTmY3aFJyYVZtN3pDcFpEOG9JS0tLQi9QNDNXR2R0RzZaR0tFRUprVzYweUFrCnFGYjdzM1Z0QWdNQkFBRUNnZ0VBS3hvNzdOWWdDb1hubHpqUTZKb0ZuSDRwRkl6bFdLMUtmS2k0ZVNKcm9YaTQKSGx1Yi9HQm0rWFo5K1RCeDVkUWxoYW5aa1hHU1RZdVZKcTVGaERrQTlCY2dnTGFWZlFPNEVpa0w0VkJDZG1kZwpTSlEzdzhqU1JrU0NqaG5oY3YxdS9LRVpWR3FtSnlnRWtLdUVpTUpFelk4bXlzUXBrVXpFcDBUekVSZENjZTljClNKT2Q2V2dGYUdzN3ZmTEpMajBmTk1SYytwcjFORnBmcTk0R2lyZFVyQUIvOHhlL2lpT3hnZXJoM1JPR0I4Z1MKZWpMeTZmZEhZK0Y1d2cyREtFMjVjeHcrdWFUeEo4MElucktWYTdhVjlqeGl1L0YvWW42a0FGT201cUFaTEdJUQo3bDVDY0dMWCtKdS96UGNpSEJRRWx2R2dSTGdZTCtxWHNPYStyZ3VvZ1FLQmdRRFpVU25xQUdvd2Zma3h1QTB2CnVxc042M3NaMHFVVUMraDB1aGZCanV1ZGxEZU8rM2U5WC9ncW1vTHFnYmpLbUNxcHZ0eFRKT2RZbWlkTG42QysKU3ZIMkw5V3RBNzVFMDB1bDdWb0VEOWs5S1c5aEU4M1ZoM0hJcnowQ3RtLzAvMEtJaVlXb2VkaWw2YktlTndUSApXci9MdlI5M2F2dHo2NUkwVWFBVjVyMjhqUUtCZ1FEU1loS2R1YzB1YUQ2VW45NW0yTmZJelRaNWxaNmZZdFFyCkZHbzByWWlTelZCRlZrNnR3akI5dmhtdmtjZjBNU21wQ1NPUUZGcjJ3Zk9UZGtBTnlxTWxwNXdHK3ZpRi9LeGMKcXNMQ1RROGhwNmFnazMzRE9MVEl2OXpKdkhnU2NsWW9pOTZqNk9Zc28rWUtITkxmTU1jVWw3dThqYmZ3YWx2dwp4Tno3WkdRVVlRS0JnSFdsZWRKamJSbFphVWxnUVV0QWZBL3FGbGR4Y01xOGM1aVZrZnpJT1lleVVLMklOMWQvCkYrTkFpSFVaeXdkcWYxWXJyQzBhd2w5MS9LWDFBZGxpeTBDaXZzT09UamdHUjJMSmJyemFNNW5uejVNM1hHd24KaWhMQnczNnZjMGFuMWNZQzVTZkM1dVZTOGM2ekxGUWNMYzdIVUx5ZVh3aHZWRlFjaUZTeStLNlZBb0dBUkFObQpwMDBBOHliS1RId2VoenRGRDJxZ1dOQXc5ckFaalUvTlFmaHo5Wm1nZ0xuMU42RlcwZC9hSi9OR0pFQ2Npa1FsCkZoZ3VqQ1dKbkR1WFc1NE4va2RnWHJWV0VPTHR5Z3QrYVJoR2N3ZmpDM2lES05DMVNVMFZrTFo0VHVaZHlqL2wKbXpIWTc4ZVF2K1l2bWU0SC9qVkxnUnFEdzVwdTNMaVlCRUdoUlNFQ2dZRUExdmNGWmsxOXVLS0JSWDhFRlgzbQphTlk2QWVhWTVJV2xVbDFJbEpHUHBFNnBnejh1aVRYNU9paG5KbGh4NDIzdjBIRU1QV0ZxNXQzcCtJdGRKZ24zCnlTQ0RNcXhyZUo4cytCS3BqeUcwVHFjN0pkbkpUcm1NN1FUMCtVUXExYmlBOENiU0FvMWVybHJpcEZ1blVMblEKSXp3SURyM1VzN0ROQkxNZmlOaDZuVWs9Ci0tLS0tRU5EIFBSSVZBVEUgS0VZLS0tLS0K\"},\"kind\":\"Secret\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"ratelimitv1withtlstest\",\"scope\":\"AmbassadorTest\"},\"name\":\"ratelimit-tls-secret\",\"namespace\":\"default\"},\"type\":\"kubernetes.io/tls\"}\n"
                     },
-                    "creationTimestamp": "2020-02-19T23:20:27Z",
+                    "creationTimestamp": "2020-02-26T15:52:59Z",
                     "labels": {
                         "kat-ambassador-id": "ratelimitv1withtlstest",
                         "scope": "AmbassadorTest"
                     },
                     "name": "ratelimit-tls-secret",
                     "namespace": "default",
-                    "resourceVersion": "56609",
+                    "resourceVersion": "67670",
                     "selfLink": "/api/v1/namespaces/default/secrets/ratelimit-tls-secret",
-                    "uid": "69a2ca5f-536e-11ea-85dd-167682b5c255"
+                    "uid": "1042ab69-58b0-11ea-86d6-0e674b3ff44f"
                 },
                 "type": "kubernetes.io/tls"
             }
@@ -46,21 +46,22 @@
                 "kind": "Service",
                 "metadata": {
                     "annotations": {
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"ratelimitv1withtlstest\",\"scope\":\"AmbassadorTest\"},\"name\":\"rate-limit-tls\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"grpc\",\"port\":5000,\"targetPort\":\"grpc\"}],\"selector\":{\"app\":\"rate-limit-tls\"},\"type\":\"ClusterIP\"}}\n"
+                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: RateLimitService\nname: ratelimit-tls\nservice: rate-limit-tls:5000\ntimeout_ms: 500\ntls: ratelimit-tls-context\nambassador_id: ratelimitv1withtlstest\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: RateLimitService\\nname: ratelimit-tls\\nservice: rate-limit-tls:5000\\ntimeout_ms: 500\\ntls: ratelimit-tls-context\\nambassador_id: ratelimitv1withtlstest\\n\"},\"labels\":{\"kat-ambassador-id\":\"ratelimitv1withtlstest\",\"scope\":\"AmbassadorTest\"},\"name\":\"rate-limit-tls\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"grpc\",\"port\":5000,\"targetPort\":\"grpc\"}],\"selector\":{\"app\":\"rate-limit-tls\"},\"type\":\"ClusterIP\"}}\n"
                     },
-                    "creationTimestamp": "2020-02-19T23:20:27Z",
+                    "creationTimestamp": "2020-02-26T15:52:58Z",
                     "labels": {
                         "kat-ambassador-id": "ratelimitv1withtlstest",
                         "scope": "AmbassadorTest"
                     },
                     "name": "rate-limit-tls",
                     "namespace": "default",
-                    "resourceVersion": "56599",
+                    "resourceVersion": "67659",
                     "selfLink": "/api/v1/namespaces/default/services/rate-limit-tls",
-                    "uid": "6992d892-536e-11ea-85dd-167682b5c255"
+                    "uid": "0f973c01-58b0-11ea-86d6-0e674b3ff44f"
                 },
                 "spec": {
-                    "clusterIP": "10.99.237.209",
+                    "clusterIP": "10.100.186.253",
                     "ports": [
                         {
                             "name": "grpc",
@@ -84,10 +85,9 @@
                 "kind": "Service",
                 "metadata": {
                     "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: RateLimitService\nname: ratelimit-tls\nservice: rate-limit-tls:5000\ntimeout_ms: 500\ntls: ratelimit-tls-context\nambassador_id: ratelimitv1withtlstest\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: RateLimitService\\nname: ratelimit-tls\\nservice: rate-limit-tls:5000\\ntimeout_ms: 500\\ntls: ratelimit-tls-context\\nambassador_id: ratelimitv1withtlstest\\n\"},\"labels\":{\"app.kubernetes.io/component\":\"ambassador-service\",\"kat-ambassador-id\":\"ratelimitv1withtlstest\",\"scope\":\"AmbassadorTest\"},\"name\":\"ratelimitv1withtlstest\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8080},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8443}],\"selector\":{\"service\":\"ratelimitv1withtlstest\"},\"type\":\"NodePort\"}}\n"
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"app.kubernetes.io/component\":\"ambassador-service\",\"kat-ambassador-id\":\"ratelimitv1withtlstest\",\"scope\":\"AmbassadorTest\"},\"name\":\"ratelimitv1withtlstest\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8080},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8443}],\"selector\":{\"service\":\"ratelimitv1withtlstest\"},\"type\":\"NodePort\"}}\n"
                     },
-                    "creationTimestamp": "2020-02-19T23:20:26Z",
+                    "creationTimestamp": "2020-02-26T15:53:01Z",
                     "labels": {
                         "app.kubernetes.io/component": "ambassador-service",
                         "kat-ambassador-id": "ratelimitv1withtlstest",
@@ -95,24 +95,24 @@
                     },
                     "name": "ratelimitv1withtlstest",
                     "namespace": "default",
-                    "resourceVersion": "56588",
+                    "resourceVersion": "67700",
                     "selfLink": "/api/v1/namespaces/default/services/ratelimitv1withtlstest",
-                    "uid": "69666218-536e-11ea-85dd-167682b5c255"
+                    "uid": "11385605-58b0-11ea-86d6-0e674b3ff44f"
                 },
                 "spec": {
-                    "clusterIP": "10.111.107.219",
+                    "clusterIP": "10.97.241.162",
                     "externalTrafficPolicy": "Cluster",
                     "ports": [
                         {
                             "name": "http",
-                            "nodePort": 31485,
+                            "nodePort": 32207,
                             "port": 80,
                             "protocol": "TCP",
                             "targetPort": 8080
                         },
                         {
                             "name": "https",
-                            "nodePort": 31886,
+                            "nodePort": 32342,
                             "port": 443,
                             "protocol": "TCP",
                             "targetPort": 8443
@@ -135,7 +135,7 @@
                     "annotations": {
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"ratelimitv1withtlstest\",\"scope\":\"AmbassadorTest\",\"service\":\"ratelimitv1withtlstest-admin\"},\"name\":\"ratelimitv1withtlstest-admin\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"ratelimitv1withtlstest-admin\",\"port\":8877,\"targetPort\":8877}],\"selector\":{\"service\":\"ratelimitv1withtlstest\"},\"type\":\"NodePort\"}}\n"
                     },
-                    "creationTimestamp": "2020-02-19T23:20:26Z",
+                    "creationTimestamp": "2020-02-26T15:53:01Z",
                     "labels": {
                         "kat-ambassador-id": "ratelimitv1withtlstest",
                         "scope": "AmbassadorTest",
@@ -143,17 +143,17 @@
                     },
                     "name": "ratelimitv1withtlstest-admin",
                     "namespace": "default",
-                    "resourceVersion": "56593",
+                    "resourceVersion": "67709",
                     "selfLink": "/api/v1/namespaces/default/services/ratelimitv1withtlstest-admin",
-                    "uid": "69756b77-536e-11ea-85dd-167682b5c255"
+                    "uid": "1168cf58-58b0-11ea-86d6-0e674b3ff44f"
                 },
                 "spec": {
-                    "clusterIP": "10.111.242.176",
+                    "clusterIP": "10.104.91.200",
                     "externalTrafficPolicy": "Cluster",
                     "ports": [
                         {
                             "name": "ratelimitv1withtlstest-admin",
-                            "nodePort": 32199,
+                            "nodePort": 30410,
                             "port": 8877,
                             "protocol": "TCP",
                             "targetPort": 8877
@@ -177,19 +177,19 @@
                         "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: TLSContext\nname: ratelimit-tls-context\nsecret: ratelimit-tls-secret\nalpn_protocols: h2\nambassador_id: ratelimitv1withtlstest\n---\napiVersion: ambassador/v1\nkind: Mapping\nname: ratelimit_target_mapping\nprefix: /target/\nservice: ratelimitv1withtlstest-http\nlabels:\n  ambassador:\n  - request_label_group:\n    - x-ambassador-test-allow:\n        header: \"x-ambassador-test-allow\"\n        omit_if_not_present: true\nambassador_id: ratelimitv1withtlstest\n",
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: TLSContext\\nname: ratelimit-tls-context\\nsecret: ratelimit-tls-secret\\nalpn_protocols: h2\\nambassador_id: ratelimitv1withtlstest\\n---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: ratelimit_target_mapping\\nprefix: /target/\\nservice: ratelimitv1withtlstest-http\\nlabels:\\n  ambassador:\\n  - request_label_group:\\n    - x-ambassador-test-allow:\\n        header: \\\"x-ambassador-test-allow\\\"\\n        omit_if_not_present: true\\nambassador_id: ratelimitv1withtlstest\\n\"},\"labels\":{\"kat-ambassador-id\":\"ratelimitv1withtlstest\",\"scope\":\"AmbassadorTest\"},\"name\":\"ratelimitv1withtlstest-http\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8117},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8480}],\"selector\":{\"backend\":\"superpod-default\"}}}\n"
                     },
-                    "creationTimestamp": "2020-02-19T23:20:27Z",
+                    "creationTimestamp": "2020-02-26T15:53:02Z",
                     "labels": {
                         "kat-ambassador-id": "ratelimitv1withtlstest",
                         "scope": "AmbassadorTest"
                     },
                     "name": "ratelimitv1withtlstest-http",
                     "namespace": "default",
-                    "resourceVersion": "56617",
+                    "resourceVersion": "67720",
                     "selfLink": "/api/v1/namespaces/default/services/ratelimitv1withtlstest-http",
-                    "uid": "69b04ed6-536e-11ea-85dd-167682b5c255"
+                    "uid": "11cb3685-58b0-11ea-86d6-0e674b3ff44f"
                 },
                 "spec": {
-                    "clusterIP": "10.96.90.75",
+                    "clusterIP": "10.105.118.201",
                     "ports": [
                         {
                             "name": "http",

--- a/python/tests/gold/redirecttests/snapshots/econf.json
+++ b/python/tests/gold/redirecttests/snapshots/econf.json
@@ -306,8 +306,7 @@
                                     }
                                 ]
                             }
-                        },
-                        "use_proxy_proto": false
+                        }
                     }
                 ],
                 "listener_filters": [
@@ -439,8 +438,7 @@
                                     "xff_num_trusted_hops": 0
                                 }
                             }
-                        ],
-                        "use_proxy_proto": false
+                        ]
                     }
                 ],
                 "listener_filters": [],

--- a/python/tests/gold/redirecttests/snapshots/snapshot.yaml
+++ b/python/tests/gold/redirecttests/snapshots/snapshot.yaml
@@ -26,16 +26,16 @@
                     "annotations": {
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"data\":{\"tls.crt\":\"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwakNDQW82Z0F3SUJBZ0lKQUpxa1Z4Y1RtQ1FITUEwR0NTcUdTSWIzRFFFQkN3VUFNR2d4Q3pBSkJnTlYKQkFZVEFsVlRNUXN3Q1FZRFZRUUlEQUpOUVRFUE1BMEdBMVVFQnd3R1FtOXpkRzl1TVJFd0R3WURWUVFLREFoRQpZWFJoZDJseVpURVVNQklHQTFVRUN3d0xSVzVuYVc1bFpYSnBibWN4RWpBUUJnTlZCQU1NQ1d4dlkyRnNhRzl6CmREQWVGdzB4T0RFd01UQXhNREk1TURKYUZ3MHlPREV3TURjeE1ESTVNREphTUdneEN6QUpCZ05WQkFZVEFsVlQKTVFzd0NRWURWUVFJREFKTlFURVBNQTBHQTFVRUJ3d0dRbTl6ZEc5dU1SRXdEd1lEVlFRS0RBaEVZWFJoZDJseQpaVEVVTUJJR0ExVUVDd3dMUlc1bmFXNWxaWEpwYm1jeEVqQVFCZ05WQkFNTUNXeHZZMkZzYUc5emREQ0NBU0l3CkRRWUpLb1pJaHZjTkFRRUJCUUFEZ2dFUEFEQ0NBUW9DZ2dFQkFMcTZtdS9FSzlQc1Q0YkR1WWg0aEZPVnZiblAKekV6MGpQcnVzdXcxT05MQk9jT2htbmNSTnE4c1FyTGxBZ3NicDBuTFZmQ1pSZHQ4UnlOcUFGeUJlR29XS3IvZAprQVEybVBucjBQRHlCTzk0UHo4VHdydDBtZEtEU1dGanNxMjlOYVJaT0JqdStLcGV6RytOZ3pLMk04M0ZtSldUCnFYdTI3ME9pOXlqb2VGQ3lPMjdwUkdvcktkQk9TcmIwd3ozdFdWUGk4NFZMdnFKRWprT0JVZjJYNVF3b25XWngKMktxVUJ6OUFSZVVUMzdwUVJZQkJMSUdvSnM4U042cjF4MSt1dTNLdTVxSkN1QmRlSHlJbHpKb2V0aEp2K3pTMgowN0pFc2ZKWkluMWNpdXhNNzNPbmVRTm1LUkpsL2NEb3BLemswSldRSnRSV1NnbktneFNYWkRrZjJMOENBd0VBCkFhTlRNRkV3SFFZRFZSME9CQllFRkJoQzdDeVRpNGFkSFVCd0wvTkZlRTZLdnFIRE1COEdBMVVkSXdRWU1CYUEKRkJoQzdDeVRpNGFkSFVCd0wvTkZlRTZLdnFIRE1BOEdBMVVkRXdFQi93UUZNQU1CQWY4d0RRWUpLb1pJaHZjTgpBUUVMQlFBRGdnRUJBSFJvb0xjcFdEa1IyMEhENEJ5d1BTUGRLV1hjWnN1U2tXYWZyekhoYUJ5MWJZcktIR1o1CmFodFF3L1gwQmRnMWtidlpZUDJSTzdGTFhBSlNTdXVJT0NHTFVwS0pkVHE1NDREUThNb1daWVZKbTc3UWxxam0KbHNIa2VlTlRNamFOVjdMd0MzalBkMERYelczbGVnWFRoYWpmZ2dtLzBJZXNGRzBVWjFEOTJHNURmc0hLekpSagpNSHZyVDNtVmJGZjkrSGJhRE4yT2g5VjIxUWhWSzF2M0F2dWNXczhUWCswZHZFZ1dtWHBRcndEd2pTMU04QkRYCldoWjVsZTZjVzhNYjhnZmRseG1JckpnQStuVVZzMU9EbkJKS1F3MUY4MVdkc25tWXdweVUrT2xVais4UGt1TVoKSU4rUlhQVnZMSWJ3czBmamJ4UXRzbTArZVBpRnN2d0NsUFk9Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K\",\"tls.key\":\"LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0tCk1JSUV2Z0lCQURBTkJna3Foa2lHOXcwQkFRRUZBQVNDQktnd2dnU2tBZ0VBQW9JQkFRQzZ1cHJ2eEN2VDdFK0cKdzdtSWVJUlRsYjI1ejh4TTlJejY3ckxzTlRqU3dUbkRvWnAzRVRhdkxFS3k1UUlMRzZkSnkxWHdtVVhiZkVjagphZ0JjZ1hocUZpcS8zWkFFTnBqNTY5RHc4Z1R2ZUQ4L0U4SzdkSm5TZzBsaFk3S3R2VFdrV1RnWTd2aXFYc3h2CmpZTXl0alBOeFppVms2bDd0dTlEb3ZjbzZIaFFzanR1NlVScUt5blFUa3EyOU1NOTdWbFQ0dk9GUzc2aVJJNUQKZ1ZIOWwrVU1LSjFtY2RpcWxBYy9RRVhsRTkrNlVFV0FRU3lCcUNiUEVqZXE5Y2RmcnJ0eXJ1YWlRcmdYWGg4aQpKY3lhSHJZU2IvczB0dE95UkxIeVdTSjlYSXJzVE85enAza0RaaWtTWmYzQTZLU3M1TkNWa0NiVVZrb0p5b01VCmwyUTVIOWkvQWdNQkFBRUNnZ0VBSVFsZzNpamNCRHViK21Eb2syK1hJZDZ0V1pHZE9NUlBxUm5RU0NCR2RHdEIKV0E1Z2NNNTMyVmhBV0x4UnR6dG1ScFVXR0dKVnpMWlpNN2ZPWm85MWlYZHdpcytkYWxGcWtWVWFlM2FtVHVQOApkS0YvWTRFR3Nnc09VWSs5RGlZYXRvQWVmN0xRQmZ5TnVQTFZrb1JQK0FrTXJQSWFHMHhMV3JFYmYzNVp3eFRuCnd5TTF3YVpQb1oxWjZFdmhHQkxNNzlXYmY2VFY0WXVzSTRNOEVQdU1GcWlYcDNlRmZ4L0tnNHhtYnZtN1JhYzcKOEJ3Z3pnVmljNXlSbkVXYjhpWUh5WGtyazNTL0VCYUNEMlQwUjM5VmlVM1I0VjBmMUtyV3NjRHowVmNiVWNhKwpzeVdyaVhKMHBnR1N0Q3FWK0dRYy9aNmJjOGt4VWpTTWxOUWtudVJRZ1FLQmdRRHpwM1ZaVmFzMTA3NThVT00rCnZUeTFNL0V6azg4cWhGb21kYVFiSFRlbStpeGpCNlg3RU9sRlkya3JwUkwvbURDSEpwR0MzYlJtUHNFaHVGSUwKRHhSQ2hUcEtTVmNsSytaaUNPaWE1ektTVUpxZnBOcW15RnNaQlhJNnRkNW9mWk42aFpJVTlJR2RUaGlYMjBONwppUW01UnZlSUx2UHVwMWZRMmRqd2F6Ykgvd0tCZ1FERU1MN21Mb2RqSjBNTXh6ZnM3MW1FNmZOUFhBMVY2ZEgrCllCVG4xS2txaHJpampRWmFNbXZ6dEZmL1F3Wkhmd3FKQUVuNGx2em5ncUNzZTMvUElZMy8zRERxd1p2NE1vdy8KRGdBeTBLQmpQYVJGNjhYT1B1d0VuSFN1UjhyZFg2UzI3TXQ2cEZIeFZ2YjlRRFJuSXc4a3grSFVreml4U0h5Ugo2NWxESklEdlFRS0JnUURpQTF3ZldoQlBCZk9VYlpQZUJydmhlaVVycXRob29BemYwQkJCOW9CQks1OHczVTloCjdQWDFuNWxYR3ZEY2x0ZXRCbUhEK3RQMFpCSFNyWit0RW5mQW5NVE5VK3E2V0ZhRWFhOGF3WXR2bmNWUWdTTXgKd25oK1pVYm9udnVJQWJSajJyTC9MUzl1TTVzc2dmKy9BQWM5RGs5ZXkrOEtXY0Jqd3pBeEU4TGxFUUtCZ0IzNwoxVEVZcTFoY0I4Tk1MeC9tOUtkN21kUG5IYUtqdVpSRzJ1c1RkVWNxajgxdklDbG95MWJUbVI5Si93dXVQczN4ClhWekF0cVlyTUtNcnZMekxSQWgyZm9OaVU1UDdKYlA5VDhwMFdBN1N2T2h5d0NobE5XeisvRlltWXJxeWcxbngKbHFlSHRYNU03REtJUFhvRndhcTlZYVk3V2M2K1pVdG4xbVNNajZnQkFvR0JBSTgwdU9iTkdhRndQTVYrUWhiZApBelkrSFNGQjBkWWZxRytzcTBmRVdIWTNHTXFmNFh0aVRqUEFjWlg3RmdtT3Q5Uit3TlFQK0dFNjZoV0JpKzBWCmVLV3prV0lXeS9sTVZCSW0zVWtlSlRCT3NudTFVaGhXbm5WVDhFeWhEY1FxcndPSGlhaUo3bFZSZmRoRWFyQysKSnpaU0czOHVZUVlyc0lITnRVZFgySmdPCi0tLS0tRU5EIFBSSVZBVEUgS0VZLS0tLS0K\"},\"kind\":\"Secret\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"redirecttests\",\"scope\":\"AmbassadorTest\"},\"name\":\"redirect-cert\",\"namespace\":\"default\"},\"type\":\"kubernetes.io/tls\"}\n"
                     },
-                    "creationTimestamp": "2020-02-19T23:20:30Z",
+                    "creationTimestamp": "2020-02-26T15:53:03Z",
                     "labels": {
                         "kat-ambassador-id": "redirecttests",
                         "scope": "AmbassadorTest"
                     },
                     "name": "redirect-cert",
                     "namespace": "default",
-                    "resourceVersion": "56656",
+                    "resourceVersion": "67734",
                     "selfLink": "/api/v1/namespaces/default/secrets/redirect-cert",
-                    "uid": "6b63b350-536e-11ea-85dd-167682b5c255"
+                    "uid": "127805f2-58b0-11ea-86d6-0e674b3ff44f"
                 },
                 "type": "kubernetes.io/tls"
             }
@@ -49,7 +49,7 @@
                         "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Module\nname: tls\nambassador_id: redirecttests\nconfig:\n  server:\n    enabled: True\n    secret: redirect-cert\n    redirect_cleartext_from: 8080\n",
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Module\\nname: tls\\nambassador_id: redirecttests\\nconfig:\\n  server:\\n    enabled: True\\n    secret: redirect-cert\\n    redirect_cleartext_from: 8080\\n\"},\"labels\":{\"app.kubernetes.io/component\":\"ambassador-service\",\"kat-ambassador-id\":\"redirecttests\",\"scope\":\"AmbassadorTest\"},\"name\":\"redirecttests\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8080},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8443}],\"selector\":{\"service\":\"redirecttests\"},\"type\":\"NodePort\"}}\n"
                     },
-                    "creationTimestamp": "2020-02-19T23:20:27Z",
+                    "creationTimestamp": "2020-02-26T15:53:06Z",
                     "labels": {
                         "app.kubernetes.io/component": "ambassador-service",
                         "kat-ambassador-id": "redirecttests",
@@ -57,24 +57,24 @@
                     },
                     "name": "redirecttests",
                     "namespace": "default",
-                    "resourceVersion": "56630",
+                    "resourceVersion": "67763",
                     "selfLink": "/api/v1/namespaces/default/services/redirecttests",
-                    "uid": "69e43d96-536e-11ea-85dd-167682b5c255"
+                    "uid": "141ea8a5-58b0-11ea-86d6-0e674b3ff44f"
                 },
                 "spec": {
-                    "clusterIP": "10.105.142.103",
+                    "clusterIP": "10.109.138.233",
                     "externalTrafficPolicy": "Cluster",
                     "ports": [
                         {
                             "name": "http",
-                            "nodePort": 31840,
+                            "nodePort": 30741,
                             "port": 80,
                             "protocol": "TCP",
                             "targetPort": 8080
                         },
                         {
                             "name": "https",
-                            "nodePort": 31004,
+                            "nodePort": 31806,
                             "port": 443,
                             "protocol": "TCP",
                             "targetPort": 8443
@@ -97,7 +97,7 @@
                     "annotations": {
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"redirecttests\",\"scope\":\"AmbassadorTest\",\"service\":\"redirecttests-admin\"},\"name\":\"redirecttests-admin\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"redirecttests-admin\",\"port\":8877,\"targetPort\":8877}],\"selector\":{\"service\":\"redirecttests\"},\"type\":\"NodePort\"}}\n"
                     },
-                    "creationTimestamp": "2020-02-19T23:20:28Z",
+                    "creationTimestamp": "2020-02-26T15:53:06Z",
                     "labels": {
                         "kat-ambassador-id": "redirecttests",
                         "scope": "AmbassadorTest",
@@ -105,17 +105,17 @@
                     },
                     "name": "redirecttests-admin",
                     "namespace": "default",
-                    "resourceVersion": "56639",
+                    "resourceVersion": "67774",
                     "selfLink": "/api/v1/namespaces/default/services/redirecttests-admin",
-                    "uid": "6a480709-536e-11ea-85dd-167682b5c255"
+                    "uid": "1444827a-58b0-11ea-86d6-0e674b3ff44f"
                 },
                 "spec": {
-                    "clusterIP": "10.96.232.205",
+                    "clusterIP": "10.107.145.141",
                     "externalTrafficPolicy": "Cluster",
                     "ports": [
                         {
                             "name": "redirecttests-admin",
-                            "nodePort": 30061,
+                            "nodePort": 31130,
                             "port": 8877,
                             "protocol": "TCP",
                             "targetPort": 8877
@@ -139,19 +139,19 @@
                         "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: tls_target_mapping\nprefix: /tls-target/\nservice: redirecttests-http\nambassador_id: redirecttests\n",
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: tls_target_mapping\\nprefix: /tls-target/\\nservice: redirecttests-http\\nambassador_id: redirecttests\\n\"},\"labels\":{\"kat-ambassador-id\":\"redirecttests\",\"scope\":\"AmbassadorTest\"},\"name\":\"redirecttests-http\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8118},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8481}],\"selector\":{\"backend\":\"superpod-default\"}}}\n"
                     },
-                    "creationTimestamp": "2020-02-19T23:20:30Z",
+                    "creationTimestamp": "2020-02-26T15:53:06Z",
                     "labels": {
                         "kat-ambassador-id": "redirecttests",
                         "scope": "AmbassadorTest"
                     },
                     "name": "redirecttests-http",
                     "namespace": "default",
-                    "resourceVersion": "56660",
+                    "resourceVersion": "67787",
                     "selfLink": "/api/v1/namespaces/default/services/redirecttests-http",
-                    "uid": "6b7a7fa8-536e-11ea-85dd-167682b5c255"
+                    "uid": "147e1099-58b0-11ea-86d6-0e674b3ff44f"
                 },
                 "spec": {
-                    "clusterIP": "10.99.155.22",
+                    "clusterIP": "10.100.215.242",
                     "ports": [
                         {
                             "name": "http",

--- a/python/tests/gold/redirecttestsinvalidsecret/snapshots/econf.json
+++ b/python/tests/gold/redirecttestsinvalidsecret/snapshots/econf.json
@@ -290,8 +290,7 @@
                                     "xff_num_trusted_hops": 0
                                 }
                             }
-                        ],
-                        "use_proxy_proto": false
+                        ]
                     }
                 ],
                 "listener_filters": [],
@@ -418,8 +417,7 @@
                                     "xff_num_trusted_hops": 0
                                 }
                             }
-                        ],
-                        "use_proxy_proto": false
+                        ]
                     }
                 ],
                 "listener_filters": [],

--- a/python/tests/gold/redirecttestsinvalidsecret/snapshots/snapshot.yaml
+++ b/python/tests/gold/redirecttestsinvalidsecret/snapshots/snapshot.yaml
@@ -21,9 +21,58 @@
                 "kind": "Service",
                 "metadata": {
                     "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Module\nname: tls\nambassador_id: redirecttestsinvalidsecret\nconfig:\n  server:\n    enabled: True\n    secret: does-not-exist-secret\n    redirect_cleartext_from: 8080\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Module\\nname: tls\\nambassador_id: redirecttestsinvalidsecret\\nconfig:\\n  server:\\n    enabled: True\\n    secret: does-not-exist-secret\\n    redirect_cleartext_from: 8080\\n\"},\"labels\":{\"app.kubernetes.io/component\":\"ambassador-service\",\"kat-ambassador-id\":\"redirecttestsinvalidsecret\",\"scope\":\"AmbassadorTest\"},\"name\":\"redirecttestsinvalidsecret\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8080},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8443}],\"selector\":{\"service\":\"redirecttestsinvalidsecret\"},\"type\":\"NodePort\"}}\n"
+                    },
+                    "creationTimestamp": "2020-02-26T15:53:09Z",
+                    "labels": {
+                        "app.kubernetes.io/component": "ambassador-service",
+                        "kat-ambassador-id": "redirecttestsinvalidsecret",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "redirecttestsinvalidsecret",
+                    "namespace": "default",
+                    "resourceVersion": "67835",
+                    "selfLink": "/api/v1/namespaces/default/services/redirecttestsinvalidsecret",
+                    "uid": "1639fe17-58b0-11ea-86d6-0e674b3ff44f"
+                },
+                "spec": {
+                    "clusterIP": "10.109.179.38",
+                    "externalTrafficPolicy": "Cluster",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "nodePort": 31325,
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8080
+                        },
+                        {
+                            "name": "https",
+                            "nodePort": 30615,
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8443
+                        }
+                    ],
+                    "selector": {
+                        "service": "redirecttestsinvalidsecret"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "NodePort"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"redirecttestsinvalidsecret\",\"scope\":\"AmbassadorTest\",\"service\":\"redirecttestsinvalidsecret-admin\"},\"name\":\"redirecttestsinvalidsecret-admin\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"redirecttestsinvalidsecret-admin\",\"port\":8877,\"targetPort\":8877}],\"selector\":{\"service\":\"redirecttestsinvalidsecret\"},\"type\":\"NodePort\"}}\n"
                     },
-                    "creationTimestamp": "2020-02-19T23:20:33Z",
+                    "creationTimestamp": "2020-02-26T15:53:10Z",
                     "labels": {
                         "kat-ambassador-id": "redirecttestsinvalidsecret",
                         "scope": "AmbassadorTest",
@@ -31,17 +80,17 @@
                     },
                     "name": "redirecttestsinvalidsecret-admin",
                     "namespace": "default",
-                    "resourceVersion": "56726",
+                    "resourceVersion": "67843",
                     "selfLink": "/api/v1/namespaces/default/services/redirecttestsinvalidsecret-admin",
-                    "uid": "6da7f5d5-536e-11ea-85dd-167682b5c255"
+                    "uid": "165f978b-58b0-11ea-86d6-0e674b3ff44f"
                 },
                 "spec": {
-                    "clusterIP": "10.108.210.127",
+                    "clusterIP": "10.108.215.207",
                     "externalTrafficPolicy": "Cluster",
                     "ports": [
                         {
                             "name": "redirecttestsinvalidsecret-admin",
-                            "nodePort": 30313,
+                            "nodePort": 31453,
                             "port": 8877,
                             "protocol": "TCP",
                             "targetPort": 8877
@@ -65,19 +114,19 @@
                         "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: tls_target_mapping\nprefix: /tls-target/\nservice: redirecttestsinvalidsecret-http\nambassador_id: redirecttestsinvalidsecret\n",
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: tls_target_mapping\\nprefix: /tls-target/\\nservice: redirecttestsinvalidsecret-http\\nambassador_id: redirecttestsinvalidsecret\\n\"},\"labels\":{\"kat-ambassador-id\":\"redirecttestsinvalidsecret\",\"scope\":\"AmbassadorTest\"},\"name\":\"redirecttestsinvalidsecret-http\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8120},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8483}],\"selector\":{\"backend\":\"superpod-default\"}}}\n"
                     },
-                    "creationTimestamp": "2020-02-19T23:20:34Z",
+                    "creationTimestamp": "2020-02-26T15:53:10Z",
                     "labels": {
                         "kat-ambassador-id": "redirecttestsinvalidsecret",
                         "scope": "AmbassadorTest"
                     },
                     "name": "redirecttestsinvalidsecret-http",
                     "namespace": "default",
-                    "resourceVersion": "56736",
+                    "resourceVersion": "67852",
                     "selfLink": "/api/v1/namespaces/default/services/redirecttestsinvalidsecret-http",
-                    "uid": "6e0a2238-536e-11ea-85dd-167682b5c255"
+                    "uid": "168d6342-58b0-11ea-86d6-0e674b3ff44f"
                 },
                 "spec": {
-                    "clusterIP": "10.103.135.166",
+                    "clusterIP": "10.99.170.80",
                     "ports": [
                         {
                             "name": "http",
@@ -97,55 +146,6 @@
                     },
                     "sessionAffinity": "None",
                     "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Module\nname: tls\nambassador_id: redirecttestsinvalidsecret\nconfig:\n  server:\n    enabled: True\n    secret: does-not-exist-secret\n    redirect_cleartext_from: 8080\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Module\\nname: tls\\nambassador_id: redirecttestsinvalidsecret\\nconfig:\\n  server:\\n    enabled: True\\n    secret: does-not-exist-secret\\n    redirect_cleartext_from: 8080\\n\"},\"labels\":{\"app.kubernetes.io/component\":\"ambassador-service\",\"kat-ambassador-id\":\"redirecttestsinvalidsecret\",\"scope\":\"AmbassadorTest\"},\"name\":\"redirecttestsinvalidsecret\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8080},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8443}],\"selector\":{\"service\":\"redirecttestsinvalidsecret\"},\"type\":\"NodePort\"}}\n"
-                    },
-                    "creationTimestamp": "2020-02-19T23:20:33Z",
-                    "labels": {
-                        "app.kubernetes.io/component": "ambassador-service",
-                        "kat-ambassador-id": "redirecttestsinvalidsecret",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "redirecttestsinvalidsecret",
-                    "namespace": "default",
-                    "resourceVersion": "56720",
-                    "selfLink": "/api/v1/namespaces/default/services/redirecttestsinvalidsecret",
-                    "uid": "6d8b0088-536e-11ea-85dd-167682b5c255"
-                },
-                "spec": {
-                    "clusterIP": "10.111.5.75",
-                    "externalTrafficPolicy": "Cluster",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "nodePort": 31318,
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8080
-                        },
-                        {
-                            "name": "https",
-                            "nodePort": 30810,
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8443
-                        }
-                    ],
-                    "selector": {
-                        "service": "redirecttestsinvalidsecret"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "NodePort"
                 },
                 "status": {
                     "loadBalancer": {}

--- a/python/tests/gold/redirecttestswithproxyproto/snapshots/econf.json
+++ b/python/tests/gold/redirecttestswithproxyproto/snapshots/econf.json
@@ -302,11 +302,15 @@
                                     "xff_num_trusted_hops": 0
                                 }
                             }
-                        ],
-                        "use_proxy_proto": true
+                        ]
                     }
                 ],
-                "listener_filters": [],
+                "listener_filters": [
+                    {
+                        "config": {},
+                        "name": "envoy.listener.proxy_protocol"
+                    }
+                ],
                 "name": "ambassador-listener-8080",
                 "traffic_direction": "UNSPECIFIED"
             }

--- a/python/tests/gold/redirecttestswithproxyproto/snapshots/snapshot.yaml
+++ b/python/tests/gold/redirecttestswithproxyproto/snapshots/snapshot.yaml
@@ -20,10 +20,55 @@
                 "kind": "Service",
                 "metadata": {
                     "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: tls_target_mapping\nprefix: /tls-target/\nservice: redirecttestswithproxyproto-http\nambassador_id: redirecttestswithproxyproto\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: tls_target_mapping\\nprefix: /tls-target/\\nservice: redirecttestswithproxyproto-http\\nambassador_id: redirecttestswithproxyproto\\n\"},\"labels\":{\"kat-ambassador-id\":\"redirecttestswithproxyproto\",\"scope\":\"AmbassadorTest\"},\"name\":\"redirecttestswithproxyproto-http\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8119},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8482}],\"selector\":{\"backend\":\"superpod-default\"}}}\n"
+                    },
+                    "creationTimestamp": "2020-02-26T15:53:08Z",
+                    "labels": {
+                        "kat-ambassador-id": "redirecttestswithproxyproto",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "redirecttestswithproxyproto-http",
+                    "namespace": "default",
+                    "resourceVersion": "67816",
+                    "selfLink": "/api/v1/namespaces/default/services/redirecttestswithproxyproto-http",
+                    "uid": "15612ea8-58b0-11ea-86d6-0e674b3ff44f"
+                },
+                "spec": {
+                    "clusterIP": "10.100.170.204",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8119
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8482
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-default"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
                         "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Module\nname: ambassador\nconfig:\n  use_proxy_proto: true\n  enable_ipv6: true\nambassador_id: redirecttestswithproxyproto\n",
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Module\\nname: ambassador\\nconfig:\\n  use_proxy_proto: true\\n  enable_ipv6: true\\nambassador_id: redirecttestswithproxyproto\\n\"},\"labels\":{\"app.kubernetes.io/component\":\"ambassador-service\",\"kat-ambassador-id\":\"redirecttestswithproxyproto\",\"scope\":\"AmbassadorTest\"},\"name\":\"redirecttestswithproxyproto\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8080},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8443}],\"selector\":{\"service\":\"redirecttestswithproxyproto\"},\"type\":\"NodePort\"}}\n"
                     },
-                    "creationTimestamp": "2020-02-19T23:20:32Z",
+                    "creationTimestamp": "2020-02-26T15:53:08Z",
                     "labels": {
                         "app.kubernetes.io/component": "ambassador-service",
                         "kat-ambassador-id": "redirecttestswithproxyproto",
@@ -31,24 +76,24 @@
                     },
                     "name": "redirecttestswithproxyproto",
                     "namespace": "default",
-                    "resourceVersion": "56692",
+                    "resourceVersion": "67802",
                     "selfLink": "/api/v1/namespaces/default/services/redirecttestswithproxyproto",
-                    "uid": "6cbbe1e0-536e-11ea-85dd-167682b5c255"
+                    "uid": "151ecb53-58b0-11ea-86d6-0e674b3ff44f"
                 },
                 "spec": {
-                    "clusterIP": "10.107.40.131",
+                    "clusterIP": "10.111.21.40",
                     "externalTrafficPolicy": "Cluster",
                     "ports": [
                         {
                             "name": "http",
-                            "nodePort": 30683,
+                            "nodePort": 32393,
                             "port": 80,
                             "protocol": "TCP",
                             "targetPort": 8080
                         },
                         {
                             "name": "https",
-                            "nodePort": 30159,
+                            "nodePort": 30700,
                             "port": 443,
                             "protocol": "TCP",
                             "targetPort": 8443
@@ -71,7 +116,7 @@
                     "annotations": {
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"redirecttestswithproxyproto\",\"scope\":\"AmbassadorTest\",\"service\":\"redirecttestswithproxyproto-admin\"},\"name\":\"redirecttestswithproxyproto-admin\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"redirecttestswithproxyproto-admin\",\"port\":8877,\"targetPort\":8877}],\"selector\":{\"service\":\"redirecttestswithproxyproto\"},\"type\":\"NodePort\"}}\n"
                     },
-                    "creationTimestamp": "2020-02-19T23:20:32Z",
+                    "creationTimestamp": "2020-02-26T15:53:08Z",
                     "labels": {
                         "kat-ambassador-id": "redirecttestswithproxyproto",
                         "scope": "AmbassadorTest",
@@ -79,17 +124,17 @@
                     },
                     "name": "redirecttestswithproxyproto-admin",
                     "namespace": "default",
-                    "resourceVersion": "56697",
+                    "resourceVersion": "67807",
                     "selfLink": "/api/v1/namespaces/default/services/redirecttestswithproxyproto-admin",
-                    "uid": "6cc52a1d-536e-11ea-85dd-167682b5c255"
+                    "uid": "154054c9-58b0-11ea-86d6-0e674b3ff44f"
                 },
                 "spec": {
-                    "clusterIP": "10.107.175.8",
+                    "clusterIP": "10.108.28.178",
                     "externalTrafficPolicy": "Cluster",
                     "ports": [
                         {
                             "name": "redirecttestswithproxyproto-admin",
-                            "nodePort": 32064,
+                            "nodePort": 31241,
                             "port": 8877,
                             "protocol": "TCP",
                             "targetPort": 8877
@@ -100,51 +145,6 @@
                     },
                     "sessionAffinity": "None",
                     "type": "NodePort"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: tls_target_mapping\nprefix: /tls-target/\nservice: redirecttestswithproxyproto-http\nambassador_id: redirecttestswithproxyproto\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: tls_target_mapping\\nprefix: /tls-target/\\nservice: redirecttestswithproxyproto-http\\nambassador_id: redirecttestswithproxyproto\\n\"},\"labels\":{\"kat-ambassador-id\":\"redirecttestswithproxyproto\",\"scope\":\"AmbassadorTest\"},\"name\":\"redirecttestswithproxyproto-http\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8119},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8482}],\"selector\":{\"backend\":\"superpod-default\"}}}\n"
-                    },
-                    "creationTimestamp": "2020-02-19T23:20:33Z",
-                    "labels": {
-                        "kat-ambassador-id": "redirecttestswithproxyproto",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "redirecttestswithproxyproto-http",
-                    "namespace": "default",
-                    "resourceVersion": "56706",
-                    "selfLink": "/api/v1/namespaces/default/services/redirecttestswithproxyproto-http",
-                    "uid": "6d2b2fb0-536e-11ea-85dd-167682b5c255"
-                },
-                "spec": {
-                    "clusterIP": "10.101.125.45",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8119
-                        },
-                        {
-                            "name": "https",
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8482
-                        }
-                    ],
-                    "selector": {
-                        "backend": "superpod-default"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "ClusterIP"
                 },
                 "status": {
                     "loadBalancer": {}

--- a/python/tests/gold/retrypolicytest/snapshots/econf.json
+++ b/python/tests/gold/retrypolicytest/snapshots/econf.json
@@ -386,8 +386,7 @@
                                     "xff_num_trusted_hops": 0
                                 }
                             }
-                        ],
-                        "use_proxy_proto": false
+                        ]
                     }
                 ],
                 "listener_filters": [],

--- a/python/tests/gold/retrypolicytest/snapshots/snapshot.yaml
+++ b/python/tests/gold/retrypolicytest/snapshots/snapshot.yaml
@@ -23,7 +23,7 @@
                         "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: RetryPolicyTest-normal\nprefix: /RetryPolicyTest-normal/\nservice: retrypolicytest-http\ntimeout_ms: 3000\nambassador_id: retrypolicytest\n\n---\napiVersion: ambassador/v1\nkind: Mapping\nname: RetryPolicyTest-target\nprefix: /RetryPolicyTest-retry/\nservice: retrypolicytest-http\ntimeout_ms: 3000\nretry_policy:\n  retry_on: \"5xx\"\n  num_retries: 4\nambassador_id: retrypolicytest\n\n---\napiVersion: ambassador/v0\nkind: Module\nname: ambassador\nconfig:\n  retry_policy:\n    retry_on: \"retriable-4xx\"\n    num_retries: 4\nambassador_id: retrypolicytest\n",
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: RetryPolicyTest-normal\\nprefix: /RetryPolicyTest-normal/\\nservice: retrypolicytest-http\\ntimeout_ms: 3000\\nambassador_id: retrypolicytest\\n\\n---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: RetryPolicyTest-target\\nprefix: /RetryPolicyTest-retry/\\nservice: retrypolicytest-http\\ntimeout_ms: 3000\\nretry_policy:\\n  retry_on: \\\"5xx\\\"\\n  num_retries: 4\\nambassador_id: retrypolicytest\\n\\n---\\napiVersion: ambassador/v0\\nkind: Module\\nname: ambassador\\nconfig:\\n  retry_policy:\\n    retry_on: \\\"retriable-4xx\\\"\\n    num_retries: 4\\nambassador_id: retrypolicytest\\n\"},\"labels\":{\"app.kubernetes.io/component\":\"ambassador-service\",\"kat-ambassador-id\":\"retrypolicytest\",\"scope\":\"AmbassadorTest\"},\"name\":\"retrypolicytest\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8080},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8443}],\"selector\":{\"service\":\"retrypolicytest\"},\"type\":\"NodePort\"}}\n"
                     },
-                    "creationTimestamp": "2020-02-19T23:21:52Z",
+                    "creationTimestamp": "2020-02-26T15:54:02Z",
                     "labels": {
                         "app.kubernetes.io/component": "ambassador-service",
                         "kat-ambassador-id": "retrypolicytest",
@@ -31,24 +31,24 @@
                     },
                     "name": "retrypolicytest",
                     "namespace": "default",
-                    "resourceVersion": "57785",
+                    "resourceVersion": "68745",
                     "selfLink": "/api/v1/namespaces/default/services/retrypolicytest",
-                    "uid": "9c53a150-536e-11ea-85dd-167682b5c255"
+                    "uid": "3584e8e5-58b0-11ea-86d6-0e674b3ff44f"
                 },
                 "spec": {
-                    "clusterIP": "10.98.92.224",
+                    "clusterIP": "10.102.100.187",
                     "externalTrafficPolicy": "Cluster",
                     "ports": [
                         {
                             "name": "http",
-                            "nodePort": 32548,
+                            "nodePort": 30479,
                             "port": 80,
                             "protocol": "TCP",
                             "targetPort": 8080
                         },
                         {
                             "name": "https",
-                            "nodePort": 31044,
+                            "nodePort": 32301,
                             "port": 443,
                             "protocol": "TCP",
                             "targetPort": 8443
@@ -71,7 +71,7 @@
                     "annotations": {
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"retrypolicytest\",\"scope\":\"AmbassadorTest\",\"service\":\"retrypolicytest-admin\"},\"name\":\"retrypolicytest-admin\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"retrypolicytest-admin\",\"port\":8877,\"targetPort\":8877}],\"selector\":{\"service\":\"retrypolicytest\"},\"type\":\"NodePort\"}}\n"
                     },
-                    "creationTimestamp": "2020-02-19T23:21:53Z",
+                    "creationTimestamp": "2020-02-26T15:54:02Z",
                     "labels": {
                         "kat-ambassador-id": "retrypolicytest",
                         "scope": "AmbassadorTest",
@@ -79,17 +79,17 @@
                     },
                     "name": "retrypolicytest-admin",
                     "namespace": "default",
-                    "resourceVersion": "57795",
+                    "resourceVersion": "68754",
                     "selfLink": "/api/v1/namespaces/default/services/retrypolicytest-admin",
-                    "uid": "9d26c8be-536e-11ea-85dd-167682b5c255"
+                    "uid": "35aec30f-58b0-11ea-86d6-0e674b3ff44f"
                 },
                 "spec": {
-                    "clusterIP": "10.100.41.202",
+                    "clusterIP": "10.97.245.73",
                     "externalTrafficPolicy": "Cluster",
                     "ports": [
                         {
                             "name": "retrypolicytest-admin",
-                            "nodePort": 30916,
+                            "nodePort": 32330,
                             "port": 8877,
                             "protocol": "TCP",
                             "targetPort": 8877
@@ -112,19 +112,19 @@
                     "annotations": {
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"retrypolicytest\",\"scope\":\"AmbassadorTest\"},\"name\":\"retrypolicytest-http\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8136},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8499}],\"selector\":{\"backend\":\"superpod-default\"}}}\n"
                     },
-                    "creationTimestamp": "2020-02-19T23:21:55Z",
+                    "creationTimestamp": "2020-02-26T15:54:04Z",
                     "labels": {
                         "kat-ambassador-id": "retrypolicytest",
                         "scope": "AmbassadorTest"
                     },
                     "name": "retrypolicytest-http",
                     "namespace": "default",
-                    "resourceVersion": "57810",
+                    "resourceVersion": "68769",
                     "selfLink": "/api/v1/namespaces/default/services/retrypolicytest-http",
-                    "uid": "9e363477-536e-11ea-85dd-167682b5c255"
+                    "uid": "3697ce87-58b0-11ea-86d6-0e674b3ff44f"
                 },
                 "spec": {
-                    "clusterIP": "10.105.151.74",
+                    "clusterIP": "10.109.226.109",
                     "ports": [
                         {
                             "name": "http",

--- a/python/tests/gold/saferegexmapping/snapshots/econf.json
+++ b/python/tests/gold/saferegexmapping/snapshots/econf.json
@@ -350,8 +350,7 @@
                                     "xff_num_trusted_hops": 0
                                 }
                             }
-                        ],
-                        "use_proxy_proto": false
+                        ]
                     }
                 ],
                 "listener_filters": [],

--- a/python/tests/gold/saferegexmapping/snapshots/snapshot.yaml
+++ b/python/tests/gold/saferegexmapping/snapshots/snapshot.yaml
@@ -20,9 +20,58 @@
                 "kind": "Service",
                 "metadata": {
                     "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: SafeRegexMapping\nprefix: /SafeRegexMapping/\nprefix_regex: true\nhost: \"[a-zA-Z].*\"\nhost_regex: true\nregex_headers:\n  X-Foo: \"^[a-z].*\"\nservice: http://saferegexmapping-http\nambassador_id: saferegexmapping\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: SafeRegexMapping\\nprefix: /SafeRegexMapping/\\nprefix_regex: true\\nhost: \\\"[a-zA-Z].*\\\"\\nhost_regex: true\\nregex_headers:\\n  X-Foo: \\\"^[a-z].*\\\"\\nservice: http://saferegexmapping-http\\nambassador_id: saferegexmapping\\n\"},\"labels\":{\"app.kubernetes.io/component\":\"ambassador-service\",\"kat-ambassador-id\":\"saferegexmapping\",\"scope\":\"AmbassadorTest\"},\"name\":\"saferegexmapping\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8080},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8443}],\"selector\":{\"service\":\"saferegexmapping\"},\"type\":\"NodePort\"}}\n"
+                    },
+                    "creationTimestamp": "2020-02-26T15:51:37Z",
+                    "labels": {
+                        "app.kubernetes.io/component": "ambassador-service",
+                        "kat-ambassador-id": "saferegexmapping",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "saferegexmapping",
+                    "namespace": "default",
+                    "resourceVersion": "65846",
+                    "selfLink": "/api/v1/namespaces/default/services/saferegexmapping",
+                    "uid": "df3ac1df-58af-11ea-86d6-0e674b3ff44f"
+                },
+                "spec": {
+                    "clusterIP": "10.109.31.70",
+                    "externalTrafficPolicy": "Cluster",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "nodePort": 31104,
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8080
+                        },
+                        {
+                            "name": "https",
+                            "nodePort": 31655,
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8443
+                        }
+                    ],
+                    "selector": {
+                        "service": "saferegexmapping"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "NodePort"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"saferegexmapping\",\"scope\":\"AmbassadorTest\",\"service\":\"saferegexmapping-admin\"},\"name\":\"saferegexmapping-admin\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"saferegexmapping-admin\",\"port\":8877,\"targetPort\":8877}],\"selector\":{\"service\":\"saferegexmapping\"},\"type\":\"NodePort\"}}\n"
                     },
-                    "creationTimestamp": "2020-02-19T23:19:55Z",
+                    "creationTimestamp": "2020-02-26T15:51:37Z",
                     "labels": {
                         "kat-ambassador-id": "saferegexmapping",
                         "scope": "AmbassadorTest",
@@ -30,17 +79,17 @@
                     },
                     "name": "saferegexmapping-admin",
                     "namespace": "default",
-                    "resourceVersion": "55175",
+                    "resourceVersion": "65851",
                     "selfLink": "/api/v1/namespaces/default/services/saferegexmapping-admin",
-                    "uid": "56c35c28-536e-11ea-85dd-167682b5c255"
+                    "uid": "df45d8f3-58af-11ea-86d6-0e674b3ff44f"
                 },
                 "spec": {
-                    "clusterIP": "10.110.134.171",
+                    "clusterIP": "10.96.172.192",
                     "externalTrafficPolicy": "Cluster",
                     "ports": [
                         {
                             "name": "saferegexmapping-admin",
-                            "nodePort": 30790,
+                            "nodePort": 30946,
                             "port": 8877,
                             "protocol": "TCP",
                             "targetPort": 8877
@@ -63,19 +112,19 @@
                     "annotations": {
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"saferegexmapping\",\"scope\":\"AmbassadorTest\"},\"name\":\"saferegexmapping-http\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8082},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8445}],\"selector\":{\"backend\":\"superpod-default\"}}}\n"
                     },
-                    "creationTimestamp": "2020-02-19T23:19:55Z",
+                    "creationTimestamp": "2020-02-26T15:51:37Z",
                     "labels": {
                         "kat-ambassador-id": "saferegexmapping",
                         "scope": "AmbassadorTest"
                     },
                     "name": "saferegexmapping-http",
                     "namespace": "default",
-                    "resourceVersion": "55182",
+                    "resourceVersion": "65859",
                     "selfLink": "/api/v1/namespaces/default/services/saferegexmapping-http",
-                    "uid": "56d0e3e8-536e-11ea-85dd-167682b5c255"
+                    "uid": "df5c8d66-58af-11ea-86d6-0e674b3ff44f"
                 },
                 "spec": {
-                    "clusterIP": "10.110.171.23",
+                    "clusterIP": "10.111.51.204",
                     "ports": [
                         {
                             "name": "http",
@@ -95,55 +144,6 @@
                     },
                     "sessionAffinity": "None",
                     "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Mapping\nname: SafeRegexMapping\nprefix: /SafeRegexMapping/\nprefix_regex: true\nhost: \"[a-zA-Z].*\"\nhost_regex: true\nregex_headers:\n  X-Foo: \"^[a-z].*\"\nservice: http://saferegexmapping-http\nambassador_id: saferegexmapping\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: SafeRegexMapping\\nprefix: /SafeRegexMapping/\\nprefix_regex: true\\nhost: \\\"[a-zA-Z].*\\\"\\nhost_regex: true\\nregex_headers:\\n  X-Foo: \\\"^[a-z].*\\\"\\nservice: http://saferegexmapping-http\\nambassador_id: saferegexmapping\\n\"},\"labels\":{\"app.kubernetes.io/component\":\"ambassador-service\",\"kat-ambassador-id\":\"saferegexmapping\",\"scope\":\"AmbassadorTest\"},\"name\":\"saferegexmapping\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8080},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8443}],\"selector\":{\"service\":\"saferegexmapping\"},\"type\":\"NodePort\"}}\n"
-                    },
-                    "creationTimestamp": "2020-02-19T23:19:55Z",
-                    "labels": {
-                        "app.kubernetes.io/component": "ambassador-service",
-                        "kat-ambassador-id": "saferegexmapping",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "saferegexmapping",
-                    "namespace": "default",
-                    "resourceVersion": "55171",
-                    "selfLink": "/api/v1/namespaces/default/services/saferegexmapping",
-                    "uid": "56bc01ff-536e-11ea-85dd-167682b5c255"
-                },
-                "spec": {
-                    "clusterIP": "10.111.131.228",
-                    "externalTrafficPolicy": "Cluster",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "nodePort": 31811,
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8080
-                        },
-                        {
-                            "name": "https",
-                            "nodePort": 31728,
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8443
-                        }
-                    ],
-                    "selector": {
-                        "service": "saferegexmapping"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "NodePort"
                 },
                 "status": {
                     "loadBalancer": {}

--- a/python/tests/gold/servernametest/snapshots/econf.json
+++ b/python/tests/gold/servernametest/snapshots/econf.json
@@ -302,8 +302,7 @@
                                     "xff_num_trusted_hops": 0
                                 }
                             }
-                        ],
-                        "use_proxy_proto": false
+                        ]
                     }
                 ],
                 "listener_filters": [],

--- a/python/tests/gold/servernametest/snapshots/snapshot.yaml
+++ b/python/tests/gold/servernametest/snapshots/snapshot.yaml
@@ -23,7 +23,7 @@
                         "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Module\nname: ambassador\nconfig:\n  server_name: \"test-server\"\nambassador_id: servernametest\n---\napiVersion: ambassador/v0\nkind: Mapping\nname: servernametest/server-name\nprefix: /server-name\nservice: servernametest-http\nambassador_id: servernametest\n",
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Module\\nname: ambassador\\nconfig:\\n  server_name: \\\"test-server\\\"\\nambassador_id: servernametest\\n---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: servernametest/server-name\\nprefix: /server-name\\nservice: servernametest-http\\nambassador_id: servernametest\\n\"},\"labels\":{\"app.kubernetes.io/component\":\"ambassador-service\",\"kat-ambassador-id\":\"servernametest\",\"scope\":\"AmbassadorTest\"},\"name\":\"servernametest\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8080},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8443}],\"selector\":{\"service\":\"servernametest\"},\"type\":\"NodePort\"}}\n"
                     },
-                    "creationTimestamp": "2020-02-19T23:19:55Z",
+                    "creationTimestamp": "2020-02-26T15:51:37Z",
                     "labels": {
                         "app.kubernetes.io/component": "ambassador-service",
                         "kat-ambassador-id": "servernametest",
@@ -31,24 +31,24 @@
                     },
                     "name": "servernametest",
                     "namespace": "default",
-                    "resourceVersion": "55147",
+                    "resourceVersion": "65822",
                     "selfLink": "/api/v1/namespaces/default/services/servernametest",
-                    "uid": "568a984a-536e-11ea-85dd-167682b5c255"
+                    "uid": "def3ca1a-58af-11ea-86d6-0e674b3ff44f"
                 },
                 "spec": {
-                    "clusterIP": "10.104.235.77",
+                    "clusterIP": "10.107.243.156",
                     "externalTrafficPolicy": "Cluster",
                     "ports": [
                         {
                             "name": "http",
-                            "nodePort": 31496,
+                            "nodePort": 32202,
                             "port": 80,
                             "protocol": "TCP",
                             "targetPort": 8080
                         },
                         {
                             "name": "https",
-                            "nodePort": 31277,
+                            "nodePort": 32365,
                             "port": 443,
                             "protocol": "TCP",
                             "targetPort": 8443
@@ -71,7 +71,7 @@
                     "annotations": {
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"servernametest\",\"scope\":\"AmbassadorTest\",\"service\":\"servernametest-admin\"},\"name\":\"servernametest-admin\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"servernametest-admin\",\"port\":8877,\"targetPort\":8877}],\"selector\":{\"service\":\"servernametest\"},\"type\":\"NodePort\"}}\n"
                     },
-                    "creationTimestamp": "2020-02-19T23:19:55Z",
+                    "creationTimestamp": "2020-02-26T15:51:37Z",
                     "labels": {
                         "kat-ambassador-id": "servernametest",
                         "scope": "AmbassadorTest",
@@ -79,17 +79,17 @@
                     },
                     "name": "servernametest-admin",
                     "namespace": "default",
-                    "resourceVersion": "55151",
+                    "resourceVersion": "65826",
                     "selfLink": "/api/v1/namespaces/default/services/servernametest-admin",
-                    "uid": "5691662b-536e-11ea-85dd-167682b5c255"
+                    "uid": "defd160b-58af-11ea-86d6-0e674b3ff44f"
                 },
                 "spec": {
-                    "clusterIP": "10.96.157.210",
+                    "clusterIP": "10.99.217.193",
                     "externalTrafficPolicy": "Cluster",
                     "ports": [
                         {
                             "name": "servernametest-admin",
-                            "nodePort": 30030,
+                            "nodePort": 32135,
                             "port": 8877,
                             "protocol": "TCP",
                             "targetPort": 8877
@@ -112,19 +112,19 @@
                     "annotations": {
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"servernametest\",\"scope\":\"AmbassadorTest\"},\"name\":\"servernametest-http\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8081},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8444}],\"selector\":{\"backend\":\"superpod-default\"}}}\n"
                     },
-                    "creationTimestamp": "2020-02-19T23:19:55Z",
+                    "creationTimestamp": "2020-02-26T15:51:37Z",
                     "labels": {
                         "kat-ambassador-id": "servernametest",
                         "scope": "AmbassadorTest"
                     },
                     "name": "servernametest-http",
                     "namespace": "default",
-                    "resourceVersion": "55158",
+                    "resourceVersion": "65833",
                     "selfLink": "/api/v1/namespaces/default/services/servernametest-http",
-                    "uid": "569f60ed-536e-11ea-85dd-167682b5c255"
+                    "uid": "df13a4b8-58af-11ea-86d6-0e674b3ff44f"
                 },
                 "spec": {
-                    "clusterIP": "10.101.41.232",
+                    "clusterIP": "10.96.55.51",
                     "ports": [
                         {
                             "name": "http",

--- a/python/tests/gold/tcpmappingtest/snapshots/econf.json
+++ b/python/tests/gold/tcpmappingtest/snapshots/econf.json
@@ -357,8 +357,7 @@
                                     }
                                 ]
                             }
-                        },
-                        "use_proxy_proto": false
+                        }
                     },
                     {
                         "filter_chain_match": {
@@ -501,8 +500,7 @@
                                     }
                                 ]
                             }
-                        },
-                        "use_proxy_proto": false
+                        }
                     },
                     {
                         "filter_chain_match": {
@@ -645,8 +643,7 @@
                                     }
                                 ]
                             }
-                        },
-                        "use_proxy_proto": false
+                        }
                     }
                 ],
                 "listener_filters": [

--- a/python/tests/gold/tcpmappingtest/snapshots/snapshot.yaml
+++ b/python/tests/gold/tcpmappingtest/snapshots/snapshot.yaml
@@ -26,16 +26,16 @@
                     "annotations": {
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"data\":{\"tls.crt\":\"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURnRENDQW1pZ0F3SUJBZ0lKQUlIWTY3cFNoZ3NyTUEwR0NTcUdTSWIzRFFFQkN3VUFNRlV4Q3pBSkJnTlYKQkFZVEFsVlRNUXN3Q1FZRFZRUUlEQUpOUVRFUE1BMEdBMVVFQnd3R1FtOXpkRzl1TVFzd0NRWURWUVFLREFKRQpWekViTUJrR0ExVUVBd3dTZEd4ekxXTnZiblJsZUhRdGFHOXpkQzB5TUI0WERURTRNVEV3TVRFME1EUXhObG9YCkRUSTRNVEF5T1RFME1EUXhObG93VlRFTE1Ba0dBMVVFQmhNQ1ZWTXhDekFKQmdOVkJBZ01BazFCTVE4d0RRWUQKVlFRSERBWkNiM04wYjI0eEN6QUpCZ05WQkFvTUFrUlhNUnN3R1FZRFZRUUREQkowYkhNdFkyOXVkR1Y0ZEMxbwpiM04wTFRJd2dnRWlNQTBHQ1NxR1NJYjNEUUVCQVFVQUE0SUJEd0F3Z2dFS0FvSUJBUURjQThZdGgvUFdhT0dTCm9ObXZFSFoyNGpRN1BLTitENG93TEhXZWl1UmRtaEEwWU92VTN3cUczVnFZNFpwbFpBVjBQS2xELysyWlNGMTQKejh3MWVGNFFUelphWXh3eTkrd2ZITmtUREVwTWpQOEpNMk9FYnlrVVJ4VVJ2VzQrN0QzMEUyRXo1T1BseG1jMApNWU0vL0pINUVEUWhjaURybFlxZTFTUk1SQUxaZVZta2FBeXU2TkhKVEJ1ajBTSVB1ZExUY2grOTBxK3Jkd255CmZrVDF4M09UYW5iV2pub21FSmU3TXZ5NG12dnFxSUh1NDhTOUM4WmQxQkdWUGJ1OFYvVURyU1dROXpZQ1g0U0cKT2FzbDhDMFhtSDZrZW1oUERsRC9UdjB4dnlINXE1TVVjSGk0bUp0Titnem9iNTREd3pWR0VqZWY1TGVTMVY1RgowVEFQMGQrWEFnTUJBQUdqVXpCUk1CMEdBMVVkRGdRV0JCUWRGMEdRSGRxbHRoZG5RWXFWaXVtRXJsUk9mREFmCkJnTlZIU01FR0RBV2dCUWRGMEdRSGRxbHRoZG5RWXFWaXVtRXJsUk9mREFQQmdOVkhSTUJBZjhFQlRBREFRSC8KTUEwR0NTcUdTSWIzRFFFQkN3VUFBNElCQVFBbUFLYkNsdUhFZS9JRmJ1QWJneDBNenV6aTkwd2xtQVBiOGdtTwpxdmJwMjl1T1ZzVlNtUUFkZFBuZEZhTVhWcDFaaG1UVjVDU1F0ZFgyQ1ZNVyswVzQ3Qy9DT0Jkb1NFUTl5akJmCmlGRGNseG04QU4yUG1hR1FhK3hvT1hnWkxYZXJDaE5LV0JTWlIrWktYTEpTTTlVYUVTbEhmNXVuQkxFcENqK2oKZEJpSXFGY2E3eElGUGtyKzBSRW9BVmMveFBubnNhS2pMMlV5Z0dqUWZGTnhjT042Y3VjYjZMS0pYT1pFSVRiNQpINjhKdWFSQ0tyZWZZK0l5aFFWVk5taWk3dE1wY1UyS2pXNXBrVktxVTNkS0l0RXEyVmtTZHpNVUtqTnhZd3FGCll6YnozNFQ1MENXbm9HbU5SQVdKc0xlVmlPWVUyNmR3YkFXZDlVYitWMDFRam43OAotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==\",\"tls.key\":\"LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0tCk1JSUV2d0lCQURBTkJna3Foa2lHOXcwQkFRRUZBQVNDQktrd2dnU2xBZ0VBQW9JQkFRRGNBOFl0aC9QV2FPR1MKb05tdkVIWjI0alE3UEtOK0Q0b3dMSFdlaXVSZG1oQTBZT3ZVM3dxRzNWcVk0WnBsWkFWMFBLbEQvKzJaU0YxNAp6OHcxZUY0UVR6WmFZeHd5OSt3ZkhOa1RERXBNalA4Sk0yT0VieWtVUnhVUnZXNCs3RDMwRTJFejVPUGx4bWMwCk1ZTS8vSkg1RURRaGNpRHJsWXFlMVNSTVJBTFplVm1rYUF5dTZOSEpUQnVqMFNJUHVkTFRjaCs5MHErcmR3bnkKZmtUMXgzT1RhbmJXam5vbUVKZTdNdnk0bXZ2cXFJSHU0OFM5QzhaZDFCR1ZQYnU4Vi9VRHJTV1E5ellDWDRTRwpPYXNsOEMwWG1INmtlbWhQRGxEL1R2MHh2eUg1cTVNVWNIaTRtSnROK2d6b2I1NER3elZHRWplZjVMZVMxVjVGCjBUQVAwZCtYQWdNQkFBRUNnZ0VCQUk2U3I0anYwZForanJhN0gzVnZ3S1RYZnl0bjV6YVlrVjhZWUh3RjIyakEKbm9HaTBSQllIUFU2V2l3NS9oaDRFWVM2anFHdkptUXZYY3NkTldMdEJsK2hSVUtiZVRtYUtWd2NFSnRrV24xeQozUTQwUytnVk5OU2NINDRvYUZuRU0zMklWWFFRZnBKMjJJZ2RFY1dVUVcvWnpUNWpPK3dPTXc4c1plSTZMSEtLCkdoOENsVDkrRGUvdXFqbjNCRnQwelZ3cnFLbllKSU1DSWFrb2lDRmtIcGhVTURFNVkyU1NLaGFGWndxMWtLd0sKdHFvWFpKQnlzYXhnUTFRa21mS1RnRkx5WlpXT01mRzVzb1VrU1RTeURFRzFsYnVYcHpUbTlVSTlKU2lsK01yaAp1LzVTeXBLOHBCSHhBdFg5VXdiTjFiRGw3Sng1SWJyMnNoM0F1UDF4OUpFQ2dZRUE4dGNTM09URXNOUFpQZlptCk9jaUduOW9STTdHVmVGdjMrL05iL3JodHp1L1RQUWJBSzhWZ3FrS0dPazNGN1krY2txS1NTWjFnUkF2SHBsZEIKaTY0Y0daT1dpK01jMWZVcEdVV2sxdnZXbG1nTUlQVjVtbFpvOHowMlNTdXhLZTI1Y2VNb09oenFlay9vRmFtdgoyTmxFeTh0dEhOMUxMS3grZllhMkpGcWVycThDZ1lFQTUvQUxHSXVrU3J0K0dkektJLzV5cjdSREpTVzIzUTJ4CkM5ZklUTUFSL1Q4dzNsWGhyUnRXcmlHL3l0QkVPNXdTMVIwdDkydW1nVkhIRTA5eFFXbzZ0Tm16QVBNb1RSekMKd08yYnJqQktBdUJkQ0RISjZsMlFnOEhPQWovUncrK2x4bEN0VEI2YS8xWEZIZnNHUGhqMEQrWlJiWVZzaE00UgpnSVVmdmpmQ1Y1a0NnWUVBMzdzL2FieHJhdThEaTQ3a0NBQ3o1N3FsZHBiNk92V2d0OFF5MGE5aG0vSmhFQ3lVCkNML0VtNWpHeWhpMWJuV05yNXVRWTdwVzR0cG5pdDJCU2d1VFlBMFYrck8zOFhmNThZcTBvRTFPR3l5cFlBUkoKa09SanRSYUVXVTJqNEJsaGJZZjNtL0xnSk9oUnp3T1RPNXFSUTZHY1dhZVlod1ExVmJrelByTXUxNGtDZ1lCbwp4dEhjWnNqelVidm5wd3hTTWxKUStaZ1RvZlAzN0lWOG1pQk1POEJrclRWQVczKzFtZElRbkFKdWRxTThZb2RICmF3VW03cVNyYXV3SjF5dU1wNWFadUhiYkNQMjl5QzVheFh3OHRtZlk0TTVtTTBmSjdqYW9ydGFId1pqYmNObHMKdTJsdUo2MVJoOGVpZ1pJU1gyZHgvMVB0ckFhWUFCZDcvYWVYWU0wVWtRS0JnUUNVbkFIdmRQUGhIVnJDWU1rTgpOOFBEK0t0YmhPRks2S3MvdlgyUkcyRnFmQkJPQWV3bEo1d0xWeFBLT1RpdytKS2FSeHhYMkcvREZVNzduOEQvCkR5V2RjM2ZCQWQ0a1lJamZVaGRGa1hHNEFMUDZBNVFIZVN4NzNScTFLNWxMVWhPbEZqc3VPZ0NKS28wVlFmRC8KT05paDB6SzN5Wmc3aDVQamZ1TUdGb09OQWc9PQotLS0tLUVORCBQUklWQVRFIEtFWS0tLS0tCg==\"},\"kind\":\"Secret\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"tcpmappingtest\",\"scope\":\"AmbassadorTest\"},\"name\":\"supersecret\",\"namespace\":\"tcp-namespace\"},\"type\":\"kubernetes.io/tls\"}\n"
                     },
-                    "creationTimestamp": "2020-02-19T23:20:37Z",
+                    "creationTimestamp": "2020-02-26T15:53:11Z",
                     "labels": {
                         "kat-ambassador-id": "tcpmappingtest",
                         "scope": "AmbassadorTest"
                     },
                     "name": "supersecret",
                     "namespace": "tcp-namespace",
-                    "resourceVersion": "56782",
+                    "resourceVersion": "67897",
                     "selfLink": "/api/v1/namespaces/tcp-namespace/secrets/supersecret",
-                    "uid": "6fc73e5b-536e-11ea-85dd-167682b5c255"
+                    "uid": "17730bde-58b0-11ea-86d6-0e674b3ff44f"
                 },
                 "type": "kubernetes.io/tls"
             }
@@ -49,19 +49,19 @@
                         "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: TCPMapping\nname: TCPMappingTest-3\nport: 6789\nhost: tls-context-host-3\nservice: tcpmappingtest-http-target3.tcp-namespace\ntls: true\nambassador_id: tcpmappingtest\n",
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: TCPMapping\\nname: TCPMappingTest-3\\nport: 6789\\nhost: tls-context-host-3\\nservice: tcpmappingtest-http-target3.tcp-namespace\\ntls: true\\nambassador_id: tcpmappingtest\\n\"},\"labels\":{\"kat-ambassador-id\":\"tcpmappingtest\",\"scope\":\"AmbassadorTest\"},\"name\":\"tcpmappingtest-http-target3\",\"namespace\":\"tcp-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8081},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8444}],\"selector\":{\"backend\":\"superpod-tcp-namespace\"}}}\n"
                     },
-                    "creationTimestamp": "2020-02-19T23:20:40Z",
+                    "creationTimestamp": "2020-02-26T15:53:16Z",
                     "labels": {
                         "kat-ambassador-id": "tcpmappingtest",
                         "scope": "AmbassadorTest"
                     },
                     "name": "tcpmappingtest-http-target3",
                     "namespace": "tcp-namespace",
-                    "resourceVersion": "56852",
+                    "resourceVersion": "67960",
                     "selfLink": "/api/v1/namespaces/tcp-namespace/services/tcpmappingtest-http-target3",
-                    "uid": "71ceba2b-536e-11ea-85dd-167682b5c255"
+                    "uid": "19e75d5d-58b0-11ea-86d6-0e674b3ff44f"
                 },
                 "spec": {
-                    "clusterIP": "10.109.45.159",
+                    "clusterIP": "10.105.96.150",
                     "ports": [
                         {
                             "name": "http",
@@ -94,19 +94,19 @@
                         "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: TCPMapping\nname: TCPMappingTest-2\nport: 6789\nhost: tls-context-host-2\nservice: tcpmappingtest-http-target2.other-namespace\ntls: TCPMappingTest-tlscontext\nambassador_id: tcpmappingtest\n",
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: TCPMapping\\nname: TCPMappingTest-2\\nport: 6789\\nhost: tls-context-host-2\\nservice: tcpmappingtest-http-target2.other-namespace\\ntls: TCPMappingTest-tlscontext\\nambassador_id: tcpmappingtest\\n\"},\"labels\":{\"kat-ambassador-id\":\"tcpmappingtest\",\"scope\":\"AmbassadorTest\"},\"name\":\"tcpmappingtest-http-target2\",\"namespace\":\"other-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8080},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8443}],\"selector\":{\"backend\":\"superpod-other-namespace\"}}}\n"
                     },
-                    "creationTimestamp": "2020-02-19T23:20:40Z",
+                    "creationTimestamp": "2020-02-26T15:53:15Z",
                     "labels": {
                         "kat-ambassador-id": "tcpmappingtest",
                         "scope": "AmbassadorTest"
                     },
                     "name": "tcpmappingtest-http-target2",
                     "namespace": "other-namespace",
-                    "resourceVersion": "56846",
+                    "resourceVersion": "67955",
                     "selfLink": "/api/v1/namespaces/other-namespace/services/tcpmappingtest-http-target2",
-                    "uid": "71bd948a-536e-11ea-85dd-167682b5c255"
+                    "uid": "19abd485-58b0-11ea-86d6-0e674b3ff44f"
                 },
                 "spec": {
-                    "clusterIP": "10.96.209.147",
+                    "clusterIP": "10.100.142.53",
                     "ports": [
                         {
                             "name": "http",
@@ -139,7 +139,7 @@
                         "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: TLSContext\nname: TCPMappingTest-tlscontext\nhosts:\n- tls-context-host-1\n- tls-context-host-2\n- tls-context-host-3\nsecret: supersecret\nambassador_id: tcpmappingtest\n",
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: TLSContext\\nname: TCPMappingTest-tlscontext\\nhosts:\\n- tls-context-host-1\\n- tls-context-host-2\\n- tls-context-host-3\\nsecret: supersecret\\nambassador_id: tcpmappingtest\\n\"},\"labels\":{\"app.kubernetes.io/component\":\"ambassador-service\",\"kat-ambassador-id\":\"tcpmappingtest\",\"scope\":\"AmbassadorTest\"},\"name\":\"tcpmappingtest\",\"namespace\":\"tcp-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8080},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8443},{\"name\":\"extra-6789\",\"port\":6789,\"protocol\":\"TCP\",\"targetPort\":6789},{\"name\":\"extra-7654\",\"port\":7654,\"protocol\":\"TCP\",\"targetPort\":7654},{\"name\":\"extra-8765\",\"port\":8765,\"protocol\":\"TCP\",\"targetPort\":8765},{\"name\":\"extra-9876\",\"port\":9876,\"protocol\":\"TCP\",\"targetPort\":9876}],\"selector\":{\"service\":\"tcpmappingtest\"},\"type\":\"NodePort\"}}\n"
                     },
-                    "creationTimestamp": "2020-02-19T23:20:38Z",
+                    "creationTimestamp": "2020-02-26T15:53:13Z",
                     "labels": {
                         "app.kubernetes.io/component": "ambassador-service",
                         "kat-ambassador-id": "tcpmappingtest",
@@ -147,52 +147,52 @@
                     },
                     "name": "tcpmappingtest",
                     "namespace": "tcp-namespace",
-                    "resourceVersion": "56812",
+                    "resourceVersion": "67924",
                     "selfLink": "/api/v1/namespaces/tcp-namespace/services/tcpmappingtest",
-                    "uid": "709d2698-536e-11ea-85dd-167682b5c255"
+                    "uid": "18aa8c69-58b0-11ea-86d6-0e674b3ff44f"
                 },
                 "spec": {
-                    "clusterIP": "10.102.252.141",
+                    "clusterIP": "10.108.151.215",
                     "externalTrafficPolicy": "Cluster",
                     "ports": [
                         {
                             "name": "http",
-                            "nodePort": 31979,
+                            "nodePort": 31004,
                             "port": 80,
                             "protocol": "TCP",
                             "targetPort": 8080
                         },
                         {
                             "name": "https",
-                            "nodePort": 32072,
+                            "nodePort": 30474,
                             "port": 443,
                             "protocol": "TCP",
                             "targetPort": 8443
                         },
                         {
                             "name": "extra-6789",
-                            "nodePort": 32478,
+                            "nodePort": 30736,
                             "port": 6789,
                             "protocol": "TCP",
                             "targetPort": 6789
                         },
                         {
                             "name": "extra-7654",
-                            "nodePort": 31086,
+                            "nodePort": 30311,
                             "port": 7654,
                             "protocol": "TCP",
                             "targetPort": 7654
                         },
                         {
                             "name": "extra-8765",
-                            "nodePort": 30750,
+                            "nodePort": 31912,
                             "port": 8765,
                             "protocol": "TCP",
                             "targetPort": 8765
                         },
                         {
                             "name": "extra-9876",
-                            "nodePort": 32743,
+                            "nodePort": 30785,
                             "port": 9876,
                             "protocol": "TCP",
                             "targetPort": 9876
@@ -215,7 +215,7 @@
                     "annotations": {
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"tcpmappingtest\",\"scope\":\"AmbassadorTest\",\"service\":\"tcpmappingtest-admin\"},\"name\":\"tcpmappingtest-admin\",\"namespace\":\"tcp-namespace\"},\"spec\":{\"ports\":[{\"name\":\"tcpmappingtest-admin\",\"port\":8877,\"targetPort\":8877}],\"selector\":{\"service\":\"tcpmappingtest\"},\"type\":\"NodePort\"}}\n"
                     },
-                    "creationTimestamp": "2020-02-19T23:20:39Z",
+                    "creationTimestamp": "2020-02-26T15:53:14Z",
                     "labels": {
                         "kat-ambassador-id": "tcpmappingtest",
                         "scope": "AmbassadorTest",
@@ -223,17 +223,17 @@
                     },
                     "name": "tcpmappingtest-admin",
                     "namespace": "tcp-namespace",
-                    "resourceVersion": "56823",
+                    "resourceVersion": "67933",
                     "selfLink": "/api/v1/namespaces/tcp-namespace/services/tcpmappingtest-admin",
-                    "uid": "7105972f-536e-11ea-85dd-167682b5c255"
+                    "uid": "190f3cab-58b0-11ea-86d6-0e674b3ff44f"
                 },
                 "spec": {
-                    "clusterIP": "10.103.235.118",
+                    "clusterIP": "10.100.22.115",
                     "externalTrafficPolicy": "Cluster",
                     "ports": [
                         {
                             "name": "tcpmappingtest-admin",
-                            "nodePort": 31444,
+                            "nodePort": 30386,
                             "port": 8877,
                             "protocol": "TCP",
                             "targetPort": 8877
@@ -257,19 +257,19 @@
                         "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: TCPMapping\nname: TCPMappingTest\nport: 9876\nservice: tcpmappingtest-http-target1.tcp-namespace:443\nambassador_id: tcpmappingtest\n---\napiVersion: ambassador/v1\nkind: TCPMapping\nname: TCPMappingTest-local-only\naddress: 127.0.0.1\nport: 8765\nservice: tcpmappingtest-http-target1.tcp-namespace:443\nambassador_id: tcpmappingtest\n---\napiVersion: ambassador/v1\nkind: TCPMapping\nname: TCPMappingTest-clear-to-tls\nport: 7654\ntls: true\nservice: tcpmappingtest-http-target2.other-namespace:443\nambassador_id: tcpmappingtest\n---\napiVersion: ambassador/v1\nkind: TCPMapping\nname: TCPMappingTest-1\nport: 6789\nhost: tls-context-host-1\nservice: tcpmappingtest-http-target1.tcp-namespace:80\nambassador_id: tcpmappingtest\n",
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: TCPMapping\\nname: TCPMappingTest\\nport: 9876\\nservice: tcpmappingtest-http-target1.tcp-namespace:443\\nambassador_id: tcpmappingtest\\n---\\napiVersion: ambassador/v1\\nkind: TCPMapping\\nname: TCPMappingTest-local-only\\naddress: 127.0.0.1\\nport: 8765\\nservice: tcpmappingtest-http-target1.tcp-namespace:443\\nambassador_id: tcpmappingtest\\n---\\napiVersion: ambassador/v1\\nkind: TCPMapping\\nname: TCPMappingTest-clear-to-tls\\nport: 7654\\ntls: true\\nservice: tcpmappingtest-http-target2.other-namespace:443\\nambassador_id: tcpmappingtest\\n---\\napiVersion: ambassador/v1\\nkind: TCPMapping\\nname: TCPMappingTest-1\\nport: 6789\\nhost: tls-context-host-1\\nservice: tcpmappingtest-http-target1.tcp-namespace:80\\nambassador_id: tcpmappingtest\\n\"},\"labels\":{\"kat-ambassador-id\":\"tcpmappingtest\",\"scope\":\"AmbassadorTest\"},\"name\":\"tcpmappingtest-http-target1\",\"namespace\":\"tcp-namespace\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8080},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8443}],\"selector\":{\"backend\":\"superpod-tcp-namespace\"}}}\n"
                     },
-                    "creationTimestamp": "2020-02-19T23:20:40Z",
+                    "creationTimestamp": "2020-02-26T15:53:15Z",
                     "labels": {
                         "kat-ambassador-id": "tcpmappingtest",
                         "scope": "AmbassadorTest"
                     },
                     "name": "tcpmappingtest-http-target1",
                     "namespace": "tcp-namespace",
-                    "resourceVersion": "56837",
+                    "resourceVersion": "67949",
                     "selfLink": "/api/v1/namespaces/tcp-namespace/services/tcpmappingtest-http-target1",
-                    "uid": "715904cd-536e-11ea-85dd-167682b5c255"
+                    "uid": "1956f917-58b0-11ea-86d6-0e674b3ff44f"
                 },
                 "spec": {
-                    "clusterIP": "10.108.26.165",
+                    "clusterIP": "10.106.238.198",
                     "ports": [
                         {
                             "name": "http",

--- a/python/tests/gold/tls/snapshots/econf.json
+++ b/python/tests/gold/tls/snapshots/econf.json
@@ -242,8 +242,7 @@
                                     }
                                 ]
                             }
-                        },
-                        "use_proxy_proto": false
+                        }
                     }
                 ],
                 "listener_filters": [

--- a/python/tests/gold/tls/snapshots/snapshot.yaml
+++ b/python/tests/gold/tls/snapshots/snapshot.yaml
@@ -26,16 +26,16 @@
                     "annotations": {
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"data\":{\"tls.crt\":\"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwakNDQW82Z0F3SUJBZ0lKQUpxa1Z4Y1RtQ1FITUEwR0NTcUdTSWIzRFFFQkN3VUFNR2d4Q3pBSkJnTlYKQkFZVEFsVlRNUXN3Q1FZRFZRUUlEQUpOUVRFUE1BMEdBMVVFQnd3R1FtOXpkRzl1TVJFd0R3WURWUVFLREFoRQpZWFJoZDJseVpURVVNQklHQTFVRUN3d0xSVzVuYVc1bFpYSnBibWN4RWpBUUJnTlZCQU1NQ1d4dlkyRnNhRzl6CmREQWVGdzB4T0RFd01UQXhNREk1TURKYUZ3MHlPREV3TURjeE1ESTVNREphTUdneEN6QUpCZ05WQkFZVEFsVlQKTVFzd0NRWURWUVFJREFKTlFURVBNQTBHQTFVRUJ3d0dRbTl6ZEc5dU1SRXdEd1lEVlFRS0RBaEVZWFJoZDJseQpaVEVVTUJJR0ExVUVDd3dMUlc1bmFXNWxaWEpwYm1jeEVqQVFCZ05WQkFNTUNXeHZZMkZzYUc5emREQ0NBU0l3CkRRWUpLb1pJaHZjTkFRRUJCUUFEZ2dFUEFEQ0NBUW9DZ2dFQkFMcTZtdS9FSzlQc1Q0YkR1WWg0aEZPVnZiblAKekV6MGpQcnVzdXcxT05MQk9jT2htbmNSTnE4c1FyTGxBZ3NicDBuTFZmQ1pSZHQ4UnlOcUFGeUJlR29XS3IvZAprQVEybVBucjBQRHlCTzk0UHo4VHdydDBtZEtEU1dGanNxMjlOYVJaT0JqdStLcGV6RytOZ3pLMk04M0ZtSldUCnFYdTI3ME9pOXlqb2VGQ3lPMjdwUkdvcktkQk9TcmIwd3ozdFdWUGk4NFZMdnFKRWprT0JVZjJYNVF3b25XWngKMktxVUJ6OUFSZVVUMzdwUVJZQkJMSUdvSnM4U042cjF4MSt1dTNLdTVxSkN1QmRlSHlJbHpKb2V0aEp2K3pTMgowN0pFc2ZKWkluMWNpdXhNNzNPbmVRTm1LUkpsL2NEb3BLemswSldRSnRSV1NnbktneFNYWkRrZjJMOENBd0VBCkFhTlRNRkV3SFFZRFZSME9CQllFRkJoQzdDeVRpNGFkSFVCd0wvTkZlRTZLdnFIRE1COEdBMVVkSXdRWU1CYUEKRkJoQzdDeVRpNGFkSFVCd0wvTkZlRTZLdnFIRE1BOEdBMVVkRXdFQi93UUZNQU1CQWY4d0RRWUpLb1pJaHZjTgpBUUVMQlFBRGdnRUJBSFJvb0xjcFdEa1IyMEhENEJ5d1BTUGRLV1hjWnN1U2tXYWZyekhoYUJ5MWJZcktIR1o1CmFodFF3L1gwQmRnMWtidlpZUDJSTzdGTFhBSlNTdXVJT0NHTFVwS0pkVHE1NDREUThNb1daWVZKbTc3UWxxam0KbHNIa2VlTlRNamFOVjdMd0MzalBkMERYelczbGVnWFRoYWpmZ2dtLzBJZXNGRzBVWjFEOTJHNURmc0hLekpSagpNSHZyVDNtVmJGZjkrSGJhRE4yT2g5VjIxUWhWSzF2M0F2dWNXczhUWCswZHZFZ1dtWHBRcndEd2pTMU04QkRYCldoWjVsZTZjVzhNYjhnZmRseG1JckpnQStuVVZzMU9EbkJKS1F3MUY4MVdkc25tWXdweVUrT2xVais4UGt1TVoKSU4rUlhQVnZMSWJ3czBmamJ4UXRzbTArZVBpRnN2d0NsUFk9Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K\",\"tls.key\":\"LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0tCk1JSUV2Z0lCQURBTkJna3Foa2lHOXcwQkFRRUZBQVNDQktnd2dnU2tBZ0VBQW9JQkFRQzZ1cHJ2eEN2VDdFK0cKdzdtSWVJUlRsYjI1ejh4TTlJejY3ckxzTlRqU3dUbkRvWnAzRVRhdkxFS3k1UUlMRzZkSnkxWHdtVVhiZkVjagphZ0JjZ1hocUZpcS8zWkFFTnBqNTY5RHc4Z1R2ZUQ4L0U4SzdkSm5TZzBsaFk3S3R2VFdrV1RnWTd2aXFYc3h2CmpZTXl0alBOeFppVms2bDd0dTlEb3ZjbzZIaFFzanR1NlVScUt5blFUa3EyOU1NOTdWbFQ0dk9GUzc2aVJJNUQKZ1ZIOWwrVU1LSjFtY2RpcWxBYy9RRVhsRTkrNlVFV0FRU3lCcUNiUEVqZXE5Y2RmcnJ0eXJ1YWlRcmdYWGg4aQpKY3lhSHJZU2IvczB0dE95UkxIeVdTSjlYSXJzVE85enAza0RaaWtTWmYzQTZLU3M1TkNWa0NiVVZrb0p5b01VCmwyUTVIOWkvQWdNQkFBRUNnZ0VBSVFsZzNpamNCRHViK21Eb2syK1hJZDZ0V1pHZE9NUlBxUm5RU0NCR2RHdEIKV0E1Z2NNNTMyVmhBV0x4UnR6dG1ScFVXR0dKVnpMWlpNN2ZPWm85MWlYZHdpcytkYWxGcWtWVWFlM2FtVHVQOApkS0YvWTRFR3Nnc09VWSs5RGlZYXRvQWVmN0xRQmZ5TnVQTFZrb1JQK0FrTXJQSWFHMHhMV3JFYmYzNVp3eFRuCnd5TTF3YVpQb1oxWjZFdmhHQkxNNzlXYmY2VFY0WXVzSTRNOEVQdU1GcWlYcDNlRmZ4L0tnNHhtYnZtN1JhYzcKOEJ3Z3pnVmljNXlSbkVXYjhpWUh5WGtyazNTL0VCYUNEMlQwUjM5VmlVM1I0VjBmMUtyV3NjRHowVmNiVWNhKwpzeVdyaVhKMHBnR1N0Q3FWK0dRYy9aNmJjOGt4VWpTTWxOUWtudVJRZ1FLQmdRRHpwM1ZaVmFzMTA3NThVT00rCnZUeTFNL0V6azg4cWhGb21kYVFiSFRlbStpeGpCNlg3RU9sRlkya3JwUkwvbURDSEpwR0MzYlJtUHNFaHVGSUwKRHhSQ2hUcEtTVmNsSytaaUNPaWE1ektTVUpxZnBOcW15RnNaQlhJNnRkNW9mWk42aFpJVTlJR2RUaGlYMjBONwppUW01UnZlSUx2UHVwMWZRMmRqd2F6Ykgvd0tCZ1FERU1MN21Mb2RqSjBNTXh6ZnM3MW1FNmZOUFhBMVY2ZEgrCllCVG4xS2txaHJpampRWmFNbXZ6dEZmL1F3Wkhmd3FKQUVuNGx2em5ncUNzZTMvUElZMy8zRERxd1p2NE1vdy8KRGdBeTBLQmpQYVJGNjhYT1B1d0VuSFN1UjhyZFg2UzI3TXQ2cEZIeFZ2YjlRRFJuSXc4a3grSFVreml4U0h5Ugo2NWxESklEdlFRS0JnUURpQTF3ZldoQlBCZk9VYlpQZUJydmhlaVVycXRob29BemYwQkJCOW9CQks1OHczVTloCjdQWDFuNWxYR3ZEY2x0ZXRCbUhEK3RQMFpCSFNyWit0RW5mQW5NVE5VK3E2V0ZhRWFhOGF3WXR2bmNWUWdTTXgKd25oK1pVYm9udnVJQWJSajJyTC9MUzl1TTVzc2dmKy9BQWM5RGs5ZXkrOEtXY0Jqd3pBeEU4TGxFUUtCZ0IzNwoxVEVZcTFoY0I4Tk1MeC9tOUtkN21kUG5IYUtqdVpSRzJ1c1RkVWNxajgxdklDbG95MWJUbVI5Si93dXVQczN4ClhWekF0cVlyTUtNcnZMekxSQWgyZm9OaVU1UDdKYlA5VDhwMFdBN1N2T2h5d0NobE5XeisvRlltWXJxeWcxbngKbHFlSHRYNU03REtJUFhvRndhcTlZYVk3V2M2K1pVdG4xbVNNajZnQkFvR0JBSTgwdU9iTkdhRndQTVYrUWhiZApBelkrSFNGQjBkWWZxRytzcTBmRVdIWTNHTXFmNFh0aVRqUEFjWlg3RmdtT3Q5Uit3TlFQK0dFNjZoV0JpKzBWCmVLV3prV0lXeS9sTVZCSW0zVWtlSlRCT3NudTFVaGhXbm5WVDhFeWhEY1FxcndPSGlhaUo3bFZSZmRoRWFyQysKSnpaU0czOHVZUVlyc0lITnRVZFgySmdPCi0tLS0tRU5EIFBSSVZBVEUgS0VZLS0tLS0K\"},\"kind\":\"Secret\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"tls\",\"scope\":\"AmbassadorTest\"},\"name\":\"test-tls-secret\",\"namespace\":\"default\"},\"type\":\"kubernetes.io/tls\"}\n"
                     },
-                    "creationTimestamp": "2020-02-19T23:20:50Z",
+                    "creationTimestamp": "2020-02-26T15:53:22Z",
                     "labels": {
                         "kat-ambassador-id": "tls",
                         "scope": "AmbassadorTest"
                     },
                     "name": "test-tls-secret",
                     "namespace": "default",
-                    "resourceVersion": "57043",
+                    "resourceVersion": "68085",
                     "selfLink": "/api/v1/namespaces/default/secrets/test-tls-secret",
-                    "uid": "77b21fcc-536e-11ea-85dd-167682b5c255"
+                    "uid": "1d8e37c2-58b0-11ea-86d6-0e674b3ff44f"
                 },
                 "type": "kubernetes.io/tls"
             }
@@ -49,7 +49,7 @@
                         "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Module\nname: tls\nambassador_id: tls\nconfig:\n  server:\n    enabled: True\n    secret: test-tls-secret\n",
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Module\\nname: tls\\nambassador_id: tls\\nconfig:\\n  server:\\n    enabled: True\\n    secret: test-tls-secret\\n\"},\"labels\":{\"app.kubernetes.io/component\":\"ambassador-service\",\"kat-ambassador-id\":\"tls\",\"scope\":\"AmbassadorTest\"},\"name\":\"tls\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8080},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8443}],\"selector\":{\"service\":\"tls\"},\"type\":\"NodePort\"}}\n"
                     },
-                    "creationTimestamp": "2020-02-19T23:20:50Z",
+                    "creationTimestamp": "2020-02-26T15:53:23Z",
                     "labels": {
                         "app.kubernetes.io/component": "ambassador-service",
                         "kat-ambassador-id": "tls",
@@ -57,24 +57,24 @@
                     },
                     "name": "tls",
                     "namespace": "default",
-                    "resourceVersion": "57030",
+                    "resourceVersion": "68110",
                     "selfLink": "/api/v1/namespaces/default/services/tls",
-                    "uid": "774f39b5-536e-11ea-85dd-167682b5c255"
+                    "uid": "1e53239c-58b0-11ea-86d6-0e674b3ff44f"
                 },
                 "spec": {
-                    "clusterIP": "10.97.0.185",
+                    "clusterIP": "10.110.252.187",
                     "externalTrafficPolicy": "Cluster",
                     "ports": [
                         {
                             "name": "http",
-                            "nodePort": 32213,
+                            "nodePort": 32294,
                             "port": 80,
                             "protocol": "TCP",
                             "targetPort": 8080
                         },
                         {
                             "name": "https",
-                            "nodePort": 30476,
+                            "nodePort": 30848,
                             "port": 443,
                             "protocol": "TCP",
                             "targetPort": 8443
@@ -97,7 +97,7 @@
                     "annotations": {
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"tls\",\"scope\":\"AmbassadorTest\",\"service\":\"tls-admin\"},\"name\":\"tls-admin\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"tls-admin\",\"port\":8877,\"targetPort\":8877}],\"selector\":{\"service\":\"tls\"},\"type\":\"NodePort\"}}\n"
                     },
-                    "creationTimestamp": "2020-02-19T23:20:50Z",
+                    "creationTimestamp": "2020-02-26T15:53:23Z",
                     "labels": {
                         "kat-ambassador-id": "tls",
                         "scope": "AmbassadorTest",
@@ -105,17 +105,17 @@
                     },
                     "name": "tls-admin",
                     "namespace": "default",
-                    "resourceVersion": "57036",
+                    "resourceVersion": "68116",
                     "selfLink": "/api/v1/namespaces/default/services/tls-admin",
-                    "uid": "7790a727-536e-11ea-85dd-167682b5c255"
+                    "uid": "1e6a0e59-58b0-11ea-86d6-0e674b3ff44f"
                 },
                 "spec": {
-                    "clusterIP": "10.97.8.26",
+                    "clusterIP": "10.110.186.207",
                     "externalTrafficPolicy": "Cluster",
                     "ports": [
                         {
                             "name": "tls-admin",
-                            "nodePort": 32019,
+                            "nodePort": 31637,
                             "port": 8877,
                             "protocol": "TCP",
                             "targetPort": 8877
@@ -139,19 +139,19 @@
                         "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: tls_target_mapping\nprefix: /tls-target/\nservice: tls-http\nambassador_id: tls\n",
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: tls_target_mapping\\nprefix: /tls-target/\\nservice: tls-http\\nambassador_id: tls\\n\"},\"labels\":{\"kat-ambassador-id\":\"tls\",\"scope\":\"AmbassadorTest\"},\"name\":\"tls-http\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8125},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8488}],\"selector\":{\"backend\":\"superpod-default\"}}}\n"
                     },
-                    "creationTimestamp": "2020-02-19T23:20:51Z",
+                    "creationTimestamp": "2020-02-26T15:53:24Z",
                     "labels": {
                         "kat-ambassador-id": "tls",
                         "scope": "AmbassadorTest"
                     },
                     "name": "tls-http",
                     "namespace": "default",
-                    "resourceVersion": "57052",
+                    "resourceVersion": "68127",
                     "selfLink": "/api/v1/namespaces/default/services/tls-http",
-                    "uid": "78147920-536e-11ea-85dd-167682b5c255"
+                    "uid": "1eb36ad1-58b0-11ea-86d6-0e674b3ff44f"
                 },
                 "spec": {
-                    "clusterIP": "10.107.81.105",
+                    "clusterIP": "10.96.55.15",
                     "ports": [
                         {
                             "name": "http",

--- a/python/tests/gold/tlscontextciphersuites/snapshots/econf.json
+++ b/python/tests/gold/tlscontextciphersuites/snapshots/econf.json
@@ -262,8 +262,7 @@
                                     "tls_maximum_protocol_version": "TLSv1_2"
                                 }
                             }
-                        },
-                        "use_proxy_proto": false
+                        }
                     }
                 ],
                 "listener_filters": [

--- a/python/tests/gold/tlscontextciphersuites/snapshots/snapshot.yaml
+++ b/python/tests/gold/tlscontextciphersuites/snapshots/snapshot.yaml
@@ -26,16 +26,16 @@
                     "annotations": {
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"data\":{\"tls.crt\":\"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURnRENDQW1pZ0F3SUJBZ0lKQUpycUl0ekY2MTBpTUEwR0NTcUdTSWIzRFFFQkN3VUFNRlV4Q3pBSkJnTlYKQkFZVEFsVlRNUXN3Q1FZRFZRUUlEQUpOUVRFUE1BMEdBMVVFQnd3R1FtOXpkRzl1TVFzd0NRWURWUVFLREFKRQpWekViTUJrR0ExVUVBd3dTZEd4ekxXTnZiblJsZUhRdGFHOXpkQzB4TUI0WERURTRNVEV3TVRFek5UTXhPRm9YCkRUSTRNVEF5T1RFek5UTXhPRm93VlRFTE1Ba0dBMVVFQmhNQ1ZWTXhDekFKQmdOVkJBZ01BazFCTVE4d0RRWUQKVlFRSERBWkNiM04wYjI0eEN6QUpCZ05WQkFvTUFrUlhNUnN3R1FZRFZRUUREQkowYkhNdFkyOXVkR1Y0ZEMxbwpiM04wTFRFd2dnRWlNQTBHQ1NxR1NJYjNEUUVCQVFVQUE0SUJEd0F3Z2dFS0FvSUJBUUM5T2dDOHd4eUlyUHpvCkdYc0xwUEt0NzJERXgyd2p3VzhuWFcyd1dieWEzYzk2bjJuU0NLUEJuODVoYnFzaHpqNWloU1RBTURJb2c5RnYKRzZSS1dVUFhUNEtJa1R2M0NESHFYc0FwSmxKNGxTeW5ReW8yWnYwbytBZjhDTG5nWVpCK3JmenRad3llRGhWcAp3WXpCVjIzNXp6NisycWJWbUNabHZCdVhiVXFUbEVZWXZ1R2xNR3o3cFBmT1dLVXBlWW9kYkcyZmIraEZGcGVvCkN4a1VYclFzT29SNUpkSEc1aldyWnVCTzQ1NVNzcnpCTDhSbGU1VUhvMDVXY0s3YkJiaVF6MTA2cEhDSllaK3AKdmxQSWNOU1g1S2gzNEZnOTZVUHg5bFFpQTN6RFRLQmZ5V2NMUStxMWNabExjV2RnUkZjTkJpckdCLzdyYTFWVApnRUplR2tQekFnTUJBQUdqVXpCUk1CMEdBMVVkRGdRV0JCUkRWVUtYWWJsRFdNTzE3MUJuWWZhYlkzM0NFVEFmCkJnTlZIU01FR0RBV2dCUkRWVUtYWWJsRFdNTzE3MUJuWWZhYlkzM0NFVEFQQmdOVkhSTUJBZjhFQlRBREFRSC8KTUEwR0NTcUdTSWIzRFFFQkN3VUFBNElCQVFBUE8vRDRUdDUyWHJsQ0NmUzZnVUVkRU5DcnBBV05YRHJvR2M2dApTVGx3aC8rUUxRYk5hZEtlaEtiZjg5clhLaituVXF0cS9OUlpQSXNBSytXVWtHOVpQb1FPOFBRaVY0V1g1clE3CjI5dUtjSmZhQlhrZHpVVzdxTlFoRTRjOEJhc0JySWVzcmtqcFQ5OVF4SktuWFFhTitTdzdvRlBVSUFOMzhHcWEKV2wvS1BNVHRicWt3eWFjS01CbXExVkx6dldKb0g1Q2l6Skp3aG5rWHh0V0tzLzY3clROblBWTXorbWVHdHZTaQpkcVg2V1NTbUdMRkVFcjJoZ1VjQVpqazNWdVFoLzc1aFh1K1UySXRzQys1cXBsaEc3Q1hzb1huS0t5MVhsT0FFCmI4a3IyZFdXRWs2STVZNm5USnpXSWxTVGtXODl4d1hyY3RtTjlzYjlxNFNuaVZsegotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==\",\"tls.key\":\"LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0tCk1JSUV2UUlCQURBTkJna3Foa2lHOXcwQkFRRUZBQVNDQktjd2dnU2pBZ0VBQW9JQkFRQzlPZ0M4d3h5SXJQem8KR1hzTHBQS3Q3MkRFeDJ3andXOG5YVzJ3V2J5YTNjOTZuMm5TQ0tQQm44NWhicXNoemo1aWhTVEFNRElvZzlGdgpHNlJLV1VQWFQ0S0lrVHYzQ0RIcVhzQXBKbEo0bFN5blF5bzJadjBvK0FmOENMbmdZWkIrcmZ6dFp3eWVEaFZwCndZekJWMjM1eno2KzJxYlZtQ1psdkJ1WGJVcVRsRVlZdnVHbE1HejdwUGZPV0tVcGVZb2RiRzJmYitoRkZwZW8KQ3hrVVhyUXNPb1I1SmRIRzVqV3JadUJPNDU1U3NyekJMOFJsZTVVSG8wNVdjSzdiQmJpUXoxMDZwSENKWVorcAp2bFBJY05TWDVLaDM0Rmc5NlVQeDlsUWlBM3pEVEtCZnlXY0xRK3ExY1psTGNXZGdSRmNOQmlyR0IvN3JhMVZUCmdFSmVHa1B6QWdNQkFBRUNnZ0VBQmFsN3BpcE1hMGFKMXNRVWEzZkhEeTlQZlBQZXAzODlQVGROZGU1cGQxVFYKeFh5SnBSQS9IaWNTL05WYjU0b05VZE5jRXlnZUNCcFJwUHAxd3dmQ3dPbVBKVmo3SzF3aWFqbmxsQldpZUJzMgpsOWFwcDdFVE9DdWJ5WTNWU2dLQldWa0piVzBjOG9uSFdEL0RYM0duUjhkTXdGYzRrTUdadkllUlo4bU1acmdHCjZPdDNKOHI2eVZsZWI2OGF1WmtneXMwR2VGc3pNdVRubHJCOEw5djI1UUtjVGtESjIvRWx1Y1p5aER0eGF0OEIKTzZOUnNubmNyOHhwUVdPci9sV3M5VVFuZEdCdHFzbXMrdGNUN1ZUNU9UanQ4WHY5NVhNSHB5Z29pTHk3czhvYwpJMGprNDJabzRKZW5JT3c2Rm0weUFEZ0E3eWlXcks0bEkzWGhqaTVSb1FLQmdRRGRqaWNkTUpYVUZWc28rNTJkCkUwT2EwcEpVMFNSaC9JQmdvRzdNakhrVWxiaXlpR1pNanA5MEo5VHFaL1ErM1pWZVdqMmxPSWF0OG5nUzB6MDAKVzA3T1ZxYXprMVNYaFZlY2tGNWFEcm5PRDNhU2VWMSthV3JUdDFXRWdqOVFxYnJZYVA5emd4UkpkRzV3WENCUApGNDNFeXE5ZEhXOWF6SSt3UHlJQ0JqNnZBd0tCZ1FEYXBTelhPR2ViMi9SMWhlWXdWV240czNGZEtYVjgzemtTCnFSWDd6d1pLdkk5OGMybDU1Y1ZNUzBoTGM0bTVPMXZCaUd5SG80eTB2SVAvR0k0Rzl4T1FhMXdpVnNmUVBiSU4KLzJPSDFnNXJLSFdCWVJUaHZGcERqdHJRU2xyRHVjWUNSRExCd1hUcDFrbVBkL09mY2FybG42MjZEamthZllieAp3dWUydlhCTVVRS0JnQm4vTmlPOHNiZ0RFWUZMbFFEN1k3RmxCL3FmMTg4UG05aTZ1b1dSN2hzMlBrZmtyV3hLClIvZVBQUEtNWkNLRVNhU2FuaVVtN3RhMlh0U0dxT1hkMk85cFI0Skd4V1JLSnkrZDJSUmtLZlU5NTBIa3I4M0gKZk50KzVhLzR3SWtzZ1ZvblorSWIvV05wSUJSYkd3ZHMwaHZIVkxCdVpjU1h3RHlFQysrRTRCSVZBb0dCQUoxUQp6eXlqWnRqYnI4NkhZeEpQd29teEF0WVhLSE9LWVJRdUdLVXZWY1djV2xrZTZUdE51V0dsb1FTNHd0VkdBa1VECmxhTWFaL2o2MHJaT3dwSDhZRlUvQ2ZHakl1MlFGbmEvMUtzOXR1NGZGRHpjenh1RVhDWFR1Vmk0eHdtZ3R2bVcKZkRhd3JTQTZrSDdydlp4eE9wY3hCdHloc3pCK05RUHFTckpQSjJlaEFvR0FkdFJKam9vU0lpYURVU25lZUcyZgpUTml1T01uazJkeFV3RVF2S1E4eWNuUnpyN0QwaEtZVWIycThHKzE2bThQUjNCcFMzZDFLbkpMVnI3TUhaWHpSCitzZHNaWGtTMWVEcEZhV0RFREFEWWI0ckRCb2RBdk8xYm03ZXdTMzhSbk1UaTlhdFZzNVNTODNpZG5HbFZiSmsKYkZKWG0rWWxJNHFkaXowTFdjWGJyREE9Ci0tLS0tRU5EIFBSSVZBVEUgS0VZLS0tLS0K\"},\"kind\":\"Secret\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"tlscontextciphersuites\",\"scope\":\"AmbassadorTest\"},\"name\":\"secret.cipher-suites\",\"namespace\":\"default\"},\"type\":\"kubernetes.io/tls\"}\n"
                     },
-                    "creationTimestamp": "2020-02-19T23:21:13Z",
+                    "creationTimestamp": "2020-02-26T15:53:36Z",
                     "labels": {
                         "kat-ambassador-id": "tlscontextciphersuites",
                         "scope": "AmbassadorTest"
                     },
                     "name": "secret.cipher-suites",
                     "namespace": "default",
-                    "resourceVersion": "57392",
+                    "resourceVersion": "68358",
                     "selfLink": "/api/v1/namespaces/default/secrets/secret.cipher-suites",
-                    "uid": "8502b043-536e-11ea-85dd-167682b5c255"
+                    "uid": "262b5cd2-58b0-11ea-86d6-0e674b3ff44f"
                 },
                 "type": "kubernetes.io/tls"
             }
@@ -49,7 +49,7 @@
                         "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: TLSContextCipherSuites-same-prefix-1\nprefix: /tls-context-same/\nservice: https://tlscontextciphersuites-http\nhost: tls-context-host-1\nambassador_id: tlscontextciphersuites\n\n---\napiVersion: ambassador/v1\nkind: TLSContext\nname: TLSContextCipherSuites-same-context-1\nhosts:\n- tls-context-host-1\nsecret: secret.cipher-suites\nsecret_namespacing: False\nmax_tls_version: v1.2\ncipher_suites:\n- ECDHE-RSA-AES128-GCM-SHA256\necdh_curves:\n- P-256\nambassador_id: tlscontextciphersuites\n",
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: TLSContextCipherSuites-same-prefix-1\\nprefix: /tls-context-same/\\nservice: https://tlscontextciphersuites-http\\nhost: tls-context-host-1\\nambassador_id: tlscontextciphersuites\\n\\n---\\napiVersion: ambassador/v1\\nkind: TLSContext\\nname: TLSContextCipherSuites-same-context-1\\nhosts:\\n- tls-context-host-1\\nsecret: secret.cipher-suites\\nsecret_namespacing: False\\nmax_tls_version: v1.2\\ncipher_suites:\\n- ECDHE-RSA-AES128-GCM-SHA256\\necdh_curves:\\n- P-256\\nambassador_id: tlscontextciphersuites\\n\"},\"labels\":{\"app.kubernetes.io/component\":\"ambassador-service\",\"kat-ambassador-id\":\"tlscontextciphersuites\",\"scope\":\"AmbassadorTest\"},\"name\":\"tlscontextciphersuites\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8080},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8443}],\"selector\":{\"service\":\"tlscontextciphersuites\"},\"type\":\"NodePort\"}}\n"
                     },
-                    "creationTimestamp": "2020-02-19T23:21:11Z",
+                    "creationTimestamp": "2020-02-26T15:53:39Z",
                     "labels": {
                         "app.kubernetes.io/component": "ambassador-service",
                         "kat-ambassador-id": "tlscontextciphersuites",
@@ -57,24 +57,24 @@
                     },
                     "name": "tlscontextciphersuites",
                     "namespace": "default",
-                    "resourceVersion": "57371",
+                    "resourceVersion": "68388",
                     "selfLink": "/api/v1/namespaces/default/services/tlscontextciphersuites",
-                    "uid": "83d58d30-536e-11ea-85dd-167682b5c255"
+                    "uid": "27f3b237-58b0-11ea-86d6-0e674b3ff44f"
                 },
                 "spec": {
-                    "clusterIP": "10.106.76.37",
+                    "clusterIP": "10.105.235.110",
                     "externalTrafficPolicy": "Cluster",
                     "ports": [
                         {
                             "name": "http",
-                            "nodePort": 31185,
+                            "nodePort": 31723,
                             "port": 80,
                             "protocol": "TCP",
                             "targetPort": 8080
                         },
                         {
                             "name": "https",
-                            "nodePort": 31003,
+                            "nodePort": 30578,
                             "port": 443,
                             "protocol": "TCP",
                             "targetPort": 8443
@@ -97,7 +97,7 @@
                     "annotations": {
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"tlscontextciphersuites\",\"scope\":\"AmbassadorTest\",\"service\":\"tlscontextciphersuites-admin\"},\"name\":\"tlscontextciphersuites-admin\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"tlscontextciphersuites-admin\",\"port\":8877,\"targetPort\":8877}],\"selector\":{\"service\":\"tlscontextciphersuites\"},\"type\":\"NodePort\"}}\n"
                     },
-                    "creationTimestamp": "2020-02-19T23:21:12Z",
+                    "creationTimestamp": "2020-02-26T15:53:40Z",
                     "labels": {
                         "kat-ambassador-id": "tlscontextciphersuites",
                         "scope": "AmbassadorTest",
@@ -105,17 +105,17 @@
                     },
                     "name": "tlscontextciphersuites-admin",
                     "namespace": "default",
-                    "resourceVersion": "57384",
+                    "resourceVersion": "68399",
                     "selfLink": "/api/v1/namespaces/default/services/tlscontextciphersuites-admin",
-                    "uid": "845c90d3-536e-11ea-85dd-167682b5c255"
+                    "uid": "2896cd71-58b0-11ea-86d6-0e674b3ff44f"
                 },
                 "spec": {
-                    "clusterIP": "10.97.43.77",
+                    "clusterIP": "10.106.209.123",
                     "externalTrafficPolicy": "Cluster",
                     "ports": [
                         {
                             "name": "tlscontextciphersuites-admin",
-                            "nodePort": 32331,
+                            "nodePort": 32392,
                             "port": 8877,
                             "protocol": "TCP",
                             "targetPort": 8877
@@ -138,19 +138,19 @@
                     "annotations": {
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"tlscontextciphersuites\",\"scope\":\"AmbassadorTest\"},\"name\":\"tlscontextciphersuites-http\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8131},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8494}],\"selector\":{\"backend\":\"superpod-default\"}}}\n"
                     },
-                    "creationTimestamp": "2020-02-19T23:21:13Z",
+                    "creationTimestamp": "2020-02-26T15:53:41Z",
                     "labels": {
                         "kat-ambassador-id": "tlscontextciphersuites",
                         "scope": "AmbassadorTest"
                     },
                     "name": "tlscontextciphersuites-http",
                     "namespace": "default",
-                    "resourceVersion": "57396",
+                    "resourceVersion": "68416",
                     "selfLink": "/api/v1/namespaces/default/services/tlscontextciphersuites-http",
-                    "uid": "85615542-536e-11ea-85dd-167682b5c255"
+                    "uid": "292a2c45-58b0-11ea-86d6-0e674b3ff44f"
                 },
                 "spec": {
-                    "clusterIP": "10.105.223.174",
+                    "clusterIP": "10.99.44.186",
                     "ports": [
                         {
                             "name": "http",

--- a/python/tests/gold/tlscontextprotocolmaxversion/snapshots/econf.json
+++ b/python/tests/gold/tlscontextprotocolmaxversion/snapshots/econf.json
@@ -250,8 +250,7 @@
                                     "tls_minimum_protocol_version": "TLSv1_1"
                                 }
                             }
-                        },
-                        "use_proxy_proto": false
+                        }
                     }
                 ],
                 "listener_filters": [

--- a/python/tests/gold/tlscontextprotocolmaxversion/snapshots/snapshot.yaml
+++ b/python/tests/gold/tlscontextprotocolmaxversion/snapshots/snapshot.yaml
@@ -26,16 +26,16 @@
                     "annotations": {
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"data\":{\"tls.crt\":\"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURnRENDQW1pZ0F3SUJBZ0lKQUpycUl0ekY2MTBpTUEwR0NTcUdTSWIzRFFFQkN3VUFNRlV4Q3pBSkJnTlYKQkFZVEFsVlRNUXN3Q1FZRFZRUUlEQUpOUVRFUE1BMEdBMVVFQnd3R1FtOXpkRzl1TVFzd0NRWURWUVFLREFKRQpWekViTUJrR0ExVUVBd3dTZEd4ekxXTnZiblJsZUhRdGFHOXpkQzB4TUI0WERURTRNVEV3TVRFek5UTXhPRm9YCkRUSTRNVEF5T1RFek5UTXhPRm93VlRFTE1Ba0dBMVVFQmhNQ1ZWTXhDekFKQmdOVkJBZ01BazFCTVE4d0RRWUQKVlFRSERBWkNiM04wYjI0eEN6QUpCZ05WQkFvTUFrUlhNUnN3R1FZRFZRUUREQkowYkhNdFkyOXVkR1Y0ZEMxbwpiM04wTFRFd2dnRWlNQTBHQ1NxR1NJYjNEUUVCQVFVQUE0SUJEd0F3Z2dFS0FvSUJBUUM5T2dDOHd4eUlyUHpvCkdYc0xwUEt0NzJERXgyd2p3VzhuWFcyd1dieWEzYzk2bjJuU0NLUEJuODVoYnFzaHpqNWloU1RBTURJb2c5RnYKRzZSS1dVUFhUNEtJa1R2M0NESHFYc0FwSmxKNGxTeW5ReW8yWnYwbytBZjhDTG5nWVpCK3JmenRad3llRGhWcAp3WXpCVjIzNXp6NisycWJWbUNabHZCdVhiVXFUbEVZWXZ1R2xNR3o3cFBmT1dLVXBlWW9kYkcyZmIraEZGcGVvCkN4a1VYclFzT29SNUpkSEc1aldyWnVCTzQ1NVNzcnpCTDhSbGU1VUhvMDVXY0s3YkJiaVF6MTA2cEhDSllaK3AKdmxQSWNOU1g1S2gzNEZnOTZVUHg5bFFpQTN6RFRLQmZ5V2NMUStxMWNabExjV2RnUkZjTkJpckdCLzdyYTFWVApnRUplR2tQekFnTUJBQUdqVXpCUk1CMEdBMVVkRGdRV0JCUkRWVUtYWWJsRFdNTzE3MUJuWWZhYlkzM0NFVEFmCkJnTlZIU01FR0RBV2dCUkRWVUtYWWJsRFdNTzE3MUJuWWZhYlkzM0NFVEFQQmdOVkhSTUJBZjhFQlRBREFRSC8KTUEwR0NTcUdTSWIzRFFFQkN3VUFBNElCQVFBUE8vRDRUdDUyWHJsQ0NmUzZnVUVkRU5DcnBBV05YRHJvR2M2dApTVGx3aC8rUUxRYk5hZEtlaEtiZjg5clhLaituVXF0cS9OUlpQSXNBSytXVWtHOVpQb1FPOFBRaVY0V1g1clE3CjI5dUtjSmZhQlhrZHpVVzdxTlFoRTRjOEJhc0JySWVzcmtqcFQ5OVF4SktuWFFhTitTdzdvRlBVSUFOMzhHcWEKV2wvS1BNVHRicWt3eWFjS01CbXExVkx6dldKb0g1Q2l6Skp3aG5rWHh0V0tzLzY3clROblBWTXorbWVHdHZTaQpkcVg2V1NTbUdMRkVFcjJoZ1VjQVpqazNWdVFoLzc1aFh1K1UySXRzQys1cXBsaEc3Q1hzb1huS0t5MVhsT0FFCmI4a3IyZFdXRWs2STVZNm5USnpXSWxTVGtXODl4d1hyY3RtTjlzYjlxNFNuaVZsegotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==\",\"tls.key\":\"LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0tCk1JSUV2UUlCQURBTkJna3Foa2lHOXcwQkFRRUZBQVNDQktjd2dnU2pBZ0VBQW9JQkFRQzlPZ0M4d3h5SXJQem8KR1hzTHBQS3Q3MkRFeDJ3andXOG5YVzJ3V2J5YTNjOTZuMm5TQ0tQQm44NWhicXNoemo1aWhTVEFNRElvZzlGdgpHNlJLV1VQWFQ0S0lrVHYzQ0RIcVhzQXBKbEo0bFN5blF5bzJadjBvK0FmOENMbmdZWkIrcmZ6dFp3eWVEaFZwCndZekJWMjM1eno2KzJxYlZtQ1psdkJ1WGJVcVRsRVlZdnVHbE1HejdwUGZPV0tVcGVZb2RiRzJmYitoRkZwZW8KQ3hrVVhyUXNPb1I1SmRIRzVqV3JadUJPNDU1U3NyekJMOFJsZTVVSG8wNVdjSzdiQmJpUXoxMDZwSENKWVorcAp2bFBJY05TWDVLaDM0Rmc5NlVQeDlsUWlBM3pEVEtCZnlXY0xRK3ExY1psTGNXZGdSRmNOQmlyR0IvN3JhMVZUCmdFSmVHa1B6QWdNQkFBRUNnZ0VBQmFsN3BpcE1hMGFKMXNRVWEzZkhEeTlQZlBQZXAzODlQVGROZGU1cGQxVFYKeFh5SnBSQS9IaWNTL05WYjU0b05VZE5jRXlnZUNCcFJwUHAxd3dmQ3dPbVBKVmo3SzF3aWFqbmxsQldpZUJzMgpsOWFwcDdFVE9DdWJ5WTNWU2dLQldWa0piVzBjOG9uSFdEL0RYM0duUjhkTXdGYzRrTUdadkllUlo4bU1acmdHCjZPdDNKOHI2eVZsZWI2OGF1WmtneXMwR2VGc3pNdVRubHJCOEw5djI1UUtjVGtESjIvRWx1Y1p5aER0eGF0OEIKTzZOUnNubmNyOHhwUVdPci9sV3M5VVFuZEdCdHFzbXMrdGNUN1ZUNU9UanQ4WHY5NVhNSHB5Z29pTHk3czhvYwpJMGprNDJabzRKZW5JT3c2Rm0weUFEZ0E3eWlXcks0bEkzWGhqaTVSb1FLQmdRRGRqaWNkTUpYVUZWc28rNTJkCkUwT2EwcEpVMFNSaC9JQmdvRzdNakhrVWxiaXlpR1pNanA5MEo5VHFaL1ErM1pWZVdqMmxPSWF0OG5nUzB6MDAKVzA3T1ZxYXprMVNYaFZlY2tGNWFEcm5PRDNhU2VWMSthV3JUdDFXRWdqOVFxYnJZYVA5emd4UkpkRzV3WENCUApGNDNFeXE5ZEhXOWF6SSt3UHlJQ0JqNnZBd0tCZ1FEYXBTelhPR2ViMi9SMWhlWXdWV240czNGZEtYVjgzemtTCnFSWDd6d1pLdkk5OGMybDU1Y1ZNUzBoTGM0bTVPMXZCaUd5SG80eTB2SVAvR0k0Rzl4T1FhMXdpVnNmUVBiSU4KLzJPSDFnNXJLSFdCWVJUaHZGcERqdHJRU2xyRHVjWUNSRExCd1hUcDFrbVBkL09mY2FybG42MjZEamthZllieAp3dWUydlhCTVVRS0JnQm4vTmlPOHNiZ0RFWUZMbFFEN1k3RmxCL3FmMTg4UG05aTZ1b1dSN2hzMlBrZmtyV3hLClIvZVBQUEtNWkNLRVNhU2FuaVVtN3RhMlh0U0dxT1hkMk85cFI0Skd4V1JLSnkrZDJSUmtLZlU5NTBIa3I4M0gKZk50KzVhLzR3SWtzZ1ZvblorSWIvV05wSUJSYkd3ZHMwaHZIVkxCdVpjU1h3RHlFQysrRTRCSVZBb0dCQUoxUQp6eXlqWnRqYnI4NkhZeEpQd29teEF0WVhLSE9LWVJRdUdLVXZWY1djV2xrZTZUdE51V0dsb1FTNHd0VkdBa1VECmxhTWFaL2o2MHJaT3dwSDhZRlUvQ2ZHakl1MlFGbmEvMUtzOXR1NGZGRHpjenh1RVhDWFR1Vmk0eHdtZ3R2bVcKZkRhd3JTQTZrSDdydlp4eE9wY3hCdHloc3pCK05RUHFTckpQSjJlaEFvR0FkdFJKam9vU0lpYURVU25lZUcyZgpUTml1T01uazJkeFV3RVF2S1E4eWNuUnpyN0QwaEtZVWIycThHKzE2bThQUjNCcFMzZDFLbkpMVnI3TUhaWHpSCitzZHNaWGtTMWVEcEZhV0RFREFEWWI0ckRCb2RBdk8xYm03ZXdTMzhSbk1UaTlhdFZzNVNTODNpZG5HbFZiSmsKYkZKWG0rWWxJNHFkaXowTFdjWGJyREE9Ci0tLS0tRU5EIFBSSVZBVEUgS0VZLS0tLS0K\"},\"kind\":\"Secret\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"tlscontextprotocolmaxversion\",\"scope\":\"AmbassadorTest\"},\"name\":\"secret.max-version\",\"namespace\":\"default\"},\"type\":\"kubernetes.io/tls\"}\n"
                     },
-                    "creationTimestamp": "2020-02-19T23:21:02Z",
+                    "creationTimestamp": "2020-02-26T15:53:30Z",
                     "labels": {
                         "kat-ambassador-id": "tlscontextprotocolmaxversion",
                         "scope": "AmbassadorTest"
                     },
                     "name": "secret.max-version",
                     "namespace": "default",
-                    "resourceVersion": "57263",
+                    "resourceVersion": "68259",
                     "selfLink": "/api/v1/namespaces/default/secrets/secret.max-version",
-                    "uid": "7ea15f2b-536e-11ea-85dd-167682b5c255"
+                    "uid": "22bb6990-58b0-11ea-86d6-0e674b3ff44f"
                 },
                 "type": "kubernetes.io/tls"
             }
@@ -46,58 +46,9 @@
                 "kind": "Service",
                 "metadata": {
                     "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Module\nname: ambassador\nconfig:\n  defaults:\n    tls_secret_namespacing: False\nambassador_id: tlscontextprotocolmaxversion\n---\napiVersion: ambassador/v0\nkind: Mapping\nname: TLSContextProtocolMaxVersion-same-prefix-1\nprefix: /tls-context-same/\nservice: http://tlscontextprotocolmaxversion-http\nhost: tls-context-host-1\nambassador_id: tlscontextprotocolmaxversion\n---\napiVersion: ambassador/v1\nkind: TLSContext\nname: TLSContextProtocolMaxVersion-same-context-1\nhosts:\n- tls-context-host-1\nsecret: secret.max-version\nmin_tls_version: v1.1\nmax_tls_version: v1.2\nambassador_id: tlscontextprotocolmaxversion\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Module\\nname: ambassador\\nconfig:\\n  defaults:\\n    tls_secret_namespacing: False\\nambassador_id: tlscontextprotocolmaxversion\\n---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: TLSContextProtocolMaxVersion-same-prefix-1\\nprefix: /tls-context-same/\\nservice: http://tlscontextprotocolmaxversion-http\\nhost: tls-context-host-1\\nambassador_id: tlscontextprotocolmaxversion\\n---\\napiVersion: ambassador/v1\\nkind: TLSContext\\nname: TLSContextProtocolMaxVersion-same-context-1\\nhosts:\\n- tls-context-host-1\\nsecret: secret.max-version\\nmin_tls_version: v1.1\\nmax_tls_version: v1.2\\nambassador_id: tlscontextprotocolmaxversion\\n\"},\"labels\":{\"app.kubernetes.io/component\":\"ambassador-service\",\"kat-ambassador-id\":\"tlscontextprotocolmaxversion\",\"scope\":\"AmbassadorTest\"},\"name\":\"tlscontextprotocolmaxversion\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8080},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8443}],\"selector\":{\"service\":\"tlscontextprotocolmaxversion\"},\"type\":\"NodePort\"}}\n"
-                    },
-                    "creationTimestamp": "2020-02-19T23:21:01Z",
-                    "labels": {
-                        "app.kubernetes.io/component": "ambassador-service",
-                        "kat-ambassador-id": "tlscontextprotocolmaxversion",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "tlscontextprotocolmaxversion",
-                    "namespace": "default",
-                    "resourceVersion": "57245",
-                    "selfLink": "/api/v1/namespaces/default/services/tlscontextprotocolmaxversion",
-                    "uid": "7dfb7f8e-536e-11ea-85dd-167682b5c255"
-                },
-                "spec": {
-                    "clusterIP": "10.111.43.62",
-                    "externalTrafficPolicy": "Cluster",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "nodePort": 30014,
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8080
-                        },
-                        {
-                            "name": "https",
-                            "nodePort": 32560,
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8443
-                        }
-                    ],
-                    "selector": {
-                        "service": "tlscontextprotocolmaxversion"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "NodePort"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"tlscontextprotocolmaxversion\",\"scope\":\"AmbassadorTest\",\"service\":\"tlscontextprotocolmaxversion-admin\"},\"name\":\"tlscontextprotocolmaxversion-admin\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"tlscontextprotocolmaxversion-admin\",\"port\":8877,\"targetPort\":8877}],\"selector\":{\"service\":\"tlscontextprotocolmaxversion\"},\"type\":\"NodePort\"}}\n"
                     },
-                    "creationTimestamp": "2020-02-19T23:21:02Z",
+                    "creationTimestamp": "2020-02-26T15:53:31Z",
                     "labels": {
                         "kat-ambassador-id": "tlscontextprotocolmaxversion",
                         "scope": "AmbassadorTest",
@@ -105,17 +56,17 @@
                     },
                     "name": "tlscontextprotocolmaxversion-admin",
                     "namespace": "default",
-                    "resourceVersion": "57258",
+                    "resourceVersion": "68280",
                     "selfLink": "/api/v1/namespaces/default/services/tlscontextprotocolmaxversion-admin",
-                    "uid": "7e6f13a1-536e-11ea-85dd-167682b5c255"
+                    "uid": "233d96d6-58b0-11ea-86d6-0e674b3ff44f"
                 },
                 "spec": {
-                    "clusterIP": "10.103.207.142",
+                    "clusterIP": "10.102.64.180",
                     "externalTrafficPolicy": "Cluster",
                     "ports": [
                         {
                             "name": "tlscontextprotocolmaxversion-admin",
-                            "nodePort": 31035,
+                            "nodePort": 31509,
                             "port": 8877,
                             "protocol": "TCP",
                             "targetPort": 8877
@@ -138,19 +89,19 @@
                     "annotations": {
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"tlscontextprotocolmaxversion\",\"scope\":\"AmbassadorTest\"},\"name\":\"tlscontextprotocolmaxversion-http\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8129},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8492}],\"selector\":{\"backend\":\"superpod-default\"}}}\n"
                     },
-                    "creationTimestamp": "2020-02-19T23:21:02Z",
+                    "creationTimestamp": "2020-02-26T15:53:32Z",
                     "labels": {
                         "kat-ambassador-id": "tlscontextprotocolmaxversion",
                         "scope": "AmbassadorTest"
                     },
                     "name": "tlscontextprotocolmaxversion-http",
                     "namespace": "default",
-                    "resourceVersion": "57270",
+                    "resourceVersion": "68294",
                     "selfLink": "/api/v1/namespaces/default/services/tlscontextprotocolmaxversion-http",
-                    "uid": "7eed919c-536e-11ea-85dd-167682b5c255"
+                    "uid": "23a81bd4-58b0-11ea-86d6-0e674b3ff44f"
                 },
                 "spec": {
-                    "clusterIP": "10.109.212.247",
+                    "clusterIP": "10.110.41.82",
                     "ports": [
                         {
                             "name": "http",
@@ -170,6 +121,55 @@
                     },
                     "sessionAffinity": "None",
                     "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Module\nname: ambassador\nconfig:\n  defaults:\n    tls_secret_namespacing: False\nambassador_id: tlscontextprotocolmaxversion\n---\napiVersion: ambassador/v0\nkind: Mapping\nname: TLSContextProtocolMaxVersion-same-prefix-1\nprefix: /tls-context-same/\nservice: http://tlscontextprotocolmaxversion-http\nhost: tls-context-host-1\nambassador_id: tlscontextprotocolmaxversion\n---\napiVersion: ambassador/v1\nkind: TLSContext\nname: TLSContextProtocolMaxVersion-same-context-1\nhosts:\n- tls-context-host-1\nsecret: secret.max-version\nmin_tls_version: v1.1\nmax_tls_version: v1.2\nambassador_id: tlscontextprotocolmaxversion\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Module\\nname: ambassador\\nconfig:\\n  defaults:\\n    tls_secret_namespacing: False\\nambassador_id: tlscontextprotocolmaxversion\\n---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: TLSContextProtocolMaxVersion-same-prefix-1\\nprefix: /tls-context-same/\\nservice: http://tlscontextprotocolmaxversion-http\\nhost: tls-context-host-1\\nambassador_id: tlscontextprotocolmaxversion\\n---\\napiVersion: ambassador/v1\\nkind: TLSContext\\nname: TLSContextProtocolMaxVersion-same-context-1\\nhosts:\\n- tls-context-host-1\\nsecret: secret.max-version\\nmin_tls_version: v1.1\\nmax_tls_version: v1.2\\nambassador_id: tlscontextprotocolmaxversion\\n\"},\"labels\":{\"app.kubernetes.io/component\":\"ambassador-service\",\"kat-ambassador-id\":\"tlscontextprotocolmaxversion\",\"scope\":\"AmbassadorTest\"},\"name\":\"tlscontextprotocolmaxversion\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8080},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8443}],\"selector\":{\"service\":\"tlscontextprotocolmaxversion\"},\"type\":\"NodePort\"}}\n"
+                    },
+                    "creationTimestamp": "2020-02-26T15:53:31Z",
+                    "labels": {
+                        "app.kubernetes.io/component": "ambassador-service",
+                        "kat-ambassador-id": "tlscontextprotocolmaxversion",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "tlscontextprotocolmaxversion",
+                    "namespace": "default",
+                    "resourceVersion": "68274",
+                    "selfLink": "/api/v1/namespaces/default/services/tlscontextprotocolmaxversion",
+                    "uid": "230f9fd2-58b0-11ea-86d6-0e674b3ff44f"
+                },
+                "spec": {
+                    "clusterIP": "10.109.114.29",
+                    "externalTrafficPolicy": "Cluster",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "nodePort": 31256,
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8080
+                        },
+                        {
+                            "name": "https",
+                            "nodePort": 31418,
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8443
+                        }
+                    ],
+                    "selector": {
+                        "service": "tlscontextprotocolmaxversion"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "NodePort"
                 },
                 "status": {
                     "loadBalancer": {}

--- a/python/tests/gold/tlscontextprotocolminversion/snapshots/econf.json
+++ b/python/tests/gold/tlscontextprotocolminversion/snapshots/econf.json
@@ -257,8 +257,7 @@
                                     "tls_minimum_protocol_version": "TLSv1_2"
                                 }
                             }
-                        },
-                        "use_proxy_proto": false
+                        }
                     }
                 ],
                 "listener_filters": [

--- a/python/tests/gold/tlscontextprotocolminversion/snapshots/snapshot.yaml
+++ b/python/tests/gold/tlscontextprotocolminversion/snapshots/snapshot.yaml
@@ -26,16 +26,16 @@
                     "annotations": {
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"data\":{\"tls.crt\":\"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURnRENDQW1pZ0F3SUJBZ0lKQUpycUl0ekY2MTBpTUEwR0NTcUdTSWIzRFFFQkN3VUFNRlV4Q3pBSkJnTlYKQkFZVEFsVlRNUXN3Q1FZRFZRUUlEQUpOUVRFUE1BMEdBMVVFQnd3R1FtOXpkRzl1TVFzd0NRWURWUVFLREFKRQpWekViTUJrR0ExVUVBd3dTZEd4ekxXTnZiblJsZUhRdGFHOXpkQzB4TUI0WERURTRNVEV3TVRFek5UTXhPRm9YCkRUSTRNVEF5T1RFek5UTXhPRm93VlRFTE1Ba0dBMVVFQmhNQ1ZWTXhDekFKQmdOVkJBZ01BazFCTVE4d0RRWUQKVlFRSERBWkNiM04wYjI0eEN6QUpCZ05WQkFvTUFrUlhNUnN3R1FZRFZRUUREQkowYkhNdFkyOXVkR1Y0ZEMxbwpiM04wTFRFd2dnRWlNQTBHQ1NxR1NJYjNEUUVCQVFVQUE0SUJEd0F3Z2dFS0FvSUJBUUM5T2dDOHd4eUlyUHpvCkdYc0xwUEt0NzJERXgyd2p3VzhuWFcyd1dieWEzYzk2bjJuU0NLUEJuODVoYnFzaHpqNWloU1RBTURJb2c5RnYKRzZSS1dVUFhUNEtJa1R2M0NESHFYc0FwSmxKNGxTeW5ReW8yWnYwbytBZjhDTG5nWVpCK3JmenRad3llRGhWcAp3WXpCVjIzNXp6NisycWJWbUNabHZCdVhiVXFUbEVZWXZ1R2xNR3o3cFBmT1dLVXBlWW9kYkcyZmIraEZGcGVvCkN4a1VYclFzT29SNUpkSEc1aldyWnVCTzQ1NVNzcnpCTDhSbGU1VUhvMDVXY0s3YkJiaVF6MTA2cEhDSllaK3AKdmxQSWNOU1g1S2gzNEZnOTZVUHg5bFFpQTN6RFRLQmZ5V2NMUStxMWNabExjV2RnUkZjTkJpckdCLzdyYTFWVApnRUplR2tQekFnTUJBQUdqVXpCUk1CMEdBMVVkRGdRV0JCUkRWVUtYWWJsRFdNTzE3MUJuWWZhYlkzM0NFVEFmCkJnTlZIU01FR0RBV2dCUkRWVUtYWWJsRFdNTzE3MUJuWWZhYlkzM0NFVEFQQmdOVkhSTUJBZjhFQlRBREFRSC8KTUEwR0NTcUdTSWIzRFFFQkN3VUFBNElCQVFBUE8vRDRUdDUyWHJsQ0NmUzZnVUVkRU5DcnBBV05YRHJvR2M2dApTVGx3aC8rUUxRYk5hZEtlaEtiZjg5clhLaituVXF0cS9OUlpQSXNBSytXVWtHOVpQb1FPOFBRaVY0V1g1clE3CjI5dUtjSmZhQlhrZHpVVzdxTlFoRTRjOEJhc0JySWVzcmtqcFQ5OVF4SktuWFFhTitTdzdvRlBVSUFOMzhHcWEKV2wvS1BNVHRicWt3eWFjS01CbXExVkx6dldKb0g1Q2l6Skp3aG5rWHh0V0tzLzY3clROblBWTXorbWVHdHZTaQpkcVg2V1NTbUdMRkVFcjJoZ1VjQVpqazNWdVFoLzc1aFh1K1UySXRzQys1cXBsaEc3Q1hzb1huS0t5MVhsT0FFCmI4a3IyZFdXRWs2STVZNm5USnpXSWxTVGtXODl4d1hyY3RtTjlzYjlxNFNuaVZsegotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==\",\"tls.key\":\"LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0tCk1JSUV2UUlCQURBTkJna3Foa2lHOXcwQkFRRUZBQVNDQktjd2dnU2pBZ0VBQW9JQkFRQzlPZ0M4d3h5SXJQem8KR1hzTHBQS3Q3MkRFeDJ3andXOG5YVzJ3V2J5YTNjOTZuMm5TQ0tQQm44NWhicXNoemo1aWhTVEFNRElvZzlGdgpHNlJLV1VQWFQ0S0lrVHYzQ0RIcVhzQXBKbEo0bFN5blF5bzJadjBvK0FmOENMbmdZWkIrcmZ6dFp3eWVEaFZwCndZekJWMjM1eno2KzJxYlZtQ1psdkJ1WGJVcVRsRVlZdnVHbE1HejdwUGZPV0tVcGVZb2RiRzJmYitoRkZwZW8KQ3hrVVhyUXNPb1I1SmRIRzVqV3JadUJPNDU1U3NyekJMOFJsZTVVSG8wNVdjSzdiQmJpUXoxMDZwSENKWVorcAp2bFBJY05TWDVLaDM0Rmc5NlVQeDlsUWlBM3pEVEtCZnlXY0xRK3ExY1psTGNXZGdSRmNOQmlyR0IvN3JhMVZUCmdFSmVHa1B6QWdNQkFBRUNnZ0VBQmFsN3BpcE1hMGFKMXNRVWEzZkhEeTlQZlBQZXAzODlQVGROZGU1cGQxVFYKeFh5SnBSQS9IaWNTL05WYjU0b05VZE5jRXlnZUNCcFJwUHAxd3dmQ3dPbVBKVmo3SzF3aWFqbmxsQldpZUJzMgpsOWFwcDdFVE9DdWJ5WTNWU2dLQldWa0piVzBjOG9uSFdEL0RYM0duUjhkTXdGYzRrTUdadkllUlo4bU1acmdHCjZPdDNKOHI2eVZsZWI2OGF1WmtneXMwR2VGc3pNdVRubHJCOEw5djI1UUtjVGtESjIvRWx1Y1p5aER0eGF0OEIKTzZOUnNubmNyOHhwUVdPci9sV3M5VVFuZEdCdHFzbXMrdGNUN1ZUNU9UanQ4WHY5NVhNSHB5Z29pTHk3czhvYwpJMGprNDJabzRKZW5JT3c2Rm0weUFEZ0E3eWlXcks0bEkzWGhqaTVSb1FLQmdRRGRqaWNkTUpYVUZWc28rNTJkCkUwT2EwcEpVMFNSaC9JQmdvRzdNakhrVWxiaXlpR1pNanA5MEo5VHFaL1ErM1pWZVdqMmxPSWF0OG5nUzB6MDAKVzA3T1ZxYXprMVNYaFZlY2tGNWFEcm5PRDNhU2VWMSthV3JUdDFXRWdqOVFxYnJZYVA5emd4UkpkRzV3WENCUApGNDNFeXE5ZEhXOWF6SSt3UHlJQ0JqNnZBd0tCZ1FEYXBTelhPR2ViMi9SMWhlWXdWV240czNGZEtYVjgzemtTCnFSWDd6d1pLdkk5OGMybDU1Y1ZNUzBoTGM0bTVPMXZCaUd5SG80eTB2SVAvR0k0Rzl4T1FhMXdpVnNmUVBiSU4KLzJPSDFnNXJLSFdCWVJUaHZGcERqdHJRU2xyRHVjWUNSRExCd1hUcDFrbVBkL09mY2FybG42MjZEamthZllieAp3dWUydlhCTVVRS0JnQm4vTmlPOHNiZ0RFWUZMbFFEN1k3RmxCL3FmMTg4UG05aTZ1b1dSN2hzMlBrZmtyV3hLClIvZVBQUEtNWkNLRVNhU2FuaVVtN3RhMlh0U0dxT1hkMk85cFI0Skd4V1JLSnkrZDJSUmtLZlU5NTBIa3I4M0gKZk50KzVhLzR3SWtzZ1ZvblorSWIvV05wSUJSYkd3ZHMwaHZIVkxCdVpjU1h3RHlFQysrRTRCSVZBb0dCQUoxUQp6eXlqWnRqYnI4NkhZeEpQd29teEF0WVhLSE9LWVJRdUdLVXZWY1djV2xrZTZUdE51V0dsb1FTNHd0VkdBa1VECmxhTWFaL2o2MHJaT3dwSDhZRlUvQ2ZHakl1MlFGbmEvMUtzOXR1NGZGRHpjenh1RVhDWFR1Vmk0eHdtZ3R2bVcKZkRhd3JTQTZrSDdydlp4eE9wY3hCdHloc3pCK05RUHFTckpQSjJlaEFvR0FkdFJKam9vU0lpYURVU25lZUcyZgpUTml1T01uazJkeFV3RVF2S1E4eWNuUnpyN0QwaEtZVWIycThHKzE2bThQUjNCcFMzZDFLbkpMVnI3TUhaWHpSCitzZHNaWGtTMWVEcEZhV0RFREFEWWI0ckRCb2RBdk8xYm03ZXdTMzhSbk1UaTlhdFZzNVNTODNpZG5HbFZiSmsKYkZKWG0rWWxJNHFkaXowTFdjWGJyREE9Ci0tLS0tRU5EIFBSSVZBVEUgS0VZLS0tLS0K\"},\"kind\":\"Secret\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"tlscontextprotocolminversion\",\"scope\":\"AmbassadorTest\"},\"name\":\"secret.min-version\",\"namespace\":\"default\"},\"type\":\"kubernetes.io/tls\"}\n"
                     },
-                    "creationTimestamp": "2020-02-19T23:21:07Z",
+                    "creationTimestamp": "2020-02-26T15:53:32Z",
                     "labels": {
                         "kat-ambassador-id": "tlscontextprotocolminversion",
                         "scope": "AmbassadorTest"
                     },
                     "name": "secret.min-version",
                     "namespace": "default",
-                    "resourceVersion": "57333",
+                    "resourceVersion": "68297",
                     "selfLink": "/api/v1/namespaces/default/secrets/secret.min-version",
-                    "uid": "81656f2c-536e-11ea-85dd-167682b5c255"
+                    "uid": "23c70c48-58b0-11ea-86d6-0e674b3ff44f"
                 },
                 "type": "kubernetes.io/tls"
             }
@@ -49,7 +49,7 @@
                         "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: TLSContextProtocolMinVersion-same-prefix-1\nprefix: /tls-context-same/\nservice: https://tlscontextprotocolminversion-http\nhost: tls-context-host-1\nambassador_id: tlscontextprotocolminversion\n---\napiVersion: ambassador/v1\nkind: TLSContext\nname: TLSContextProtocolMinVersion-same-context-1\nhosts:\n- tls-context-host-1\nsecret: secret.min-version\nsecret_namespacing: False\nmin_tls_version: v1.2\nmax_tls_version: v1.3\nambassador_id: tlscontextprotocolminversion\n",
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: TLSContextProtocolMinVersion-same-prefix-1\\nprefix: /tls-context-same/\\nservice: https://tlscontextprotocolminversion-http\\nhost: tls-context-host-1\\nambassador_id: tlscontextprotocolminversion\\n---\\napiVersion: ambassador/v1\\nkind: TLSContext\\nname: TLSContextProtocolMinVersion-same-context-1\\nhosts:\\n- tls-context-host-1\\nsecret: secret.min-version\\nsecret_namespacing: False\\nmin_tls_version: v1.2\\nmax_tls_version: v1.3\\nambassador_id: tlscontextprotocolminversion\\n\"},\"labels\":{\"app.kubernetes.io/component\":\"ambassador-service\",\"kat-ambassador-id\":\"tlscontextprotocolminversion\",\"scope\":\"AmbassadorTest\"},\"name\":\"tlscontextprotocolminversion\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8080},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8443}],\"selector\":{\"service\":\"tlscontextprotocolminversion\"},\"type\":\"NodePort\"}}\n"
                     },
-                    "creationTimestamp": "2020-02-19T23:21:05Z",
+                    "creationTimestamp": "2020-02-26T15:53:34Z",
                     "labels": {
                         "app.kubernetes.io/component": "ambassador-service",
                         "kat-ambassador-id": "tlscontextprotocolminversion",
@@ -57,24 +57,24 @@
                     },
                     "name": "tlscontextprotocolminversion",
                     "namespace": "default",
-                    "resourceVersion": "57313",
+                    "resourceVersion": "68323",
                     "selfLink": "/api/v1/namespaces/default/services/tlscontextprotocolminversion",
-                    "uid": "8081f8ff-536e-11ea-85dd-167682b5c255"
+                    "uid": "2500bd52-58b0-11ea-86d6-0e674b3ff44f"
                 },
                 "spec": {
-                    "clusterIP": "10.96.105.97",
+                    "clusterIP": "10.108.147.44",
                     "externalTrafficPolicy": "Cluster",
                     "ports": [
                         {
                             "name": "http",
-                            "nodePort": 31472,
+                            "nodePort": 31202,
                             "port": 80,
                             "protocol": "TCP",
                             "targetPort": 8080
                         },
                         {
                             "name": "https",
-                            "nodePort": 30360,
+                            "nodePort": 32636,
                             "port": 443,
                             "protocol": "TCP",
                             "targetPort": 8443
@@ -97,7 +97,7 @@
                     "annotations": {
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"tlscontextprotocolminversion\",\"scope\":\"AmbassadorTest\",\"service\":\"tlscontextprotocolminversion-admin\"},\"name\":\"tlscontextprotocolminversion-admin\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"tlscontextprotocolminversion-admin\",\"port\":8877,\"targetPort\":8877}],\"selector\":{\"service\":\"tlscontextprotocolminversion\"},\"type\":\"NodePort\"}}\n"
                     },
-                    "creationTimestamp": "2020-02-19T23:21:06Z",
+                    "creationTimestamp": "2020-02-26T15:53:35Z",
                     "labels": {
                         "kat-ambassador-id": "tlscontextprotocolminversion",
                         "scope": "AmbassadorTest",
@@ -105,17 +105,17 @@
                     },
                     "name": "tlscontextprotocolminversion-admin",
                     "namespace": "default",
-                    "resourceVersion": "57322",
+                    "resourceVersion": "68335",
                     "selfLink": "/api/v1/namespaces/default/services/tlscontextprotocolminversion-admin",
-                    "uid": "810a61d6-536e-11ea-85dd-167682b5c255"
+                    "uid": "2581dd92-58b0-11ea-86d6-0e674b3ff44f"
                 },
                 "spec": {
-                    "clusterIP": "10.101.249.30",
+                    "clusterIP": "10.104.19.17",
                     "externalTrafficPolicy": "Cluster",
                     "ports": [
                         {
                             "name": "tlscontextprotocolminversion-admin",
-                            "nodePort": 30367,
+                            "nodePort": 30731,
                             "port": 8877,
                             "protocol": "TCP",
                             "targetPort": 8877
@@ -138,19 +138,19 @@
                     "annotations": {
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"tlscontextprotocolminversion\",\"scope\":\"AmbassadorTest\"},\"name\":\"tlscontextprotocolminversion-http\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8130},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8493}],\"selector\":{\"backend\":\"superpod-default\"}}}\n"
                     },
-                    "creationTimestamp": "2020-02-19T23:21:07Z",
+                    "creationTimestamp": "2020-02-26T15:53:36Z",
                     "labels": {
                         "kat-ambassador-id": "tlscontextprotocolminversion",
                         "scope": "AmbassadorTest"
                     },
                     "name": "tlscontextprotocolminversion-http",
                     "namespace": "default",
-                    "resourceVersion": "57342",
+                    "resourceVersion": "68352",
                     "selfLink": "/api/v1/namespaces/default/services/tlscontextprotocolminversion-http",
-                    "uid": "81c81940-536e-11ea-85dd-167682b5c255"
+                    "uid": "261790e2-58b0-11ea-86d6-0e674b3ff44f"
                 },
                 "spec": {
-                    "clusterIP": "10.106.176.11",
+                    "clusterIP": "10.101.233.196",
                     "ports": [
                         {
                             "name": "http",

--- a/python/tests/gold/tlscontextstest/snapshots/econf.json
+++ b/python/tests/gold/tlscontextstest/snapshots/econf.json
@@ -302,8 +302,7 @@
                                     "xff_num_trusted_hops": 0
                                 }
                             }
-                        ],
-                        "use_proxy_proto": false
+                        ]
                     }
                 ],
                 "listener_filters": [],

--- a/python/tests/gold/tlscontextstest/snapshots/snapshot.yaml
+++ b/python/tests/gold/tlscontextstest/snapshots/snapshot.yaml
@@ -25,16 +25,16 @@
                     "annotations": {
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"data\":{\"tls.crt\":\"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUR1RENDQXFDZ0F3SUJBZ0lKQUowWDU3ZXlwQk5UTUEwR0NTcUdTSWIzRFFFQkN3VUFNSEV4Q3pBSkJnTlYKQkFZVEFsVlRNUXN3Q1FZRFZRUUlEQUpOUVRFUE1BMEdBMVVFQnd3R1FtOXpkRzl1TVJFd0R3WURWUVFLREFoRQpZWFJoZDJseVpURVVNQklHQTFVRUN3d0xSVzVuYVc1bFpYSnBibWN4R3pBWkJnTlZCQU1NRW0xaGMzUmxjaTVrCllYUmhkMmx5WlM1cGJ6QWVGdzB4T1RBeE1UQXhPVEF6TXpCYUZ3MHlOREF4TURreE9UQXpNekJhTUhFeEN6QUoKQmdOVkJBWVRBbFZUTVFzd0NRWURWUVFJREFKTlFURVBNQTBHQTFVRUJ3d0dRbTl6ZEc5dU1SRXdEd1lEVlFRSwpEQWhFWVhSaGQybHlaVEVVTUJJR0ExVUVDd3dMUlc1bmFXNWxaWEpwYm1jeEd6QVpCZ05WQkFNTUVtMWhjM1JsCmNpNWtZWFJoZDJseVpTNXBiekNDQVNJd0RRWUpLb1pJaHZjTkFRRUJCUUFEZ2dFUEFEQ0NBUW9DZ2dFQkFPdlEKVjVad1NmcmQ1Vndtelo5SmNoOTdyUW40OXA2b1FiNkVIWjF5T2EyZXZBNzE2NWpkMHFqS1BPMlgyRk80MVg4QgpwQWFLZExnMmltaC9wL2NXN2JncjNHNnRHVEZVMVZHanllTE1EV0Q1MGV2TTYydnpYOFRuYVV6ZFRHTjFOdTM2CnJaM2JnK0VLcjhFYjI1b2RabEpyMm1mNktSeDdTcjZzT1N4NlE1VHhSb3NycmZ0d0tjejI5cHZlMGQ4b0NiZGkKRFJPVlZjNXpBaW0zc2Nmd3VwRUJrQzYxdlpKMzhmaXYwRENYOVpna3BMdEZKUTllTEVQSEdKUGp5ZmV3alNTeQovbk52L21Sc2J6aUNtQ3R3Z3BmbFRtODljK3EzSWhvbUE1YXhZQVFjQ0NqOXBvNUhVZHJtSUJKR0xBTVZ5OWJ5CkZnZE50aFdBeHZCNHZmQXl4OXNDQXdFQUFhTlRNRkV3SFFZRFZSME9CQllFRkdUOVAvOHBQeGI3UVJVeFcvV2gKaXpkMnNnbEtNQjhHQTFVZEl3UVlNQmFBRkdUOVAvOHBQeGI3UVJVeFcvV2hpemQyc2dsS01BOEdBMVVkRXdFQgovd1FGTUFNQkFmOHdEUVlKS29aSWh2Y05BUUVMQlFBRGdnRUJBS3NWT2Fyc01aSXhLOUpLUzBHVHNnRXNjYThqCllhTDg1YmFsbndBbnBxMllSMGNIMlhvd2dLYjNyM3VmbVRCNERzWS9RMGllaENKeTMzOUJyNjVQMVBKMGgvemYKZEZOcnZKNGlvWDVMWnc5YkowQVFORCtZUTBFK010dFppbE9DbHNPOVBCdm1tUEp1dWFlYVdvS2pWZnNOL1RjMAoycUxVM1pVMHo5bmhYeDZlOWJxYUZLSU1jYnFiVk9nS2p3V0ZpbDlkRG4vQ29KbGFUUzRJWjlOaHFjUzhYMXd0ClQybWQvSUtaaEtKc3A3VlBGeDU5ZWhuZ0VPakZocGhzd20xdDhnQWVxL1A3SkhaUXlBUGZYbDNyZDFSQVJuRVIKQUpmVUxET2tzWFNFb2RTZittR0NrVWh1b2QvaDhMTUdXTFh6Q2d0SHBKMndaVHA5a1ZWVWtKdkpqSVU9Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K\"},\"kind\":\"Secret\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"tlscontextstest\",\"scope\":\"AmbassadorTest\"},\"name\":\"test-tlscontexts-secret\",\"namespace\":\"default\"},\"type\":\"Opaque\"}\n"
                     },
-                    "creationTimestamp": "2020-02-19T23:20:42Z",
+                    "creationTimestamp": "2020-02-26T15:53:16Z",
                     "labels": {
                         "kat-ambassador-id": "tlscontextstest",
                         "scope": "AmbassadorTest"
                     },
                     "name": "test-tlscontexts-secret",
                     "namespace": "default",
-                    "resourceVersion": "56891",
+                    "resourceVersion": "67963",
                     "selfLink": "/api/v1/namespaces/default/secrets/test-tlscontexts-secret",
-                    "uid": "72ead33f-536e-11ea-85dd-167682b5c255"
+                    "uid": "1a0615e6-58b0-11ea-86d6-0e674b3ff44f"
                 },
                 "type": "Opaque"
             }
@@ -48,7 +48,7 @@
                         "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Module\nname: tls\nambassador_id: tlscontextstest\nconfig:\n  upstream:\n    enabled: True\n    secret: test-tlscontexts-secret\n\n---\napiVersion: ambassador/v0\nkind: Mapping\nname: tlscontextstest-http\nprefix: /TLSContextsTest/\nservice: tlscontextstest-http\nambassador_id: tlscontextstest\n",
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Module\\nname: tls\\nambassador_id: tlscontextstest\\nconfig:\\n  upstream:\\n    enabled: True\\n    secret: test-tlscontexts-secret\\n\\n---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: tlscontextstest-http\\nprefix: /TLSContextsTest/\\nservice: tlscontextstest-http\\nambassador_id: tlscontextstest\\n\"},\"labels\":{\"app.kubernetes.io/component\":\"ambassador-service\",\"kat-ambassador-id\":\"tlscontextstest\",\"scope\":\"AmbassadorTest\"},\"name\":\"tlscontextstest\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8080},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8443}],\"selector\":{\"service\":\"tlscontextstest\"},\"type\":\"NodePort\"}}\n"
                     },
-                    "creationTimestamp": "2020-02-19T23:20:42Z",
+                    "creationTimestamp": "2020-02-26T15:53:17Z",
                     "labels": {
                         "app.kubernetes.io/component": "ambassador-service",
                         "kat-ambassador-id": "tlscontextstest",
@@ -56,24 +56,24 @@
                     },
                     "name": "tlscontextstest",
                     "namespace": "default",
-                    "resourceVersion": "56875",
+                    "resourceVersion": "67983",
                     "selfLink": "/api/v1/namespaces/default/services/tlscontextstest",
-                    "uid": "72976793-536e-11ea-85dd-167682b5c255"
+                    "uid": "1ab593ed-58b0-11ea-86d6-0e674b3ff44f"
                 },
                 "spec": {
-                    "clusterIP": "10.96.197.15",
+                    "clusterIP": "10.107.237.119",
                     "externalTrafficPolicy": "Cluster",
                     "ports": [
                         {
                             "name": "http",
-                            "nodePort": 31406,
+                            "nodePort": 31581,
                             "port": 80,
                             "protocol": "TCP",
                             "targetPort": 8080
                         },
                         {
                             "name": "https",
-                            "nodePort": 31339,
+                            "nodePort": 32533,
                             "port": 443,
                             "protocol": "TCP",
                             "targetPort": 8443
@@ -96,7 +96,7 @@
                     "annotations": {
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"tlscontextstest\",\"scope\":\"AmbassadorTest\",\"service\":\"tlscontextstest-admin\"},\"name\":\"tlscontextstest-admin\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"tlscontextstest-admin\",\"port\":8877,\"targetPort\":8877}],\"selector\":{\"service\":\"tlscontextstest\"},\"type\":\"NodePort\"}}\n"
                     },
-                    "creationTimestamp": "2020-02-19T23:20:42Z",
+                    "creationTimestamp": "2020-02-26T15:53:18Z",
                     "labels": {
                         "kat-ambassador-id": "tlscontextstest",
                         "scope": "AmbassadorTest",
@@ -104,17 +104,17 @@
                     },
                     "name": "tlscontextstest-admin",
                     "namespace": "default",
-                    "resourceVersion": "56884",
+                    "resourceVersion": "67993",
                     "selfLink": "/api/v1/namespaces/default/services/tlscontextstest-admin",
-                    "uid": "72bb2325-536e-11ea-85dd-167682b5c255"
+                    "uid": "1b20c89c-58b0-11ea-86d6-0e674b3ff44f"
                 },
                 "spec": {
-                    "clusterIP": "10.102.244.35",
+                    "clusterIP": "10.106.28.142",
                     "externalTrafficPolicy": "Cluster",
                     "ports": [
                         {
                             "name": "tlscontextstest-admin",
-                            "nodePort": 30839,
+                            "nodePort": 31558,
                             "port": 8877,
                             "protocol": "TCP",
                             "targetPort": 8877
@@ -137,19 +137,19 @@
                     "annotations": {
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"tlscontextstest\",\"scope\":\"AmbassadorTest\"},\"name\":\"tlscontextstest-http\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8122},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8485}],\"selector\":{\"backend\":\"superpod-default\"}}}\n"
                     },
-                    "creationTimestamp": "2020-02-19T23:20:43Z",
+                    "creationTimestamp": "2020-02-26T15:53:18Z",
                     "labels": {
                         "kat-ambassador-id": "tlscontextstest",
                         "scope": "AmbassadorTest"
                     },
                     "name": "tlscontextstest-http",
                     "namespace": "default",
-                    "resourceVersion": "56901",
+                    "resourceVersion": "68009",
                     "selfLink": "/api/v1/namespaces/default/services/tlscontextstest-http",
-                    "uid": "738b95b3-536e-11ea-85dd-167682b5c255"
+                    "uid": "1b623b59-58b0-11ea-86d6-0e674b3ff44f"
                 },
                 "spec": {
-                    "clusterIP": "10.105.111.70",
+                    "clusterIP": "10.99.239.201",
                     "ports": [
                         {
                             "name": "http",

--- a/python/tests/gold/tlscontexttest/snapshots/econf.json
+++ b/python/tests/gold/tlscontexttest/snapshots/econf.json
@@ -334,8 +334,7 @@
                                     }
                                 ]
                             }
-                        },
-                        "use_proxy_proto": false
+                        }
                     },
                     {
                         "filter_chain_match": {
@@ -622,8 +621,7 @@
                                     "tls_minimum_protocol_version": "TLSv1_0"
                                 }
                             }
-                        },
-                        "use_proxy_proto": false
+                        }
                     },
                     {
                         "filter_chain_match": {
@@ -909,8 +907,7 @@
                                     }
                                 ]
                             }
-                        },
-                        "use_proxy_proto": false
+                        }
                     }
                 ],
                 "listener_filters": [
@@ -1086,8 +1083,7 @@
                                     "xff_num_trusted_hops": 0
                                 }
                             }
-                        ],
-                        "use_proxy_proto": false
+                        ]
                     },
                     {
                         "filter_chain_match": {
@@ -1226,8 +1222,7 @@
                                     "xff_num_trusted_hops": 0
                                 }
                             }
-                        ],
-                        "use_proxy_proto": false
+                        ]
                     }
                 ],
                 "listener_filters": [],

--- a/python/tests/gold/tlscontexttest/snapshots/snapshot.yaml
+++ b/python/tests/gold/tlscontexttest/snapshots/snapshot.yaml
@@ -26,16 +26,16 @@
                     "annotations": {
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"data\":{\"tls.crt\":\"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURnRENDQW1pZ0F3SUJBZ0lKQUpycUl0ekY2MTBpTUEwR0NTcUdTSWIzRFFFQkN3VUFNRlV4Q3pBSkJnTlYKQkFZVEFsVlRNUXN3Q1FZRFZRUUlEQUpOUVRFUE1BMEdBMVVFQnd3R1FtOXpkRzl1TVFzd0NRWURWUVFLREFKRQpWekViTUJrR0ExVUVBd3dTZEd4ekxXTnZiblJsZUhRdGFHOXpkQzB4TUI0WERURTRNVEV3TVRFek5UTXhPRm9YCkRUSTRNVEF5T1RFek5UTXhPRm93VlRFTE1Ba0dBMVVFQmhNQ1ZWTXhDekFKQmdOVkJBZ01BazFCTVE4d0RRWUQKVlFRSERBWkNiM04wYjI0eEN6QUpCZ05WQkFvTUFrUlhNUnN3R1FZRFZRUUREQkowYkhNdFkyOXVkR1Y0ZEMxbwpiM04wTFRFd2dnRWlNQTBHQ1NxR1NJYjNEUUVCQVFVQUE0SUJEd0F3Z2dFS0FvSUJBUUM5T2dDOHd4eUlyUHpvCkdYc0xwUEt0NzJERXgyd2p3VzhuWFcyd1dieWEzYzk2bjJuU0NLUEJuODVoYnFzaHpqNWloU1RBTURJb2c5RnYKRzZSS1dVUFhUNEtJa1R2M0NESHFYc0FwSmxKNGxTeW5ReW8yWnYwbytBZjhDTG5nWVpCK3JmenRad3llRGhWcAp3WXpCVjIzNXp6NisycWJWbUNabHZCdVhiVXFUbEVZWXZ1R2xNR3o3cFBmT1dLVXBlWW9kYkcyZmIraEZGcGVvCkN4a1VYclFzT29SNUpkSEc1aldyWnVCTzQ1NVNzcnpCTDhSbGU1VUhvMDVXY0s3YkJiaVF6MTA2cEhDSllaK3AKdmxQSWNOU1g1S2gzNEZnOTZVUHg5bFFpQTN6RFRLQmZ5V2NMUStxMWNabExjV2RnUkZjTkJpckdCLzdyYTFWVApnRUplR2tQekFnTUJBQUdqVXpCUk1CMEdBMVVkRGdRV0JCUkRWVUtYWWJsRFdNTzE3MUJuWWZhYlkzM0NFVEFmCkJnTlZIU01FR0RBV2dCUkRWVUtYWWJsRFdNTzE3MUJuWWZhYlkzM0NFVEFQQmdOVkhSTUJBZjhFQlRBREFRSC8KTUEwR0NTcUdTSWIzRFFFQkN3VUFBNElCQVFBUE8vRDRUdDUyWHJsQ0NmUzZnVUVkRU5DcnBBV05YRHJvR2M2dApTVGx3aC8rUUxRYk5hZEtlaEtiZjg5clhLaituVXF0cS9OUlpQSXNBSytXVWtHOVpQb1FPOFBRaVY0V1g1clE3CjI5dUtjSmZhQlhrZHpVVzdxTlFoRTRjOEJhc0JySWVzcmtqcFQ5OVF4SktuWFFhTitTdzdvRlBVSUFOMzhHcWEKV2wvS1BNVHRicWt3eWFjS01CbXExVkx6dldKb0g1Q2l6Skp3aG5rWHh0V0tzLzY3clROblBWTXorbWVHdHZTaQpkcVg2V1NTbUdMRkVFcjJoZ1VjQVpqazNWdVFoLzc1aFh1K1UySXRzQys1cXBsaEc3Q1hzb1huS0t5MVhsT0FFCmI4a3IyZFdXRWs2STVZNm5USnpXSWxTVGtXODl4d1hyY3RtTjlzYjlxNFNuaVZsegotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==\",\"tls.key\":\"LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0tCk1JSUV2UUlCQURBTkJna3Foa2lHOXcwQkFRRUZBQVNDQktjd2dnU2pBZ0VBQW9JQkFRQzlPZ0M4d3h5SXJQem8KR1hzTHBQS3Q3MkRFeDJ3andXOG5YVzJ3V2J5YTNjOTZuMm5TQ0tQQm44NWhicXNoemo1aWhTVEFNRElvZzlGdgpHNlJLV1VQWFQ0S0lrVHYzQ0RIcVhzQXBKbEo0bFN5blF5bzJadjBvK0FmOENMbmdZWkIrcmZ6dFp3eWVEaFZwCndZekJWMjM1eno2KzJxYlZtQ1psdkJ1WGJVcVRsRVlZdnVHbE1HejdwUGZPV0tVcGVZb2RiRzJmYitoRkZwZW8KQ3hrVVhyUXNPb1I1SmRIRzVqV3JadUJPNDU1U3NyekJMOFJsZTVVSG8wNVdjSzdiQmJpUXoxMDZwSENKWVorcAp2bFBJY05TWDVLaDM0Rmc5NlVQeDlsUWlBM3pEVEtCZnlXY0xRK3ExY1psTGNXZGdSRmNOQmlyR0IvN3JhMVZUCmdFSmVHa1B6QWdNQkFBRUNnZ0VBQmFsN3BpcE1hMGFKMXNRVWEzZkhEeTlQZlBQZXAzODlQVGROZGU1cGQxVFYKeFh5SnBSQS9IaWNTL05WYjU0b05VZE5jRXlnZUNCcFJwUHAxd3dmQ3dPbVBKVmo3SzF3aWFqbmxsQldpZUJzMgpsOWFwcDdFVE9DdWJ5WTNWU2dLQldWa0piVzBjOG9uSFdEL0RYM0duUjhkTXdGYzRrTUdadkllUlo4bU1acmdHCjZPdDNKOHI2eVZsZWI2OGF1WmtneXMwR2VGc3pNdVRubHJCOEw5djI1UUtjVGtESjIvRWx1Y1p5aER0eGF0OEIKTzZOUnNubmNyOHhwUVdPci9sV3M5VVFuZEdCdHFzbXMrdGNUN1ZUNU9UanQ4WHY5NVhNSHB5Z29pTHk3czhvYwpJMGprNDJabzRKZW5JT3c2Rm0weUFEZ0E3eWlXcks0bEkzWGhqaTVSb1FLQmdRRGRqaWNkTUpYVUZWc28rNTJkCkUwT2EwcEpVMFNSaC9JQmdvRzdNakhrVWxiaXlpR1pNanA5MEo5VHFaL1ErM1pWZVdqMmxPSWF0OG5nUzB6MDAKVzA3T1ZxYXprMVNYaFZlY2tGNWFEcm5PRDNhU2VWMSthV3JUdDFXRWdqOVFxYnJZYVA5emd4UkpkRzV3WENCUApGNDNFeXE5ZEhXOWF6SSt3UHlJQ0JqNnZBd0tCZ1FEYXBTelhPR2ViMi9SMWhlWXdWV240czNGZEtYVjgzemtTCnFSWDd6d1pLdkk5OGMybDU1Y1ZNUzBoTGM0bTVPMXZCaUd5SG80eTB2SVAvR0k0Rzl4T1FhMXdpVnNmUVBiSU4KLzJPSDFnNXJLSFdCWVJUaHZGcERqdHJRU2xyRHVjWUNSRExCd1hUcDFrbVBkL09mY2FybG42MjZEamthZllieAp3dWUydlhCTVVRS0JnQm4vTmlPOHNiZ0RFWUZMbFFEN1k3RmxCL3FmMTg4UG05aTZ1b1dSN2hzMlBrZmtyV3hLClIvZVBQUEtNWkNLRVNhU2FuaVVtN3RhMlh0U0dxT1hkMk85cFI0Skd4V1JLSnkrZDJSUmtLZlU5NTBIa3I4M0gKZk50KzVhLzR3SWtzZ1ZvblorSWIvV05wSUJSYkd3ZHMwaHZIVkxCdVpjU1h3RHlFQysrRTRCSVZBb0dCQUoxUQp6eXlqWnRqYnI4NkhZeEpQd29teEF0WVhLSE9LWVJRdUdLVXZWY1djV2xrZTZUdE51V0dsb1FTNHd0VkdBa1VECmxhTWFaL2o2MHJaT3dwSDhZRlUvQ2ZHakl1MlFGbmEvMUtzOXR1NGZGRHpjenh1RVhDWFR1Vmk0eHdtZ3R2bVcKZkRhd3JTQTZrSDdydlp4eE9wY3hCdHloc3pCK05RUHFTckpQSjJlaEFvR0FkdFJKam9vU0lpYURVU25lZUcyZgpUTml1T01uazJkeFV3RVF2S1E4eWNuUnpyN0QwaEtZVWIycThHKzE2bThQUjNCcFMzZDFLbkpMVnI3TUhaWHpSCitzZHNaWGtTMWVEcEZhV0RFREFEWWI0ckRCb2RBdk8xYm03ZXdTMzhSbk1UaTlhdFZzNVNTODNpZG5HbFZiSmsKYkZKWG0rWWxJNHFkaXowTFdjWGJyREE9Ci0tLS0tRU5EIFBSSVZBVEUgS0VZLS0tLS0K\"},\"kind\":\"Secret\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"tlscontexttest\",\"scope\":\"AmbassadorTest\"},\"name\":\"test-tlscontext-secret-1\",\"namespace\":\"secret-namespace\"},\"type\":\"kubernetes.io/tls\"}\n"
                     },
-                    "creationTimestamp": "2020-02-19T23:20:57Z",
+                    "creationTimestamp": "2020-02-26T15:53:26Z",
                     "labels": {
                         "kat-ambassador-id": "tlscontexttest",
                         "scope": "AmbassadorTest"
                     },
                     "name": "test-tlscontext-secret-1",
                     "namespace": "secret-namespace",
-                    "resourceVersion": "57157",
+                    "resourceVersion": "68175",
                     "selfLink": "/api/v1/namespaces/secret-namespace/secrets/test-tlscontext-secret-1",
-                    "uid": "7b684f31-536e-11ea-85dd-167682b5c255"
+                    "uid": "1ffc6671-58b0-11ea-86d6-0e674b3ff44f"
                 },
                 "type": "kubernetes.io/tls"
             },
@@ -50,16 +50,16 @@
                     "annotations": {
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"data\":{\"tls.crt\":\"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwakNDQW82Z0F3SUJBZ0lKQUpxa1Z4Y1RtQ1FITUEwR0NTcUdTSWIzRFFFQkN3VUFNR2d4Q3pBSkJnTlYKQkFZVEFsVlRNUXN3Q1FZRFZRUUlEQUpOUVRFUE1BMEdBMVVFQnd3R1FtOXpkRzl1TVJFd0R3WURWUVFLREFoRQpZWFJoZDJseVpURVVNQklHQTFVRUN3d0xSVzVuYVc1bFpYSnBibWN4RWpBUUJnTlZCQU1NQ1d4dlkyRnNhRzl6CmREQWVGdzB4T0RFd01UQXhNREk1TURKYUZ3MHlPREV3TURjeE1ESTVNREphTUdneEN6QUpCZ05WQkFZVEFsVlQKTVFzd0NRWURWUVFJREFKTlFURVBNQTBHQTFVRUJ3d0dRbTl6ZEc5dU1SRXdEd1lEVlFRS0RBaEVZWFJoZDJseQpaVEVVTUJJR0ExVUVDd3dMUlc1bmFXNWxaWEpwYm1jeEVqQVFCZ05WQkFNTUNXeHZZMkZzYUc5emREQ0NBU0l3CkRRWUpLb1pJaHZjTkFRRUJCUUFEZ2dFUEFEQ0NBUW9DZ2dFQkFMcTZtdS9FSzlQc1Q0YkR1WWg0aEZPVnZiblAKekV6MGpQcnVzdXcxT05MQk9jT2htbmNSTnE4c1FyTGxBZ3NicDBuTFZmQ1pSZHQ4UnlOcUFGeUJlR29XS3IvZAprQVEybVBucjBQRHlCTzk0UHo4VHdydDBtZEtEU1dGanNxMjlOYVJaT0JqdStLcGV6RytOZ3pLMk04M0ZtSldUCnFYdTI3ME9pOXlqb2VGQ3lPMjdwUkdvcktkQk9TcmIwd3ozdFdWUGk4NFZMdnFKRWprT0JVZjJYNVF3b25XWngKMktxVUJ6OUFSZVVUMzdwUVJZQkJMSUdvSnM4U042cjF4MSt1dTNLdTVxSkN1QmRlSHlJbHpKb2V0aEp2K3pTMgowN0pFc2ZKWkluMWNpdXhNNzNPbmVRTm1LUkpsL2NEb3BLemswSldRSnRSV1NnbktneFNYWkRrZjJMOENBd0VBCkFhTlRNRkV3SFFZRFZSME9CQllFRkJoQzdDeVRpNGFkSFVCd0wvTkZlRTZLdnFIRE1COEdBMVVkSXdRWU1CYUEKRkJoQzdDeVRpNGFkSFVCd0wvTkZlRTZLdnFIRE1BOEdBMVVkRXdFQi93UUZNQU1CQWY4d0RRWUpLb1pJaHZjTgpBUUVMQlFBRGdnRUJBSFJvb0xjcFdEa1IyMEhENEJ5d1BTUGRLV1hjWnN1U2tXYWZyekhoYUJ5MWJZcktIR1o1CmFodFF3L1gwQmRnMWtidlpZUDJSTzdGTFhBSlNTdXVJT0NHTFVwS0pkVHE1NDREUThNb1daWVZKbTc3UWxxam0KbHNIa2VlTlRNamFOVjdMd0MzalBkMERYelczbGVnWFRoYWpmZ2dtLzBJZXNGRzBVWjFEOTJHNURmc0hLekpSagpNSHZyVDNtVmJGZjkrSGJhRE4yT2g5VjIxUWhWSzF2M0F2dWNXczhUWCswZHZFZ1dtWHBRcndEd2pTMU04QkRYCldoWjVsZTZjVzhNYjhnZmRseG1JckpnQStuVVZzMU9EbkJKS1F3MUY4MVdkc25tWXdweVUrT2xVais4UGt1TVoKSU4rUlhQVnZMSWJ3czBmamJ4UXRzbTArZVBpRnN2d0NsUFk9Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K\",\"tls.key\":\"LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0tCk1JSUV2Z0lCQURBTkJna3Foa2lHOXcwQkFRRUZBQVNDQktnd2dnU2tBZ0VBQW9JQkFRQzZ1cHJ2eEN2VDdFK0cKdzdtSWVJUlRsYjI1ejh4TTlJejY3ckxzTlRqU3dUbkRvWnAzRVRhdkxFS3k1UUlMRzZkSnkxWHdtVVhiZkVjagphZ0JjZ1hocUZpcS8zWkFFTnBqNTY5RHc4Z1R2ZUQ4L0U4SzdkSm5TZzBsaFk3S3R2VFdrV1RnWTd2aXFYc3h2CmpZTXl0alBOeFppVms2bDd0dTlEb3ZjbzZIaFFzanR1NlVScUt5blFUa3EyOU1NOTdWbFQ0dk9GUzc2aVJJNUQKZ1ZIOWwrVU1LSjFtY2RpcWxBYy9RRVhsRTkrNlVFV0FRU3lCcUNiUEVqZXE5Y2RmcnJ0eXJ1YWlRcmdYWGg4aQpKY3lhSHJZU2IvczB0dE95UkxIeVdTSjlYSXJzVE85enAza0RaaWtTWmYzQTZLU3M1TkNWa0NiVVZrb0p5b01VCmwyUTVIOWkvQWdNQkFBRUNnZ0VBSVFsZzNpamNCRHViK21Eb2syK1hJZDZ0V1pHZE9NUlBxUm5RU0NCR2RHdEIKV0E1Z2NNNTMyVmhBV0x4UnR6dG1ScFVXR0dKVnpMWlpNN2ZPWm85MWlYZHdpcytkYWxGcWtWVWFlM2FtVHVQOApkS0YvWTRFR3Nnc09VWSs5RGlZYXRvQWVmN0xRQmZ5TnVQTFZrb1JQK0FrTXJQSWFHMHhMV3JFYmYzNVp3eFRuCnd5TTF3YVpQb1oxWjZFdmhHQkxNNzlXYmY2VFY0WXVzSTRNOEVQdU1GcWlYcDNlRmZ4L0tnNHhtYnZtN1JhYzcKOEJ3Z3pnVmljNXlSbkVXYjhpWUh5WGtyazNTL0VCYUNEMlQwUjM5VmlVM1I0VjBmMUtyV3NjRHowVmNiVWNhKwpzeVdyaVhKMHBnR1N0Q3FWK0dRYy9aNmJjOGt4VWpTTWxOUWtudVJRZ1FLQmdRRHpwM1ZaVmFzMTA3NThVT00rCnZUeTFNL0V6azg4cWhGb21kYVFiSFRlbStpeGpCNlg3RU9sRlkya3JwUkwvbURDSEpwR0MzYlJtUHNFaHVGSUwKRHhSQ2hUcEtTVmNsSytaaUNPaWE1ektTVUpxZnBOcW15RnNaQlhJNnRkNW9mWk42aFpJVTlJR2RUaGlYMjBONwppUW01UnZlSUx2UHVwMWZRMmRqd2F6Ykgvd0tCZ1FERU1MN21Mb2RqSjBNTXh6ZnM3MW1FNmZOUFhBMVY2ZEgrCllCVG4xS2txaHJpampRWmFNbXZ6dEZmL1F3Wkhmd3FKQUVuNGx2em5ncUNzZTMvUElZMy8zRERxd1p2NE1vdy8KRGdBeTBLQmpQYVJGNjhYT1B1d0VuSFN1UjhyZFg2UzI3TXQ2cEZIeFZ2YjlRRFJuSXc4a3grSFVreml4U0h5Ugo2NWxESklEdlFRS0JnUURpQTF3ZldoQlBCZk9VYlpQZUJydmhlaVVycXRob29BemYwQkJCOW9CQks1OHczVTloCjdQWDFuNWxYR3ZEY2x0ZXRCbUhEK3RQMFpCSFNyWit0RW5mQW5NVE5VK3E2V0ZhRWFhOGF3WXR2bmNWUWdTTXgKd25oK1pVYm9udnVJQWJSajJyTC9MUzl1TTVzc2dmKy9BQWM5RGs5ZXkrOEtXY0Jqd3pBeEU4TGxFUUtCZ0IzNwoxVEVZcTFoY0I4Tk1MeC9tOUtkN21kUG5IYUtqdVpSRzJ1c1RkVWNxajgxdklDbG95MWJUbVI5Si93dXVQczN4ClhWekF0cVlyTUtNcnZMekxSQWgyZm9OaVU1UDdKYlA5VDhwMFdBN1N2T2h5d0NobE5XeisvRlltWXJxeWcxbngKbHFlSHRYNU03REtJUFhvRndhcTlZYVk3V2M2K1pVdG4xbVNNajZnQkFvR0JBSTgwdU9iTkdhRndQTVYrUWhiZApBelkrSFNGQjBkWWZxRytzcTBmRVdIWTNHTXFmNFh0aVRqUEFjWlg3RmdtT3Q5Uit3TlFQK0dFNjZoV0JpKzBWCmVLV3prV0lXeS9sTVZCSW0zVWtlSlRCT3NudTFVaGhXbm5WVDhFeWhEY1FxcndPSGlhaUo3bFZSZmRoRWFyQysKSnpaU0czOHVZUVlyc0lITnRVZFgySmdPCi0tLS0tRU5EIFBSSVZBVEUgS0VZLS0tLS0K\"},\"kind\":\"Secret\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"tlscontexttest\",\"scope\":\"AmbassadorTest\"},\"name\":\"test-tlscontext-secret-0\",\"namespace\":\"default\"},\"type\":\"kubernetes.io/tls\"}\n"
                     },
-                    "creationTimestamp": "2020-02-19T23:20:08Z",
+                    "creationTimestamp": "2020-02-26T15:51:51Z",
                     "labels": {
                         "kat-ambassador-id": "tlscontexttest",
                         "scope": "AmbassadorTest"
                     },
                     "name": "test-tlscontext-secret-0",
                     "namespace": "default",
-                    "resourceVersion": "60446",
+                    "resourceVersion": "68169",
                     "selfLink": "/api/v1/namespaces/default/secrets/test-tlscontext-secret-0",
-                    "uid": "5e7e2378-536e-11ea-85dd-167682b5c255"
+                    "uid": "e79e40e8-58af-11ea-86d6-0e674b3ff44f"
                 },
                 "type": "kubernetes.io/tls"
             },
@@ -74,16 +74,16 @@
                     "annotations": {
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"data\":{\"tls.crt\":\"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURnRENDQW1pZ0F3SUJBZ0lKQUlIWTY3cFNoZ3NyTUEwR0NTcUdTSWIzRFFFQkN3VUFNRlV4Q3pBSkJnTlYKQkFZVEFsVlRNUXN3Q1FZRFZRUUlEQUpOUVRFUE1BMEdBMVVFQnd3R1FtOXpkRzl1TVFzd0NRWURWUVFLREFKRQpWekViTUJrR0ExVUVBd3dTZEd4ekxXTnZiblJsZUhRdGFHOXpkQzB5TUI0WERURTRNVEV3TVRFME1EUXhObG9YCkRUSTRNVEF5T1RFME1EUXhObG93VlRFTE1Ba0dBMVVFQmhNQ1ZWTXhDekFKQmdOVkJBZ01BazFCTVE4d0RRWUQKVlFRSERBWkNiM04wYjI0eEN6QUpCZ05WQkFvTUFrUlhNUnN3R1FZRFZRUUREQkowYkhNdFkyOXVkR1Y0ZEMxbwpiM04wTFRJd2dnRWlNQTBHQ1NxR1NJYjNEUUVCQVFVQUE0SUJEd0F3Z2dFS0FvSUJBUURjQThZdGgvUFdhT0dTCm9ObXZFSFoyNGpRN1BLTitENG93TEhXZWl1UmRtaEEwWU92VTN3cUczVnFZNFpwbFpBVjBQS2xELysyWlNGMTQKejh3MWVGNFFUelphWXh3eTkrd2ZITmtUREVwTWpQOEpNMk9FYnlrVVJ4VVJ2VzQrN0QzMEUyRXo1T1BseG1jMApNWU0vL0pINUVEUWhjaURybFlxZTFTUk1SQUxaZVZta2FBeXU2TkhKVEJ1ajBTSVB1ZExUY2grOTBxK3Jkd255CmZrVDF4M09UYW5iV2pub21FSmU3TXZ5NG12dnFxSUh1NDhTOUM4WmQxQkdWUGJ1OFYvVURyU1dROXpZQ1g0U0cKT2FzbDhDMFhtSDZrZW1oUERsRC9UdjB4dnlINXE1TVVjSGk0bUp0Titnem9iNTREd3pWR0VqZWY1TGVTMVY1RgowVEFQMGQrWEFnTUJBQUdqVXpCUk1CMEdBMVVkRGdRV0JCUWRGMEdRSGRxbHRoZG5RWXFWaXVtRXJsUk9mREFmCkJnTlZIU01FR0RBV2dCUWRGMEdRSGRxbHRoZG5RWXFWaXVtRXJsUk9mREFQQmdOVkhSTUJBZjhFQlRBREFRSC8KTUEwR0NTcUdTSWIzRFFFQkN3VUFBNElCQVFBbUFLYkNsdUhFZS9JRmJ1QWJneDBNenV6aTkwd2xtQVBiOGdtTwpxdmJwMjl1T1ZzVlNtUUFkZFBuZEZhTVhWcDFaaG1UVjVDU1F0ZFgyQ1ZNVyswVzQ3Qy9DT0Jkb1NFUTl5akJmCmlGRGNseG04QU4yUG1hR1FhK3hvT1hnWkxYZXJDaE5LV0JTWlIrWktYTEpTTTlVYUVTbEhmNXVuQkxFcENqK2oKZEJpSXFGY2E3eElGUGtyKzBSRW9BVmMveFBubnNhS2pMMlV5Z0dqUWZGTnhjT042Y3VjYjZMS0pYT1pFSVRiNQpINjhKdWFSQ0tyZWZZK0l5aFFWVk5taWk3dE1wY1UyS2pXNXBrVktxVTNkS0l0RXEyVmtTZHpNVUtqTnhZd3FGCll6YnozNFQ1MENXbm9HbU5SQVdKc0xlVmlPWVUyNmR3YkFXZDlVYitWMDFRam43OAotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==\",\"tls.key\":\"LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0tCk1JSUV2d0lCQURBTkJna3Foa2lHOXcwQkFRRUZBQVNDQktrd2dnU2xBZ0VBQW9JQkFRRGNBOFl0aC9QV2FPR1MKb05tdkVIWjI0alE3UEtOK0Q0b3dMSFdlaXVSZG1oQTBZT3ZVM3dxRzNWcVk0WnBsWkFWMFBLbEQvKzJaU0YxNAp6OHcxZUY0UVR6WmFZeHd5OSt3ZkhOa1RERXBNalA4Sk0yT0VieWtVUnhVUnZXNCs3RDMwRTJFejVPUGx4bWMwCk1ZTS8vSkg1RURRaGNpRHJsWXFlMVNSTVJBTFplVm1rYUF5dTZOSEpUQnVqMFNJUHVkTFRjaCs5MHErcmR3bnkKZmtUMXgzT1RhbmJXam5vbUVKZTdNdnk0bXZ2cXFJSHU0OFM5QzhaZDFCR1ZQYnU4Vi9VRHJTV1E5ellDWDRTRwpPYXNsOEMwWG1INmtlbWhQRGxEL1R2MHh2eUg1cTVNVWNIaTRtSnROK2d6b2I1NER3elZHRWplZjVMZVMxVjVGCjBUQVAwZCtYQWdNQkFBRUNnZ0VCQUk2U3I0anYwZForanJhN0gzVnZ3S1RYZnl0bjV6YVlrVjhZWUh3RjIyakEKbm9HaTBSQllIUFU2V2l3NS9oaDRFWVM2anFHdkptUXZYY3NkTldMdEJsK2hSVUtiZVRtYUtWd2NFSnRrV24xeQozUTQwUytnVk5OU2NINDRvYUZuRU0zMklWWFFRZnBKMjJJZ2RFY1dVUVcvWnpUNWpPK3dPTXc4c1plSTZMSEtLCkdoOENsVDkrRGUvdXFqbjNCRnQwelZ3cnFLbllKSU1DSWFrb2lDRmtIcGhVTURFNVkyU1NLaGFGWndxMWtLd0sKdHFvWFpKQnlzYXhnUTFRa21mS1RnRkx5WlpXT01mRzVzb1VrU1RTeURFRzFsYnVYcHpUbTlVSTlKU2lsK01yaAp1LzVTeXBLOHBCSHhBdFg5VXdiTjFiRGw3Sng1SWJyMnNoM0F1UDF4OUpFQ2dZRUE4dGNTM09URXNOUFpQZlptCk9jaUduOW9STTdHVmVGdjMrL05iL3JodHp1L1RQUWJBSzhWZ3FrS0dPazNGN1krY2txS1NTWjFnUkF2SHBsZEIKaTY0Y0daT1dpK01jMWZVcEdVV2sxdnZXbG1nTUlQVjVtbFpvOHowMlNTdXhLZTI1Y2VNb09oenFlay9vRmFtdgoyTmxFeTh0dEhOMUxMS3grZllhMkpGcWVycThDZ1lFQTUvQUxHSXVrU3J0K0dkektJLzV5cjdSREpTVzIzUTJ4CkM5ZklUTUFSL1Q4dzNsWGhyUnRXcmlHL3l0QkVPNXdTMVIwdDkydW1nVkhIRTA5eFFXbzZ0Tm16QVBNb1RSekMKd08yYnJqQktBdUJkQ0RISjZsMlFnOEhPQWovUncrK2x4bEN0VEI2YS8xWEZIZnNHUGhqMEQrWlJiWVZzaE00UgpnSVVmdmpmQ1Y1a0NnWUVBMzdzL2FieHJhdThEaTQ3a0NBQ3o1N3FsZHBiNk92V2d0OFF5MGE5aG0vSmhFQ3lVCkNML0VtNWpHeWhpMWJuV05yNXVRWTdwVzR0cG5pdDJCU2d1VFlBMFYrck8zOFhmNThZcTBvRTFPR3l5cFlBUkoKa09SanRSYUVXVTJqNEJsaGJZZjNtL0xnSk9oUnp3T1RPNXFSUTZHY1dhZVlod1ExVmJrelByTXUxNGtDZ1lCbwp4dEhjWnNqelVidm5wd3hTTWxKUStaZ1RvZlAzN0lWOG1pQk1POEJrclRWQVczKzFtZElRbkFKdWRxTThZb2RICmF3VW03cVNyYXV3SjF5dU1wNWFadUhiYkNQMjl5QzVheFh3OHRtZlk0TTVtTTBmSjdqYW9ydGFId1pqYmNObHMKdTJsdUo2MVJoOGVpZ1pJU1gyZHgvMVB0ckFhWUFCZDcvYWVYWU0wVWtRS0JnUUNVbkFIdmRQUGhIVnJDWU1rTgpOOFBEK0t0YmhPRks2S3MvdlgyUkcyRnFmQkJPQWV3bEo1d0xWeFBLT1RpdytKS2FSeHhYMkcvREZVNzduOEQvCkR5V2RjM2ZCQWQ0a1lJamZVaGRGa1hHNEFMUDZBNVFIZVN4NzNScTFLNWxMVWhPbEZqc3VPZ0NKS28wVlFmRC8KT05paDB6SzN5Wmc3aDVQamZ1TUdGb09OQWc9PQotLS0tLUVORCBQUklWQVRFIEtFWS0tLS0tCg==\"},\"kind\":\"Secret\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"tlscontexttest\",\"scope\":\"AmbassadorTest\"},\"name\":\"test-tlscontext-secret-2\",\"namespace\":\"default\"},\"type\":\"kubernetes.io/tls\"}\n"
                     },
-                    "creationTimestamp": "2020-02-19T23:20:08Z",
+                    "creationTimestamp": "2020-02-26T15:51:51Z",
                     "labels": {
                         "kat-ambassador-id": "tlscontexttest",
                         "scope": "AmbassadorTest"
                     },
                     "name": "test-tlscontext-secret-2",
                     "namespace": "default",
-                    "resourceVersion": "60447",
+                    "resourceVersion": "68177",
                     "selfLink": "/api/v1/namespaces/default/secrets/test-tlscontext-secret-2",
-                    "uid": "5e8c3f1f-536e-11ea-85dd-167682b5c255"
+                    "uid": "e7bbe0f5-58af-11ea-86d6-0e674b3ff44f"
                 },
                 "type": "kubernetes.io/tls"
             }
@@ -97,7 +97,7 @@
                         "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: TLSContextTest-same-prefix-1\nprefix: /tls-context-same/\nservice: http://tlscontexttest-http\nhost: tls-context-host-1\nambassador_id: tlscontexttest\n\n---\napiVersion: ambassador/v1\nkind: TLSContext\nname: TLSContextTest-same-context-1\nhosts:\n- tls-context-host-1\nsecret: test-tlscontext-secret-1.secret-namespace\nmin_tls_version: v1.0\nmax_tls_version: v1.3\nredirect_cleartext_from: 8080\nambassador_id: tlscontexttest\n\n---\napiVersion: ambassador/v1\nkind: Mapping\nname: TLSContextTest-same-prefix-2\nprefix: /tls-context-same/\nservice: http://tlscontexttest-http\nhost: tls-context-host-2\nambassador_id: tlscontexttest\n\n---\napiVersion: ambassador/v1\nkind: TLSContext\nname: TLSContextTest-same-context-2\nhosts:\n- tls-context-host-2\nsecret: test-tlscontext-secret-2\nalpn_protocols: h2,http/1.1\nredirect_cleartext_from: 8080\nambassador_id: tlscontexttest\n\n---\napiVersion: ambassador/v1\nkind: Module\nname: tls\nconfig:\n  server:\n    enabled: True\n    secret: test-tlscontext-secret-0\nambassador_id: tlscontexttest\n\n---\napiVersion: ambassador/v1\nkind: Mapping\nname: TLSContextTest-other-mapping\nprefix: /TLSContextTest/\nservice: https://tlscontexttest-http\nambassador_id: tlscontexttest\n\n---\napiVersion: ambassador/v1\nkind: TLSContext\nname: TLSContextTest-no-secret\nmin_tls_version: v1.0\nmax_tls_version: v1.3\nredirect_cleartext_from: 8080\nambassador_id: tlscontexttest\n\n---\napiVersion: ambassador/v1\nkind: TLSContext\nname: TLSContextTest-same-context-error\nhosts:\n- tls-context-host-1\nredirect_cleartext_from: 8080\nambassador_id: tlscontexttest\n\n---\napiVersion: ambassador/v1\nkind: TLSContext\nname: TLSContextTest-rcf-error\nhosts:\n- tls-context-host-1\nredirect_cleartext_from: 8081\nambassador_id: tlscontexttest\n",
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: TLSContextTest-same-prefix-1\\nprefix: /tls-context-same/\\nservice: http://tlscontexttest-http\\nhost: tls-context-host-1\\nambassador_id: tlscontexttest\\n\\n---\\napiVersion: ambassador/v1\\nkind: TLSContext\\nname: TLSContextTest-same-context-1\\nhosts:\\n- tls-context-host-1\\nsecret: test-tlscontext-secret-1.secret-namespace\\nmin_tls_version: v1.0\\nmax_tls_version: v1.3\\nredirect_cleartext_from: 8080\\nambassador_id: tlscontexttest\\n\\n---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: TLSContextTest-same-prefix-2\\nprefix: /tls-context-same/\\nservice: http://tlscontexttest-http\\nhost: tls-context-host-2\\nambassador_id: tlscontexttest\\n\\n---\\napiVersion: ambassador/v1\\nkind: TLSContext\\nname: TLSContextTest-same-context-2\\nhosts:\\n- tls-context-host-2\\nsecret: test-tlscontext-secret-2\\nalpn_protocols: h2,http/1.1\\nredirect_cleartext_from: 8080\\nambassador_id: tlscontexttest\\n\\n---\\napiVersion: ambassador/v1\\nkind: Module\\nname: tls\\nconfig:\\n  server:\\n    enabled: True\\n    secret: test-tlscontext-secret-0\\nambassador_id: tlscontexttest\\n\\n---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: TLSContextTest-other-mapping\\nprefix: /TLSContextTest/\\nservice: https://tlscontexttest-http\\nambassador_id: tlscontexttest\\n\\n---\\napiVersion: ambassador/v1\\nkind: TLSContext\\nname: TLSContextTest-no-secret\\nmin_tls_version: v1.0\\nmax_tls_version: v1.3\\nredirect_cleartext_from: 8080\\nambassador_id: tlscontexttest\\n\\n---\\napiVersion: ambassador/v1\\nkind: TLSContext\\nname: TLSContextTest-same-context-error\\nhosts:\\n- tls-context-host-1\\nredirect_cleartext_from: 8080\\nambassador_id: tlscontexttest\\n\\n---\\napiVersion: ambassador/v1\\nkind: TLSContext\\nname: TLSContextTest-rcf-error\\nhosts:\\n- tls-context-host-1\\nredirect_cleartext_from: 8081\\nambassador_id: tlscontexttest\\n\"},\"labels\":{\"app.kubernetes.io/component\":\"ambassador-service\",\"kat-ambassador-id\":\"tlscontexttest\",\"scope\":\"AmbassadorTest\"},\"name\":\"tlscontexttest\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8080},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8443}],\"selector\":{\"service\":\"tlscontexttest\"},\"type\":\"NodePort\"}}\n"
                     },
-                    "creationTimestamp": "2020-02-19T23:20:56Z",
+                    "creationTimestamp": "2020-02-26T15:53:27Z",
                     "labels": {
                         "app.kubernetes.io/component": "ambassador-service",
                         "kat-ambassador-id": "tlscontexttest",
@@ -105,24 +105,24 @@
                     },
                     "name": "tlscontexttest",
                     "namespace": "default",
-                    "resourceVersion": "57132",
+                    "resourceVersion": "68189",
                     "selfLink": "/api/v1/namespaces/default/services/tlscontexttest",
-                    "uid": "7ad65d7e-536e-11ea-85dd-167682b5c255"
+                    "uid": "207f16c5-58b0-11ea-86d6-0e674b3ff44f"
                 },
                 "spec": {
-                    "clusterIP": "10.110.183.228",
+                    "clusterIP": "10.103.47.126",
                     "externalTrafficPolicy": "Cluster",
                     "ports": [
                         {
                             "name": "http",
-                            "nodePort": 32378,
+                            "nodePort": 31350,
                             "port": 80,
                             "protocol": "TCP",
                             "targetPort": 8080
                         },
                         {
                             "name": "https",
-                            "nodePort": 30253,
+                            "nodePort": 32312,
                             "port": 443,
                             "protocol": "TCP",
                             "targetPort": 8443
@@ -145,7 +145,7 @@
                     "annotations": {
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"tlscontexttest\",\"scope\":\"AmbassadorTest\",\"service\":\"tlscontexttest-admin\"},\"name\":\"tlscontexttest-admin\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"tlscontexttest-admin\",\"port\":8877,\"targetPort\":8877}],\"selector\":{\"service\":\"tlscontexttest\"},\"type\":\"NodePort\"}}\n"
                     },
-                    "creationTimestamp": "2020-02-19T23:20:56Z",
+                    "creationTimestamp": "2020-02-26T15:53:27Z",
                     "labels": {
                         "kat-ambassador-id": "tlscontexttest",
                         "scope": "AmbassadorTest",
@@ -153,17 +153,17 @@
                     },
                     "name": "tlscontexttest-admin",
                     "namespace": "default",
-                    "resourceVersion": "57141",
+                    "resourceVersion": "68196",
                     "selfLink": "/api/v1/namespaces/default/services/tlscontexttest-admin",
-                    "uid": "7b37321e-536e-11ea-85dd-167682b5c255"
+                    "uid": "20b843f7-58b0-11ea-86d6-0e674b3ff44f"
                 },
                 "spec": {
-                    "clusterIP": "10.99.226.50",
+                    "clusterIP": "10.103.172.183",
                     "externalTrafficPolicy": "Cluster",
                     "ports": [
                         {
                             "name": "tlscontexttest-admin",
-                            "nodePort": 32466,
+                            "nodePort": 31697,
                             "port": 8877,
                             "protocol": "TCP",
                             "targetPort": 8877
@@ -186,19 +186,19 @@
                     "annotations": {
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"tlscontexttest\",\"scope\":\"AmbassadorTest\"},\"name\":\"tlscontexttest-http\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8127},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8490}],\"selector\":{\"backend\":\"superpod-default\"}}}\n"
                     },
-                    "creationTimestamp": "2020-02-19T23:20:57Z",
+                    "creationTimestamp": "2020-02-26T15:53:28Z",
                     "labels": {
                         "kat-ambassador-id": "tlscontexttest",
                         "scope": "AmbassadorTest"
                     },
                     "name": "tlscontexttest-http",
                     "namespace": "default",
-                    "resourceVersion": "57161",
+                    "resourceVersion": "68208",
                     "selfLink": "/api/v1/namespaces/default/services/tlscontexttest-http",
-                    "uid": "7b834148-536e-11ea-85dd-167682b5c255"
+                    "uid": "21194cb9-58b0-11ea-86d6-0e674b3ff44f"
                 },
                 "spec": {
-                    "clusterIP": "10.96.199.87",
+                    "clusterIP": "10.109.183.214",
                     "ports": [
                         {
                             "name": "http",

--- a/python/tests/gold/tlsinvalidsecret/snapshots/econf.json
+++ b/python/tests/gold/tlsinvalidsecret/snapshots/econf.json
@@ -302,8 +302,7 @@
                                     "xff_num_trusted_hops": 0
                                 }
                             }
-                        ],
-                        "use_proxy_proto": false
+                        ]
                     }
                 ],
                 "listener_filters": [],

--- a/python/tests/gold/tlsinvalidsecret/snapshots/snapshot.yaml
+++ b/python/tests/gold/tlsinvalidsecret/snapshots/snapshot.yaml
@@ -21,58 +21,9 @@
                 "kind": "Service",
                 "metadata": {
                     "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Module\nname: tls\nambassador_id: tlsinvalidsecret\nconfig:\n  server:\n    enabled: True\n    secret: test-certs-secret-invalid\n  missing-secret-key:\n    cert_chain_file: /nonesuch\n  bad-path-info:\n    cert_chain_file: /nonesuch\n    private_key_file: /nonesuch\n  validation-without-termination:\n    enabled: True\n    secret: test-certs-secret-invalid\n    ca_secret: ambassador-certs\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Module\\nname: tls\\nambassador_id: tlsinvalidsecret\\nconfig:\\n  server:\\n    enabled: True\\n    secret: test-certs-secret-invalid\\n  missing-secret-key:\\n    cert_chain_file: /nonesuch\\n  bad-path-info:\\n    cert_chain_file: /nonesuch\\n    private_key_file: /nonesuch\\n  validation-without-termination:\\n    enabled: True\\n    secret: test-certs-secret-invalid\\n    ca_secret: ambassador-certs\\n\"},\"labels\":{\"app.kubernetes.io/component\":\"ambassador-service\",\"kat-ambassador-id\":\"tlsinvalidsecret\",\"scope\":\"AmbassadorTest\"},\"name\":\"tlsinvalidsecret\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8080},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8443}],\"selector\":{\"service\":\"tlsinvalidsecret\"},\"type\":\"NodePort\"}}\n"
-                    },
-                    "creationTimestamp": "2020-02-19T23:20:52Z",
-                    "labels": {
-                        "app.kubernetes.io/component": "ambassador-service",
-                        "kat-ambassador-id": "tlsinvalidsecret",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "tlsinvalidsecret",
-                    "namespace": "default",
-                    "resourceVersion": "57077",
-                    "selfLink": "/api/v1/namespaces/default/services/tlsinvalidsecret",
-                    "uid": "78d3c577-536e-11ea-85dd-167682b5c255"
-                },
-                "spec": {
-                    "clusterIP": "10.107.11.212",
-                    "externalTrafficPolicy": "Cluster",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "nodePort": 30263,
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8080
-                        },
-                        {
-                            "name": "https",
-                            "nodePort": 30397,
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8443
-                        }
-                    ],
-                    "selector": {
-                        "service": "tlsinvalidsecret"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "NodePort"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"tlsinvalidsecret\",\"scope\":\"AmbassadorTest\",\"service\":\"tlsinvalidsecret-admin\"},\"name\":\"tlsinvalidsecret-admin\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"tlsinvalidsecret-admin\",\"port\":8877,\"targetPort\":8877}],\"selector\":{\"service\":\"tlsinvalidsecret\"},\"type\":\"NodePort\"}}\n"
                     },
-                    "creationTimestamp": "2020-02-19T23:20:53Z",
+                    "creationTimestamp": "2020-02-26T15:53:25Z",
                     "labels": {
                         "kat-ambassador-id": "tlsinvalidsecret",
                         "scope": "AmbassadorTest",
@@ -80,17 +31,17 @@
                     },
                     "name": "tlsinvalidsecret-admin",
                     "namespace": "default",
-                    "resourceVersion": "57090",
+                    "resourceVersion": "68155",
                     "selfLink": "/api/v1/namespaces/default/services/tlsinvalidsecret-admin",
-                    "uid": "793106b7-536e-11ea-85dd-167682b5c255"
+                    "uid": "1f913d34-58b0-11ea-86d6-0e674b3ff44f"
                 },
                 "spec": {
-                    "clusterIP": "10.106.205.253",
+                    "clusterIP": "10.100.42.90",
                     "externalTrafficPolicy": "Cluster",
                     "ports": [
                         {
                             "name": "tlsinvalidsecret-admin",
-                            "nodePort": 31090,
+                            "nodePort": 31820,
                             "port": 8877,
                             "protocol": "TCP",
                             "targetPort": 8877
@@ -114,19 +65,19 @@
                         "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: tls_target_mapping\nprefix: /tls-target/\nservice: tlsinvalidsecret-http\nambassador_id: tlsinvalidsecret\n",
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: tls_target_mapping\\nprefix: /tls-target/\\nservice: tlsinvalidsecret-http\\nambassador_id: tlsinvalidsecret\\n\"},\"labels\":{\"kat-ambassador-id\":\"tlsinvalidsecret\",\"scope\":\"AmbassadorTest\"},\"name\":\"tlsinvalidsecret-http\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8126},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8489}],\"selector\":{\"backend\":\"superpod-default\"}}}\n"
                     },
-                    "creationTimestamp": "2020-02-19T23:20:54Z",
+                    "creationTimestamp": "2020-02-26T15:53:25Z",
                     "labels": {
                         "kat-ambassador-id": "tlsinvalidsecret",
                         "scope": "AmbassadorTest"
                     },
                     "name": "tlsinvalidsecret-http",
                     "namespace": "default",
-                    "resourceVersion": "57109",
+                    "resourceVersion": "68163",
                     "selfLink": "/api/v1/namespaces/default/services/tlsinvalidsecret-http",
-                    "uid": "7a0b747c-536e-11ea-85dd-167682b5c255"
+                    "uid": "1fbdde90-58b0-11ea-86d6-0e674b3ff44f"
                 },
                 "spec": {
-                    "clusterIP": "10.111.28.81",
+                    "clusterIP": "10.102.183.200",
                     "ports": [
                         {
                             "name": "http",
@@ -146,6 +97,55 @@
                     },
                     "sessionAffinity": "None",
                     "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Module\nname: tls\nambassador_id: tlsinvalidsecret\nconfig:\n  server:\n    enabled: True\n    secret: test-certs-secret-invalid\n  missing-secret-key:\n    cert_chain_file: /nonesuch\n  bad-path-info:\n    cert_chain_file: /nonesuch\n    private_key_file: /nonesuch\n  validation-without-termination:\n    enabled: True\n    secret: test-certs-secret-invalid\n    ca_secret: ambassador-certs\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Module\\nname: tls\\nambassador_id: tlsinvalidsecret\\nconfig:\\n  server:\\n    enabled: True\\n    secret: test-certs-secret-invalid\\n  missing-secret-key:\\n    cert_chain_file: /nonesuch\\n  bad-path-info:\\n    cert_chain_file: /nonesuch\\n    private_key_file: /nonesuch\\n  validation-without-termination:\\n    enabled: True\\n    secret: test-certs-secret-invalid\\n    ca_secret: ambassador-certs\\n\"},\"labels\":{\"app.kubernetes.io/component\":\"ambassador-service\",\"kat-ambassador-id\":\"tlsinvalidsecret\",\"scope\":\"AmbassadorTest\"},\"name\":\"tlsinvalidsecret\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8080},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8443}],\"selector\":{\"service\":\"tlsinvalidsecret\"},\"type\":\"NodePort\"}}\n"
+                    },
+                    "creationTimestamp": "2020-02-26T15:53:25Z",
+                    "labels": {
+                        "app.kubernetes.io/component": "ambassador-service",
+                        "kat-ambassador-id": "tlsinvalidsecret",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "tlsinvalidsecret",
+                    "namespace": "default",
+                    "resourceVersion": "68147",
+                    "selfLink": "/api/v1/namespaces/default/services/tlsinvalidsecret",
+                    "uid": "1f5c33d2-58b0-11ea-86d6-0e674b3ff44f"
+                },
+                "spec": {
+                    "clusterIP": "10.100.26.208",
+                    "externalTrafficPolicy": "Cluster",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "nodePort": 31424,
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8080
+                        },
+                        {
+                            "name": "https",
+                            "nodePort": 30074,
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8443
+                        }
+                    ],
+                    "selector": {
+                        "service": "tlsinvalidsecret"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "NodePort"
                 },
                 "status": {
                     "loadBalancer": {}

--- a/python/tests/gold/tlsoriginationsecret/snapshots/econf.json
+++ b/python/tests/gold/tlsoriginationsecret/snapshots/econf.json
@@ -409,8 +409,7 @@
                                     "xff_num_trusted_hops": 0
                                 }
                             }
-                        ],
-                        "use_proxy_proto": false
+                        ]
                     }
                 ],
                 "listener_filters": [],

--- a/python/tests/gold/tlsoriginationsecret/snapshots/snapshot.yaml
+++ b/python/tests/gold/tlsoriginationsecret/snapshots/snapshot.yaml
@@ -26,16 +26,16 @@
                     "annotations": {
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"data\":{\"tls.crt\":\"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwakNDQW82Z0F3SUJBZ0lKQUpxa1Z4Y1RtQ1FITUEwR0NTcUdTSWIzRFFFQkN3VUFNR2d4Q3pBSkJnTlYKQkFZVEFsVlRNUXN3Q1FZRFZRUUlEQUpOUVRFUE1BMEdBMVVFQnd3R1FtOXpkRzl1TVJFd0R3WURWUVFLREFoRQpZWFJoZDJseVpURVVNQklHQTFVRUN3d0xSVzVuYVc1bFpYSnBibWN4RWpBUUJnTlZCQU1NQ1d4dlkyRnNhRzl6CmREQWVGdzB4T0RFd01UQXhNREk1TURKYUZ3MHlPREV3TURjeE1ESTVNREphTUdneEN6QUpCZ05WQkFZVEFsVlQKTVFzd0NRWURWUVFJREFKTlFURVBNQTBHQTFVRUJ3d0dRbTl6ZEc5dU1SRXdEd1lEVlFRS0RBaEVZWFJoZDJseQpaVEVVTUJJR0ExVUVDd3dMUlc1bmFXNWxaWEpwYm1jeEVqQVFCZ05WQkFNTUNXeHZZMkZzYUc5emREQ0NBU0l3CkRRWUpLb1pJaHZjTkFRRUJCUUFEZ2dFUEFEQ0NBUW9DZ2dFQkFMcTZtdS9FSzlQc1Q0YkR1WWg0aEZPVnZiblAKekV6MGpQcnVzdXcxT05MQk9jT2htbmNSTnE4c1FyTGxBZ3NicDBuTFZmQ1pSZHQ4UnlOcUFGeUJlR29XS3IvZAprQVEybVBucjBQRHlCTzk0UHo4VHdydDBtZEtEU1dGanNxMjlOYVJaT0JqdStLcGV6RytOZ3pLMk04M0ZtSldUCnFYdTI3ME9pOXlqb2VGQ3lPMjdwUkdvcktkQk9TcmIwd3ozdFdWUGk4NFZMdnFKRWprT0JVZjJYNVF3b25XWngKMktxVUJ6OUFSZVVUMzdwUVJZQkJMSUdvSnM4U042cjF4MSt1dTNLdTVxSkN1QmRlSHlJbHpKb2V0aEp2K3pTMgowN0pFc2ZKWkluMWNpdXhNNzNPbmVRTm1LUkpsL2NEb3BLemswSldRSnRSV1NnbktneFNYWkRrZjJMOENBd0VBCkFhTlRNRkV3SFFZRFZSME9CQllFRkJoQzdDeVRpNGFkSFVCd0wvTkZlRTZLdnFIRE1COEdBMVVkSXdRWU1CYUEKRkJoQzdDeVRpNGFkSFVCd0wvTkZlRTZLdnFIRE1BOEdBMVVkRXdFQi93UUZNQU1CQWY4d0RRWUpLb1pJaHZjTgpBUUVMQlFBRGdnRUJBSFJvb0xjcFdEa1IyMEhENEJ5d1BTUGRLV1hjWnN1U2tXYWZyekhoYUJ5MWJZcktIR1o1CmFodFF3L1gwQmRnMWtidlpZUDJSTzdGTFhBSlNTdXVJT0NHTFVwS0pkVHE1NDREUThNb1daWVZKbTc3UWxxam0KbHNIa2VlTlRNamFOVjdMd0MzalBkMERYelczbGVnWFRoYWpmZ2dtLzBJZXNGRzBVWjFEOTJHNURmc0hLekpSagpNSHZyVDNtVmJGZjkrSGJhRE4yT2g5VjIxUWhWSzF2M0F2dWNXczhUWCswZHZFZ1dtWHBRcndEd2pTMU04QkRYCldoWjVsZTZjVzhNYjhnZmRseG1JckpnQStuVVZzMU9EbkJKS1F3MUY4MVdkc25tWXdweVUrT2xVais4UGt1TVoKSU4rUlhQVnZMSWJ3czBmamJ4UXRzbTArZVBpRnN2d0NsUFk9Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K\",\"tls.key\":\"LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0tCk1JSUV2Z0lCQURBTkJna3Foa2lHOXcwQkFRRUZBQVNDQktnd2dnU2tBZ0VBQW9JQkFRQzZ1cHJ2eEN2VDdFK0cKdzdtSWVJUlRsYjI1ejh4TTlJejY3ckxzTlRqU3dUbkRvWnAzRVRhdkxFS3k1UUlMRzZkSnkxWHdtVVhiZkVjagphZ0JjZ1hocUZpcS8zWkFFTnBqNTY5RHc4Z1R2ZUQ4L0U4SzdkSm5TZzBsaFk3S3R2VFdrV1RnWTd2aXFYc3h2CmpZTXl0alBOeFppVms2bDd0dTlEb3ZjbzZIaFFzanR1NlVScUt5blFUa3EyOU1NOTdWbFQ0dk9GUzc2aVJJNUQKZ1ZIOWwrVU1LSjFtY2RpcWxBYy9RRVhsRTkrNlVFV0FRU3lCcUNiUEVqZXE5Y2RmcnJ0eXJ1YWlRcmdYWGg4aQpKY3lhSHJZU2IvczB0dE95UkxIeVdTSjlYSXJzVE85enAza0RaaWtTWmYzQTZLU3M1TkNWa0NiVVZrb0p5b01VCmwyUTVIOWkvQWdNQkFBRUNnZ0VBSVFsZzNpamNCRHViK21Eb2syK1hJZDZ0V1pHZE9NUlBxUm5RU0NCR2RHdEIKV0E1Z2NNNTMyVmhBV0x4UnR6dG1ScFVXR0dKVnpMWlpNN2ZPWm85MWlYZHdpcytkYWxGcWtWVWFlM2FtVHVQOApkS0YvWTRFR3Nnc09VWSs5RGlZYXRvQWVmN0xRQmZ5TnVQTFZrb1JQK0FrTXJQSWFHMHhMV3JFYmYzNVp3eFRuCnd5TTF3YVpQb1oxWjZFdmhHQkxNNzlXYmY2VFY0WXVzSTRNOEVQdU1GcWlYcDNlRmZ4L0tnNHhtYnZtN1JhYzcKOEJ3Z3pnVmljNXlSbkVXYjhpWUh5WGtyazNTL0VCYUNEMlQwUjM5VmlVM1I0VjBmMUtyV3NjRHowVmNiVWNhKwpzeVdyaVhKMHBnR1N0Q3FWK0dRYy9aNmJjOGt4VWpTTWxOUWtudVJRZ1FLQmdRRHpwM1ZaVmFzMTA3NThVT00rCnZUeTFNL0V6azg4cWhGb21kYVFiSFRlbStpeGpCNlg3RU9sRlkya3JwUkwvbURDSEpwR0MzYlJtUHNFaHVGSUwKRHhSQ2hUcEtTVmNsSytaaUNPaWE1ektTVUpxZnBOcW15RnNaQlhJNnRkNW9mWk42aFpJVTlJR2RUaGlYMjBONwppUW01UnZlSUx2UHVwMWZRMmRqd2F6Ykgvd0tCZ1FERU1MN21Mb2RqSjBNTXh6ZnM3MW1FNmZOUFhBMVY2ZEgrCllCVG4xS2txaHJpampRWmFNbXZ6dEZmL1F3Wkhmd3FKQUVuNGx2em5ncUNzZTMvUElZMy8zRERxd1p2NE1vdy8KRGdBeTBLQmpQYVJGNjhYT1B1d0VuSFN1UjhyZFg2UzI3TXQ2cEZIeFZ2YjlRRFJuSXc4a3grSFVreml4U0h5Ugo2NWxESklEdlFRS0JnUURpQTF3ZldoQlBCZk9VYlpQZUJydmhlaVVycXRob29BemYwQkJCOW9CQks1OHczVTloCjdQWDFuNWxYR3ZEY2x0ZXRCbUhEK3RQMFpCSFNyWit0RW5mQW5NVE5VK3E2V0ZhRWFhOGF3WXR2bmNWUWdTTXgKd25oK1pVYm9udnVJQWJSajJyTC9MUzl1TTVzc2dmKy9BQWM5RGs5ZXkrOEtXY0Jqd3pBeEU4TGxFUUtCZ0IzNwoxVEVZcTFoY0I4Tk1MeC9tOUtkN21kUG5IYUtqdVpSRzJ1c1RkVWNxajgxdklDbG95MWJUbVI5Si93dXVQczN4ClhWekF0cVlyTUtNcnZMekxSQWgyZm9OaVU1UDdKYlA5VDhwMFdBN1N2T2h5d0NobE5XeisvRlltWXJxeWcxbngKbHFlSHRYNU03REtJUFhvRndhcTlZYVk3V2M2K1pVdG4xbVNNajZnQkFvR0JBSTgwdU9iTkdhRndQTVYrUWhiZApBelkrSFNGQjBkWWZxRytzcTBmRVdIWTNHTXFmNFh0aVRqUEFjWlg3RmdtT3Q5Uit3TlFQK0dFNjZoV0JpKzBWCmVLV3prV0lXeS9sTVZCSW0zVWtlSlRCT3NudTFVaGhXbm5WVDhFeWhEY1FxcndPSGlhaUo3bFZSZmRoRWFyQysKSnpaU0czOHVZUVlyc0lITnRVZFgySmdPCi0tLS0tRU5EIFBSSVZBVEUgS0VZLS0tLS0K\"},\"kind\":\"Secret\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"tlsoriginationsecret\",\"scope\":\"AmbassadorTest\"},\"name\":\"test-origination-secret\",\"namespace\":\"default\"},\"type\":\"kubernetes.io/tls\"}\n"
                     },
-                    "creationTimestamp": "2020-02-19T23:20:47Z",
+                    "creationTimestamp": "2020-02-26T15:53:20Z",
                     "labels": {
                         "kat-ambassador-id": "tlsoriginationsecret",
                         "scope": "AmbassadorTest"
                     },
                     "name": "test-origination-secret",
                     "namespace": "default",
-                    "resourceVersion": "56981",
+                    "resourceVersion": "68047",
                     "selfLink": "/api/v1/namespaces/default/secrets/test-origination-secret",
-                    "uid": "75aa5a4b-536e-11ea-85dd-167682b5c255"
+                    "uid": "1c997360-58b0-11ea-86d6-0e674b3ff44f"
                 },
                 "type": "kubernetes.io/tls"
             }
@@ -49,7 +49,7 @@
                         "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Module\nambassador_id: tlsoriginationsecret\nname: tls\nconfig:\n  upstream:\n    secret: test-origination-secret\n  upstream-files:\n    cert_chain_file: /tmp/ambassador/snapshots/default/secrets-decoded/test-origination-secret/F94E4DCF30ABC50DEF240AA8024599B67CC03991.crt\n    private_key_file: /tmp/ambassador/snapshots/default/secrets-decoded/test-origination-secret/F94E4DCF30ABC50DEF240AA8024599B67CC03991.key\n\n---\napiVersion: ambassador/v0\nkind: Mapping\nname: tlsoriginationsecret-http\nprefix: /TLSOriginationSecret/\nservice: tlsoriginationsecret-http\ntls: upstream\nambassador_id: tlsoriginationsecret\n\n---\napiVersion: ambassador/v0\nkind: Mapping\nname: tlsoriginationsecret-http-files\nprefix: /TLSOriginationSecret-files/\nservice: tlsoriginationsecret-http\ntls: upstream-files\nambassador_id: tlsoriginationsecret\n",
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Module\\nambassador_id: tlsoriginationsecret\\nname: tls\\nconfig:\\n  upstream:\\n    secret: test-origination-secret\\n  upstream-files:\\n    cert_chain_file: /tmp/ambassador/snapshots/default/secrets-decoded/test-origination-secret/F94E4DCF30ABC50DEF240AA8024599B67CC03991.crt\\n    private_key_file: /tmp/ambassador/snapshots/default/secrets-decoded/test-origination-secret/F94E4DCF30ABC50DEF240AA8024599B67CC03991.key\\n\\n---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: tlsoriginationsecret-http\\nprefix: /TLSOriginationSecret/\\nservice: tlsoriginationsecret-http\\ntls: upstream\\nambassador_id: tlsoriginationsecret\\n\\n---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: tlsoriginationsecret-http-files\\nprefix: /TLSOriginationSecret-files/\\nservice: tlsoriginationsecret-http\\ntls: upstream-files\\nambassador_id: tlsoriginationsecret\\n\"},\"labels\":{\"app.kubernetes.io/component\":\"ambassador-service\",\"kat-ambassador-id\":\"tlsoriginationsecret\",\"scope\":\"AmbassadorTest\"},\"name\":\"tlsoriginationsecret\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8080},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8443}],\"selector\":{\"service\":\"tlsoriginationsecret\"},\"type\":\"NodePort\"}}\n"
                     },
-                    "creationTimestamp": "2020-02-19T23:20:46Z",
+                    "creationTimestamp": "2020-02-26T15:53:21Z",
                     "labels": {
                         "app.kubernetes.io/component": "ambassador-service",
                         "kat-ambassador-id": "tlsoriginationsecret",
@@ -57,24 +57,24 @@
                     },
                     "name": "tlsoriginationsecret",
                     "namespace": "default",
-                    "resourceVersion": "56965",
+                    "resourceVersion": "68067",
                     "selfLink": "/api/v1/namespaces/default/services/tlsoriginationsecret",
-                    "uid": "7536fc2e-536e-11ea-85dd-167682b5c255"
+                    "uid": "1d011528-58b0-11ea-86d6-0e674b3ff44f"
                 },
                 "spec": {
-                    "clusterIP": "10.101.195.120",
+                    "clusterIP": "10.108.209.173",
                     "externalTrafficPolicy": "Cluster",
                     "ports": [
                         {
                             "name": "http",
-                            "nodePort": 32660,
+                            "nodePort": 30431,
                             "port": 80,
                             "protocol": "TCP",
                             "targetPort": 8080
                         },
                         {
                             "name": "https",
-                            "nodePort": 31319,
+                            "nodePort": 31968,
                             "port": 443,
                             "protocol": "TCP",
                             "targetPort": 8443
@@ -97,7 +97,7 @@
                     "annotations": {
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"tlsoriginationsecret\",\"scope\":\"AmbassadorTest\",\"service\":\"tlsoriginationsecret-admin\"},\"name\":\"tlsoriginationsecret-admin\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"tlsoriginationsecret-admin\",\"port\":8877,\"targetPort\":8877}],\"selector\":{\"service\":\"tlsoriginationsecret\"},\"type\":\"NodePort\"}}\n"
                     },
-                    "creationTimestamp": "2020-02-19T23:20:47Z",
+                    "creationTimestamp": "2020-02-26T15:53:21Z",
                     "labels": {
                         "kat-ambassador-id": "tlsoriginationsecret",
                         "scope": "AmbassadorTest",
@@ -105,17 +105,17 @@
                     },
                     "name": "tlsoriginationsecret-admin",
                     "namespace": "default",
-                    "resourceVersion": "56973",
+                    "resourceVersion": "68072",
                     "selfLink": "/api/v1/namespaces/default/services/tlsoriginationsecret-admin",
-                    "uid": "759381bc-536e-11ea-85dd-167682b5c255"
+                    "uid": "1d12b155-58b0-11ea-86d6-0e674b3ff44f"
                 },
                 "spec": {
-                    "clusterIP": "10.103.184.27",
+                    "clusterIP": "10.101.66.83",
                     "externalTrafficPolicy": "Cluster",
                     "ports": [
                         {
                             "name": "tlsoriginationsecret-admin",
-                            "nodePort": 32058,
+                            "nodePort": 31314,
                             "port": 8877,
                             "protocol": "TCP",
                             "targetPort": 8877
@@ -138,19 +138,19 @@
                     "annotations": {
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"tlsoriginationsecret\",\"scope\":\"AmbassadorTest\"},\"name\":\"tlsoriginationsecret-http\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8124},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8487}],\"selector\":{\"backend\":\"superpod-default\"}}}\n"
                     },
-                    "creationTimestamp": "2020-02-19T23:20:48Z",
+                    "creationTimestamp": "2020-02-26T15:53:22Z",
                     "labels": {
                         "kat-ambassador-id": "tlsoriginationsecret",
                         "scope": "AmbassadorTest"
                     },
                     "name": "tlsoriginationsecret-http",
                     "namespace": "default",
-                    "resourceVersion": "56995",
+                    "resourceVersion": "68080",
                     "selfLink": "/api/v1/namespaces/default/services/tlsoriginationsecret-http",
-                    "uid": "764723ba-536e-11ea-85dd-167682b5c255"
+                    "uid": "1d83d47a-58b0-11ea-86d6-0e674b3ff44f"
                 },
                 "spec": {
-                    "clusterIP": "10.106.245.199",
+                    "clusterIP": "10.102.41.229",
                     "ports": [
                         {
                             "name": "http",

--- a/python/tests/gold/tracingexternalauthtest/snapshots/aconf.json
+++ b/python/tests/gold/tracingexternalauthtest/snapshots/aconf.json
@@ -4,10 +4,10 @@
         "tracingexternalauthtest-http.default.1": [
             "apiVersion ambassador/v0 is deprecated, consider upgrading"
         ],
-        "tracingexternalauthtest.default.1": [
+        "zipkin-auth.default.1": [
             "apiVersion ambassador/v0 is deprecated, consider upgrading"
         ],
-        "tracingexternalauthtest.default.2": [
+        "zipkin-auth.default.2": [
             "apiVersion ambassador/v0 is deprecated, consider upgrading"
         ]
     },
@@ -135,25 +135,24 @@
             "serialization": "ambassador_id: tracingexternalauthtest\napiVersion: ambassador/v0\nkind: Mapping\nmetadata_labels:\n  kat-ambassador-id: tracingexternalauthtest\n  scope: AmbassadorTest\nname: tracing_target_mapping\nnamespace: default\nprefix: /target/\nservice: tracingexternalauthtest-http\n",
             "service": "tracingexternalauthtest-http"
         },
-        "tracingexternalauthtest.default.1": {
+        "zipkin-auth.default.1": {
             "_referenced_by": {},
             "ambassador_id": "tracingexternalauthtest",
             "apiVersion": "getambassador.io/v0",
             "driver": "zipkin",
             "kind": "TracingService",
-            "location": "tracingexternalauthtest.default.1",
+            "location": "zipkin-auth.default.1",
             "metadata_labels": {
-                "app.kubernetes.io/component": "ambassador-service",
                 "kat-ambassador-id": "tracingexternalauthtest",
                 "scope": "AmbassadorTest"
             },
             "name": "tracing-auth",
             "namespace": "default",
-            "rkey": "tracingexternalauthtest.default.1",
-            "serialization": "ambassador_id: tracingexternalauthtest\napiVersion: ambassador/v0\ndriver: zipkin\nkind: TracingService\nmetadata_labels:\n  app.kubernetes.io/component: ambassador-service\n  kat-ambassador-id: tracingexternalauthtest\n  scope: AmbassadorTest\nname: tracing-auth\nnamespace: default\nservice: zipkin-auth:9411\n",
+            "rkey": "zipkin-auth.default.1",
+            "serialization": "ambassador_id: tracingexternalauthtest\napiVersion: ambassador/v0\ndriver: zipkin\nkind: TracingService\nmetadata_labels:\n  kat-ambassador-id: tracingexternalauthtest\n  scope: AmbassadorTest\nname: tracing-auth\nnamespace: default\nservice: zipkin-auth:9411\n",
             "service": "zipkin-auth:9411"
         },
-        "tracingexternalauthtest.default.2": {
+        "zipkin-auth.default.2": {
             "_referenced_by": {},
             "allowed_headers": [
                 "Requested-Status",
@@ -163,17 +162,16 @@
             "apiVersion": "getambassador.io/v0",
             "auth_service": "tracingexternalauthtest-ahttp-auth",
             "kind": "AuthService",
-            "location": "tracingexternalauthtest.default.2",
+            "location": "zipkin-auth.default.2",
             "metadata_labels": {
-                "app.kubernetes.io/component": "ambassador-service",
                 "kat-ambassador-id": "tracingexternalauthtest",
                 "scope": "AmbassadorTest"
             },
             "name": "tracingexternalauthtest-ahttp-auth",
             "namespace": "default",
             "path_prefix": "/extauth",
-            "rkey": "tracingexternalauthtest.default.2",
-            "serialization": "allowed_headers:\n- Requested-Status\n- Requested-Header\nambassador_id: tracingexternalauthtest\napiVersion: ambassador/v0\nauth_service: tracingexternalauthtest-ahttp-auth\nkind: AuthService\nmetadata_labels:\n  app.kubernetes.io/component: ambassador-service\n  kat-ambassador-id: tracingexternalauthtest\n  scope: AmbassadorTest\nname: tracingexternalauthtest-ahttp-auth\nnamespace: default\npath_prefix: /extauth\n"
+            "rkey": "zipkin-auth.default.2",
+            "serialization": "allowed_headers:\n- Requested-Status\n- Requested-Header\nambassador_id: tracingexternalauthtest\napiVersion: ambassador/v0\nauth_service: tracingexternalauthtest-ahttp-auth\nkind: AuthService\nmetadata_labels:\n  kat-ambassador-id: tracingexternalauthtest\n  scope: AmbassadorTest\nname: tracingexternalauthtest-ahttp-auth\nnamespace: default\npath_prefix: /extauth\n"
         }
     },
     "auth_configs": {
@@ -187,7 +185,6 @@
             "auth_service": "tracingexternalauthtest-ahttp-auth",
             "kind": "AuthService",
             "metadata_labels": {
-                "app.kubernetes.io/component": "ambassador-service",
                 "kat-ambassador-id": "tracingexternalauthtest",
                 "scope": "AmbassadorTest"
             },
@@ -282,7 +279,6 @@
             "driver": "zipkin",
             "kind": "TracingService",
             "metadata_labels": {
-                "app.kubernetes.io/component": "ambassador-service",
                 "kat-ambassador-id": "tracingexternalauthtest",
                 "scope": "AmbassadorTest"
             },

--- a/python/tests/gold/tracingexternalauthtest/snapshots/econf.json
+++ b/python/tests/gold/tracingexternalauthtest/snapshots/econf.json
@@ -498,8 +498,7 @@
                                     "xff_num_trusted_hops": 0
                                 }
                             }
-                        ],
-                        "use_proxy_proto": false
+                        ]
                     }
                 ],
                 "listener_filters": [],

--- a/python/tests/gold/tracingexternalauthtest/snapshots/ir.json
+++ b/python/tests/gold/tracingexternalauthtest/snapshots/ir.json
@@ -88,7 +88,7 @@
             "_namespace": "default",
             "_port": 80,
             "_referenced_by": [
-                "tracingexternalauthtest.default.2"
+                "zipkin-auth.default.2"
             ],
             "_rkey": "cluster_extauth_tracingexternalauthtest_ahttp_auth_default",
             "connect_timeout_ms": 3000,
@@ -98,7 +98,7 @@
             "ignore_cluster": false,
             "kind": "IRCluster",
             "lb_type": "round_robin",
-            "location": "tracingexternalauthtest.default.2",
+            "location": "zipkin-auth.default.2",
             "name": "cluster_extauth_tracingexternalauthtest_ahttp_auth_default",
             "namespace": "default",
             "service": "tracingexternalauthtest-ahttp-auth",
@@ -122,7 +122,7 @@
             "_namespace": "default",
             "_port": 9411,
             "_referenced_by": [
-                "tracingexternalauthtest.default.1"
+                "zipkin-auth.default.1"
             ],
             "_rkey": "cluster_tracing_zipkin_auth_9411_default",
             "connect_timeout_ms": 3000,
@@ -132,7 +132,7 @@
             "ignore_cluster": false,
             "kind": "IRCluster",
             "lb_type": "round_robin",
-            "location": "tracingexternalauthtest.default.1",
+            "location": "zipkin-auth.default.1",
             "name": "cluster_tracing_zipkin_auth_9411_default",
             "namespace": "default",
             "service": "zipkin-auth:9411",
@@ -189,9 +189,9 @@
             "_active": true,
             "_errored": false,
             "_referenced_by": [
-                "tracingexternalauthtest.default.2"
+                "zipkin-auth.default.2"
             ],
-            "_rkey": "tracingexternalauthtest.default.2",
+            "_rkey": "zipkin-auth.default.2",
             "add_linkerd_headers": false,
             "allow_request_body": false,
             "allowed_authorization_headers": [],
@@ -209,7 +209,7 @@
                 "_namespace": "default",
                 "_port": 80,
                 "_referenced_by": [
-                    "tracingexternalauthtest.default.2"
+                    "zipkin-auth.default.2"
                 ],
                 "_rkey": "cluster_extauth_tracingexternalauthtest_ahttp_auth_default",
                 "connect_timeout_ms": 3000,
@@ -219,7 +219,7 @@
                 "ignore_cluster": false,
                 "kind": "IRCluster",
                 "lb_type": "round_robin",
-                "location": "tracingexternalauthtest.default.2",
+                "location": "zipkin-auth.default.2",
                 "name": "cluster_extauth_tracingexternalauthtest_ahttp_auth_default",
                 "namespace": "default",
                 "service": "tracingexternalauthtest-ahttp-auth",
@@ -241,11 +241,11 @@
                     100,
                     false,
                     null,
-                    "tracingexternalauthtest.default.2"
+                    "zipkin-auth.default.2"
                 ]
             },
             "kind": "IRAuth",
-            "location": "tracingexternalauthtest.default.2",
+            "location": "zipkin-auth.default.2",
             "name": "extauth",
             "namespace": "default",
             "path_prefix": "/extauth",
@@ -762,9 +762,9 @@
         "_active": true,
         "_errored": false,
         "_referenced_by": [
-            "tracingexternalauthtest.default.1"
+            "zipkin-auth.default.1"
         ],
-        "_rkey": "tracingexternalauthtest.default.1",
+        "_rkey": "zipkin-auth.default.1",
         "cluster": {
             "_active": true,
             "_errored": false,
@@ -773,7 +773,7 @@
             "_namespace": "default",
             "_port": 9411,
             "_referenced_by": [
-                "tracingexternalauthtest.default.1"
+                "zipkin-auth.default.1"
             ],
             "_rkey": "cluster_tracing_zipkin_auth_9411_default",
             "connect_timeout_ms": 3000,
@@ -783,7 +783,7 @@
             "ignore_cluster": false,
             "kind": "IRCluster",
             "lb_type": "round_robin",
-            "location": "tracingexternalauthtest.default.1",
+            "location": "zipkin-auth.default.1",
             "name": "cluster_tracing_zipkin_auth_9411_default",
             "namespace": "default",
             "service": "zipkin-auth:9411",
@@ -805,7 +805,7 @@
         },
         "grpc": false,
         "kind": "ir.tracing",
-        "location": "tracingexternalauthtest.default.1",
+        "location": "zipkin-auth.default.1",
         "name": "tracing",
         "namespace": "default",
         "service": "zipkin-auth:9411",

--- a/python/tests/gold/tracingexternalauthtest/snapshots/snapshot.yaml
+++ b/python/tests/gold/tracingexternalauthtest/snapshots/snapshot.yaml
@@ -21,9 +21,49 @@
                 "metadata": {
                     "annotations": {
                         "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: TracingService\nname: tracing-auth\nservice: zipkin-auth:9411\ndriver: zipkin\nambassador_id: tracingexternalauthtest\n\n---\napiVersion: ambassador/v0\nkind: AuthService\nname: tracingexternalauthtest-ahttp-auth\nauth_service: \"tracingexternalauthtest-ahttp-auth\"\npath_prefix: \"/extauth\"\nallowed_headers:\n- Requested-Status\n- Requested-Header\nambassador_id: tracingexternalauthtest\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: TracingService\\nname: tracing-auth\\nservice: zipkin-auth:9411\\ndriver: zipkin\\nambassador_id: tracingexternalauthtest\\n\\n---\\napiVersion: ambassador/v0\\nkind: AuthService\\nname: tracingexternalauthtest-ahttp-auth\\nauth_service: \\\"tracingexternalauthtest-ahttp-auth\\\"\\npath_prefix: \\\"/extauth\\\"\\nallowed_headers:\\n- Requested-Status\\n- Requested-Header\\nambassador_id: tracingexternalauthtest\\n\"},\"labels\":{\"app.kubernetes.io/component\":\"ambassador-service\",\"kat-ambassador-id\":\"tracingexternalauthtest\",\"scope\":\"AmbassadorTest\"},\"name\":\"tracingexternalauthtest\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8080},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8443}],\"selector\":{\"service\":\"tracingexternalauthtest\"},\"type\":\"NodePort\"}}\n"
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: TracingService\\nname: tracing-auth\\nservice: zipkin-auth:9411\\ndriver: zipkin\\nambassador_id: tracingexternalauthtest\\n\\n---\\napiVersion: ambassador/v0\\nkind: AuthService\\nname: tracingexternalauthtest-ahttp-auth\\nauth_service: \\\"tracingexternalauthtest-ahttp-auth\\\"\\npath_prefix: \\\"/extauth\\\"\\nallowed_headers:\\n- Requested-Status\\n- Requested-Header\\nambassador_id: tracingexternalauthtest\\n\"},\"labels\":{\"kat-ambassador-id\":\"tracingexternalauthtest\",\"scope\":\"AmbassadorTest\"},\"name\":\"zipkin-auth\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":9411,\"targetPort\":\"http\"}],\"selector\":{\"app\":\"zipkin-auth\"},\"type\":\"NodePort\"}}\n"
                     },
-                    "creationTimestamp": "2020-02-19T23:21:40Z",
+                    "creationTimestamp": "2020-02-26T15:53:55Z",
+                    "labels": {
+                        "kat-ambassador-id": "tracingexternalauthtest",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "zipkin-auth",
+                    "namespace": "default",
+                    "resourceVersion": "68649",
+                    "selfLink": "/api/v1/namespaces/default/services/zipkin-auth",
+                    "uid": "3133ba5e-58b0-11ea-86d6-0e674b3ff44f"
+                },
+                "spec": {
+                    "clusterIP": "10.103.118.99",
+                    "externalTrafficPolicy": "Cluster",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "nodePort": 31689,
+                            "port": 9411,
+                            "protocol": "TCP",
+                            "targetPort": "http"
+                        }
+                    ],
+                    "selector": {
+                        "app": "zipkin-auth"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "NodePort"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"app.kubernetes.io/component\":\"ambassador-service\",\"kat-ambassador-id\":\"tracingexternalauthtest\",\"scope\":\"AmbassadorTest\"},\"name\":\"tracingexternalauthtest\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8080},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8443}],\"selector\":{\"service\":\"tracingexternalauthtest\"},\"type\":\"NodePort\"}}\n"
+                    },
+                    "creationTimestamp": "2020-02-26T15:53:58Z",
                     "labels": {
                         "app.kubernetes.io/component": "ambassador-service",
                         "kat-ambassador-id": "tracingexternalauthtest",
@@ -31,24 +71,24 @@
                     },
                     "name": "tracingexternalauthtest",
                     "namespace": "default",
-                    "resourceVersion": "57682",
+                    "resourceVersion": "68691",
                     "selfLink": "/api/v1/namespaces/default/services/tracingexternalauthtest",
-                    "uid": "95932cc8-536e-11ea-85dd-167682b5c255"
+                    "uid": "331389f5-58b0-11ea-86d6-0e674b3ff44f"
                 },
                 "spec": {
-                    "clusterIP": "10.108.234.167",
+                    "clusterIP": "10.101.179.101",
                     "externalTrafficPolicy": "Cluster",
                     "ports": [
                         {
                             "name": "http",
-                            "nodePort": 31982,
+                            "nodePort": 32576,
                             "port": 80,
                             "protocol": "TCP",
                             "targetPort": 8080
                         },
                         {
                             "name": "https",
-                            "nodePort": 31073,
+                            "nodePort": 32344,
                             "port": 443,
                             "protocol": "TCP",
                             "targetPort": 8443
@@ -71,7 +111,7 @@
                     "annotations": {
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"tracingexternalauthtest\",\"scope\":\"AmbassadorTest\",\"service\":\"tracingexternalauthtest-admin\"},\"name\":\"tracingexternalauthtest-admin\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"tracingexternalauthtest-admin\",\"port\":8877,\"targetPort\":8877}],\"selector\":{\"service\":\"tracingexternalauthtest\"},\"type\":\"NodePort\"}}\n"
                     },
-                    "creationTimestamp": "2020-02-19T23:21:42Z",
+                    "creationTimestamp": "2020-02-26T15:53:58Z",
                     "labels": {
                         "kat-ambassador-id": "tracingexternalauthtest",
                         "scope": "AmbassadorTest",
@@ -79,17 +119,17 @@
                     },
                     "name": "tracingexternalauthtest-admin",
                     "namespace": "default",
-                    "resourceVersion": "57698",
+                    "resourceVersion": "68700",
                     "selfLink": "/api/v1/namespaces/default/services/tracingexternalauthtest-admin",
-                    "uid": "96a31d23-536e-11ea-85dd-167682b5c255"
+                    "uid": "3331277f-58b0-11ea-86d6-0e674b3ff44f"
                 },
                 "spec": {
-                    "clusterIP": "10.101.4.189",
+                    "clusterIP": "10.110.129.206",
                     "externalTrafficPolicy": "Cluster",
                     "ports": [
                         {
                             "name": "tracingexternalauthtest-admin",
-                            "nodePort": 32707,
+                            "nodePort": 30587,
                             "port": 8877,
                             "protocol": "TCP",
                             "targetPort": 8877
@@ -112,19 +152,19 @@
                     "annotations": {
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"tracingexternalauthtest\",\"scope\":\"AmbassadorTest\"},\"name\":\"tracingexternalauthtest-ahttp-auth\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8080},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8443}],\"selector\":{\"backend\":\"tracingexternalauthtest-ahttp-auth\"}}}\n"
                     },
-                    "creationTimestamp": "2020-02-19T23:21:48Z",
+                    "creationTimestamp": "2020-02-26T15:53:59Z",
                     "labels": {
                         "kat-ambassador-id": "tracingexternalauthtest",
                         "scope": "AmbassadorTest"
                     },
                     "name": "tracingexternalauthtest-ahttp-auth",
                     "namespace": "default",
-                    "resourceVersion": "57748",
+                    "resourceVersion": "68713",
                     "selfLink": "/api/v1/namespaces/default/services/tracingexternalauthtest-ahttp-auth",
-                    "uid": "9a0f1d3f-536e-11ea-85dd-167682b5c255"
+                    "uid": "33950966-58b0-11ea-86d6-0e674b3ff44f"
                 },
                 "spec": {
-                    "clusterIP": "10.110.108.134",
+                    "clusterIP": "10.109.105.199",
                     "ports": [
                         {
                             "name": "http",
@@ -157,19 +197,19 @@
                         "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: tracing_target_mapping\nprefix: /target/\nservice: tracingexternalauthtest-http\nambassador_id: tracingexternalauthtest\n",
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: tracing_target_mapping\\nprefix: /target/\\nservice: tracingexternalauthtest-http\\nambassador_id: tracingexternalauthtest\\n\"},\"labels\":{\"kat-ambassador-id\":\"tracingexternalauthtest\",\"scope\":\"AmbassadorTest\"},\"name\":\"tracingexternalauthtest-http\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8135},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8498}],\"selector\":{\"backend\":\"superpod-default\"}}}\n"
                     },
-                    "creationTimestamp": "2020-02-19T23:21:47Z",
+                    "creationTimestamp": "2020-02-26T15:53:58Z",
                     "labels": {
                         "kat-ambassador-id": "tracingexternalauthtest",
                         "scope": "AmbassadorTest"
                     },
                     "name": "tracingexternalauthtest-http",
                     "namespace": "default",
-                    "resourceVersion": "57730",
+                    "resourceVersion": "68706",
                     "selfLink": "/api/v1/namespaces/default/services/tracingexternalauthtest-http",
-                    "uid": "997c5286-536e-11ea-85dd-167682b5c255"
+                    "uid": "33530974-58b0-11ea-86d6-0e674b3ff44f"
                 },
                 "spec": {
-                    "clusterIP": "10.104.81.119",
+                    "clusterIP": "10.103.175.47",
                     "ports": [
                         {
                             "name": "http",
@@ -189,46 +229,6 @@
                     },
                     "sessionAffinity": "None",
                     "type": "ClusterIP"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"tracingexternalauthtest\",\"scope\":\"AmbassadorTest\"},\"name\":\"zipkin-auth\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":9411,\"targetPort\":\"http\"}],\"selector\":{\"app\":\"zipkin-auth\"},\"type\":\"NodePort\"}}\n"
-                    },
-                    "creationTimestamp": "2020-02-19T23:21:45Z",
-                    "labels": {
-                        "kat-ambassador-id": "tracingexternalauthtest",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "zipkin-auth",
-                    "namespace": "default",
-                    "resourceVersion": "57716",
-                    "selfLink": "/api/v1/namespaces/default/services/zipkin-auth",
-                    "uid": "9895402e-536e-11ea-85dd-167682b5c255"
-                },
-                "spec": {
-                    "clusterIP": "10.102.177.118",
-                    "externalTrafficPolicy": "Cluster",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "nodePort": 32294,
-                            "port": 9411,
-                            "protocol": "TCP",
-                            "targetPort": "http"
-                        }
-                    ],
-                    "selector": {
-                        "app": "zipkin-auth"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "NodePort"
                 },
                 "status": {
                     "loadBalancer": {}

--- a/python/tests/gold/tracingtest/snapshots/aconf.json
+++ b/python/tests/gold/tracingtest/snapshots/aconf.json
@@ -4,7 +4,7 @@
         "tracingtest-http.default.1": [
             "apiVersion ambassador/v0 is deprecated, consider upgrading"
         ],
-        "tracingtest.default.1": [
+        "zipkin.default.1": [
             "apiVersion ambassador/v0 is deprecated, consider upgrading"
         ]
     },
@@ -116,22 +116,21 @@
             "serialization": "ambassador_id: tracingtest\napiVersion: ambassador/v0\nkind: Mapping\nmetadata_labels:\n  kat-ambassador-id: tracingtest\n  scope: AmbassadorTest\nname: tracing_target_mapping\nnamespace: default\nprefix: /target/\nservice: tracingtest-http\n",
             "service": "tracingtest-http"
         },
-        "tracingtest.default.1": {
+        "zipkin.default.1": {
             "_referenced_by": {},
             "ambassador_id": "tracingtest",
             "apiVersion": "getambassador.io/v0",
             "driver": "zipkin",
             "kind": "TracingService",
-            "location": "tracingtest.default.1",
+            "location": "zipkin.default.1",
             "metadata_labels": {
-                "app.kubernetes.io/component": "ambassador-service",
                 "kat-ambassador-id": "tracingtest",
                 "scope": "AmbassadorTest"
             },
             "name": "tracing",
             "namespace": "default",
-            "rkey": "tracingtest.default.1",
-            "serialization": "ambassador_id: tracingtest\napiVersion: ambassador/v0\ndriver: zipkin\nkind: TracingService\nmetadata_labels:\n  app.kubernetes.io/component: ambassador-service\n  kat-ambassador-id: tracingtest\n  scope: AmbassadorTest\nname: tracing\nnamespace: default\nservice: zipkin:9411\n",
+            "rkey": "zipkin.default.1",
+            "serialization": "ambassador_id: tracingtest\napiVersion: ambassador/v0\ndriver: zipkin\nkind: TracingService\nmetadata_labels:\n  kat-ambassador-id: tracingtest\n  scope: AmbassadorTest\nname: tracing\nnamespace: default\nservice: zipkin:9411\n",
             "service": "zipkin:9411"
         }
     },
@@ -209,7 +208,6 @@
             "driver": "zipkin",
             "kind": "TracingService",
             "metadata_labels": {
-                "app.kubernetes.io/component": "ambassador-service",
                 "kat-ambassador-id": "tracingtest",
                 "scope": "AmbassadorTest"
             },

--- a/python/tests/gold/tracingtest/snapshots/econf.json
+++ b/python/tests/gold/tracingtest/snapshots/econf.json
@@ -334,8 +334,7 @@
                                     "xff_num_trusted_hops": 0
                                 }
                             }
-                        ],
-                        "use_proxy_proto": false
+                        ]
                     }
                 ],
                 "listener_filters": [],

--- a/python/tests/gold/tracingtest/snapshots/ir.json
+++ b/python/tests/gold/tracingtest/snapshots/ir.json
@@ -88,7 +88,7 @@
             "_namespace": "default",
             "_port": 9411,
             "_referenced_by": [
-                "tracingtest.default.1"
+                "zipkin.default.1"
             ],
             "_rkey": "cluster_tracing_zipkin_9411_default",
             "connect_timeout_ms": 3000,
@@ -98,7 +98,7 @@
             "ignore_cluster": false,
             "kind": "IRCluster",
             "lb_type": "round_robin",
-            "location": "tracingtest.default.1",
+            "location": "zipkin.default.1",
             "name": "cluster_tracing_zipkin_9411_default",
             "namespace": "default",
             "service": "zipkin:9411",
@@ -644,9 +644,9 @@
         "_active": true,
         "_errored": false,
         "_referenced_by": [
-            "tracingtest.default.1"
+            "zipkin.default.1"
         ],
-        "_rkey": "tracingtest.default.1",
+        "_rkey": "zipkin.default.1",
         "cluster": {
             "_active": true,
             "_errored": false,
@@ -655,7 +655,7 @@
             "_namespace": "default",
             "_port": 9411,
             "_referenced_by": [
-                "tracingtest.default.1"
+                "zipkin.default.1"
             ],
             "_rkey": "cluster_tracing_zipkin_9411_default",
             "connect_timeout_ms": 3000,
@@ -665,7 +665,7 @@
             "ignore_cluster": false,
             "kind": "IRCluster",
             "lb_type": "round_robin",
-            "location": "tracingtest.default.1",
+            "location": "zipkin.default.1",
             "name": "cluster_tracing_zipkin_9411_default",
             "namespace": "default",
             "service": "zipkin:9411",
@@ -687,7 +687,7 @@
         },
         "grpc": false,
         "kind": "ir.tracing",
-        "location": "tracingtest.default.1",
+        "location": "zipkin.default.1",
         "name": "tracing",
         "namespace": "default",
         "service": "zipkin:9411",

--- a/python/tests/gold/tracingtest/snapshots/snapshot.yaml
+++ b/python/tests/gold/tracingtest/snapshots/snapshot.yaml
@@ -20,22 +20,111 @@
                 "kind": "Service",
                 "metadata": {
                     "annotations": {
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"app.kubernetes.io/component\":\"ambassador-service\",\"kat-ambassador-id\":\"tracingtest\",\"scope\":\"AmbassadorTest\"},\"name\":\"tracingtest\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8080},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8443}],\"selector\":{\"service\":\"tracingtest\"},\"type\":\"NodePort\"}}\n"
+                    },
+                    "creationTimestamp": "2020-02-26T15:53:47Z",
+                    "labels": {
+                        "app.kubernetes.io/component": "ambassador-service",
+                        "kat-ambassador-id": "tracingtest",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "tracingtest",
+                    "namespace": "default",
+                    "resourceVersion": "68530",
+                    "selfLink": "/api/v1/namespaces/default/services/tracingtest",
+                    "uid": "2c916d0f-58b0-11ea-86d6-0e674b3ff44f"
+                },
+                "spec": {
+                    "clusterIP": "10.107.81.114",
+                    "externalTrafficPolicy": "Cluster",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "nodePort": 31265,
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8080
+                        },
+                        {
+                            "name": "https",
+                            "nodePort": 31257,
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8443
+                        }
+                    ],
+                    "selector": {
+                        "service": "tracingtest"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "NodePort"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"tracingtest\",\"scope\":\"AmbassadorTest\",\"service\":\"tracingtest-admin\"},\"name\":\"tracingtest-admin\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"tracingtest-admin\",\"port\":8877,\"targetPort\":8877}],\"selector\":{\"service\":\"tracingtest\"},\"type\":\"NodePort\"}}\n"
+                    },
+                    "creationTimestamp": "2020-02-26T15:53:47Z",
+                    "labels": {
+                        "kat-ambassador-id": "tracingtest",
+                        "scope": "AmbassadorTest",
+                        "service": "tracingtest-admin"
+                    },
+                    "name": "tracingtest-admin",
+                    "namespace": "default",
+                    "resourceVersion": "68539",
+                    "selfLink": "/api/v1/namespaces/default/services/tracingtest-admin",
+                    "uid": "2cf1dc79-58b0-11ea-86d6-0e674b3ff44f"
+                },
+                "spec": {
+                    "clusterIP": "10.101.46.71",
+                    "externalTrafficPolicy": "Cluster",
+                    "ports": [
+                        {
+                            "name": "tracingtest-admin",
+                            "nodePort": 32075,
+                            "port": 8877,
+                            "protocol": "TCP",
+                            "targetPort": 8877
+                        }
+                    ],
+                    "selector": {
+                        "service": "tracingtest"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "NodePort"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
                         "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: tracing_target_mapping\nprefix: /target/\nservice: tracingtest-http\nambassador_id: tracingtest\n",
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: tracing_target_mapping\\nprefix: /target/\\nservice: tracingtest-http\\nambassador_id: tracingtest\\n\"},\"labels\":{\"kat-ambassador-id\":\"tracingtest\",\"scope\":\"AmbassadorTest\"},\"name\":\"tracingtest-http\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8133},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8496}],\"selector\":{\"backend\":\"superpod-default\"}}}\n"
                     },
-                    "creationTimestamp": "2020-02-19T23:21:28Z",
+                    "creationTimestamp": "2020-02-26T15:53:48Z",
                     "labels": {
                         "kat-ambassador-id": "tracingtest",
                         "scope": "AmbassadorTest"
                     },
                     "name": "tracingtest-http",
                     "namespace": "default",
-                    "resourceVersion": "57549",
+                    "resourceVersion": "68549",
                     "selfLink": "/api/v1/namespaces/default/services/tracingtest-http",
-                    "uid": "8e6b2d4a-536e-11ea-85dd-167682b5c255"
+                    "uid": "2d34825f-58b0-11ea-86d6-0e674b3ff44f"
                 },
                 "spec": {
-                    "clusterIP": "10.99.8.91",
+                    "clusterIP": "10.96.204.171",
                     "ports": [
                         {
                             "name": "http",
@@ -65,26 +154,27 @@
                 "kind": "Service",
                 "metadata": {
                     "annotations": {
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"tracingtest\",\"scope\":\"AmbassadorTest\"},\"name\":\"zipkin\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":9411,\"targetPort\":\"http\"}],\"selector\":{\"app\":\"zipkin\"},\"type\":\"NodePort\"}}\n"
+                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: TracingService\nname: tracing\nservice: zipkin:9411\ndriver: zipkin\nambassador_id: tracingtest\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: TracingService\\nname: tracing\\nservice: zipkin:9411\\ndriver: zipkin\\nambassador_id: tracingtest\\n\"},\"labels\":{\"kat-ambassador-id\":\"tracingtest\",\"scope\":\"AmbassadorTest\"},\"name\":\"zipkin\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":9411,\"targetPort\":\"http\"}],\"selector\":{\"app\":\"zipkin\"},\"type\":\"NodePort\"}}\n"
                     },
-                    "creationTimestamp": "2020-02-19T23:21:28Z",
+                    "creationTimestamp": "2020-02-26T15:53:45Z",
                     "labels": {
                         "kat-ambassador-id": "tracingtest",
                         "scope": "AmbassadorTest"
                     },
                     "name": "zipkin",
                     "namespace": "default",
-                    "resourceVersion": "57541",
+                    "resourceVersion": "68491",
                     "selfLink": "/api/v1/namespaces/default/services/zipkin",
-                    "uid": "8de41237-536e-11ea-85dd-167682b5c255"
+                    "uid": "2bae14dd-58b0-11ea-86d6-0e674b3ff44f"
                 },
                 "spec": {
-                    "clusterIP": "10.110.211.10",
+                    "clusterIP": "10.105.81.160",
                     "externalTrafficPolicy": "Cluster",
                     "ports": [
                         {
                             "name": "http",
-                            "nodePort": 30688,
+                            "nodePort": 32316,
                             "port": 9411,
                             "protocol": "TCP",
                             "targetPort": "http"
@@ -92,96 +182,6 @@
                     ],
                     "selector": {
                         "app": "zipkin"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "NodePort"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: TracingService\nname: tracing\nservice: zipkin:9411\ndriver: zipkin\nambassador_id: tracingtest\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: TracingService\\nname: tracing\\nservice: zipkin:9411\\ndriver: zipkin\\nambassador_id: tracingtest\\n\"},\"labels\":{\"app.kubernetes.io/component\":\"ambassador-service\",\"kat-ambassador-id\":\"tracingtest\",\"scope\":\"AmbassadorTest\"},\"name\":\"tracingtest\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8080},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8443}],\"selector\":{\"service\":\"tracingtest\"},\"type\":\"NodePort\"}}\n"
-                    },
-                    "creationTimestamp": "2020-02-19T23:21:26Z",
-                    "labels": {
-                        "app.kubernetes.io/component": "ambassador-service",
-                        "kat-ambassador-id": "tracingtest",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "tracingtest",
-                    "namespace": "default",
-                    "resourceVersion": "57514",
-                    "selfLink": "/api/v1/namespaces/default/services/tracingtest",
-                    "uid": "8d1ac268-536e-11ea-85dd-167682b5c255"
-                },
-                "spec": {
-                    "clusterIP": "10.101.65.186",
-                    "externalTrafficPolicy": "Cluster",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "nodePort": 30457,
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8080
-                        },
-                        {
-                            "name": "https",
-                            "nodePort": 30163,
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8443
-                        }
-                    ],
-                    "selector": {
-                        "service": "tracingtest"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "NodePort"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"tracingtest\",\"scope\":\"AmbassadorTest\",\"service\":\"tracingtest-admin\"},\"name\":\"tracingtest-admin\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"tracingtest-admin\",\"port\":8877,\"targetPort\":8877}],\"selector\":{\"service\":\"tracingtest\"},\"type\":\"NodePort\"}}\n"
-                    },
-                    "creationTimestamp": "2020-02-19T23:21:27Z",
-                    "labels": {
-                        "kat-ambassador-id": "tracingtest",
-                        "scope": "AmbassadorTest",
-                        "service": "tracingtest-admin"
-                    },
-                    "name": "tracingtest-admin",
-                    "namespace": "default",
-                    "resourceVersion": "57528",
-                    "selfLink": "/api/v1/namespaces/default/services/tracingtest-admin",
-                    "uid": "8dbabbff-536e-11ea-85dd-167682b5c255"
-                },
-                "spec": {
-                    "clusterIP": "10.100.56.14",
-                    "externalTrafficPolicy": "Cluster",
-                    "ports": [
-                        {
-                            "name": "tracingtest-admin",
-                            "nodePort": 31405,
-                            "port": 8877,
-                            "protocol": "TCP",
-                            "targetPort": 8877
-                        }
-                    ],
-                    "selector": {
-                        "service": "tracingtest"
                     },
                     "sessionAffinity": "None",
                     "type": "NodePort"

--- a/python/tests/gold/tracingtestshorttraceid/snapshots/aconf.json
+++ b/python/tests/gold/tracingtestshorttraceid/snapshots/aconf.json
@@ -4,7 +4,7 @@
         "tracingtestshorttraceid-http.default.1": [
             "apiVersion ambassador/v0 is deprecated, consider upgrading"
         ],
-        "tracingtestshorttraceid.default.1": [
+        "zipkin-64.default.1": [
             "apiVersion ambassador/v0 is deprecated, consider upgrading"
         ]
     },
@@ -116,7 +116,7 @@
             "serialization": "ambassador_id: tracingtestshorttraceid\napiVersion: ambassador/v0\nkind: Mapping\nmetadata_labels:\n  kat-ambassador-id: tracingtestshorttraceid\n  scope: AmbassadorTest\nname: tracing_target_mapping_64\nnamespace: default\nprefix: /target-64/\nservice: tracingtestshorttraceid-http\n",
             "service": "tracingtestshorttraceid-http"
         },
-        "tracingtestshorttraceid.default.1": {
+        "zipkin-64.default.1": {
             "_referenced_by": {},
             "ambassador_id": "tracingtestshorttraceid",
             "apiVersion": "getambassador.io/v0",
@@ -125,16 +125,15 @@
             },
             "driver": "zipkin",
             "kind": "TracingService",
-            "location": "tracingtestshorttraceid.default.1",
+            "location": "zipkin-64.default.1",
             "metadata_labels": {
-                "app.kubernetes.io/component": "ambassador-service",
                 "kat-ambassador-id": "tracingtestshorttraceid",
                 "scope": "AmbassadorTest"
             },
             "name": "tracing-64",
             "namespace": "default",
-            "rkey": "tracingtestshorttraceid.default.1",
-            "serialization": "ambassador_id: tracingtestshorttraceid\napiVersion: ambassador/v0\nconfig:\n  trace_id_128bit: false\ndriver: zipkin\nkind: TracingService\nmetadata_labels:\n  app.kubernetes.io/component: ambassador-service\n  kat-ambassador-id: tracingtestshorttraceid\n  scope: AmbassadorTest\nname: tracing-64\nnamespace: default\nservice: zipkin-64:9411\n",
+            "rkey": "zipkin-64.default.1",
+            "serialization": "ambassador_id: tracingtestshorttraceid\napiVersion: ambassador/v0\nconfig:\n  trace_id_128bit: false\ndriver: zipkin\nkind: TracingService\nmetadata_labels:\n  kat-ambassador-id: tracingtestshorttraceid\n  scope: AmbassadorTest\nname: tracing-64\nnamespace: default\nservice: zipkin-64:9411\n",
             "service": "zipkin-64:9411"
         }
     },
@@ -215,7 +214,6 @@
             "driver": "zipkin",
             "kind": "TracingService",
             "metadata_labels": {
-                "app.kubernetes.io/component": "ambassador-service",
                 "kat-ambassador-id": "tracingtestshorttraceid",
                 "scope": "AmbassadorTest"
             },

--- a/python/tests/gold/tracingtestshorttraceid/snapshots/econf.json
+++ b/python/tests/gold/tracingtestshorttraceid/snapshots/econf.json
@@ -334,8 +334,7 @@
                                     "xff_num_trusted_hops": 0
                                 }
                             }
-                        ],
-                        "use_proxy_proto": false
+                        ]
                     }
                 ],
                 "listener_filters": [],

--- a/python/tests/gold/tracingtestshorttraceid/snapshots/ir.json
+++ b/python/tests/gold/tracingtestshorttraceid/snapshots/ir.json
@@ -88,7 +88,7 @@
             "_namespace": "default",
             "_port": 9411,
             "_referenced_by": [
-                "tracingtestshorttraceid.default.1"
+                "zipkin-64.default.1"
             ],
             "_rkey": "cluster_tracing_zipkin_64_9411_default",
             "connect_timeout_ms": 3000,
@@ -98,7 +98,7 @@
             "ignore_cluster": false,
             "kind": "IRCluster",
             "lb_type": "round_robin",
-            "location": "tracingtestshorttraceid.default.1",
+            "location": "zipkin-64.default.1",
             "name": "cluster_tracing_zipkin_64_9411_default",
             "namespace": "default",
             "service": "zipkin-64:9411",
@@ -644,9 +644,9 @@
         "_active": true,
         "_errored": false,
         "_referenced_by": [
-            "tracingtestshorttraceid.default.1"
+            "zipkin-64.default.1"
         ],
-        "_rkey": "tracingtestshorttraceid.default.1",
+        "_rkey": "zipkin-64.default.1",
         "cluster": {
             "_active": true,
             "_errored": false,
@@ -655,7 +655,7 @@
             "_namespace": "default",
             "_port": 9411,
             "_referenced_by": [
-                "tracingtestshorttraceid.default.1"
+                "zipkin-64.default.1"
             ],
             "_rkey": "cluster_tracing_zipkin_64_9411_default",
             "connect_timeout_ms": 3000,
@@ -665,7 +665,7 @@
             "ignore_cluster": false,
             "kind": "IRCluster",
             "lb_type": "round_robin",
-            "location": "tracingtestshorttraceid.default.1",
+            "location": "zipkin-64.default.1",
             "name": "cluster_tracing_zipkin_64_9411_default",
             "namespace": "default",
             "service": "zipkin-64:9411",
@@ -688,7 +688,7 @@
         },
         "grpc": false,
         "kind": "ir.tracing",
-        "location": "tracingtestshorttraceid.default.1",
+        "location": "zipkin-64.default.1",
         "name": "tracing",
         "namespace": "default",
         "service": "zipkin-64:9411",

--- a/python/tests/gold/tracingtestshorttraceid/snapshots/snapshot.yaml
+++ b/python/tests/gold/tracingtestshorttraceid/snapshots/snapshot.yaml
@@ -20,10 +20,9 @@
                 "kind": "Service",
                 "metadata": {
                     "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: TracingService\nname: tracing-64\nservice: zipkin-64:9411\ndriver: zipkin\nconfig:\n  trace_id_128bit: false\nambassador_id: tracingtestshorttraceid\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: TracingService\\nname: tracing-64\\nservice: zipkin-64:9411\\ndriver: zipkin\\nconfig:\\n  trace_id_128bit: false\\nambassador_id: tracingtestshorttraceid\\n\"},\"labels\":{\"app.kubernetes.io/component\":\"ambassador-service\",\"kat-ambassador-id\":\"tracingtestshorttraceid\",\"scope\":\"AmbassadorTest\"},\"name\":\"tracingtestshorttraceid\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8080},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8443}],\"selector\":{\"service\":\"tracingtestshorttraceid\"},\"type\":\"NodePort\"}}\n"
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"app.kubernetes.io/component\":\"ambassador-service\",\"kat-ambassador-id\":\"tracingtestshorttraceid\",\"scope\":\"AmbassadorTest\"},\"name\":\"tracingtestshorttraceid\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8080},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8443}],\"selector\":{\"service\":\"tracingtestshorttraceid\"},\"type\":\"NodePort\"}}\n"
                     },
-                    "creationTimestamp": "2020-02-19T23:21:32Z",
+                    "creationTimestamp": "2020-02-26T15:53:52Z",
                     "labels": {
                         "app.kubernetes.io/component": "ambassador-service",
                         "kat-ambassador-id": "tracingtestshorttraceid",
@@ -31,24 +30,24 @@
                     },
                     "name": "tracingtestshorttraceid",
                     "namespace": "default",
-                    "resourceVersion": "57596",
+                    "resourceVersion": "68610",
                     "selfLink": "/api/v1/namespaces/default/services/tracingtestshorttraceid",
-                    "uid": "90b27c1d-536e-11ea-85dd-167682b5c255"
+                    "uid": "2f738536-58b0-11ea-86d6-0e674b3ff44f"
                 },
                 "spec": {
-                    "clusterIP": "10.97.132.215",
+                    "clusterIP": "10.105.166.179",
                     "externalTrafficPolicy": "Cluster",
                     "ports": [
                         {
                             "name": "http",
-                            "nodePort": 30687,
+                            "nodePort": 30504,
                             "port": 80,
                             "protocol": "TCP",
                             "targetPort": 8080
                         },
                         {
                             "name": "https",
-                            "nodePort": 31821,
+                            "nodePort": 31834,
                             "port": 443,
                             "protocol": "TCP",
                             "targetPort": 8443
@@ -71,7 +70,7 @@
                     "annotations": {
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"tracingtestshorttraceid\",\"scope\":\"AmbassadorTest\",\"service\":\"tracingtestshorttraceid-admin\"},\"name\":\"tracingtestshorttraceid-admin\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"tracingtestshorttraceid-admin\",\"port\":8877,\"targetPort\":8877}],\"selector\":{\"service\":\"tracingtestshorttraceid\"},\"type\":\"NodePort\"}}\n"
                     },
-                    "creationTimestamp": "2020-02-19T23:21:34Z",
+                    "creationTimestamp": "2020-02-26T15:53:52Z",
                     "labels": {
                         "kat-ambassador-id": "tracingtestshorttraceid",
                         "scope": "AmbassadorTest",
@@ -79,17 +78,17 @@
                     },
                     "name": "tracingtestshorttraceid-admin",
                     "namespace": "default",
-                    "resourceVersion": "57605",
+                    "resourceVersion": "68620",
                     "selfLink": "/api/v1/namespaces/default/services/tracingtestshorttraceid-admin",
-                    "uid": "918d7645-536e-11ea-85dd-167682b5c255"
+                    "uid": "2fcc4497-58b0-11ea-86d6-0e674b3ff44f"
                 },
                 "spec": {
-                    "clusterIP": "10.99.7.171",
+                    "clusterIP": "10.106.65.165",
                     "externalTrafficPolicy": "Cluster",
                     "ports": [
                         {
                             "name": "tracingtestshorttraceid-admin",
-                            "nodePort": 31818,
+                            "nodePort": 31835,
                             "port": 8877,
                             "protocol": "TCP",
                             "targetPort": 8877
@@ -113,19 +112,19 @@
                         "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: Mapping\nname: tracing_target_mapping_64\nprefix: /target-64/\nservice: tracingtestshorttraceid-http\nambassador_id: tracingtestshorttraceid\n",
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: Mapping\\nname: tracing_target_mapping_64\\nprefix: /target-64/\\nservice: tracingtestshorttraceid-http\\nambassador_id: tracingtestshorttraceid\\n\"},\"labels\":{\"kat-ambassador-id\":\"tracingtestshorttraceid\",\"scope\":\"AmbassadorTest\"},\"name\":\"tracingtestshorttraceid-http\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8134},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8497}],\"selector\":{\"backend\":\"superpod-default\"}}}\n"
                     },
-                    "creationTimestamp": "2020-02-19T23:21:36Z",
+                    "creationTimestamp": "2020-02-26T15:53:54Z",
                     "labels": {
                         "kat-ambassador-id": "tracingtestshorttraceid",
                         "scope": "AmbassadorTest"
                     },
                     "name": "tracingtestshorttraceid-http",
                     "namespace": "default",
-                    "resourceVersion": "57655",
+                    "resourceVersion": "68635",
                     "selfLink": "/api/v1/namespaces/default/services/tracingtestshorttraceid-http",
-                    "uid": "932776bd-536e-11ea-85dd-167682b5c255"
+                    "uid": "30b8ad35-58b0-11ea-86d6-0e674b3ff44f"
                 },
                 "spec": {
-                    "clusterIP": "10.110.245.85",
+                    "clusterIP": "10.111.20.143",
                     "ports": [
                         {
                             "name": "http",
@@ -155,26 +154,27 @@
                 "kind": "Service",
                 "metadata": {
                     "annotations": {
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"tracingtestshorttraceid\",\"scope\":\"AmbassadorTest\"},\"name\":\"zipkin-64\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":9411,\"targetPort\":\"http\"}],\"selector\":{\"app\":\"zipkin-64\"},\"type\":\"NodePort\"}}\n"
+                        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind: TracingService\nname: tracing-64\nservice: zipkin-64:9411\ndriver: zipkin\nconfig:\n  trace_id_128bit: false\nambassador_id: tracingtestshorttraceid\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v0\\nkind: TracingService\\nname: tracing-64\\nservice: zipkin-64:9411\\ndriver: zipkin\\nconfig:\\n  trace_id_128bit: false\\nambassador_id: tracingtestshorttraceid\\n\"},\"labels\":{\"kat-ambassador-id\":\"tracingtestshorttraceid\",\"scope\":\"AmbassadorTest\"},\"name\":\"zipkin-64\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":9411,\"targetPort\":\"http\"}],\"selector\":{\"app\":\"zipkin-64\"},\"type\":\"NodePort\"}}\n"
                     },
-                    "creationTimestamp": "2020-02-19T23:21:36Z",
+                    "creationTimestamp": "2020-02-26T15:53:50Z",
                     "labels": {
                         "kat-ambassador-id": "tracingtestshorttraceid",
                         "scope": "AmbassadorTest"
                     },
                     "name": "zipkin-64",
                     "namespace": "default",
-                    "resourceVersion": "57627",
+                    "resourceVersion": "68570",
                     "selfLink": "/api/v1/namespaces/default/services/zipkin-64",
-                    "uid": "92a686b6-536e-11ea-85dd-167682b5c255"
+                    "uid": "2e2f588c-58b0-11ea-86d6-0e674b3ff44f"
                 },
                 "spec": {
-                    "clusterIP": "10.99.212.191",
+                    "clusterIP": "10.104.22.100",
                     "externalTrafficPolicy": "Cluster",
                     "ports": [
                         {
                             "name": "http",
-                            "nodePort": 32746,
+                            "nodePort": 32040,
                             "port": 9411,
                             "protocol": "TCP",
                             "targetPort": "http"

--- a/python/tests/gold/unsaferegexmapping/snapshots/econf.json
+++ b/python/tests/gold/unsaferegexmapping/snapshots/econf.json
@@ -320,8 +320,7 @@
                                     "xff_num_trusted_hops": 0
                                 }
                             }
-                        ],
-                        "use_proxy_proto": false
+                        ]
                     }
                 ],
                 "listener_filters": [],

--- a/python/tests/gold/unsaferegexmapping/snapshots/snapshot.yaml
+++ b/python/tests/gold/unsaferegexmapping/snapshots/snapshot.yaml
@@ -20,58 +20,9 @@
                 "kind": "Service",
                 "metadata": {
                     "annotations": {
-                        "getambassador.io/config": "---\napiVersion: ambassador/v2\nkind: Mapping\nname: UnsafeRegexMapping\nprefix: /UnsafeRegexMapping/\nprefix_regex: true\nhost: \"[a-zA-Z].*\"\nhost_regex: true\nregex_headers:\n  X-Foo: \"^[a-z].*\"\nservice: http://unsaferegexmapping-http\nambassador_id: unsaferegexmapping\n---\napiVersion: ambassador/v2\nkind: Module\nname: ambassador\nconfig:\n  regex_type: unsafe\nambassador_id: unsaferegexmapping\n",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v2\\nkind: Mapping\\nname: UnsafeRegexMapping\\nprefix: /UnsafeRegexMapping/\\nprefix_regex: true\\nhost: \\\"[a-zA-Z].*\\\"\\nhost_regex: true\\nregex_headers:\\n  X-Foo: \\\"^[a-z].*\\\"\\nservice: http://unsaferegexmapping-http\\nambassador_id: unsaferegexmapping\\n---\\napiVersion: ambassador/v2\\nkind: Module\\nname: ambassador\\nconfig:\\n  regex_type: unsafe\\nambassador_id: unsaferegexmapping\\n\"},\"labels\":{\"app.kubernetes.io/component\":\"ambassador-service\",\"kat-ambassador-id\":\"unsaferegexmapping\",\"scope\":\"AmbassadorTest\"},\"name\":\"unsaferegexmapping\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8080},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8443}],\"selector\":{\"service\":\"unsaferegexmapping\"},\"type\":\"NodePort\"}}\n"
-                    },
-                    "creationTimestamp": "2020-02-19T23:19:55Z",
-                    "labels": {
-                        "app.kubernetes.io/component": "ambassador-service",
-                        "kat-ambassador-id": "unsaferegexmapping",
-                        "scope": "AmbassadorTest"
-                    },
-                    "name": "unsaferegexmapping",
-                    "namespace": "default",
-                    "resourceVersion": "55195",
-                    "selfLink": "/api/v1/namespaces/default/services/unsaferegexmapping",
-                    "uid": "56ef9e0c-536e-11ea-85dd-167682b5c255"
-                },
-                "spec": {
-                    "clusterIP": "10.103.125.197",
-                    "externalTrafficPolicy": "Cluster",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "nodePort": 32522,
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 8080
-                        },
-                        {
-                            "name": "https",
-                            "nodePort": 31362,
-                            "port": 443,
-                            "protocol": "TCP",
-                            "targetPort": 8443
-                        }
-                    ],
-                    "selector": {
-                        "service": "unsaferegexmapping"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "NodePort"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"unsaferegexmapping\",\"scope\":\"AmbassadorTest\",\"service\":\"unsaferegexmapping-admin\"},\"name\":\"unsaferegexmapping-admin\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"unsaferegexmapping-admin\",\"port\":8877,\"targetPort\":8877}],\"selector\":{\"service\":\"unsaferegexmapping\"},\"type\":\"NodePort\"}}\n"
                     },
-                    "creationTimestamp": "2020-02-19T23:19:55Z",
+                    "creationTimestamp": "2020-02-26T15:51:38Z",
                     "labels": {
                         "kat-ambassador-id": "unsaferegexmapping",
                         "scope": "AmbassadorTest",
@@ -79,17 +30,17 @@
                     },
                     "name": "unsaferegexmapping-admin",
                     "namespace": "default",
-                    "resourceVersion": "55199",
+                    "resourceVersion": "65878",
                     "selfLink": "/api/v1/namespaces/default/services/unsaferegexmapping-admin",
-                    "uid": "56f8a372-536e-11ea-85dd-167682b5c255"
+                    "uid": "df97e922-58af-11ea-86d6-0e674b3ff44f"
                 },
                 "spec": {
-                    "clusterIP": "10.111.83.223",
+                    "clusterIP": "10.103.37.97",
                     "externalTrafficPolicy": "Cluster",
                     "ports": [
                         {
                             "name": "unsaferegexmapping-admin",
-                            "nodePort": 31564,
+                            "nodePort": 30538,
                             "port": 8877,
                             "protocol": "TCP",
                             "targetPort": 8877
@@ -112,19 +63,19 @@
                     "annotations": {
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"unsaferegexmapping\",\"scope\":\"AmbassadorTest\"},\"name\":\"unsaferegexmapping-http\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8083},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8446}],\"selector\":{\"backend\":\"superpod-default\"}}}\n"
                     },
-                    "creationTimestamp": "2020-02-19T23:19:56Z",
+                    "creationTimestamp": "2020-02-26T15:51:38Z",
                     "labels": {
                         "kat-ambassador-id": "unsaferegexmapping",
                         "scope": "AmbassadorTest"
                     },
                     "name": "unsaferegexmapping-http",
                     "namespace": "default",
-                    "resourceVersion": "55207",
+                    "resourceVersion": "65885",
                     "selfLink": "/api/v1/namespaces/default/services/unsaferegexmapping-http",
-                    "uid": "570b17d7-536e-11ea-85dd-167682b5c255"
+                    "uid": "dfaa3404-58af-11ea-86d6-0e674b3ff44f"
                 },
                 "spec": {
-                    "clusterIP": "10.105.17.87",
+                    "clusterIP": "10.106.175.17",
                     "ports": [
                         {
                             "name": "http",
@@ -144,6 +95,55 @@
                     },
                     "sessionAffinity": "None",
                     "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v2\nkind: Mapping\nname: UnsafeRegexMapping\nprefix: /UnsafeRegexMapping/\nprefix_regex: true\nhost: \"[a-zA-Z].*\"\nhost_regex: true\nregex_headers:\n  X-Foo: \"^[a-z].*\"\nservice: http://unsaferegexmapping-http\nambassador_id: unsaferegexmapping\n---\napiVersion: ambassador/v2\nkind: Module\nname: ambassador\nconfig:\n  regex_type: unsafe\nambassador_id: unsaferegexmapping\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v2\\nkind: Mapping\\nname: UnsafeRegexMapping\\nprefix: /UnsafeRegexMapping/\\nprefix_regex: true\\nhost: \\\"[a-zA-Z].*\\\"\\nhost_regex: true\\nregex_headers:\\n  X-Foo: \\\"^[a-z].*\\\"\\nservice: http://unsaferegexmapping-http\\nambassador_id: unsaferegexmapping\\n---\\napiVersion: ambassador/v2\\nkind: Module\\nname: ambassador\\nconfig:\\n  regex_type: unsafe\\nambassador_id: unsaferegexmapping\\n\"},\"labels\":{\"app.kubernetes.io/component\":\"ambassador-service\",\"kat-ambassador-id\":\"unsaferegexmapping\",\"scope\":\"AmbassadorTest\"},\"name\":\"unsaferegexmapping\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8080},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8443}],\"selector\":{\"service\":\"unsaferegexmapping\"},\"type\":\"NodePort\"}}\n"
+                    },
+                    "creationTimestamp": "2020-02-26T15:51:38Z",
+                    "labels": {
+                        "app.kubernetes.io/component": "ambassador-service",
+                        "kat-ambassador-id": "unsaferegexmapping",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "unsaferegexmapping",
+                    "namespace": "default",
+                    "resourceVersion": "65873",
+                    "selfLink": "/api/v1/namespaces/default/services/unsaferegexmapping",
+                    "uid": "df899bad-58af-11ea-86d6-0e674b3ff44f"
+                },
+                "spec": {
+                    "clusterIP": "10.106.182.10",
+                    "externalTrafficPolicy": "Cluster",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "nodePort": 31481,
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8080
+                        },
+                        {
+                            "name": "https",
+                            "nodePort": 30524,
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8443
+                        }
+                    ],
+                    "selector": {
+                        "service": "unsaferegexmapping"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "NodePort"
                 },
                 "status": {
                     "loadBalancer": {}

--- a/python/tests/gold/xfpredirect/snapshots/econf.json
+++ b/python/tests/gold/xfpredirect/snapshots/econf.json
@@ -290,8 +290,7 @@
                                     "xff_num_trusted_hops": 0
                                 }
                             }
-                        ],
-                        "use_proxy_proto": false
+                        ]
                     }
                 ],
                 "listener_filters": [],

--- a/python/tests/gold/xfpredirect/snapshots/snapshot.yaml
+++ b/python/tests/gold/xfpredirect/snapshots/snapshot.yaml
@@ -20,22 +20,63 @@
                 "kind": "Service",
                 "metadata": {
                     "annotations": {
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"xfpredirect\",\"scope\":\"AmbassadorTest\",\"service\":\"xfpredirect-admin\"},\"name\":\"xfpredirect-admin\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"xfpredirect-admin\",\"port\":8877,\"targetPort\":8877}],\"selector\":{\"service\":\"xfpredirect\"},\"type\":\"NodePort\"}}\n"
+                    },
+                    "creationTimestamp": "2020-02-26T15:53:11Z",
+                    "labels": {
+                        "kat-ambassador-id": "xfpredirect",
+                        "scope": "AmbassadorTest",
+                        "service": "xfpredirect-admin"
+                    },
+                    "name": "xfpredirect-admin",
+                    "namespace": "default",
+                    "resourceVersion": "67877",
+                    "selfLink": "/api/v1/namespaces/default/services/xfpredirect-admin",
+                    "uid": "171e347e-58b0-11ea-86d6-0e674b3ff44f"
+                },
+                "spec": {
+                    "clusterIP": "10.101.83.175",
+                    "externalTrafficPolicy": "Cluster",
+                    "ports": [
+                        {
+                            "name": "xfpredirect-admin",
+                            "nodePort": 32102,
+                            "port": 8877,
+                            "protocol": "TCP",
+                            "targetPort": 8877
+                        }
+                    ],
+                    "selector": {
+                        "service": "xfpredirect"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "NodePort"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
                         "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Module\nname: ambassador\nconfig:\n  x_forwarded_proto_redirect: true\n  use_remote_address: false\nambassador_id: xfpredirect\n---\napiVersion: ambassador/v1\nkind: Mapping\nname: XFPRedirect\nprefix: /XFPRedirect/\nservice: xfpredirect-http\nambassador_id: xfpredirect\n",
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Module\\nname: ambassador\\nconfig:\\n  x_forwarded_proto_redirect: true\\n  use_remote_address: false\\nambassador_id: xfpredirect\\n---\\napiVersion: ambassador/v1\\nkind: Mapping\\nname: XFPRedirect\\nprefix: /XFPRedirect/\\nservice: xfpredirect-http\\nambassador_id: xfpredirect\\n\"},\"labels\":{\"kat-ambassador-id\":\"xfpredirect\",\"scope\":\"AmbassadorTest\"},\"name\":\"xfpredirect-http\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8121},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8484}],\"selector\":{\"backend\":\"superpod-default\"}}}\n"
                     },
-                    "creationTimestamp": "2020-02-19T23:20:36Z",
+                    "creationTimestamp": "2020-02-26T15:53:11Z",
                     "labels": {
                         "kat-ambassador-id": "xfpredirect",
                         "scope": "AmbassadorTest"
                     },
                     "name": "xfpredirect-http",
                     "namespace": "default",
-                    "resourceVersion": "56772",
+                    "resourceVersion": "67885",
                     "selfLink": "/api/v1/namespaces/default/services/xfpredirect-http",
-                    "uid": "6f66b6bf-536e-11ea-85dd-167682b5c255"
+                    "uid": "17457c1b-58b0-11ea-86d6-0e674b3ff44f"
                 },
                 "spec": {
-                    "clusterIP": "10.110.255.172",
+                    "clusterIP": "10.103.124.247",
                     "ports": [
                         {
                             "name": "http",
@@ -67,7 +108,7 @@
                     "annotations": {
                         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"app.kubernetes.io/component\":\"ambassador-service\",\"kat-ambassador-id\":\"xfpredirect\",\"scope\":\"AmbassadorTest\"},\"name\":\"xfpredirect\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8080},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8443}],\"selector\":{\"service\":\"xfpredirect\"},\"type\":\"NodePort\"}}\n"
                     },
-                    "creationTimestamp": "2020-02-19T23:20:36Z",
+                    "creationTimestamp": "2020-02-26T15:53:11Z",
                     "labels": {
                         "app.kubernetes.io/component": "ambassador-service",
                         "kat-ambassador-id": "xfpredirect",
@@ -75,68 +116,27 @@
                     },
                     "name": "xfpredirect",
                     "namespace": "default",
-                    "resourceVersion": "56753",
+                    "resourceVersion": "67872",
                     "selfLink": "/api/v1/namespaces/default/services/xfpredirect",
-                    "uid": "6efe6652-536e-11ea-85dd-167682b5c255"
+                    "uid": "1706f868-58b0-11ea-86d6-0e674b3ff44f"
                 },
                 "spec": {
-                    "clusterIP": "10.102.90.91",
+                    "clusterIP": "10.101.87.184",
                     "externalTrafficPolicy": "Cluster",
                     "ports": [
                         {
                             "name": "http",
-                            "nodePort": 31298,
+                            "nodePort": 30136,
                             "port": 80,
                             "protocol": "TCP",
                             "targetPort": 8080
                         },
                         {
                             "name": "https",
-                            "nodePort": 31286,
+                            "nodePort": 30542,
                             "port": 443,
                             "protocol": "TCP",
                             "targetPort": 8443
-                        }
-                    ],
-                    "selector": {
-                        "service": "xfpredirect"
-                    },
-                    "sessionAffinity": "None",
-                    "type": "NodePort"
-                },
-                "status": {
-                    "loadBalancer": {}
-                }
-            },
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                    "annotations": {
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"xfpredirect\",\"scope\":\"AmbassadorTest\",\"service\":\"xfpredirect-admin\"},\"name\":\"xfpredirect-admin\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"xfpredirect-admin\",\"port\":8877,\"targetPort\":8877}],\"selector\":{\"service\":\"xfpredirect\"},\"type\":\"NodePort\"}}\n"
-                    },
-                    "creationTimestamp": "2020-02-19T23:20:36Z",
-                    "labels": {
-                        "kat-ambassador-id": "xfpredirect",
-                        "scope": "AmbassadorTest",
-                        "service": "xfpredirect-admin"
-                    },
-                    "name": "xfpredirect-admin",
-                    "namespace": "default",
-                    "resourceVersion": "56762",
-                    "selfLink": "/api/v1/namespaces/default/services/xfpredirect-admin",
-                    "uid": "6f4c30ad-536e-11ea-85dd-167682b5c255"
-                },
-                "spec": {
-                    "clusterIP": "10.101.165.169",
-                    "externalTrafficPolicy": "Cluster",
-                    "ports": [
-                        {
-                            "name": "xfpredirect-admin",
-                            "nodePort": 30819,
-                            "port": 8877,
-                            "protocol": "TCP",
-                            "targetPort": 8877
                         }
                     ],
                     "selector": {


### PR DESCRIPTION
There are three things going on this commit, but all of them need to be in one commit for things to work.

1. `use_proxy_proto` is no longer a `VHost` thing.
   a. This is why you see all the deletion of stuff in `V2VirtualHost` about `use_proxy_proto`.
   b. This is also why you see `use_proxy_proto` vanishing from all the calls instantiating a `V2VirtualHost`.

2. `use_proxy_proto` is instead now a `V2Listener` thing.
   a. This is OK because, at present, `use_proxy_proto` is a system-wide configuration. Later, it needs to be part of the per-listener config.
   b. This is why you see `use_proxy_proto` getting added to `V2Listener`.

3. `V2ListenerCollection` gains a `get` method, because 
   a. using `__getitem__` really didn't make sense, it was a design choice back when I thought more needed to be in the `V2ListenerCollection` class
   b. we really need to pass `use_proxy_proto` in on creation, and ` __getitem__` relying on two inputs would be even more absurd than it used to be.

Tagging @alexgervais and @ark3 for review since Luke shouldn't have to do _all_ of them... :wink:

Fixes #2348.

Documentation doesn't need to change. Testing was with KAT and using `curl --haproxy` to test the TLS termination + PROXY protocol case.