### PR TITLE
Improve Knative support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,15 @@ Format:
 --->
 
 <!--- CueAddReleaseNotes --->
+## [Next]
+[Next]: https://github.com/datawire/ambassador/compare/v1.4.2...master
+
+### Ambassador API Gateway + Ambassador Edge Stack
+
+- Bugfix: Only update Knative ingress CRDs when the generation changes
+- Feature: Inform Knative of the route to the Ambassador service if available
+- Feature: Support the path and timeout options of the Knative ingress path rules
+
 ## [1.4.2] April 22, 2020
 [1.4.2]: https://github.com/datawire/ambassador/compare/v1.4.1...v1.4.2
 

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -34,7 +34,7 @@ ever find anything missing from this list.
  - bash
  - rsync (with the --info option)
  - golang 1.13
- - python 3.6+
+ - python 3.7+
  - kubectl
  - a kubernetes cluster
  - a docker registry

--- a/builder/requirements.txt
+++ b/builder/requirements.txt
@@ -15,6 +15,7 @@ kubernetes==8.0.0
 click==7.0
 jsonpatch==1.24
 expiringdict==1.2.0
+durationpy==0.5
 
 # Dev requirements
 gitpython

--- a/python/ambassador/config/config.py
+++ b/python/ambassador/config/config.py
@@ -75,8 +75,6 @@ class Config:
         'logservice': "log_services",
     }
 
-    KnativeResources = { 'clusteringress', 'knativeingress' }
-
     SupportedVersions: ClassVar[Dict[str, str]] = {
         "v0": "is deprecated, consider upgrading",
         "v1": "ok",
@@ -221,20 +219,9 @@ class Config:
     def as_json(self):
         return json.dumps(self.as_dict(), sort_keys=True, indent=4)
 
-    def ambassador_id_required(self, resource_kind: str) -> bool:
-        if resource_kind in self.KnativeResources:
-            return False
-
-        return True
-
     # Often good_ambassador_id will be passed an ACResource, but sometimes
     # just a plain old dict.
     def good_ambassador_id(self, resource: dict):
-        resource_kind = resource.get('kind', '').lower()
-        if not self.ambassador_id_required(resource_kind):
-            self.logger.debug(f"Resource: {resource_kind} does not require an Ambassador ID")
-            return True
-
         # Is an ambassador_id present in this object?
         #
         # NOTE WELL: when we update the status of a Host (or a Mapping?) then reserialization

--- a/python/ambassador/config/resourcefetcher.py
+++ b/python/ambassador/config/resourcefetcher.py
@@ -11,10 +11,12 @@ from .acresource import ACResource
 from .resourceprocessor import (
     ResourceDict,
     ResourceEmission,
+    ResourceKind,
     ResourceManager,
     ResourceProcessor,
     AggregateResourceProcessor,
     DeduplicatingResourceProcessor,
+    CounterResourceProcessor,
     KnativeIngressResourceProcessor,
 )
 
@@ -66,8 +68,10 @@ class ResourceFetcher:
                  skip_init_dir: bool=False, watch_only=False) -> None:
         self.aconf = aconf
         self.logger = logger
-        self.manager = ResourceManager(self.aconf, self.logger)
+        self.manager = ResourceManager(self.logger, self.aconf)
         self.processor = DeduplicatingResourceProcessor(AggregateResourceProcessor([
+            CounterResourceProcessor(self.aconf, ResourceKind.for_knative_networking('Ingress'), 'knative_ingress'),
+            CounterResourceProcessor(self.aconf, ResourceKind.for_knative_networking('ClusterIngress'), 'knative_cluster_ingress'),
             KnativeIngressResourceProcessor(self.manager),
         ]))
         self.watch_only = watch_only

