### PR TITLE
python: Handle k8s services with no metadata

### DIFF
--- a/python/ambassador/config/resourcefetcher.py
+++ b/python/ambassador/config/resourcefetcher.py
@@ -793,6 +793,10 @@ class ResourceFetcher:
         # Again, we're trusting that the input isn't overly bloated on that latter bit.
 
         metadata = k8s_object.get('metadata', None)
+        if not metadata:
+            self.logger.debug("ignoring K8s Service with no metadata")
+            return None
+
         metadata_labels: Optional[Dict[str, str]] = metadata.get('labels')
         resource_name = metadata.get('name') if metadata else None
         resource_namespace = metadata.get('namespace', 'default') if metadata else None

--- a/python/tests/test_resourcefetcher.py
+++ b/python/tests/test_resourcefetcher.py
@@ -41,12 +41,16 @@ def test_resourcefetcher_handle_k8s_service():
     aconf = Config()
 
     fetcher = ResourceFetcher(logger, aconf)
-    svc = {
-        "metadata": {
-            "name": "testservice",
-            "annotations": {
-                "foo": "bar"
-            }
+
+    # Test no metadata key
+    svc = {}
+    result = fetcher.handle_k8s_service(svc)
+    assert result == None
+
+    svc["metadata"] = {
+        "name": "testservice",
+        "annotations": {
+            "foo": "bar"
         }
     }
     # Test no ambassador annotation


### PR DESCRIPTION
This case should probably never happen.
This could happen for testing.

## Description
A few sentences describing the overall goals of the pull request's commits.

## Related Issues
List related issues.

## Testing
A few sentences describing what testing you've done, e.g., manual tests, automated tests, deployed in production, etc.

## Tasks That Must Be Done
- [ ] Did you update CHANGELOG.md?
- [ ] Did you add or update tests?
- [ ] Did you update documentation?
- [ ] Were there any special dev tricks you had to use to work on this code efficiently?
  + [ ] Did you add them to DEVELOPING.md?

## Other
* If this is a documentation change, please open the pull request at https://github.com/datawire/ambassador-docs instead.
* Code changes should occur against `master`.
