### PR TITLE
Using Host resources instead of TLSContext

### DIFF
--- a/python/ambassador/config/resourcefetcher.py
+++ b/python/ambassador/config/resourcefetcher.py
@@ -585,33 +585,41 @@ class ResourceFetcher:
 
         ingress_tls = ingress_spec.get('tls', [])
         for tls_count, tls in enumerate(ingress_tls):
-            tls_unique_identifier = f"{ingress_name}-{tls_count}"
 
             tls_secret = tls.get('secretName', None)
-
             if tls_secret is not None:
-                ingress_tls_context: Dict[str, Any] = {
-                    'apiVersion': 'getambassador.io/v2',
-                    'kind': 'TLSContext',
-                    'metadata': {
-                        'name': tls_unique_identifier,
-                        'namespace': ingress_namespace
-                    },
-                    'spec': {
-                        'secret': tls_secret,
-                        'ambassador_id': ambassador_id
+
+                for host_count, host in enumerate(tls.get('hosts', ['*'])):
+                    tls_unique_identifier = f"{ingress_name}-{tls_count}-{host_count}"
+
+                    ingress_host: Dict[str, Any] = {
+                        'apiVersion': 'getambassador.io/v2',
+                        'kind': 'Host',
+                        'metadata': {
+                            'name': tls_unique_identifier,
+                            'namespace': ingress_namespace
+                        },
+                        'spec': {
+                            'hostname': host,
+                            'acmeProvider': {
+                                'authority': 'none'
+                            },
+                            'tlsSecret': {
+                                'name': tls_secret
+                            },
+                            'requestPolicy': {
+                                'insecure': {
+                                    'action': 'Route'
+                                }
+                            }
+                        }
                     }
-                }
 
-                if metadata_labels:
-                    ingress_tls_context['metadata']['labels'] = metadata_labels
+                    if metadata_labels:
+                        ingress_host['metadata']['labels'] = metadata_labels
 
-                tls_hosts = tls.get('hosts', None)
-                if tls_hosts is not None:
-                    ingress_tls_context['spec']['hosts'] = tls_hosts
-
-                self.logger.info(f"Generated TLS Context from ingress {ingress_name}: {ingress_tls_context}")
-                self.handle_k8s_crd(ingress_tls_context)
+                    self.logger.info(f"Generated Host from ingress {ingress_name}: {ingress_host}")
+                    self.handle_k8s_crd(ingress_host)
 
         # parse ingress.spec.backend
         default_backend = ingress_spec.get('backend', {})

--- a/python/ambassador/config/resourcefetcher.py
+++ b/python/ambassador/config/resourcefetcher.py
@@ -600,6 +600,7 @@ class ResourceFetcher:
                             'namespace': ingress_namespace
                         },
                         'spec': {
+                            'ambassador_id': [ambassador_id],
                             'hostname': host,
                             'acmeProvider': {
                                 'authority': 'none'

--- a/python/ambassador/ir/irhost.py
+++ b/python/ambassador/ir/irhost.py
@@ -159,6 +159,9 @@ class IRHost(IRResource):
         # namespace, fall back to the Ambassador's namespace.
         namespace = self.namespace or ir.ambassador_namespace
 
+        if "." in secret_name:
+            secret_name, namespace = secret_name.split('.', 1)
+
         return ir.resolve_secret(self, secret_name, namespace)
 
 


### PR DESCRIPTION
## Description
Using Host resources instead of TLSContext to allow insecure route policy.

## Related Issues
https://github.com/datawire/apro/issues/1089

## Testing
Validated using ingress-controller-conformance.

## Tasks That Must Be Done
- [ ] Did you update CHANGELOG.md?
- [ ] Did you add or update tests?
- [ ] Did you update documentation?
- [ ] Were there any special dev tricks you had to use to work on this code efficiently?
  + [ ] Did you add them to DEVELOPING.md?
