### PR TITLE
Fixing Ingress default path and precedence

### DIFF
--- a/python/ambassador/config/resourcefetcher.py
+++ b/python/ambassador/config/resourcefetcher.py
@@ -654,7 +654,7 @@ class ResourceFetcher:
 
                 service_name = path_backend.get('serviceName', None)
                 service_port = path_backend.get('servicePort', None)
-                path_location = path.get('path', None)
+                path_location = path.get('path', '/')
 
                 if not service_name or not service_port or not path_location:
                     continue
@@ -677,6 +677,7 @@ class ResourceFetcher:
                         'ambassador_id': ambassador_id,
                         'prefix': path_location,
                         'prefix_exact': is_exact_prefix,
+                        'precedence': 1 if is_exact_prefix else 0,  # Make sure exact paths are evaluated before prefix
                         'service': f'{service_name}.{ingress_namespace}:{service_port}'
                     }
                 }


### PR DESCRIPTION
## Description
2 fixes to align with Ingress spec:
- default `path` is `/`, meaning Ambassador won't fail if the path was not specified.
- Exact paths have precedence over Prefix path matches.

## Related Issues
https://github.com/datawire/apro/issues/1092

## Testing
Using ingress-conformance tests.

## Tasks That Must Be Done
- [ ] Did you update CHANGELOG.md?
- [ ] Did you add or update tests?
- [ ] Did you update documentation?
- [ ] Were there any special dev tricks you had to use to work on this code efficiently?
  + [ ] Did you add them to DEVELOPING.md?
