### PR TITLE
Identify `kind` as a KnownLocalCluster

### DIFF
--- a/cmd/edgectl/aes_install.go
+++ b/cmd/edgectl/aes_install.go
@@ -373,6 +373,9 @@ func (i *Installer) Perform(kcontext string) error {
 		} else if strings.Contains(clusterNodeLabels, "minikube") {
 			clusterInfo = "minikube"
 			isKnownLocalCluster = true
+		} else if strings.Contains(clusterNodeLabels, "kind-control-plane") {
+			clusterInfo = "kind"
+			isKnownLocalCluster = true
 		} else if strings.Contains(clusterNodeLabels, "gke") {
 			clusterInfo = "gke"
 		} else if strings.Contains(clusterNodeLabels, "aks") {


### PR DESCRIPTION
## Description
Playing around with my [KIND](https://kind.sigs.k8s.io/) installation, I want `edgectl` to correctly identify `kind` as a KnownLocalCluster and not attempt to create & wait for a LoadBalancer service with a public IP.

## Related Issues
None.

## Testing
Manual tests with:
```
~ k get no -Lkubernetes.io/hostname
NAME                 STATUS   ROLES    AGE   VERSION           HOSTNAME
kind-control-plane   Ready    master   61s   v1.19.0-alpha.0   kind-control-plane
```

Please note it is possible to configure KIND and rename the control-plane! However, this change should catch _most_ standard installs of KIND.

## Tasks That Must Be Done
- [ ] Did you update CHANGELOG.md?
- [ ] Did you add or update tests?
- [ ] Did you update documentation?
- [ ] Were there any special dev tricks you had to use to work on this code efficiently?
  + [ ] Did you add them to DEVELOPING.md?

## Other
* If this is a documentation change, please open the pull request at https://github.com/datawire/ambassador-docs instead.
* Code changes should occur against `master`.
