### PR TITLE
Restore correct 889 tests for Edge Stack.

### DIFF
--- a/python/tests/t_no_ui.py
+++ b/python/tests/t_no_ui.py
@@ -33,9 +33,5 @@ spec:
 
     def queries(self):
         yield(Query(self.url("ambassador/v0/diag/"), expected=404))
-
-        if EDGE_STACK:
-          yield(Query(self.url("edge_stack/admin/"), expected=200))
-        else:
-          yield(Query(self.url("edge_stack/admin/"), expected=404))
+        yield(Query(self.url("edge_stack/admin/"), expected=404))
 


### PR DESCRIPTION
Test-only change, as we land Edge Stack's ability to disable the Edge Policy Console.