### PR TITLE
Add support for additional installers in builder and prod image

### DIFF
--- a/build-aux-local/install.sh
+++ b/build-aux-local/install.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# Expections
+# - Exist as /opt/image-build/install.sh
+# - Get called from post-install.sh
+# - Run all scripts in /opt/image-build/installers/
+# - Be run once as part of prod docker build
+# - Be run repeatedly in the builder container
+# See also: installers/README.md
+
+set -e
+
+cd /opt/image-build/installers
+shopt -s nullglob
+for installer in /opt/image-build/installers/*; do
+    if [ -x "$installer" ]; then
+        echo Installing $(basename "$installer")
+        "$installer"
+    fi
+done

--- a/build-aux-local/installers/README.md
+++ b/build-aux-local/installers/README.md
@@ -1,0 +1,10 @@
+# Installers
+
+Executables (scripts) in this directory are intended to install and configure additional packages needed by non-OSS modules. AES uses this to add a few features. 
+
+These installers are run
+
+- During `docker build` of the production image as an early step
+- From `post-compile.sh` (which is run after every compilation of Go code) repeatedly, to keep the builder container up-to-date
+
+OSS Ambassador doesn't need any installers here because this is the base module: everything it needs to install is listed directly in the Dockerfile.

--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -111,6 +111,10 @@ RUN ln -s /usr/bin/python3 /usr/bin/python
 COPY --from=artifacts /usr/bin/kubectl /usr/bin/kubectl
 COPY --from=artifacts /usr/lib/libyaml* /usr/lib/
 
+# Other installers
+COPY --from=artifacts /opt/image-build /opt/image-build
+RUN /opt/image-build/install.sh
+
 # External Python packages we use
 COPY --from=artifacts /usr/lib/python3.7/site-packages /usr/lib/python3.7/site-packages
 

--- a/post-compile.sh
+++ b/post-compile.sh
@@ -20,3 +20,13 @@ sudo ln -sf /opt/ambassador/bin/ambassador /opt/ambassador/bin/ambex
 sudo ln -sf /opt/ambassador/bin/ambassador /opt/ambassador/bin/kubestatus
 sudo ln -sf /opt/ambassador/bin/ambassador /opt/ambassador/bin/watt
 sudo install /buildroot/bin/capabilities_wrapper /opt/ambassador/bin/wrapper
+
+# Copy installer support into /opt/image-build to be run at docker build for the
+# production image. Then run the installers for the builder container.
+# Note: When this (ambassador's) post-compile runs, it always runs first, and
+# every other post-compile runs as well. So this is the place to recreate the
+# /opt/image-build tree from scratch so the builder container stays valid.
+sudo rm -rf /opt/image-build
+sudo install -D -t /opt/image-build /buildroot/ambassador/build-aux-local/install.sh
+sudo cp -a /buildroot/ambassador/build-aux-local/installers /opt/image-build/
+sudo /opt/image-build/install.sh


### PR DESCRIPTION
Ambassador OSS installs and configures all the packages it needs in its Dockerfile. But other modules that build on Ambassador (like AES) sometimes need to install and configure additional packages that OSS does not need. This PR makes that possible.
