### PR TITLE
Don't test functionality that's not there.

### DIFF
--- a/python/tests/t_no_ui.py
+++ b/python/tests/t_no_ui.py
@@ -33,5 +33,9 @@ spec:
 
     def queries(self):
         yield(Query(self.url("ambassador/v0/diag/"), expected=404))
-        yield(Query(self.url("edge_stack/admin/"), expected=404))
+
+        if EDGE_STACK:
+          yield(Query(self.url("edge_stack/admin/"), expected=200))
+        else:
+          yield(Query(self.url("edge_stack/admin/"), expected=404))
 


### PR DESCRIPTION
We can't actually test disabling the Edge Policy Console until Edge Stack supports disabling the Edge Policy Console... 😛 

(The basic issue here is that, for multirepo features, you have to be very careful about the order in which you land things. 😛)