### PR TITLE
Combine all go binaries into a single ambassador binary

### DIFF
--- a/cmd/ambassador/main.go
+++ b/cmd/ambassador/main.go
@@ -15,7 +15,12 @@ import (
 	"github.com/datawire/ambassador/cmd/watt"
 )
 
+var Version = "(unknown version)"
+
 func main() {
+	ambex.Version = Version
+	watt.Version = Version
+
 	name := filepath.Base(os.Args[0])
 	if name == "ambassador" && len(os.Args) > 1 {
 		name = os.Args[1]
@@ -32,8 +37,8 @@ func main() {
 		fmt.Println("The Ambassador main program is a multi-call binary that combines various")
 		fmt.Println("support programs into one executable.")
 		fmt.Println()
-		fmt.Println("Usage: ambassador [program] [arguments]...")
-		fmt.Println("   or: [program] [arguments]...")
+		fmt.Println("Usage: ambassador <PROGRAM> [arguments]...")
+		fmt.Println("   or: <PROGRAM> [arguments]...")
 		fmt.Println()
 		fmt.Println("Available programs: ambex kubestatus watt")
 		fmt.Println()

--- a/cmd/ambassador/main.go
+++ b/cmd/ambassador/main.go
@@ -1,0 +1,39 @@
+// Ambassador combines the various Golang binaries used in the Ambassador
+// container, dispatching on os.Args[0] like BusyBox.
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/datawire/ambassador/cmd/ambex"
+	"github.com/datawire/ambassador/cmd/kubestatus"
+	"github.com/datawire/ambassador/cmd/watt"
+)
+
+func main() {
+	name := filepath.Base(os.Args[0])
+	if name == "ambassador" && len(os.Args) > 1 {
+		name = os.Args[1]
+		os.Args = os.Args[1:]
+	}
+	switch name {
+	case "ambex":
+		ambex.Main()
+	case "watt":
+		watt.Main()
+	case "kubestatus":
+		kubestatus.Main()
+	default:
+		fmt.Println("The Ambassador main program is a multi-call binary that combines various")
+		fmt.Println("support programs into one executable.")
+		fmt.Println()
+		fmt.Println("Usage: ambassador [program] [arguments]...")
+		fmt.Println("   or: [program] [arguments]...")
+		fmt.Println()
+		fmt.Println("Available programs: ambex kubestatus watt")
+		fmt.Println()
+		fmt.Printf("Unknown name %q\n", name)
+	}
+}

--- a/cmd/ambassador/main.go
+++ b/cmd/ambassador/main.go
@@ -1,5 +1,8 @@
 // Ambassador combines the various Golang binaries used in the Ambassador
-// container, dispatching on os.Args[0] like BusyBox.
+// container, dispatching on os.Args[0] like BusyBox. Note that the
+// capabilities_wrapper binary is _not_ included here. That one has special
+// permissions magic applied to it that is not appropriate for these other
+// binaries.
 package main
 
 import (

--- a/cmd/ambex/main.go
+++ b/cmd/ambex/main.go
@@ -1,4 +1,4 @@
-package main
+package ambex
 
 /**********************************************
  * ambex: Ambassador Experimental ADS server
@@ -345,7 +345,7 @@ func (l logger) OnFetchResponse(req *v2.DiscoveryRequest, res *v2.DiscoveryRespo
 	l.Infof("Fetch response: %v -> %v", req, res)
 }
 
-func main() {
+func Main() {
 	flag.Parse()
 
 	if debug {

--- a/cmd/kubestatus/main.go
+++ b/cmd/kubestatus/main.go
@@ -1,4 +1,4 @@
-package main
+package kubestatus
 
 import (
 	"encoding/json"
@@ -11,7 +11,7 @@ import (
 	"github.com/datawire/ambassador/pkg/k8s"
 )
 
-func main() {
+func Main() {
 	var st = &cobra.Command{
 		Use:           "kubestatus <kind>",
 		Short:         "get and set status of kubernetes resources",
@@ -84,5 +84,4 @@ func main() {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)
 	}
-
 }

--- a/cmd/watt/aggregator.go
+++ b/cmd/watt/aggregator.go
@@ -1,4 +1,4 @@
-package main
+package watt
 
 import (
 	"encoding/json"

--- a/cmd/watt/aggregator_test.go
+++ b/cmd/watt/aggregator_test.go
@@ -1,4 +1,4 @@
-package main
+package watt
 
 import (
 	"context"

--- a/cmd/watt/consulwatchman.go
+++ b/cmd/watt/consulwatchman.go
@@ -1,4 +1,4 @@
-package main
+package watt
 
 import (
 	"fmt"

--- a/cmd/watt/consulwatchman_test.go
+++ b/cmd/watt/consulwatchman_test.go
@@ -1,4 +1,4 @@
-package main
+package watt
 
 import (
 	"context"

--- a/cmd/watt/invoker.go
+++ b/cmd/watt/invoker.go
@@ -1,4 +1,4 @@
-package main
+package watt
 
 import (
 	"fmt"

--- a/cmd/watt/kubewatchman.go
+++ b/cmd/watt/kubewatchman.go
@@ -1,4 +1,4 @@
-package main
+package watt
 
 import (
 	"fmt"

--- a/cmd/watt/kubewatchman_test.go
+++ b/cmd/watt/kubewatchman_test.go
@@ -1,4 +1,4 @@
-package main
+package watt
 
 import (
 	"context"

--- a/cmd/watt/main.go
+++ b/cmd/watt/main.go
@@ -1,4 +1,4 @@
-package main
+package watt
 
 import (
 	"context"
@@ -161,7 +161,7 @@ func _runWatt(cmd *cobra.Command, args []string) int {
 	return 0
 }
 
-func main() {
+func Main() {
 	if err := rootCmd.Execute(); err != nil {
 		log.Println(err)
 		os.Exit(1)

--- a/cmd/watt/testutils.go
+++ b/cmd/watt/testutils.go
@@ -1,4 +1,4 @@
-package main
+package watt
 
 import (
 	"fmt"

--- a/cmd/watt/watchmaker_api.go
+++ b/cmd/watt/watchmaker_api.go
@@ -1,4 +1,4 @@
-package main
+package watt
 
 import (
 	"fmt"

--- a/cmd/watt/watchmaker_api_test.go
+++ b/cmd/watt/watchmaker_api_test.go
@@ -1,4 +1,4 @@
-package main
+package watt
 
 import (
 	"os"

--- a/post-compile.sh
+++ b/post-compile.sh
@@ -1,10 +1,17 @@
 #!/hint/bash
 set -e
 
-# Create symlinks to the multi-call binary
+# Create symlinks to the multi-call binary so the original names can be used in
+# the builder shell easily (from the shell PATH).
 ln -sf /buildroot/bin/ambassador /buildroot/bin/ambex
 ln -sf /buildroot/bin/ambassador /buildroot/bin/kubestatus
 ln -sf /buildroot/bin/ambassador /buildroot/bin/watt
+
+# Also note there is a different ambassador binary, written in Python, that
+# shows up earlier in the shell PATH:
+#   $ type -a ambassador
+#   ambassador is /usr/bin/ambassador
+#   ambassador is /buildroot/bin/ambassador
 
 # Stuff in /opt/ambassador/bin in the builder winds up in /usr/local/bin in the
 # production image.

--- a/post-compile.sh
+++ b/post-compile.sh
@@ -1,8 +1,15 @@
 #!/hint/bash
 set -e
 
-sudo install -D -t /opt/ambassador/bin/ \
-     /buildroot/bin/ambex \
-     /buildroot/bin/watt \
-     /buildroot/bin/kubestatus
+# Create symlinks to the multi-call binary
+ln -sf /buildroot/bin/ambassador /buildroot/bin/ambex
+ln -sf /buildroot/bin/ambassador /buildroot/bin/kubestatus
+ln -sf /buildroot/bin/ambassador /buildroot/bin/watt
+
+# Stuff in /opt/ambassador/bin in the builder winds up in /usr/local/bin in the
+# production image.
+sudo install -D -t /opt/ambassador/bin/ /buildroot/bin/ambassador
+sudo ln -sf /opt/ambassador/bin/ambassador /opt/ambassador/bin/ambex
+sudo ln -sf /opt/ambassador/bin/ambassador /opt/ambassador/bin/kubestatus
+sudo ln -sf /opt/ambassador/bin/ambassador /opt/ambassador/bin/watt
 sudo install /buildroot/bin/capabilities_wrapper /opt/ambassador/bin/wrapper


### PR DESCRIPTION
- Modify the original programs so they can be embedded this way
- Modify build stuff so things still work as they did

Net effect is the ambassador image is 50 MB smaller.