### PR TITLE
Improve performance of edgectl connect

### DIFF
--- a/cmd/edgectl/cluster.go
+++ b/cmd/edgectl/cluster.go
@@ -150,6 +150,7 @@ type TrafficManager struct {
 	apiPort        int
 	sshPort        int
 	client         *http.Client
+	namespace      string
 	interceptables []string
 	totalClusCepts int
 	snapshotSent   bool
@@ -174,7 +175,12 @@ func NewTrafficManager(p *supervisor.Process, cluster *KCluster, managerNs strin
 	}
 	kpfArgStr := fmt.Sprintf("port-forward -n %s svc/telepresence-proxy %d:8022 %d:8081", managerNs, sshPort, apiPort)
 	kpfArgs := cluster.GetKubectlArgs(strings.Fields(kpfArgStr)...)
-	tm := &TrafficManager{apiPort: apiPort, sshPort: sshPort, client: &http.Client{Timeout: 10 * time.Second}}
+	tm := &TrafficManager{
+		apiPort:   apiPort,
+		sshPort:   sshPort,
+		namespace: managerNs,
+		client:    &http.Client{Timeout: 10 * time.Second},
+	}
 
 	pf, err := CheckedRetryingCommand(p, "traffic-kpf", kpfArgs, cluster.RAI(), tm.check, 15*time.Second)
 	if err != nil {

--- a/cmd/edgectl/intercept.go
+++ b/cmd/edgectl/intercept.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -322,7 +321,7 @@ func MakeIntercept(p *supervisor.Process, out *Emitter, tm *TrafficManager, clus
 		Spec: mappingSpec{
 			AmbassadorID: []string{fmt.Sprintf("intercept-%s", ii.Deployment)},
 			Prefix:       ii.Prefix,
-			Service:      fmt.Sprintf("telepresence-proxy.%s:%d", cluster.namespace, port),
+			Service:      fmt.Sprintf("telepresence-proxy.%s:%d", tm.namespace, port),
 			Headers:      ii.Patterns,
 		},
 	}
@@ -333,13 +332,10 @@ func MakeIntercept(p *supervisor.Process, out *Emitter, tm *TrafficManager, clus
 		return nil, errors.Wrap(err, "Intercept: mapping could not be constructed")
 	}
 
-	p.Logf("%s: Intercept using mapping %v", ii.Name, string(manifest))
 	out.Printf("%s: applying intercept mapping in namespace %s\n", ii.Name, ii.Namespace)
 
 	apply := cluster.GetKubectlCmdNoNamespace(p, "apply", "-f", "-")
 	apply.Stdin = strings.NewReader(string(manifest))
-	apply.Stdout = os.Stdout
-	apply.Stderr = os.Stderr
 	err = apply.Run()
 
 	if err != nil {

--- a/cmd/edgectl/main.go
+++ b/cmd/edgectl/main.go
@@ -1,8 +1,12 @@
 package main
 
 import (
+	"crypto/tls"
 	"fmt"
+	"net"
+	"net/http"
 	"os"
+	"time"
 
 	"github.com/spf13/cobra"
 )
@@ -33,6 +37,23 @@ to troubleshoot problems.
 
 // edgectl is the full path to the Edge Control binary
 var edgectl string
+
+var simpleTransport = &http.Transport{
+	// #nosec G402
+	TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+	Proxy:           nil,
+	DialContext: (&net.Dialer{
+		Timeout:   10 * time.Second,
+		KeepAlive: 1 * time.Second,
+		DualStack: true,
+	}).DialContext,
+	DisableKeepAlives: true,
+}
+
+var hClient = &http.Client{
+	Transport: simpleTransport,
+	Timeout:   15 * time.Second,
+}
 
 func main() {
 	// Figure out our executable and save it

--- a/cmd/edgectl/net_override.go
+++ b/cmd/edgectl/net_override.go
@@ -3,7 +3,6 @@ package main
 import (
 	"fmt"
 	"io/ioutil"
-	"net/http"
 	"time"
 
 	"github.com/pkg/errors"
@@ -29,11 +28,9 @@ func (d *Daemon) MakeNetOverride(p *supervisor.Process) error {
 }
 
 // checkNetOverride checks the status of teleproxy intercept by doing the
-// equivalent of curl http://teleproxy/api/tables/. It's okay to create a new
-// client each time because we don't want to reuse connections.
+// equivalent of curl http://teleproxy/api/tables/.
 func checkNetOverride(p *supervisor.Process) error {
-	client := http.Client{Timeout: 10 * time.Second}
-	res, err := client.Get(fmt.Sprintf(
+	res, err := hClient.Get(fmt.Sprintf(
 		"http://teleproxy%d.cachebust.telepresence.io/api/tables",
 		time.Now().Unix(),
 	))


### PR DESCRIPTION
- If there's a traffic manager available, grab an initial cluster snapshot from the manager and use that to bootstrap Teleproxy. This can happen while Teleproxy's own watchers warm up.
- Make better/correct use of Golang's HTTP Client by configuring one client correctly and using it everywhere.
- Fix some bugs around use of namespaces in the intercept code
