### PR TITLE
Clean up behavior around edgectl connect and namespaces

### DIFF
--- a/cmd/edgectl/cli.go
+++ b/cmd/edgectl/cli.go
@@ -124,7 +124,8 @@ func (d *Daemon) getRootCommand(p *supervisor.Process, out *Emitter, data *Clien
 		RunE: func(cmd *cobra.Command, args []string) error {
 			context, _ := cmd.Flags().GetString("context")
 			namespace, _ := cmd.Flags().GetString("namespace")
-			if err := d.Connect(p, out, data.RAI, context, namespace, args); err != nil {
+			managerNs, _ := cmd.Flags().GetString("manager-namespace")
+			if err := d.Connect(p, out, data.RAI, context, namespace, managerNs, args); err != nil {
 				return err
 			}
 			return out.Err()
@@ -137,6 +138,10 @@ func (d *Daemon) getRootCommand(p *supervisor.Process, out *Emitter, data *Clien
 	_ = connectCmd.Flags().StringP(
 		"namespace", "n", "",
 		"The Kubernetes namespace to use. Defaults to kubectl's default for the context.",
+	)
+	_ = connectCmd.Flags().StringP(
+		"manager-namespace", "m", "ambassador",
+		"The Kubernetes namespace in which the Traffic Manager is running.",
 	)
 	rootCmd.AddCommand(connectCmd)
 	rootCmd.AddCommand(&cobra.Command{

--- a/cmd/edgectl/notify.go
+++ b/cmd/edgectl/notify.go
@@ -47,10 +47,3 @@ func Notify(p *supervisor.Process, message string) {
 		p.Logf("ERROR while notifying: %v", err)
 	}
 }
-
-// MaybeNotify displays a notification only if a value changes
-func MaybeNotify(p *supervisor.Process, name string, old, new bool) {
-	if old != new {
-		Notify(p, fmt.Sprintf("%s: %t -> %t", name, old, new))
-	}
-}

--- a/cmd/edgectl/notify.go
+++ b/cmd/edgectl/notify.go
@@ -7,10 +7,21 @@ import (
 	"github.com/datawire/ambassador/pkg/supervisor"
 )
 
-var notifyRAI *RunAsInfo
+var (
+	notifyRAI     *RunAsInfo
+	notifyEnabled = false
+)
 
 // Notify displays a desktop banner notification to the user
 func Notify(p *supervisor.Process, message string) {
+	p.Logf("----------------------------------------------------------------------")
+	p.Logf("NOTIFY: %s", message)
+	p.Logf("----------------------------------------------------------------------")
+
+	if !notifyEnabled {
+		return
+	}
+
 	if notifyRAI == nil {
 		var err error
 		notifyRAI, err = GuessRunAsInfo(p)
@@ -31,7 +42,6 @@ func Notify(p *supervisor.Process, message string) {
 		return
 	}
 
-	p.Logf("NOTIFY: %s", message)
 	cmd := notifyRAI.Command(p, args...)
 	if err := cmd.Run(); err != nil {
 		p.Logf("ERROR while notifying: %v", err)


### PR DESCRIPTION
- Namespace, where teleproxy runs, is whatever the context says by default
- Manager namespace, where the manager runs, is ambassador by default
- Both can be set independently