### PR TITLE
kat-server: grpc-auth: Use fewer magic numbers

### DIFF
--- a/cmd/kat-server/services/grpc-auth.go
+++ b/cmd/kat-server/services/grpc-auth.go
@@ -18,9 +18,9 @@ import (
 	pb_legacy "github.com/datawire/ambassador/pkg/api/envoy/service/auth/v2alpha"
 	envoy_type "github.com/datawire/ambassador/pkg/api/envoy/type"
 
-	rpc "istio.io/gogo-genproto/googleapis/google/rpc"
 	gogo_type "github.com/gogo/protobuf/types"
 	"google.golang.org/grpc"
+	rpc "istio.io/gogo-genproto/googleapis/google/rpc"
 )
 
 // GRPCAUTH server object (all fields are required).
@@ -231,8 +231,8 @@ func (r *Response) GetResponse() *pb.CheckResponse {
 	rs := &pb.CheckResponse{}
 	switch {
 	// Ok respose.
-	case r.status == 200 || r.status == 0:
-		rs.Status = &rpc.Status{Code: int32(0)}
+	case r.status == http.StatusOK || r.status == 0:
+		rs.Status = &rpc.Status{Code: int32(rpc.OK)}
 		rs.HttpResponse = &pb.CheckResponse_OkResponse{
 			OkResponse: &pb.OkHttpResponse{
 				Headers: r.headers,
@@ -241,7 +241,7 @@ func (r *Response) GetResponse() *pb.CheckResponse {
 
 	// Denied response.
 	default:
-		rs.Status = &rpc.Status{Code: int32(16)}
+		rs.Status = &rpc.Status{Code: int32(rpc.UNAUTHENTICATED)}
 		rs.HttpResponse = &pb.CheckResponse_DeniedResponse{
 			DeniedResponse: &pb.DeniedHttpResponse{
 				Status: &envoy_type.HttpStatus{


### PR DESCRIPTION
## Description

I notice that I had this commit sitting around.  Adjust the kat-server's grpc-auth to use named constants from `http` and `rpc` instead of hard-coding magic numbers.  This is essentially a style change.

## Tasks That Must Be Done
- [x] Did you update CHANGELOG.md? - no applicable changes
- [x] Did you add or update tests? - no expected behavior changes
- [x] Did you update documentation? - no applicable changes
- [x] Were there any special dev tricks you had to use to work on this code efficiently? - no