### PR TITLE
Ingress tls secrets can't be namespaced using ambassador syntax

### DIFF
--- a/python/ambassador/ir/irhost.py
+++ b/python/ambassador/ir/irhost.py
@@ -159,9 +159,6 @@ class IRHost(IRResource):
         # namespace, fall back to the Ambassador's namespace.
         namespace = self.namespace or ir.ambassador_namespace
 
-        if "." in secret_name:
-            secret_name, namespace = secret_name.split('.', 1)
-
         return ir.resolve_secret(self, secret_name, namespace)
 
 

--- a/python/tests/t_tls.py
+++ b/python/tests/t_tls.py
@@ -913,6 +913,12 @@ service: https://{self.target.path.fqdn}
                 if host_header == 'tls-context-host-3':
                     host_header = 'localhost'
 
+                # Yep, that's expected. Since the TLS secret for 'tls-context-host-1' is
+                # not namespaced it should only resolve to the Ingress' own
+                # namespace, and can't use the 'secret.namespace' Ambassador syntax
+                if host_header == 'tls-context-host-1':
+                    host_header = 'localhost'
+
                 assert host_header == tls_common_name, "test %d wanted CN %s, but got %s" % (idx, host_header, tls_common_name)
 
             idx += 1


### PR DESCRIPTION
## Description
Ingress TLS secrets can't be namespaced using ambassador's "secret.namespace" syntax

## Related Issues
https://github.com/datawire/apro/issues/1041

## Testing
KAT tests were adjusted.

## Tasks That Must Be Done
- [ ] Did you update CHANGELOG.md?
- [x] Did you add or update tests?
- [ ] Did you update documentation?
- [ ] Were there any special dev tricks you had to use to work on this code efficiently?
  + [ ] Did you add them to DEVELOPING.md?
