### PR TITLE
WIP markdown for OS detection on docs - Quick Start

### DIFF
--- a/docs/user-guide/DetectOS.js
+++ b/docs/user-guide/DetectOS.js
@@ -1,0 +1,22 @@
+import { Component } from "react";
+
+export default class DetectOS extends Component {
+  componentDidMount() {
+    var os = "other";
+    if (/Mac(intosh|Intel|PPC|68K)/.test(window.navigator.platform)) {
+      os = 'mac';
+    } else if (/Win(dows|36|64|CE)/.test(window.navigator.platform)) {
+      os = 'windows';
+    } else if (/Linux/.test(window.navigator.platform)) {
+      os = 'linux';
+    }
+
+    document.querySelectorAll(`details.os-instructions[data-os="${os}"]`).forEach((el) => {
+      el.open = true;
+    })
+  }
+
+  render() {
+    return null;
+  }
+}

--- a/docs/user-guide/getting-started.md
+++ b/docs/user-guide/getting-started.md
@@ -73,9 +73,7 @@ Your terminal will show you something similar to the following as the installer 
 a load balancer, configures TLS, and provides you with an `edgestack.me` subdomain:
 
 <div class="styles-module--CodeBlock--1UB4s">
-  <pre class="language-">
-    <div class="token-line">
-      <span class="token plain">
+<pre class="language-">
 $ <span class="edgectlInstall">edgectl install</span>
 -> Installing the Ambassador Edge Stack $version$.
 Downloading images. (This may take a minute.)
@@ -87,9 +85,7 @@ Your AES installation's IP address is 4.3.2.1
 Please enter an email address. We'll use this email address to notify you prior
 to domain and certificate expiration. We also share this email address with
 Let's Encrypt to acquire your certificate for TLS.
-      </span>
-    </div>
-  </pre>
+</pre>
 </div>
 
 Provide an email address as required by the ACME TLS certificate provider, Let's

--- a/docs/user-guide/getting-started.md
+++ b/docs/user-guide/getting-started.md
@@ -72,8 +72,11 @@ Windows. For other options, such as Docker, click [here](/user-guide/install).
 Your terminal will show you something similar to the following as the installer provisions
 a load balancer, configures TLS, and provides you with an `edgestack.me` subdomain:
 
-```
-$ edgectl install
+<div className="styles-module--CodeBlock--1UB4s">
+  <pre className="language-">
+    <div className="token-line">
+      <span className="token plain">
+$ <span className="edgectlInstall">edgectl install</span>
 -> Installing the Ambassador Edge Stack $version$.
 Downloading images. (This may take a minute.)
 -> Provisioning a cloud load balancer. (This may take a minute, depending on
@@ -84,7 +87,10 @@ Your AES installation's IP address is 4.3.2.1
 Please enter an email address. We'll use this email address to notify you prior
 to domain and certificate expiration. We also share this email address with
 Let's Encrypt to acquire your certificate for TLS.
-```
+      </span>
+    </div>
+  </pre>
+</div>
 
 Provide an email address as required by the ACME TLS certificate provider, Let's
 Encrypt. Then your terminal will print something similar to the following:

--- a/docs/user-guide/getting-started.md
+++ b/docs/user-guide/getting-started.md
@@ -1,6 +1,11 @@
 ---
    description: In this guide, we'll walk through the process of deploying Ambassador Edge Stack in Kubernetes for ingress routing.
 ---
+
+import DetectOS from './DetectOS'
+
+<DetectOS/>
+
 # Quick Start Installation Guide
 
 In just four minutes, your cluster will be routing HTTPS requests from the
@@ -9,7 +14,12 @@ Internet to a backend service.
 The Ambassador Edge Stack is deployed to Kubernetes via YAML for MacOS, Linux, and
 Windows. For other options, such as Docker, click [here](/user-guide/install).
 
+<details class="os-instructions" data-os="mac">
+<summary class="heading">
+
 ### Install on MacOS
+
+</summary>
 
 1. Download the `edgectl` file [here](https://metriton.datawire.io/downloads/darwin/edgectl) or download it with a curl command:
 
@@ -24,7 +34,14 @@ Windows. For other options, such as Docker, click [here](/user-guide/install).
 
 2. Run the installer with `./edgectl install`
 
+</details>
+
+<details class="os-instructions" data-os="linux">
+<summary class="heading">
+
 ### Install on Linux
+
+</summary>
 
 1. Download the `edgectl` file
    [here](https://metriton.datawire.io/downloads/linux/edgectl) or download it with a curl
@@ -35,11 +52,20 @@ Windows. For other options, such as Docker, click [here](/user-guide/install).
     ```
 2. Run the installer with `./edgectl install`
 
+</details>
+
+<details class="os-instructions" data-os="windows">
+<summary class="heading">
+
 ### Install on Windows
+
+</summary>
 
 1. Download the `edgectl` file
    [here](https://metriton.datawire.io/downloads/windows/edgectl.exe).
 2. Run the installer with `edgectl.exe install`
+
+</details>
 
 ## Installation
 

--- a/docs/user-guide/getting-started.md
+++ b/docs/user-guide/getting-started.md
@@ -72,11 +72,11 @@ Windows. For other options, such as Docker, click [here](/user-guide/install).
 Your terminal will show you something similar to the following as the installer provisions
 a load balancer, configures TLS, and provides you with an `edgestack.me` subdomain:
 
-<div className="styles-module--CodeBlock--1UB4s">
-  <pre className="language-">
-    <div className="token-line">
-      <span className="token plain">
-$ <span className="edgectlInstall">edgectl install</span>
+<div class="styles-module--CodeBlock--1UB4s">
+  <pre class="language-">
+    <div class="token-line">
+      <span class="token plain">
+$ <span class="edgectlInstall">edgectl install</span>
 -> Installing the Ambassador Edge Stack $version$.
 Downloading images. (This may take a minute.)
 -> Provisioning a cloud load balancer. (This may take a minute, depending on


### PR DESCRIPTION
Improvements to the Getting Started page Apro #1100

## Related Issues
“For other options, such as Docker, click [here].” -> “For Docker and other options, go to the [more detailed instructions].” (I hate the “here” because it’s not stylistically business English.) You don’t need [here] because the link is obvious with colors and underlines.

 The sections “Install on MacOS”, “Install on Linux”, etc. need to be collapsable and only the current one for the current operating system expanded. Cindy knows how to do this, so you can ask her. You will need to use HTML instead of Markdown.

 The OS sections need to have their little operating system logos (apple, penguin, windows, etc) for visual appeal.

 The “edgectl install…” and “Obtaining a TLS certificate…” blocks need to not have the “Copy” to clipboard button.

 The “edgectl install...” and “Obtaining a TLS certificate…” blocks need to have bold for the user entered text and not-bold for everything else.

 The “Note that the provided random-word.edgestack.me domain name will expire after 90 days.” note needs to go at the bottom of the page.

## Testing
A few sentences describing what testing you've done, e.g., manual tests, automated tests, deployed in production, etc.

## Tasks That Must Be Done
- [ ] Did you update CHANGELOG.md?
- [ ] Did you add or update tests?
- [ ] Did you update documentation?
- [ ] Were there any special dev tricks you had to use to work on this code efficiently?
  + [ ] Did you add them to DEVELOPING.md?

## Other
* If this is a documentation change, please open the pull request at https://github.com/datawire/ambassador-docs instead.
* Code changes should occur against `master`.