--- a/python/ambassador/config/resourcefetcher.py
+++ b/python/ambassador/config/resourcefetcher.py
@@ -9,7 +9,7 @@ import re
 from .config import Config
 from .acresource import ACResource
 from .resourceprocessor import (
-    ResourceEmission,
+    NormalizedResource,
     ResourceManager,
     KubernetesObject,
     KubernetesGVK,
@@ -396,7 +396,7 @@ class ResourceFetcher:
                 # if not obj:
                 #     self.logger.debug("%s: empty object from %s" % (self.location, serialization))
 
-                self.manager.emit(ResourceEmission(obj, rkey=rkey))
+                self.manager.emit(NormalizedResource(obj, rkey=rkey))
 
         self.manager.locations.pop()
 

--- a/python/ambassador/config/resourceprocessor.py
+++ b/python/ambassador/config/resourceprocessor.py
@@ -1,0 +1,643 @@
+from __future__ import annotations
+from typing import Any, ClassVar, ContextManager, Dict, FrozenSet, Iterator, List, Mapping, Optional, Set
+
+import collections
+import collections.abc
+import contextlib
+import dataclasses
+import datetime
+import itertools
+import json
+import logging
+
+import durationpy
+
+from .config import Config
+from .acresource import ACResource
+
+from ..utils import dump_yaml
+
+
+@dataclasses.dataclass(frozen=True)
+class ResourceKind:
+    """
+    Represents a Kubernetes resource type (API version and kind).
+    """
+
+    api_version: str
+    kind: str
+
+    @property
+    def api_group(self) -> Optional[str]:
+        # These are backward-indexed to support apiVersion: v1, which has a
+        # version but no group.
+        try:
+            return self.api_version.split('/', 1)[-2]
+        except IndexError:
+            return None
+
+    @property
+    def version(self) -> str:
+        return self.api_version.split('/', 1)[-1]
+
+    @property
+    def domain(self) -> str:
+        if self.api_group:
+            return f'{self.kind.lower()}.{self.api_group}'
+        else:
+            return self.kind.lower()
+
+    @classmethod
+    def for_ambassador(cls, kind: str) -> ResourceKind:
+        return cls('getambassador.io/v2', kind)
+
+
+@dataclasses.dataclass(frozen=True)
+class ResourceIdent:
+    """
+    Represents a single Kubernetes resource by kind and name.
+    """
+
+    kind: ResourceKind
+    namespace: Optional[str]
+    name: str
+
+
+@dataclasses.dataclass
+class Location:
+    """
+    Represents a location for parsing.
+    """
+
+    filename: Optional[str] = None
+    ocount: int = 1
+
+    def mark_annotation(self) -> None:
+        if self.filename is None:
+            return
+        elif self.filename.endswith(':annotation'):
+            return
+
+        self.filename += ':annotation'
+
+    def __str__(self) -> str:
+        return f"{self.filename or 'anonymous YAML'}.{self.ocount}"
+
+
+class LocationManager:
+    """
+    Manages locations contextually.
+    """
+
+    previous: List[Location]
+    current: Location
+
+    def __init__(self) -> None:
+        self.previous = []
+        self.current = Location()
+
+    def push(self, filename: Optional[str] = None, ocount: int = 1) -> ContextManager[Location]:
+        self.previous.append(self.current)
+        self.current = Location(filename, ocount)
+
+        # This trick lets you use the return value of this method in a `with`
+        # statement. At the conclusion of the statement block, the location will
+        # automatically be popped from the stack.
+        @contextlib.contextmanager
+        def popper():
+            yield
+            self.pop()
+
+        return popper()
+
+    def push_reset(self) -> ContextManager[Location]:
+        """
+        Like push, but simply resets ocount keeping the current filename. Useful
+        for changing resource types.
+        """
+        return self.push(filename=self.current.filename)
+
+    def pop(self) -> Location:
+        current = self.current
+        self.current = self.previous.pop()
+        return current
+
+
+class ResourceDict(collections.abc.Mapping):
+    """
+    Represents a raw resource from Kubernetes.
+    """
+
+    default_namespace: Optional[str]
+
+    def __init__(self, delegate: Dict[str, Any], default_namespace: Optional[str] = None) -> None:
+        self.delegate = delegate
+        self.default_namespace = default_namespace
+
+        try:
+            self.kind
+            self.name
+        except KeyError:
+            raise ValueError('delegate is not a valid Kubernetes resource')
+
+    def __getitem__(self, key: str) -> Any:
+        return self.delegate[key]
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(self.delegate)
+
+    def __len__(self) -> int:
+        return len(self.delegate)
+
+    @property
+    def kind(self) -> ResourceKind:
+        return ResourceKind(self['apiVersion'], self['kind'])
+
+    @property
+    def metadata(self) -> Dict[str, Any]:
+        return self['metadata']
+
+    @property
+    def namespace(self) -> Optional[str]:
+        val = self.metadata.get('namespace', self.default_namespace)
+        if val == '_automatic_':
+            val = Config.ambassador_namespace
+
+        return val
+
+    @property
+    def name(self) -> str:
+        return self.metadata['name']
+
+    @property
+    def ident(self) -> ResourceIdent:
+        return ResourceIdent(self.kind, self.namespace, self.name)
+
+    @property
+    def generation(self) -> int:
+        return self.metadata.get('generation', 1)
+
+    @property
+    def annotations(self) -> Dict[str, str]:
+        return self.metadata.get('annotations', {})
+
+    @property
+    def ambassador_id(self) -> str:
+        return self.annotations.get('getambassador.io/ambassador-id', 'default')
+
+    @property
+    def labels(self) -> Dict[str, str]:
+        return self.metadata.get('labels', {})
+
+    @property
+    def spec(self) -> Dict[str, Any]:
+        return self.get('spec', {})
+
+    @property
+    def status(self) -> Dict[str, Any]:
+        return self.get('status', {})
+
+
+@dataclasses.dataclass
+class ResourceEmission:
+    """
+    Represents an object emitted after processing a resource.
+    """
+
+    object: dict
+    rkey: Optional[str] = None
+
+    @classmethod
+    def from_data(cls, kind: ResourceKind, name: str, namespace: str = 'default',
+                  generation: int = 1, labels: Dict[str, Any] = None, spec: Dict[str, Any] = None) -> ResourceEmission:
+        rkey = f'{name}.{namespace}'
+
+        ir_obj = {}
+        if spec:
+            ir_obj.update(spec)
+
+        ir_obj['apiVersion'] = kind.api_version
+        ir_obj['name'] = name
+        ir_obj['namespace'] = namespace
+        ir_obj['kind'] = kind.kind
+        ir_obj['generation'] = generation
+
+        ir_obj['labels'] = {}
+        if labels:
+            ir_obj['labels'].update(labels)
+
+        ir_obj['labels']['ambassador_crd'] = rkey
+
+        return cls(ir_obj, rkey)
+
+    @classmethod
+    def from_resource(cls, obj: ResourceDict) -> ResourceEmission:
+        return cls.from_data(
+            obj.kind,
+            obj.name,
+            namespace=obj.namespace or 'default',
+            generation=obj.generation,
+            labels=obj.labels,
+            spec=obj.spec,
+        )
+
+
+class ResourceManager:
+    """
+    Holder for managed resources before they are processed and emitted as IR.
+    """
+
+    aconf: Config
+    logger: logging.Logger
+    locations: LocationManager
+    ambassador_service: Optional[ResourceDict]
+    elements: List[ACResource]
+    services: Dict[str, Dict[str, Any]]
+
+    def __init__(self, aconf: Config, logger: logging.Logger):
+        self.aconf = aconf
+        self.logger = logger
+        self.locations = LocationManager()
+        self.ambassador_service = None
+        self.elements = []
+        self.services = {}
+
+    @property
+    def location(self) -> str:
+        return str(self.locations.current)
+
+    def _emit(self, emission: ResourceEmission) -> bool:
+        obj = emission.object
+        rkey = emission.rkey
+
+        if not isinstance(obj, dict):
+            # Bug!!
+            if not obj:
+                self.aconf.post_error("%s is empty" % self.location)
+            else:
+                self.aconf.post_error("%s is not a dictionary? %s" %
+                                      (self.location, json.dumps(obj, indent=4, sort_keys=4)))
+            return True
+
+        if not self.aconf.good_ambassador_id(obj):
+            self.logger.debug("%s ignoring object with mismatched ambassador_id" % self.location)
+            return True
+
+        if 'kind' not in obj:
+            # Bug!!
+            self.aconf.post_error("%s is missing 'kind'?? %s" %
+                                  (self.location, json.dumps(obj, indent=4, sort_keys=True)))
+            return True
+
+        # self.logger.debug("%s PROCESS %s initial rkey %s" % (self.location, obj['kind'], rkey))
+
+        # Is this a pragma object?
+        if obj['kind'] == 'Pragma':
+            # Why did I think this was a good idea? [ :) ]
+            new_source = obj.get('source', None)
+
+            if new_source:
+                # We don't save the old self.filename here, so this change will last until
+                # the next input source (or the next Pragma).
+                self.locations.current.filename = new_source
+
+            # Don't count Pragma objects, since the user generally doesn't write them.
+            return False
+
+        if not rkey:
+            rkey = self.locations.current.filename
+
+        rkey = "%s.%d" % (rkey, self.locations.current.ocount)
+
+        # self.logger.debug("%s PROCESS %s updated rkey to %s" % (self.location, obj['kind'], rkey))
+
+        # Force the namespace and metadata_labels, if need be.
+        # TODO(impl): Remove this?
+        # if namespace and not obj.get('namespace', None):
+        #     obj['namespace'] = namespace
+
+        # Brutal hackery.
+        if obj['kind'] == 'Service':
+            self.logger.debug("%s PROCESS saving service %s" % (self.location, obj['name']))
+            self.services[obj['name']] = obj
+        else:
+            # Fine. Fine fine fine.
+            serialization = dump_yaml(obj, default_flow_style=False)
+
+            try:
+                r = ACResource.from_dict(rkey, rkey, serialization, obj)
+                self.elements.append(r)
+            except Exception as e:
+                self.aconf.post_error(e.args[0])
+
+            self.logger.debug("%s PROCESS %s save %s: %s" % (self.location, obj['kind'], rkey, serialization))
+
+        return True
+
+    def emit(self, emission: ResourceEmission):
+        if self._emit(emission):
+            self.locations.current.ocount += 1
+
+
+class ResourceProcessor:
+    """
+    An abstract processor for Kubernetes resources that emit configuration
+    resources.
+    """
+
+    def kinds(self) -> FrozenSet[ResourceKind]:
+        # Override kinds to describe the types of resources this processor wants
+        # to process.
+        return frozenset()
+
+    def _process(self, obj: ResourceDict) -> None:
+        # Override _process to handle a single resource. Note that the entry
+        # point for _process is try_process; _process should not be called
+        # directly.
+        pass
+
+    def try_process(self, obj: ResourceDict) -> bool:
+        if obj.kind not in self.kinds():
+            return False
+
+        self._process(obj)
+        return True
+
+    def finalize(self) -> None:
+        # Override finalize to do processing at the end of the configuration
+        # fetching.
+        pass
+
+
+class ManagedResourceProcessor (ResourceProcessor):
+    """
+    An abstract processor that provides access to a resource manager.
+    """
+
+    manager: ResourceManager
+
+    def __init__(self, manager: ResourceManager):
+        self.manager = manager
+
+    @property
+    def aconf(self) -> Config:
+        return self.manager.aconf
+
+    @property
+    def logger(self) -> logging.Logger:
+        return self.manager.logger
+
+
+class AmbassadorResourceProcessor (ManagedResourceProcessor):
+    """
+    A resource processor that emits direct IR from an Ambassador CRD.
+    """
+
+    def kinds(self) -> FrozenSet[ResourceKind]:
+        api_version = 'getambassador.io/v2'
+        kinds = [
+            'AuthService',
+            'ConsulResolver',
+            'Host',
+            'KubernetesEndpointResolver',
+            'KubernetesServiceResolver',
+            'LogService',
+            'Mapping',
+            'Module',
+            'RateLimitService',
+            'TCPMapping',
+            'TLSContext',
+            'TracingService',
+        ]
+
+        return frozenset([ResourceKind(api_version, kind) for kind in kinds])
+
+    def _process(self, obj: ResourceDict) -> None:
+        self.manager.emit(ResourceEmission.from_resource(obj))
+
+
+class KnativeIngressResourceProcessor (ManagedResourceProcessor):
+    """
+    A resource processor that emits mappings from Knative Ingresses.
+    """
+
+    INGRESS_CLASS: ClassVar[str] = 'ambassador.ingress.networking.knative.dev'
+
+    def kinds(self) -> FrozenSet[ResourceKind]:
+        api_version = 'networking.internal.knative.dev/v1alpha1'
+        kinds = [
+            'Ingress',
+            'ClusterIngress',
+        ]
+
+        return frozenset([ResourceKind(api_version, kind) for kind in kinds])
+
+    def _has_required_annotations(self, obj: ResourceDict) -> bool:
+        annotations = obj.annotations
+
+        # Let's not parse KnativeIngress if it's not meant for us. We only need
+        # to ignore KnativeIngress iff networking.knative.dev/ingress.class is
+        # present in annotation. If it's not there, then we accept all ingress
+        # classes.
+        ingress_class = annotations.get('networking.knative.dev/ingress.class', self.INGRESS_CLASS)
+        if ingress_class.lower() != self.INGRESS_CLASS:
+            self.logger.debug(f'Ignoring Knative {obj.kind.kind} {obj.name}; set networking.knative.dev/ingress.class '
+                              f'annotation to {self.INGRESS_CLASS} for ambassador to parse it.')
+            return False
+
+        # We don't want to deal with non-matching Ambassador IDs
+        if obj.ambassador_id != Config.ambassador_id:
+            self.logger.info(f"Knative {obj.kind.kind} {obj.name} does not have Ambassador ID {Config.ambassador_id}, ignoring...")
+            return False
+
+        return True
+
+    def _emit_mapping(self, obj: ResourceDict, rule_count: int, rule: Dict[str, Any]) -> None:
+        hosts = rule.get('hosts', [])
+
+        split_mapping_specs: List[Dict[str, Any]] = []
+
+        paths = rule.get('http', {}).get('paths', [])
+        for path in paths:
+            global_headers = path.get('appendHeaders', {})
+
+            splits = path.get('splits', [])
+            for split in splits:
+                service_name = split.get('serviceName')
+                if not service_name:
+                    continue
+
+                service_namespace = split.get('serviceNamespace', obj.namespace)
+                service_port = split.get('servicePort', 80)
+
+                headers = split.get('appendHeaders', {})
+                headers = {**global_headers, **headers}
+
+                split_mapping_specs.append({
+                    'service': f"{service_name}.{service_namespace}:{service_port}",
+                    'add_request_headers': headers,
+                    'weight': split.get('percent', 100),
+                    'prefix': path.get('path', '/'),
+                    'prefix_regex': True,
+                    'timeout_ms': int(durationpy.from_str(path.get('timeout', '15s')).total_seconds() * 1000),
+                })
+
+        for split_count, (host, split_mapping_spec) in enumerate(itertools.product(hosts, split_mapping_specs)):
+            mapping_identifier = f"{obj.name}-{rule_count}-{split_count}"
+
+            spec = {
+                'ambassador_id': obj.ambassador_id,
+                'host': host,
+            }
+            spec.update(split_mapping_spec)
+
+            mapping = ResourceEmission.from_data(
+                ResourceKind.for_ambassador('Mapping'),
+                mapping_identifier,
+                namespace=obj.namespace or 'default',
+                generation=obj.generation,
+                labels=obj.labels,
+                spec=spec,
+            )
+
+            self.logger.debug(f"Generated mapping from Knative {obj.kind.kind}: {mapping}")
+            self.manager.emit(mapping)
+
+    def _make_status(self, generation: int = 1, lb_domain: Optional[str] = None) -> Dict[str, Any]:
+        utcnow = datetime.datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
+        status = {
+            "observedGeneration": generation,
+            "conditions": [
+                {
+                    "lastTransitionTime": utcnow,
+                    "status": "True",
+                    "type": "LoadBalancerReady"
+                },
+                {
+                    "lastTransitionTime": utcnow,
+                    "status": "True",
+                    "type": "NetworkConfigured"
+                },
+                {
+                    "lastTransitionTime": utcnow,
+                    "status": "True",
+                    "type": "Ready"
+                }
+            ]
+        }
+
+        if lb_domain:
+            load_balancer = {
+                "ingress": [
+                    {
+                        "domainInternal": lb_domain,
+                    }
+                ]
+            }
+
+            status['loadBalancer'] = load_balancer
+            status['privateLoadBalancer'] = load_balancer
+
+        return status
+
+    def _update_status(self, obj: ResourceDict) -> None:
+        current_generation = obj.spec.get('generation', 1)
+        has_new_generation = current_generation > obj.status.get('observedGeneration', 0)
+
+        # Knative expects the load balancer information on the ingress, which it
+        # then propagates to an ExternalName service for intra-cluster use. We
+        # pull that information here. Otherwise, it will continue to use the DNS
+        # name configured by the Knative service and go through an
+        # out-of-cluster ingress to access the service.
+        current_lb_domain = None
+
+        if not self.manager.ambassador_service or not self.manager.ambassador_service.name:
+            self.logger.warn(f"Unable to set Knative {obj.kind.kind} {obj.name}'s load balancer, could not find Ambassador service")
+        else:
+            # TODO: It is technically possible to use a domain other than
+            # cluster.local (common-ish on bare metal clusters). We can resolve
+            # the relevant domain by doing a DNS lookup on
+            # kubernetes.default.svc, but this problem appears elsewhere in the
+            # code as well and probably should just be fixed all at once.
+            current_lb_domain = f"{self.manager.ambassador_service.name}.{self.manager.ambassador_service.namespace or 'default'}.svc.cluster.local"
+
+        observed_ingress: Dict[str, Any] = next(iter(obj.status.get('privateLoadBalancer', {}).get('ingress', [])), {})
+        observed_lb_domain = observed_ingress.get('domainInternal')
+
+        has_new_lb_domain = current_lb_domain != observed_lb_domain
+
+        if has_new_generation or has_new_lb_domain:
+            status = self._make_status(generation=current_generation, lb_domain=current_lb_domain)
+            status_update = (obj.kind.domain, obj.namespace, status)
+
+            self.logger.info(f"Updating Knative {obj.kind.kind} {obj.name} status to {status_update}")
+            self.aconf.k8s_status_updates[f"{obj.name}.{obj.namespace}"] = status_update
+        else:
+            self.logger.debug(f"Not reconciling Knative {obj.kind.kind} {obj.name}: observed and current generations are in sync")
+
+    def _process(self, obj: ResourceDict) -> None:
+        if not self._has_required_annotations(obj):
+            return
+
+        rules = obj.spec.get('rules', [])
+        for rule_count, rule in enumerate(rules):
+            self._emit_mapping(obj, rule_count, rule)
+
+        self._update_status(obj)
+
+
+class AggregateResourceProcessor (ResourceProcessor):
+    """
+    This resource processor aggregates many resource processors into a single
+    convenient processor.
+    """
+
+    delegates: List[ResourceProcessor]
+    mapping: Mapping[ResourceKind, List[ResourceProcessor]]
+
+    def __init__(self, delegates: List[ResourceProcessor]) -> None:
+        self.delegates = delegates
+        self.mapping = collections.defaultdict(list)
+
+        for proc in self.delegates:
+            for kind in proc.kinds():
+                self.mapping[kind].append(proc)
+
+    def kinds(self) -> FrozenSet[ResourceKind]:
+        return frozenset(iter(self.mapping))
+
+    def _process(self, obj: ResourceDict) -> None:
+        procs = self.mapping.get(obj.kind, [])
+        for proc in procs:
+            proc.try_process(obj)
+
+    def finalize(self):
+        for proc in self.delegates:
+            proc.finalize()
+
+
+class DeduplicatingResourceProcessor (ResourceProcessor):
+    """
+    This resource processor delegates work to another processor but prevents the
+    same object from being processed multiple times.
+    """
+
+    delegate: ResourceProcessor
+    cache: Set[ResourceIdent]
+
+    def __init__(self, delegate: ResourceProcessor) -> None:
+        self.delegate = delegate
+        self.cache = set()
+
+    def kinds(self) -> FrozenSet[ResourceKind]:
+        return self.delegate.kinds()
+
+    def _process(self, obj: ResourceDict) -> None:
+        if obj.ident in self.cache:
+            return
+
+        self.cache.add(obj.ident)
+        self.delegate.try_process(obj)
+
+    def finalize(self):
+        self.delegate.finalize()

--- a/python/ambassador/config/resourceprocessor.py
+++ b/python/ambassador/config/resourceprocessor.py
@@ -137,8 +137,8 @@ class KubernetesGVK:
             return self.kind.lower()
 
     @classmethod
-    def for_ambassador(cls, kind: str) -> KubernetesGVK:
-        return cls('getambassador.io/v2', kind)
+    def for_ambassador(cls, kind: str, version: str = 'v2') -> KubernetesGVK:
+        return cls(f'getambassador.io/{version}', kind)
 
     @classmethod
     def for_knative_networking(cls, kind: str) -> KubernetesGVK:
@@ -417,7 +417,9 @@ class AmbassadorProcessor (ManagedKubernetesProcessor):
             'TracingService',
         ]
 
