### PR TITLE
Move ambassador-docs CI config to ambassador

### DIFF
--- a/.ci/blc-website-preview
+++ b/.ci/blc-website-preview
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+
+# Copyright 2019 Datawire. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License
+
+set -o errexit
+set -o nounset
+
+website_branch=${1:-master}
+
+if ! [[ -d /tmp/getambassador.io-$website_branch/public ]]; then
+	echo '[blc-website-preview] skipping: website preview was not built'
+	exit 0
+fi
+
+if [[ -n "$TRAVIS_PULL_REQUEST_SHA" ]]; then
+	build_type=pr
+else
+	build_type=push
+fi
+
+set -o verbose
+
+pushd "/tmp/getambassador.io-$website_branch/public"
+python3 -m http.server 2>/dev/null &
+trap "kill $!" EXIT
+popd
+
+cd /tmp/getambassador.io-blc
+./blc.js http://localhost:8000/ > /tmp/blc.txt
+
+set +o verbose
+num_complaints=$(grep ^Page /tmp/blc.txt | sort -u | wc -l)
+RED=$'\033[1;31m'
+GRN=$'\033[1;32m'
+BLD=$'\033[1m'
+END=$'\033[0m'
+if [[ $num_complaints -eq 0 ]]; then
+	printf "%s======================= 0 broken-link-checker complaints for %s =======================%s\n" "$GRN$BLD" "$website_branch" "$END"
+else
+	printf "%s======================= %d broken-link-checker complaints for %s ======================%s\n" "$RED$BLD" $num_complaints "$website_branch" "$END"
+	grep ^Page /tmp/blc.txt | sort -u
+	printf "%s====================== end broken-link-checker complaints for %s ======================%s\n" "$RED$BLD" "$website_branch" "$END"
+fi
+set -o verbose
+
+cat >/tmp/github-status.json <<EOF
+{
+  "context": "broken-link-check/${build_type}",
+  "state": "$(if [[ $num_complaints -eq 0 ]]; then echo success; else echo failure; fi)",
+  "target_url": "${TRAVIS_JOB_WEB_URL}",
+  "description": "Found ${num_complaints} bad links in the website ${website_branch} preview"
+}
+EOF
+
+cat /tmp/github-status.json
+
+curl --fail \
+	-H "Accept: application/json" \
+	-H "Content-Type: application/json" \
+	-X POST \
+	--data '@/tmp/github-status.json' \
+	"https://${GH_TOKEN}@api.github.com/repos/datawire/ambassador-docs/statuses/${TRAVIS_PULL_REQUEST_SHA:-${TRAVIS_COMMIT}}"

--- a/.ci/blc-website-preview
+++ b/.ci/blc-website-preview
@@ -71,4 +71,4 @@ curl --fail \
 	-H "Content-Type: application/json" \
 	-X POST \
 	--data '@/tmp/github-status.json' \
-	"https://${GH_TOKEN}@api.github.com/repos/datawire/ambassador-docs/statuses/${TRAVIS_PULL_REQUEST_SHA:-${TRAVIS_COMMIT}}"
+	"https://${GH_TOKEN}@api.github.com/repos/datawire/ambassador/statuses/${TRAVIS_PULL_REQUEST_SHA:-${TRAVIS_COMMIT}}"

--- a/.ci/install-blc
+++ b/.ci/install-blc
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+# Copyright 2019 Datawire. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License
+
+set -o errexit
+set -o nounset
+set -o verbose
+
+cd /tmp
+git clone https://github.com/datawire/getambassador.io-blc.git
+cd getambassador.io-blc
+npm install
+sed -i '39iif (url.endsWith(".pdf")) { return Promise.reject(); }' node_modules/broken-link-checker/lib/internal/streamHtml.js # FFS

--- a/.ci/pr-build-website-preview
+++ b/.ci/pr-build-website-preview
@@ -24,6 +24,7 @@ rm -rf "/tmp/getambassador.io-$website_branch"
 git clone --single-branch --branch="$website_branch" https://d6e-automaton:${GH_TOKEN}@github.com/datawire/getambassador.io.git "/tmp/getambassador.io-$website_branch"
 cd "/tmp/getambassador.io-$website_branch"
 git submodule update --init --reference="$TRAVIS_BUILD_DIR"
