### PR TITLE
add kind as a known local cluster type

### DIFF
--- a/cmd/edgectl/aes_install.go
+++ b/cmd/edgectl/aes_install.go
@@ -373,6 +373,9 @@ func (i *Installer) Perform(kcontext string) error {
 		} else if strings.Contains(clusterNodeLabels, "minikube") {
 			clusterInfo = "minikube"
 			isKnownLocalCluster = true
+		} else if strings.Contains(clusterNodeLabels, "kind") {
+			clusterInfo = "kind"
+			isKnownLocalCluster = true
 		} else if strings.Contains(clusterNodeLabels, "gke") {
 			clusterInfo = "gke"
 		} else if strings.Contains(clusterNodeLabels, "aks") {


### PR DESCRIPTION
## Description
This change recognizes "kind" (https://github.com/kubernetes-sigs/kind) as a known local cluster type, giving it the same status in edgectl as minikube and docker-local.

## Related Issues
None

## Testing
Manually tested on linux using kind 0.7.0. Successfully installs ambassador in the kind cluster. Note that kind (like minikube) does not provide the LoadBalancer type, so accessing the ambassador UI requires port-forwarding via kubectl.