-        return frozenset([KubernetesGVK.for_ambassador(kind) for kind in kinds])
+        return frozenset([
+            KubernetesGVK.for_ambassador(kind, version=version) for (kind, version) in itertools.product(kinds, ['v1', 'v2'])
+        ])
 
     def _process(self, obj: KubernetesObject) -> None:
         self.manager.emit(obj.as_normalized_resource())

--- a/python/ambassador/ir/ir.py
+++ b/python/ambassador/ir/ir.py
@@ -879,6 +879,9 @@ class IR:
         od['endpoint_routing_envoy_maglev_count'] = endpoint_routing_envoy_maglev_count
         od['endpoint_routing_envoy_lr_count'] = endpoint_routing_envoy_lr_count
 
+        od['cluster_ingress_count'] = self.aconf.get_count('knative_cluster_ingress')
+        od['knative_ingress_count'] = self.aconf.get_count('knative_ingress')
+
         od['k8s_ingress_count'] = len(self.aconf.k8s_ingresses)
         od['k8s_ingress_class_count'] = len(self.aconf.k8s_ingress_classes)
 

--- a/python/ambassador/utils.py
+++ b/python/ambassador/utils.py
@@ -59,7 +59,7 @@ yaml_logged_loader = False
 yaml_logged_dumper = False
 
 
