### PR TITLE
[WIP] Fix broken and "ugly" links

### DIFF
--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -15,7 +15,7 @@ We're happy to help!
 * The [FAQ](latest/about/faq) has answers to many common questions
 * Join our open source [Slack channel](https://d6e.co/slack)
 * Report bugs in [GitHub](https://github.com/datawire/ambassador)
-* Need commercial support? [Contact us](https://www.getambassador.io/contact/)
+* Need commercial support? [Contact us](/contact/)
 
 ## How the Documentation is Organized
 

--- a/docs/docs/latest/howtos/basic-auth.md
+++ b/docs/docs/latest/howtos/basic-auth.md
@@ -1,6 +1,6 @@
 # Authentication
 
-Ambassador can authenticate incoming requests before routing them to a backing service. In this tutorial, we'll configure Ambassador to use an external third party authentication service. Note that if you're using the Ambassador Edge Stack, the [`External` filter](../topics/using/filters) is a more powerful way to manage authentication. 
+Ambassador can authenticate incoming requests before routing them to a backing service. In this tutorial, we'll configure Ambassador to use an external third party authentication service. Note that if you're using the Ambassador Edge Stack, the [`External` filter](../../topics/using/filters) is a more powerful way to manage authentication. 
 
 ## Before You Get Started
 

--- a/docs/docs/latest/index.md
+++ b/docs/docs/latest/index.md
@@ -15,7 +15,7 @@ We're happy to help!
 * The [FAQ](about/faq) has answers to many common questions
 * Join our open source [Slack channel](https://d6e.co/slack)
 * Report bugs in [GitHub](https://github.com/datawire/ambassador)
-* Need commercial support? [Contact us](https://www.getambassador.io/contact/)
+* Need commercial support? [Contact us](/contact/)
 
 ## How the Documentation is Organized
 

--- a/docs/docs/latest/topics/concepts/kubernetes-network-architecture.md
+++ b/docs/docs/latest/topics/concepts/kubernetes-network-architecture.md
@@ -47,4 +47,4 @@ The Ambassador Edge Stack supports routing both to Kubernetes services and direc
 ## Further reading
 
 * [Kubernetes Ingress 101](https://blog.getambassador.io/kubernetes-ingress-nodeport-load-balancers-and-ingress-controllers-6e29f1c44f2d)
-* [Envoy Proxy Performance on Kubernetes](https://www.getambassador.io/resources/envoyproxy-performance-on-k8s/)
+* [Envoy Proxy Performance on Kubernetes](/resources/envoyproxy-performance-on-k8s/)

--- a/docs/docs/latest/topics/running/debugging.md
+++ b/docs/docs/latest/topics/running/debugging.md
@@ -70,7 +70,7 @@ In both the Deployment Pod and the individual Pods, take the necessary action to
 
 The Ambassador logging can provide information on anything that might be abnormal or malfunctioning. While there may be a large amount of data to sort through, look for key errors such as the Ambassador process restarting unexpectedly, or a malformed Envoy configuration.
 
-You can turn on Debug mode in the [Edge Policy Console](../using/edge-policy-console), which generates verbose logging data that can be useful when trying to find a subtle error or bug.
+You can turn on Debug mode in the [Edge Policy Console](../../using/edge-policy-console), which generates verbose logging data that can be useful when trying to find a subtle error or bug.
 
 1. Use the following command to target an individual Ambassador Pod: `kubectl get pods -n ambassador`
 

--- a/docs/docs/latest/topics/running/ingress-controller.md
+++ b/docs/docs/latest/topics/running/ingress-controller.md
@@ -23,7 +23,7 @@ If you're new to the Ambassador Edge Stack and to Kubernetes, we'd recommend you
 
 - The Ambassador Edge Stack will need RBAC permissions to get, list, watch, and update `Ingress` resources.
 
-  You can see this in the [`aes-crds.yaml`](../../../../yaml/aes.yaml)
+  You can see this in the [`aes-crds.yaml`](/yaml/aes.yaml)
   file, but this is the critical rule to add to the Ambassador Edge Stack's `Role` or `ClusterRole`:
 
       - apiGroups: [ "extensions", "networking.k8s.io" ]

--- a/docs/docs/latest/topics/running/load-balancer.md
+++ b/docs/docs/latest/topics/running/load-balancer.md
@@ -1,6 +1,6 @@
 # Load Balancing in Ambassador Edge Stack
 
-Load balancing configuration can be set for all Ambassador Edge Stack mappings in the [`ambassador Module`](ambassador), or set per [`Mapping`](../../using/mappings#configuring-mappings). If nothing is set, simple round robin balancing is used via Kubernetes services.
+Load balancing configuration can be set for all Ambassador Edge Stack mappings in the [`ambassador Module`](../ambassador), or set per [`Mapping`](../../using/mappings#configuring-mappings). If nothing is set, simple round robin balancing is used via Kubernetes services.
 
 To use advanced load balancing, you must first configure a [resolver](../resolvers) that supports advanced load balancing (e.g., the Kubernetes Endpoint Resolver or Consul Resolver). Once a resolver is configured, you can use the `load_balancer` attribute. The following fields are supported:
 

--- a/docs/docs/latest/topics/using/circuit-breakers.md
+++ b/docs/docs/latest/topics/using/circuit-breakers.md
@@ -79,7 +79,7 @@ service: quote
 
 ## Circuit Breakers and Automatic Retries
 
-Circuit breakers are best used in conjunction with [automatic retries](retries). Here are some examples:
+Circuit breakers are best used in conjunction with [automatic retries](../retries). Here are some examples:
 
 * You've configured automatic retries for failed requests to a service. Your service is under heavy load, and starting to time out on servicing requests. In this case, automatic retries can exacerbate your problem, increasing the total request volume by 2x or more. By aggressively circuit breaking, you can mitigate failure in this scenario.
 * To circuit break when services are slow, you can combine circuit breakers with retries. Reduce the time out for retries, and then set a circuit breaker that detects many retries. In this setup, if your service doesn't respond quickly, a flood of retries will occur, which can then trip the circuit breaker.


### PR DESCRIPTION
Fix the following broken and "ugly" links:

Page http://localhost:8000/docs/latest/ has an ugly link: "https://www.getambassador.io/contact/" has a domain (did you mean "/contact/"?)

Page http://localhost:8000/docs/latest/howtos/basic-auth/ has a broken link: "../topics/using/filters" (HTTP_404)

Page http://localhost:8000/docs/latest/topics/concepts/kubernetes-network-architecture/ has an ugly link: "https://www.getambassador.io/resources/envoyproxy-performance-on-k8s/" has a domain (did you mean "/resources/envoyproxy-performance-on-k8s/"?)

Page http://localhost:8000/docs/latest/topics/running/debugging/ has a broken link: "../using/edge-policy-console" (HTTP_404)

Page http://localhost:8000/docs/latest/topics/running/ingress-controller/ has a broken link: "../../../../yaml/aes.yaml" (HTTP_404)

Page http://localhost:8000/docs/latest/topics/running/load-balancer/ has a broken link: "ambassador" (HTTP_404)

Page http://localhost:8000/docs/latest/topics/using/circuit-breakers/ has a broken link: "retries" (HTTP_404)
