### PR TITLE
builder: Use docker cp instead of rsync when possible

### DIFF
--- a/builder/builder.sh
+++ b/builder/builder.sh
@@ -42,7 +42,14 @@ declare -a dsynced
 
 dsync() {
     printf "${GRN}Synchronizing... $*${END}\n"
-    IFS='|' read -ra dsynced <<<"$(rsync --info=name -aO -e 'docker exec -i' $@ 2> >(fgrep -v 'rsync: failed to set permissions on' >&2) | tr '\n' '|')"
+    TIMEFORMAT="(sync took %1R seconds)"
+    time IFS='|' read -ra dsynced <<<"$(rsync --info=name -aO -e 'docker exec -i' $@ 2> >(fgrep -v 'rsync: failed to set permissions on' >&2) | tr '\n' '|')"
+}
+
+dcopy() {
+    printf "${GRN}Copying... $*${END}\n"
+    TIMEFORMAT="(copy took %1R seconds)"
+    time docker cp $@
 }
 
 dexec() {
@@ -88,8 +95,8 @@ bootstrap() {
         printf "${GRN}Started build container ${BLU}$(builder)${END}\n"
     fi
 
-    dsync ${DIR}/builder.sh $(builder):/buildroot
-    dsync ${DIR}/builder_bash_rc $(builder):/home/dw/.bashrc
+    dcopy ${DIR}/builder.sh $(builder):/buildroot
+    dcopy ${DIR}/builder_bash_rc $(builder):/home/dw/.bashrc
 }
 
 module_version() {


### PR DESCRIPTION
... because `docker cp` is much faster than `rsync`, especially with a remote Docker host.

Reviewer: Please check my use/non-use of quotation marks.