+cp -r ambassador/docs/* content/
 git -C content checkout "$TRAVIS_COMMIT"
 npm install
 npm run build

--- a/.ci/pr-build-website-preview
+++ b/.ci/pr-build-website-preview
@@ -24,7 +24,9 @@ rm -rf "/tmp/getambassador.io-$website_branch"
 git clone --single-branch --branch="$website_branch" https://d6e-automaton:${GH_TOKEN}@github.com/datawire/getambassador.io.git "/tmp/getambassador.io-$website_branch"
 cd "/tmp/getambassador.io-$website_branch"
 git submodule update --init --reference="$TRAVIS_BUILD_DIR"
-cp -r ambassador/docs/* content/
+rm -rf content/
+mkdir content
+cp -rf ambassador/docs/. content/
 git -C content checkout "$TRAVIS_COMMIT"
 npm install
 npm run build

--- a/.ci/pr-build-website-preview
+++ b/.ci/pr-build-website-preview
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+# Copyright 2018-2019 Datawire. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License
+
+set -o errexit
+set -o nounset
+set -o xtrace
+
+website_branch=${1:-master}
+
+rm -rf "/tmp/getambassador.io-$website_branch"
+git clone --single-branch --branch="$website_branch" https://d6e-automaton:${GH_TOKEN}@github.com/datawire/getambassador.io.git "/tmp/getambassador.io-$website_branch"
+cd "/tmp/getambassador.io-$website_branch"
+git submodule update --init --reference="$TRAVIS_BUILD_DIR"
+git -C content checkout "$TRAVIS_COMMIT"
+npm install
+npm run build

--- a/.ci/publish-website
+++ b/.ci/publish-website
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+# Copyright 2018 Datawire. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License
+
+set -o errexit
+set -o nounset
+set -o verbose
+
+remote_url=https://d6e-automaton:${GH_TOKEN}@github.com/datawire/getambassador.io.git
+
+rm -rf /tmp/getambassador.io
+git clone -b master "$remote_url" /tmp/getambassador.io
+cd /tmp/getambassador.io
+npm run pull-docs
+git push origin master
+
+rm -rf "$PWD-esu"
+git worktree add "$PWD-esu" Edge-stack-update || exit 0
+cd "$PWD-esu"
+npm run pull-docs
+git push origin Edge-stack-update

--- a/.ci/publish-website-preview
+++ b/.ci/publish-website-preview
@@ -58,4 +58,4 @@ curl --fail \
 	-H "Content-Type: application/json" \
 	-X POST \
 	--data '@/tmp/github-status.json' \
-	"https://${GH_TOKEN}@api.github.com/repos/datawire/ambassador-docs/statuses/${TRAVIS_PULL_REQUEST_SHA:-${TRAVIS_COMMIT}}"
+	"https://${GH_TOKEN}@api.github.com/repos/datawire/ambassador/statuses/${TRAVIS_PULL_REQUEST_SHA:-${TRAVIS_COMMIT}}"

--- a/.ci/publish-website-preview
+++ b/.ci/publish-website-preview
@@ -36,7 +36,7 @@ npm install netlify-cli -g
 
 netlify deploy \
 	--dir="/tmp/getambassador.io-${website_branch}/public" \
-	--message="ambassador-docs.git preview ${TRAVIS_JOB_WEB_URL}" \
+	--message="ambassador.git preview ${TRAVIS_JOB_WEB_URL}" \
 	--site=1d6f5395-6386-49af-8b47-e85aa28488f8 \
 	--auth="${NETLIFY_AUTH_TOKEN}" \
 	--json \

--- a/.ci/publish-website-preview
+++ b/.ci/publish-website-preview
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+
+# Copyright 2019 Datawire. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License
+
+set -o errexit
+set -o nounset
+
+website_branch=${1:-master}
+
+if ! [[ -d /tmp/getambassador.io-${website_branch}/public ]]; then
+	echo '[publish-website-preview] skipping: website preview was not built'
+	exit 0
+fi
+
+if [[ -n "$TRAVIS_PULL_REQUEST_SHA" ]]; then
+	build_type=pr
+else
+	build_type=push
+fi
+
+set -o verbose
+
+npm install netlify-cli -g
+
+netlify deploy \
+	--dir="/tmp/getambassador.io-${website_branch}/public" \
+	--message="ambassador-docs.git preview ${TRAVIS_JOB_WEB_URL}" \
+	--site=1d6f5395-6386-49af-8b47-e85aa28488f8 \
+	--auth="${NETLIFY_AUTH_TOKEN}" \
+	--json \
+	> /tmp/netlify-deploy.json
+
+cat /tmp/netlify-deploy.json
+
+cat >/tmp/github-status.json <<EOF
+{
+  "context": "website-preview/${build_type}",
+  "state": "success",
+  "target_url": $(jq .deploy_url </tmp/netlify-deploy.json),
+  "description": "Website ${website_branch} preview"
+}
+EOF
+
+curl --fail \
+	-H "Accept: application/json" \
+	-H "Content-Type: application/json" \
+	-X POST \
+	--data '@/tmp/github-status.json' \
+	"https://${GH_TOKEN}@api.github.com/repos/datawire/ambassador-docs/statuses/${TRAVIS_PULL_REQUEST_SHA:-${TRAVIS_COMMIT}}"

--- a/.ci/travis-fix-env
+++ b/.ci/travis-fix-env
@@ -1,0 +1,40 @@
+#!/hint/sh
+
+# Don't trust $TRAVIS_COMMIT, use $(git rev-parse HEAD) instead.
+#
+# For PRs, it's often set to a stale merge commit that isn't fetched,
+# instead of the actual commit pointed to by refs/pull/NNN/merge which
+# is checked out.  For example, on
+# <https://travis-ci.org/datawire/ambassador-docs/builds/629117603>,
+# the webui says         it's testing commit cb8dc0029465119ada1ee9222539c825f5a7c015,
+# and TRAVIS_COMMIT says it's testing commit cb8dc0029465119ada1ee9222539c825f5a7c015,
+# but in fact            it's testing commit d23659347cd125267b079f2f7900c3e1b032ea4b.
+original_TRAVIS_COMMIT=$TRAVIS_COMMIT
+TRAVIS_COMMIT=$(git rev-parse HEAD)
+echo "adjusted TRAVIS_COMMIT : ${original_TRAVIS_COMMIT} -> ${TRAVIS_COMMIT}"
+
+# Don't trust $TRAVIS_BRANCH for PRs; it can be wrong in the same way
+# that $TRAVIS_COMMIT is wrong.
+#
+# For example: https://travis-ci.org/datawire/ambassador-docs/builds/632583559
+if [ -n "$TRAVIS_PULL_REQUEST_SHA" ]; then
+	original_TRAVIS_BRANCH=$TRAVIS_BRANCH
+	# Because this is for a PR, `$TRAVIS_COMMIT` is a synthesized merge-commit with 2 parents.  The first
+	# parent (which is given by `$TRAVIS_COMMIT^`) is the target branch, and the second parent is the PR
+	# branch.
+	#
+	# So, we need to look at `$TRAVIS_COMMIT^` and decide which remote tracking branch that corresponds
+	# to.  Sounds like a job for `git describe`... except that `git describe` has mind-bogglingly poor
+	# options for selecting which refs to consider.  Instead, we'll do this ourselves with awk by parsing
+	# `git show-ref`.
+	#
+	# The output of `git show-ref` looks like
+	#     4e206c51ef558f83d5c67e4586279e1ea15cdda2 refs/heads/master
+	#     4e206c51ef558f83d5c67e4586279e1ea15cdda2 refs/remotes/origin/HEAD
+	#     c8d4e9a3579e45cfefdc3374de8f0e9b3c956ad0 refs/remotes/origin/early-access
+	#     4e206c51ef558f83d5c67e4586279e1ea15cdda2 refs/remotes/origin/master
+	#
+	# Resolve the "what if multiple refs match" question by limiting to just "master" or "early-access".
+	TRAVIS_BRANCH=$(git show-ref | awk -vcommit="$(git rev-parse "$TRAVIS_COMMIT^")" '$1 == commit && $2 ~ /^refs\/remotes\/origin\/(master|early-access)$/ { sub("refs/remotes/origin/", ""); print $2; exit; }')
+	echo "adjusted TRAVIS_BRANCH : ${original_TRAVIS_BRANCH} -> ${TRAVIS_BRANCH}"
+fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,18 +48,41 @@ env:
     # - AWS_SECRET_ACCESS_KEY
     - secure: "F9oY34UDI8aXuZ9nb6z3/ltlqrNs4RUQHDZHa2YSFoq0r2Rn272Yg7oHfPh3deYNKxtUOBwwcpiC/7G9MqhkuLQEYhqY/KowidG6gOxCZdTDEVS10C4GDEMGj64URlUCS722tQYMIpniiB6LW2kEOOcEuzC6JsVxS7BowUEVk7Ly8BTzrgNuGFN2bSphRyrJyrS3Reo5a1YI3joUMzI29t7fegefTIHHONKhZpIE86wFRk11nwvJdt54Eu9dVFwiEiGW9L9SnG2ph4UiqN6z3iQFCQ8HNvnf+BvNasdMBR3f85DPnG/syqOcQrrE1e5T88UXRxyUwR2ty1ad+ZvQPggwsoFs1FmdJH04pGn0Tgpo/AHNe5c67tvDbw2W4jlFJgVI/keoFvQigSM2DUuL1i0v48TkZw8lgcfasRjtJi7iDTC4qqjyMLkY6y2TRTVDG/86qxK3No7vvJZajzntU3c6MUttiSDubaHL5RuklQ+7MjN5Dp1cD09L3Qqnm9KcjWzbNoyqriBO84VU4aJFF72jJ18qADX/UUj7cxi0ShY19BHX2Vrp3pPSNiePfO7okUrg5Wc4eD7u4eC+aUVHboEX35NhBnfj7/ASrsltIANYFmNarv3tvd67JIsm/Wz3pge6YOSV1pBr2IsGk5UVIXdJ/mm6GVWFlJ9PiELDBGc="
 
+git:
+  depth: false
+
 install:
   - ./releng/travis-install.sh
   # Adjust the environment per travis-install.sh
   - PATH=~/bin:$PATH
   - source ~/.gimme/envs/latest.env
   - export DEV_KUBECONFIG=~/.kube/$(cat ~/kubernaut-claim.txt).yaml
+  - node --version
+  - nvm use 11
+  - node --version
+  - source ./.ci/travis-fix-env
+  - ./.ci/install-blc
 
 script:
   #- docker pull ${DEV_REGISTRY}/builder:latest
   - ./releng/travis-script.sh
+  - ./.ci/pr-build-website-preview master
+  - ./.ci/publish-website-preview master
+  - ./.ci/blc-website-preview master
 
 after_script:
   # release the kubernaut claim
   - ./releng/travis-cleanup.sh
   # - docker tag builder:latest ${DEV_REGISTRY}/builder:latest && docker push ${DEV_REGISTRY}/builder:latest
+
+deploy:
+  - provider: script
+    script: ./.ci/publish-website
+    skip_cleanup: true
+    on:
+      branch: master
+  - provider: script
+    script: ./.ci/publish-website
+    skip_cleanup: true
+    on:
+      branch: early-access

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,6 +57,7 @@ install:
   - PATH=~/bin:$PATH
   - source ~/.gimme/envs/latest.env
   - export DEV_KUBECONFIG=~/.kube/$(cat ~/kubernaut-claim.txt).yaml
+  # Setup for docs
   - node --version
   - nvm use 11
   - node --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -76,14 +76,10 @@ after_script:
   - ./releng/travis-cleanup.sh
   # - docker tag builder:latest ${DEV_REGISTRY}/builder:latest && docker push ${DEV_REGISTRY}/builder:latest
 
-deploy:
-  - provider: script
-    script: ./.ci/publish-website
-    skip_cleanup: true
-    on:
-      branch: master
-  - provider: script
-    script: ./.ci/publish-website
-    skip_cleanup: true
-    on:
-      branch: early-access
+# TODO: enable this post netlify testing
+#deploy:
+#  - provider: script
+#    script: ./.ci/publish-website
+#    skip_cleanup: true
+#    on:
+#      branch: master


### PR DESCRIPTION
**--- OK TO REVIEW, NOT OK TO MERGE ---**

This PR adds docs related CI machinery to ambassador which is mostly based on CI config from https://github.com/datawire/ambassador-docs.

Currently I've disabled the bits which push to getambassador.io.git which deploys our website. I'd first test the netlify preview and blc test and then enable it.

Do not merge before https://github.com/datawire/getambassador.io/pull/202/