-def parse_yaml(serialization: str, **kwargs) -> Any:
+def parse_yaml(serialization: str) -> Any:
     global yaml_logged_loader
 
     if not yaml_logged_loader:

--- a/python/tests/test_docker.py
+++ b/python/tests/test_docker.py
@@ -1,6 +1,8 @@
 import os
+import sys
 
 import pexpect
+import pytest
 import requests
 import time
 
@@ -109,4 +111,4 @@ def test_docker():
     assert test_status, 'test failed'
 
 if __name__ == '__main__':
-    test_docker()
+    pytest.main(sys.argv)

--- a/python/tests/test_envvar_expansion.py
+++ b/python/tests/test_envvar_expansion.py
@@ -2,6 +2,9 @@ from typing import Optional
 
 import logging
 import os
+import sys
+
+import pytest
 
 logging.basicConfig(
     level=logging.INFO,
@@ -44,4 +47,4 @@ def test_envvar_expansion():
 
 
 if __name__ == '__main__':
-    test_envvar_expansion()
+    pytest.main(sys.argv)

--- a/python/tests/test_knative.py
+++ b/python/tests/test_knative.py
@@ -1,16 +1,17 @@
-import pytest
-
 import logging
 from urllib import request
 from urllib.error import URLError, HTTPError
-from utils import run_and_assert, apply_kube_artifacts, install_ambassador, qotm_manifests, create_qotm_mapping
 from retry import retry
+import sys
+
+import pytest
 
 from kat.harness import is_knative
 from kat.harness import load_manifest
 from ambassador import Config, IR
 from ambassador.config import ResourceFetcher
 from ambassador.utils import NullSecretHandler
+from utils import run_and_assert, apply_kube_artifacts, install_ambassador, qotm_manifests, create_qotm_mapping
 
 logger = logging.getLogger('ambassador')
 
@@ -168,4 +169,4 @@ def test_knative():
 
 
 if __name__ == '__main__':
-    test_knative()
+    pytest.main(sys.argv)

--- a/python/tests/test_lookup.py
+++ b/python/tests/test_lookup.py
@@ -1,6 +1,9 @@
 from typing import Optional
 
 import logging
+import sys
+
+import pytest
 
 logging.basicConfig(
     level=logging.INFO,
@@ -104,5 +107,4 @@ def test_lookup():
     assert t2.lookup('max_request_words', 77, default_key='altered2', default_class='/') == 77
 
 if __name__ == '__main__':
-    test_lookup()
-
+    pytest.main(sys.argv)

--- a/python/tests/test_resourcefetcher.py
+++ b/python/tests/test_resourcefetcher.py
@@ -1,6 +1,9 @@
 from typing import Optional
 
 import logging
+import sys
+
+import pytest
 
 logging.basicConfig(
     level=logging.INFO,
@@ -80,5 +83,4 @@ service: test:9999"""
     assert result == ('testservice.default', [expected])
 
 if __name__ == '__main__':
-    test_resourcefetcher()
-
+    pytest.main(sys.argv)

--- a/python/tests/test_resourceprocessor.py
+++ b/python/tests/test_resourceprocessor.py
@@ -126,21 +126,21 @@ class TestKubernetesObject:
             k8s_object_from_yaml('apiVersion: v1')
 
 
-class TestResourceEmission:
+class TestNormalizedResource:
 
     def test_kubernetes_object_conversion(self):
-        emission = valid_mapping.as_resource_emission()
+        resource = valid_mapping.as_normalized_resource()
 
-        assert emission.rkey == f'{valid_mapping.name}.{valid_mapping.namespace}'
-        assert emission.object['apiVersion'] == valid_mapping.gvk.api_version
-        assert emission.object['kind'] == valid_mapping.gvk.kind
-        assert emission.object['name'] == valid_mapping.name
-        assert emission.object['namespace'] == valid_mapping.namespace
-        assert emission.object['generation'] == valid_mapping.generation
-        assert len(emission.object['labels']) == 1
-        assert emission.object['labels']['ambassador_crd'] == emission.rkey
-        assert emission.object['prefix'] == valid_mapping.spec['prefix']
-        assert emission.object['service'] == valid_mapping.spec['service']
+        assert resource.rkey == f'{valid_mapping.name}.{valid_mapping.namespace}'
+        assert resource.object['apiVersion'] == valid_mapping.gvk.api_version
+        assert resource.object['kind'] == valid_mapping.gvk.kind
+        assert resource.object['name'] == valid_mapping.name
+        assert resource.object['namespace'] == valid_mapping.namespace
+        assert resource.object['generation'] == valid_mapping.generation
+        assert len(resource.object['labels']) == 1
+        assert resource.object['labels']['ambassador_crd'] == resource.rkey
+        assert resource.object['prefix'] == valid_mapping.spec['prefix']
+        assert resource.object['service'] == valid_mapping.spec['service']
 
 
 class TestLocationManager:

--- a/python/tests/test_resourceprocessor.py
+++ b/python/tests/test_resourceprocessor.py
@@ -1,0 +1,228 @@
+import sys
+
+import pytest
+
+from ambassador import Config
+from ambassador.config.resourceprocessor import (
+    ResourceKind,
+    ResourceDict,
+    ResourceEmission,
+    LocationManager,
+    ResourceProcessor,
+    AggregateResourceProcessor,
+    CounterResourceProcessor,
+    DeduplicatingResourceProcessor,
+)
+from ambassador.utils import parse_yaml
+
+
+def resource_dict_from_yaml(yaml: str, **kwargs) -> ResourceDict:
+    return ResourceDict(parse_yaml(yaml)[0], **kwargs)
+
+
+valid_knative_ingress = resource_dict_from_yaml('''
+---
+apiVersion: networking.internal.knative.dev/v1alpha1
+kind: Ingress
+metadata:
+  annotations:
+    getambassador.io/ambassador-id: webhook
+    networking.knative.dev/ingress.class: ambassador.ingress.networking.knative.dev
+  generation: 2
+  labels:
+    serving.knative.dev/route: helloworld-go
+    serving.knative.dev/routeNamespace: test
+    serving.knative.dev/service: helloworld-go
+  name: helloworld-go
+  namespace: test
+spec:
+  rules:
+  - hosts:
+    - helloworld-go.test.svc.cluster.local
+    http:
+      paths:
+      - retries:
+          attempts: 3
+          perTryTimeout: 10m0s
+        splits:
+        - appendHeaders:
+            Knative-Serving-Namespace: test
+            Knative-Serving-Revision: helloworld-go-qf94m
+          percent: 100
+          serviceName: helloworld-go-qf94m
+          serviceNamespace: test
+          servicePort: 80
+        timeout: 10m0s
+    visibility: ClusterLocal
+  visibility: ExternalIP
+status:
+  loadBalancer:
+    ingress:
+    - domainInternal: ambassador.ambassador-webhook.svc.cluster.local
+  observedGeneration: 2
+''')
+
+valid_mapping = resource_dict_from_yaml('''
+---
+apiVersion: getambassador.io/v2
+kind: Mapping
+metadata:
+  name: test
+spec:
+    prefix: /test/
+    service: test.default
+''', default_namespace='default')
+
+
+class TestResourceKind:
+
+    def test_legacy(self):
+        rk = ResourceKind('v1', 'Service')
+
+        assert rk.api_version == 'v1'
+        assert rk.kind == 'Service'
+        assert rk.api_group is None
+        assert rk.version == 'v1'
+        assert rk.domain == 'service'
+
+    def test_group(self):
+        rk = ResourceKind.for_ambassador('Mapping')
+
+        assert rk.api_version == 'getambassador.io/v2'
+        assert rk.kind == 'Mapping'
+        assert rk.api_group == 'getambassador.io'
+        assert rk.version == 'v2'
+        assert rk.domain == 'mapping.getambassador.io'
+
+
+class TestResourceDict:
+
+    def test_valid(self):
+        assert valid_knative_ingress.kind == ResourceKind.for_knative_networking('Ingress')
+        assert valid_knative_ingress.namespace == 'test'
+        assert valid_knative_ingress.name == 'helloworld-go'
+        assert valid_knative_ingress.generation == 2
+        assert len(valid_knative_ingress.annotations) == 2
+        assert valid_knative_ingress.ambassador_id == 'webhook'
+        assert len(valid_knative_ingress.labels) == 3
+        assert valid_knative_ingress.spec['rules'][0]['hosts'][0] == 'helloworld-go.test.svc.cluster.local'
+        assert valid_knative_ingress.status['observedGeneration'] == 2
+
+        # Test default namespace fallback:
+        assert valid_mapping.namespace == 'default'
+
+    def test_invalid(self):
+        with pytest.raises(ValueError, match='not a valid Kubernetes resource'):
+            resource_dict_from_yaml('apiVersion: v1')
+
+
+class TestResourceEmission:
+
+    def test_from_resource(self):
+        emission = ResourceEmission.from_resource(valid_mapping)
+
+        assert emission.rkey == f'{valid_mapping.name}.{valid_mapping.namespace}'
+        assert emission.object['apiVersion'] == valid_mapping.kind.api_version
+        assert emission.object['kind'] == valid_mapping.kind.kind
+        assert emission.object['name'] == valid_mapping.name
+        assert emission.object['namespace'] == valid_mapping.namespace
+        assert emission.object['generation'] == valid_mapping.generation
+        assert len(emission.object['labels']) == 1
+        assert emission.object['labels']['ambassador_crd'] == emission.rkey
+        assert emission.object['prefix'] == valid_mapping.spec['prefix']
+        assert emission.object['service'] == valid_mapping.spec['service']
+
+
+class TestLocationManager:
+
+    def test_context_manager(self):
+        lm = LocationManager()
+
+        assert len(lm.previous) == 0
+
+        assert lm.current.filename is None
+        assert lm.current.ocount == 1
+
+        with lm.push(filename='test', ocount=2) as loc:
+            assert len(lm.previous) == 1
+            assert lm.current == loc
+
+            assert loc.filename == 'test'
+            assert loc.ocount == 2
+
+            with lm.push_reset() as rloc:
+                assert len(lm.previous) == 2
+                assert lm.current == rloc
+
+                assert rloc.filename == 'test'
+                assert rloc.ocount == 1
+
+        assert len(lm.previous) == 0
+
+        assert lm.current.filename is None
+        assert lm.current.ocount == 1
+
+
+class FinalizingResourceProcessor (ResourceProcessor):
+
+    finalize: bool = False
+
+    def finalize(self):
+        self.finalized = True
+
+
+class TestAggregateResourceProcessor:
+
+    def test_aggregation(self):
+        aconf = Config()
+
+        frp = FinalizingResourceProcessor()
+
+        rp = AggregateResourceProcessor([
+            CounterResourceProcessor(aconf, valid_knative_ingress.kind, 'test_1'),
+            CounterResourceProcessor(aconf, valid_mapping.kind, 'test_2'),
+            frp,
+        ])
+
+        assert len(rp.kinds()) == 2
+
+        assert rp.try_process(valid_knative_ingress)
+        assert rp.try_process(valid_mapping)
+
+        assert aconf.get_count('test_1') == 1
+        assert aconf.get_count('test_2') == 1
+
+        rp.finalize()
+        assert frp.finalized, 'Aggregate resource processor did not call finalizers'
+
+
+class TestDeduplicatingResourceProcessor:
+
+    def test_deduplication(self):
+        aconf = Config()
+
+        rp = DeduplicatingResourceProcessor(CounterResourceProcessor(aconf, valid_mapping.kind, 'test'))
+
+        assert rp.try_process(valid_mapping)
+        assert rp.try_process(valid_mapping)
+        assert rp.try_process(valid_mapping)
+
+        assert aconf.get_count('test') == 1
+
+
+class TestCounterResourceProcessor:
+
+    def test_count(self):
+        aconf = Config()
+
+        rp = CounterResourceProcessor(aconf, valid_mapping.kind, 'test')
+
+        assert rp.try_process(valid_mapping), 'Resource processor rejected matching resource'
+        assert rp.try_process(valid_mapping), 'Resource processor rejected matching resource (again)'
+        assert not rp.try_process(valid_knative_ingress), 'Resource processor accepted non-matching resource'
+
+        assert aconf.get_count('test') == 2, 'Resource processor did not increment counter'
+
+
+if __name__ == '__main__':
+    pytest.main(sys.argv)

--- a/python/tests/test_schemas.py
+++ b/python/tests/test_schemas.py
@@ -6,6 +6,7 @@ import os
 import sys
 
 import jsonschema
+import pytest
 
 logging.basicConfig(
     level=logging.INFO,
@@ -73,5 +74,4 @@ def test_schemas():
 
 
 if __name__ == '__main__':
-    test_schemas()
-
+    pytest.main(sys.argv)

--- a/python/tests/test_scout.py
+++ b/python/tests/test_scout.py
@@ -2,8 +2,10 @@ from typing import Any, Dict, List, Optional
 
 import os
 import time
+import sys
 
 import pexpect
+import pytest
 import requests
 
 DockerImage = os.environ.get("AMBASSADOR_DOCKER_IMAGE", None)
@@ -216,5 +218,4 @@ def test_scout():
     assert test_status, 'test failed'
 
 if __name__ == '__main__':
-    test_scout()
-
+    pytest.main(sys.argv)

--- a/python/tests/test_watt_scaling.py
+++ b/python/tests/test_watt_scaling.py
@@ -1,5 +1,9 @@
 import time
+import sys
+
+import pytest
 from urllib import request
+
 from utils import run_and_assert, apply_kube_artifacts, delete_kube_artifacts, install_ambassador, qotm_manifests
 
 
@@ -126,4 +130,4 @@ def test_watt():
 
 
 if __name__ == '__main__':
-    test_watt()
+    pytest.main(sys.argv)

--- a/python/tests/test_watt_scaling.py
+++ b/python/tests/test_watt_scaling.py
@@ -62,7 +62,12 @@ spec:
         namespace = 'watt-rapid'
 
         # Install Ambassador
-        install_ambassador(namespace=namespace)
+        install_ambassador(namespace=namespace, envs=[
+            {
+                'name': 'AMBASSADOR_SINGLE_NAMESPACE',
+                'value': 'true'
+            }
+        ])
 
         # Install QOTM
         apply_kube_artifacts(namespace=namespace, artifacts=qotm_manifests)


### PR DESCRIPTION
## Description
This change improves support for Knative:

* We move the CRD processing from the IR to the resource fetcher, and emit Mappings to the IR directly. This mirrors how Kubernetes Ingresses are currently processed.
* We make sure to check the current generation of the CRD against the observed generation; the current implementation will reprocess the CRD every second because the timestamp in the conditions changes.
* We map each host by itself instead of using a regular expression, as the regular expressions were not being escaped and I wasn't comfortable bringing in a dependency on pyre2 to do the escaping.
* We inform Knative of the internal route to the Ambassador service, if present. This should improve performance and allows cluster-local Knative services to resolve.
* We handle the path and timeout properties of the ingress paths in the CRDs.

I made these changes specifically to support our use case, so please let me know if anything seems out of place. Of course this is my first time hacking on this code as well; I am very open to any and all feedback!

## Related Issues
This incidentally fixes #2140.

## Testing
This has been tested using the integration tests in the repository and validated locally and in a testing cluster. We are planning to use this in a production environment soon.

## Tasks That Must Be Done
- [x] Did you update CHANGELOG.md?
- [x] Did you add or update tests?
- [ ] Did you update documentation?
- [ ] Were there any special dev tricks you had to use to work on this code efficiently?
  + [ ] Did you add them to DEVELOPING.md?

## Other
* If this is a documentation change, please open the pull request at https://github.com/datawire/ambassador-docs instead.
* Code changes should occur against `master`.
