### PR TITLE
Add tcp mapping to the overview.html page

### DIFF
--- a/python/templates/overview.html
+++ b/python/templates/overview.html
@@ -277,6 +277,59 @@ limitations under the License
 
       <div class="row">
         <div class="col-12">
+          Ambassador TCP Mappings
+
+          <div class="row">
+            <div class="col-12">
+              <table cellpadding="2em" width="100%">
+                <thead>
+                  <td><b>Name</b></td>
+                  <td><b>Port</b></td>
+                  <td><b>Source</b></td>
+                  <td><b>Service</b></td>
+                </thead>
+                <tbody>
+                  {% for group_id, group in groups.items() if group.kind == "IRTCPMappingGroup" %}
+                  <tr
+                    {% if loop.index % 2 %}
+                      style="background: rgba(86,61,124,.05);"
+                    {% endif %}
+                    >
+                    <td>
+                      <code style="color: black">
+                        {{ group.name | replace("GROUP: ", "") }}
+                        {% if group['host'] %}
+                          <br/>
+                          host: {{ group['host'] }}
+                        {% endif %}
+                      </code>
+                    </td>
+                    <td>
+                      {{ group.port }}
+                    </td>
+                    <td>
+                      <!--<a href="/ambassador/v0/diag/{{ group_id }}">-->
+                        {{ group.location }}
+                      <!--</a>-->
+                    </td>
+                    <td>
+                        {% if group['mappings'] %}
+                          {% for mapping in group['mappings'] %}
+                            {{ mapping.cluster.service }}
+                          {% endfor %}
+                        {% endif %}
+                    </td>
+                  {% endfor %}
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="row">
+        <div class="col-12">
           Color Legend
           <div class="row">
             <div class="col-12">


### PR DESCRIPTION
## Description
Add tcp mapping to the overview.html page

## Related Issues
The overview page shows only the http mappings, so adding the tcp mapping is useful when there are some defined.

It's very basic right now, it probably needs improvements, polishing. It's a first iteration.
I don't know if it can be merged as is as a first basic step or if it's better to have something more polished for merging.