### PR TITLE
Allow running sshd to port forward as the telepresence user

### DIFF
--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -44,7 +44,9 @@ ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/local
 # build it locally -- just using pip won't work.
 
 RUN apk --no-cache add bash bash-completion ncurses curl jq rsync python3 python3-dev build-base libffi-dev openssl-dev sudo \
-                       iptables docker openssh-client libcap libcap-dev yaml-dev cython git nodejs npm && \
+                       iptables docker openssh-client libcap libcap-dev yaml-dev cython git nodejs npm openssh && \
+    ssh-keygen -A && \
+    echo -e "ClientAliveInterval 1\nGatewayPorts yes\nPermitEmptyPasswords yes\nPort 8022\nClientAliveCountMax 10\n" >> /etc/ssh/sshd_config && \
     pip3 install -U pip && \
     curl --fail https://dl.google.com/go/go1.13.linux-amd64.tar.gz | tar -C /usr/local -xzf - && \
     curl --fail -L https://storage.googleapis.com/kubernetes-release/release/v1.16.0/bin/linux/amd64/kubectl -o /usr/bin/kubectl && \
@@ -89,6 +91,7 @@ RUN mkdir -p /ambassador/sidecars && \
     ln -s /buildroot/ambassador/python/kubewatch.py /ambassador/kubewatch.py
 
 RUN adduser dw --disabled-password
+RUN adduser telepresence -G root -D -H -s /bin/false && passwd -d telepresence
 # SUDO_USERS HOSTS=(AS_USER) TAGS COMMANDS
 RUN echo "dw ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/datawire
 RUN chown dw /buildroot
@@ -106,8 +109,10 @@ FROM ${artifacts} as artifacts
 FROM ${base} as ambassador
 
 # External stuff that should change infrequently
-RUN apk --no-cache add bash curl python3 libcap
+RUN apk --no-cache add bash curl python3 libcap openssh
 RUN ln -s /usr/bin/python3 /usr/bin/python
+RUN adduser telepresence -G root -D -H -s /bin/false && passwd -d telepresence && ssh-keygen -A && \
+    echo -e "ClientAliveInterval 1\nGatewayPorts yes\nPermitEmptyPasswords yes\nPort 8022\nClientAliveCountMax 10\n" >> /etc/ssh/sshd_config
 COPY --from=artifacts /usr/bin/kubectl /usr/bin/kubectl
 COPY --from=artifacts /usr/lib/libyaml* /usr/lib/
 


### PR DESCRIPTION
This adds OpenSSH Server and a password-less telepresence user to the builder and production AES images. The password-less user has a shell of `/bin/false` so potential damage is limited. The server is not launched by anything here.
