### PR TITLE
Support Ingress defaultBackend

### DIFF
--- a/python/ambassador/config/resourcefetcher.py
+++ b/python/ambassador/config/resourcefetcher.py
@@ -538,8 +538,9 @@ class ResourceFetcher:
                 self.logger.info(f"Generated TLS Context from ingress {ingress_name}: {ingress_tls_context}")
                 self.handle_k8s_crd(ingress_tls_context)
 
-        # parse ingress.spec.backend
-        default_backend = ingress_spec.get('backend', {})
+        # parse ingress.spec.defaultBackend
+        # using ingress.spec.backend as a fallback, for older versions of the Ingress resource.
+        default_backend = ingress_spec.get('defaultBackend', ingress_spec.get('backend', {}))
         db_service_name = default_backend.get('serviceName', None)
         db_service_port = default_backend.get('servicePort', None)
         if db_service_name is not None and db_service_port is not None:

--- a/python/tests/gold/plain/snapshots/econf.json
+++ b/python/tests/gold/plain/snapshots/econf.json
@@ -2544,6 +2544,60 @@
                 "dns_lookup_family": "V4_ONLY",
                 "lb_policy": "ROUND_ROBIN",
                 "load_assignment": {
+                    "cluster_name": "cluster_plain_simplemappingingressdefaul-0",
+                    "endpoints": [
+                        {
+                            "lb_endpoints": [
+                                {
+                                    "endpoint": {
+                                        "address": {
+                                            "socket_address": {
+                                                "address": "plain-simplemappingingressdefaultbackend-grpc-grpc.plain-namespace",
+                                                "port_value": 80,
+                                                "protocol": "TCP"
+                                            }
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                "name": "cluster_plain_simplemappingingressdefaul-0",
+                "type": "STRICT_DNS"
+            },
+            {
+                "connect_timeout": "3.000s",
+                "dns_lookup_family": "V4_ONLY",
+                "lb_policy": "ROUND_ROBIN",
+                "load_assignment": {
+                    "cluster_name": "cluster_plain_simplemappingingressdefaul-1",
+                    "endpoints": [
+                        {
+                            "lb_endpoints": [
+                                {
+                                    "endpoint": {
+                                        "address": {
+                                            "socket_address": {
+                                                "address": "plain-simplemappingingressdefaultbackend-http-http.plain-namespace",
+                                                "port_value": 80,
+                                                "protocol": "TCP"
+                                            }
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                "name": "cluster_plain_simplemappingingressdefaul-1",
+                "type": "STRICT_DNS"
+            },
+            {
+                "connect_timeout": "3.000s",
+                "dns_lookup_family": "V4_ONLY",
+                "lb_policy": "ROUND_ROBIN",
+                "load_assignment": {
                     "cluster_name": "cluster_plain_tlsorigination_grpc_explic-0",
                     "endpoints": [
                         {
@@ -8097,6 +8151,94 @@
                                                             "prefix_rewrite": "/ambassador/v0/",
                                                             "priority": null,
                                                             "timeout": "10.000s"
+                                                        }
+                                                    },
+                                                    {
+                                                        "match": {
+                                                            "case_sensitive": true,
+                                                            "headers": [
+                                                                {
+                                                                    "exact_match": "https",
+                                                                    "name": "x-forwarded-proto"
+                                                                }
+                                                            ],
+                                                            "prefix": "/",
+                                                            "runtime_fraction": {
+                                                                "default_value": {
+                                                                    "denominator": "HUNDRED",
+                                                                    "numerator": 50
+                                                                },
+                                                                "runtime_key": "routing.traffic_shift.cluster_plain_simplemappingingressdefaul-0"
+                                                            }
+                                                        },
+                                                        "route": {
+                                                            "cluster": "cluster_plain_simplemappingingressdefaul-0",
+                                                            "prefix_rewrite": "/",
+                                                            "priority": null,
+                                                            "timeout": "3.000s"
+                                                        }
+                                                    },
+                                                    {
+                                                        "match": {
+                                                            "case_sensitive": true,
+                                                            "prefix": "/",
+                                                            "runtime_fraction": {
+                                                                "default_value": {
+                                                                    "denominator": "HUNDRED",
+                                                                    "numerator": 50
+                                                                },
+                                                                "runtime_key": "routing.traffic_shift.cluster_plain_simplemappingingressdefaul-0"
+                                                            }
+                                                        },
+                                                        "route": {
+                                                            "cluster": "cluster_plain_simplemappingingressdefaul-0",
+                                                            "prefix_rewrite": "/",
+                                                            "priority": null,
+                                                            "timeout": "3.000s"
+                                                        }
+                                                    },
+                                                    {
+                                                        "match": {
+                                                            "case_sensitive": true,
+                                                            "headers": [
+                                                                {
+                                                                    "exact_match": "https",
+                                                                    "name": "x-forwarded-proto"
+                                                                }
+                                                            ],
+                                                            "prefix": "/",
+                                                            "runtime_fraction": {
+                                                                "default_value": {
+                                                                    "denominator": "HUNDRED",
+                                                                    "numerator": 100
+                                                                },
+                                                                "runtime_key": "routing.traffic_shift.cluster_plain_simplemappingingressdefaul-1"
+                                                            }
+                                                        },
+                                                        "route": {
+                                                            "cluster": "cluster_plain_simplemappingingressdefaul-1",
+                                                            "prefix_rewrite": "/",
+                                                            "priority": null,
+                                                            "timeout": "3.000s"
+                                                        }
+                                                    },
+                                                    {
+                                                        "match": {
+                                                            "case_sensitive": true,
+                                                            "prefix": "/",
+                                                            "runtime_fraction": {
+                                                                "default_value": {
+                                                                    "denominator": "HUNDRED",
+                                                                    "numerator": 100
+                                                                },
+                                                                "runtime_key": "routing.traffic_shift.cluster_plain_simplemappingingressdefaul-1"
+                                                            }
+                                                        },
+                                                        "route": {
+                                                            "cluster": "cluster_plain_simplemappingingressdefaul-1",
+                                                            "prefix_rewrite": "/",
+                                                            "priority": null,
+                                                            "timeout": "3.000s"
                                                         }
                                                     }
                                                 ]

--- a/python/tests/t_mappingtests.py
+++ b/python/tests/t_mappingtests.py
@@ -94,6 +94,41 @@ spec:
                 assert r.backend.request.headers['x-envoy-original-path'][0] == f'/{self.name}/'
 
 
+class SimpleMappingIngressDefaultBackend(MappingTest):
+
+    parent: AmbassadorTest
+    target: ServiceType
+
+    @classmethod
+    def variants(cls):
+        for st in variants(ServiceType):
+            yield cls(st, name="{self.target.name}")
+
+    def manifests(self) -> str:
+        return f"""
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: ambassador
+    getambassador.io/ambassador-id: plain
+  name: {self.name.lower()}
+spec:
+  backend:
+    serviceName: {self.target.path.k8s}
+    servicePort: 80
+"""
+
+    def queries(self):
+        yield Query(self.parent.url(self.name))
+
+    def check(self):
+        for r in self.results:
+            if r.backend:
+                assert r.backend.name == self.target.path.k8s, (r.backend.name, self.target.path.k8s)
+                assert r.backend.request.headers['x-envoy-original-path'][0] == f'/{self.name}'
+
+
 class SimpleIngressWithAnnotations(MappingTest):
 
     parent: AmbassadorTest


### PR DESCRIPTION
## Description
Support Ingress defaultBackend.

## Related Issues
https://github.com/datawire/apro/issues/1093

## Testing
Pending on support for the `spec.defaultBackend` field in the Ingress resource, along with conformance tests.

Previous versions of Ingress v1beta1 must pass regression tests given the fallback support for `spec.backend`

## Tasks That Must Be Done
- [ ] Did you update CHANGELOG.md?
- [x] Did you add or update tests?
- [ ] Did you update documentation?
- [ ] Were there any special dev tricks you had to use to work on this code efficiently?
  + [ ] Did you add them to DEVELOPING.md?
