### PR TITLE
Bruce/celebrate with user 1

### DIFF
--- a/cmd/edgectl/aes_install.go
+++ b/cmd/edgectl/aes_install.go
@@ -83,6 +83,16 @@ func aesInstall(cmd *cobra.Command, args []string) error {
 	kcontext, _ := cmd.Flags().GetString("context")
 	i := NewInstaller(verbose)
 
+	// If Scout is disabled (environment variable set to non-null), inform the user.
+	// TODO: should be i.scout.Disabled() when Alex's PR #2496 is merged.
+	if os.Getenv("SCOUT_DISABLE") != "" {
+		i.show.Printf("[aesInstall] Scout is disabled; metrics will not be written to Metriton.")
+	}
+
+	// Both printed and logged when verbose.
+	i.log.Printf("[aesInstall] the install_id is: %s", i.scout.installID)
+	i.log.Printf("[aesInstall] the trace_id is:   %s", i.scout.metadata["trace_id"])
+
 	sup := supervisor.WithContext(i.ctx)
 	sup.Logger = i.log
 
@@ -415,6 +425,7 @@ func (i *Installer) Perform(kcontext string) error {
 
 	// Attempt to use kubectl
 	_, err := i.GetKubectlPath()
+	//err = errors.New("early error for testing")  // TODO: remove for production
 	if err != nil {
 		i.Report("fail_no_kubectl")
 		return fmt.Errorf(noKubectl)
@@ -1000,7 +1011,6 @@ const noTlsSuccess = "Congratulations! You've successfully installed the Ambassa
 
 const noKubectl = `
 The installer depends on the 'kubectl' executable. Make sure you have the latest release downloaded in your PATH, and that you have executable permissions.
-
 Visit https://kubernetes.io/docs/tasks/tools/install-kubectl/ for more information and instructions.`
 
 const noCluster = `

--- a/cmd/edgectl/aes_install.go
+++ b/cmd/edgectl/aes_install.go
@@ -761,7 +761,7 @@ func (i *Installer) Perform(kcontext string) error {
 	i.show.Println()
 	i.ShowWrapped(color.Info.Sprintf(fullSuccess,
 		chalk.Bold.TextStyle(i.hostname),
-		chalk.Bold.TextStyle("edgectl login --namespace=ambassador "+i.hostname)))
+		chalk.Bold.TextStyle("edgectl login "+i.hostname)))
 
 	i.show.Println()
 
@@ -1030,7 +1030,7 @@ const fullSuccess = `Congratulations! You've successfully installed the Ambassad
 
 In the future, to log back in to the Ambassador Edge Policy Console, run
 $ %s
-from the command line.` // hostname, "edgectl login --namespace=ambassador <hostname>"
+from the command line.` // hostname, "edgectl login <hostname>"
 
 const noTlsSuccess = "Congratulations! You've successfully installed the Ambassador Edge Stack in your Kubernetes cluster. However, we cannot connect to your cluster from the Internet, so we could not configure TLS automatically."
 

--- a/cmd/edgectl/aes_install.go
+++ b/cmd/edgectl/aes_install.go
@@ -757,7 +757,8 @@ func (i *Installer) Perform(kcontext string) error {
 	}
 
 	i.show.Println("AES Installation Complete!")
-	i.show.Println("================================\n")
+	i.show.Println("================================")
+	i.show.Println()
 
 	i.ShowWrapped(fmt.Sprintf(fullSuccess,
 		color.Bold.Sprintf(i.hostname),

--- a/cmd/edgectl/aes_install.go
+++ b/cmd/edgectl/aes_install.go
@@ -87,8 +87,7 @@ func aesInstall(cmd *cobra.Command, args []string) error {
 	i := NewInstaller(verbose)
 
 	// If Scout is disabled (environment variable set to non-null), inform the user.
-	// TODO: should be i.scout.Disabled() when Alex's PR #2496 is merged.
-	if os.Getenv("SCOUT_DISABLE") != "" {
+	if i.scout.Disabled() != "" {
 		i.show.Printf(color.Info.Sprintf(phoneHomeDisabled))
 	}
 
@@ -757,7 +756,7 @@ func (i *Installer) Perform(kcontext string) error {
 	i.show.Println()
 	i.ShowWrapped(color.Info.Sprintf(fullSuccess,
 		chalk.Bold.TextStyle(i.hostname),
-		chalk.Bold.TextStyle("edgectl install "+i.hostname)))
+		chalk.Bold.TextStyle("edgectl login --namespace=ambassador "+i.hostname)))
 
 	i.show.Println()
 
@@ -1011,12 +1010,11 @@ $ kubectl delete crd -l product=aes
 
 The installer will now quit to avoid corrupting an existing (but undetected) installation.
 `
-
-const seeDocs    = "See https://www.getambassador.io/docs/latest/tutorials/getting-started/"
 const seeDocsURL = "https://www.getambassador.io/docs/latest/tutorials/getting-started/"
+const seeDocs    = "See " + seeDocsURL
 
-const phoneHomeDisabled  = "[aesInstall] Info: phone-home is disabled by environment variable"
-const installAndTraceIDs = "[aesInstall] Info: install_id = %s; trace_id = %s"
+const phoneHomeDisabled  = "Info: phone-home is disabled by environment variable"
+const installAndTraceIDs = "Info: install_id = %s; trace_id = %s"
 
 var validEmailAddress = regexp.MustCompile("^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$")
 
@@ -1028,16 +1026,15 @@ from the command line.` // hostname, "edgectl login --namespace=ambassador <host
 
 const noTlsSuccess = "Congratulations! You've successfully installed the Ambassador Edge Stack in your Kubernetes cluster. However, we cannot connect to your cluster from the Internet, so we could not configure TLS automatically."
 
+const noKubectlURL = "https://kubernetes.io/docs/tasks/tools/install-kubectl/"
 const noKubectl = `
 The installer depends on the 'kubectl' executable. Make sure you have the latest release downloaded in your PATH, and that you have executable permissions.
-Visit https://kubernetes.io/docs/tasks/tools/install-kubectl/ for more information and instructions.`
+Visit ` + noKubectlURL + `  for more information and instructions.`
 
-const noKubectlURL = "https://kubernetes.io/docs/tasks/tools/install-kubectl/"
-
+const noClusterURL = "https://kubernetes.io/docs/setup/"
 const noCluster = `
 Unable to communicate with the remote Kubernetes cluster using your kubectl context.
 
 To further debug and diagnose cluster problems, use 'kubectl cluster-info dump' 
-or get started and run Kubernetes https://kubernetes.io/docs/setup/`
+or get started and run Kubernetes` + noClusterURL
 
-const noClusterURL = "https://kubernetes.io/docs/setup/"

--- a/cmd/edgectl/aes_install.go
+++ b/cmd/edgectl/aes_install.go
@@ -753,7 +753,9 @@ func (i *Installer) Perform(kcontext string) error {
 	// Add a little color
 
 	i.show.Println()
-	i.ShowWrapped(color.Info.Sprintf(fullSuccess, chalk.Bold.TextStyle(i.hostname), chalk.Bold.TextStyle("edgectl install")))
+	i.ShowWrapped(color.Info.Sprintf(fullSuccess,
+		chalk.Bold.TextStyle(i.hostname),
+		chalk.Bold.TextStyle("edgectl install namespace=ambassador \\\n"+i.hostname)))
 
 	i.show.Println()
 
@@ -1017,7 +1019,7 @@ const fullSuccess = `Congratulations! You've successfully installed the Ambassad
 
 To access your Edge Stack installation and for additional configuration.  In the future, to log back in to the Ambassador Edge Stack, run
 %s
-from the command line.` // hostname, "edgectl login"
+from the command line.` // hostname, "edgectl login --namespace=ambassador <hostname>"
 
 const noTlsSuccess = "Congratulations! You've successfully installed the Ambassador Edge Stack in your Kubernetes cluster. However, we cannot connect to your cluster from the Internet, so we could not configure TLS automatically."
 

--- a/cmd/edgectl/aes_install.go
+++ b/cmd/edgectl/aes_install.go
@@ -755,7 +755,7 @@ func (i *Installer) Perform(kcontext string) error {
 	i.show.Println()
 	i.ShowWrapped(color.Info.Sprintf(fullSuccess,
 		chalk.Bold.TextStyle(i.hostname),
-		chalk.Bold.TextStyle("edgectl install namespace=ambassador \\\n"+i.hostname)))
+		chalk.Bold.TextStyle("edgectl install "+i.hostname)))
 
 	i.show.Println()
 
@@ -1018,7 +1018,7 @@ const fullSuccess = `Congratulations! You've successfully installed the Ambassad
 %s
 
 To access your Edge Stack installation and for additional configuration.  In the future, to log back in to the Ambassador Edge Stack, run
-%s
+$ %s
 from the command line.` // hostname, "edgectl login --namespace=ambassador <hostname>"
 
 const noTlsSuccess = "Congratulations! You've successfully installed the Ambassador Edge Stack in your Kubernetes cluster. However, we cannot connect to your cluster from the Internet, so we could not configure TLS automatically."

--- a/cmd/edgectl/aes_install.go
+++ b/cmd/edgectl/aes_install.go
@@ -87,7 +87,7 @@ func aesInstall(cmd *cobra.Command, args []string) error {
 	i := NewInstaller(verbose)
 
 	// If Scout is disabled (environment variable set to non-null), inform the user.
-	if i.scout.Disabled() != "" {
+	if i.scout.Disabled() {
 		i.show.Printf(color.Info.Sprintf(phoneHomeDisabled))
 	}
 
@@ -1037,12 +1037,12 @@ const noTlsSuccess = "Congratulations! You've successfully installed the Ambassa
 const noKubectlURL = "https://kubernetes.io/docs/tasks/tools/install-kubectl/"
 const noKubectl = `
 The installer depends on the 'kubectl' executable. Make sure you have the latest release downloaded in your PATH, and that you have executable permissions.
-Visit ` + noKubectlURL + `  for more information and instructions.`
+Visit ` + noKubectlURL + ` for more information and instructions.`
 
 const noClusterURL = "https://kubernetes.io/docs/setup/"
 const noCluster = `
 Unable to communicate with the remote Kubernetes cluster using your kubectl context.
 
 To further debug and diagnose cluster problems, use 'kubectl cluster-info dump' 
-or get started and run Kubernetes` + noClusterURL
+or get started and run Kubernetes: ` + noClusterURL
 

--- a/cmd/edgectl/aes_install.go
+++ b/cmd/edgectl/aes_install.go
@@ -26,7 +26,6 @@ import (
 	"github.com/gookit/color"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"github.com/ttacon/chalk"
 	k8sTypesMetaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sClientCoreV1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/rest"
@@ -88,11 +87,11 @@ func aesInstall(cmd *cobra.Command, args []string) error {
 
 	// If Scout is disabled (environment variable set to non-null), inform the user.
 	if i.scout.Disabled() {
-		i.show.Printf(color.Info.Sprintf(phoneHomeDisabled))
+		i.show.Printf(phoneHomeDisabled)
 	}
 
 	// Both printed and logged when verbose (Installer.log is responsible for --verbose)
-	i.log.Printf(color.Info.Sprintf(installAndTraceIDs, i.scout.installID, i.scout.metadata["trace_id"]))
+	i.log.Printf(fmt.Sprintf(installAndTraceIDs, i.scout.installID, i.scout.metadata["trace_id"]))
 
 	sup := supervisor.WithContext(i.ctx)
 	sup.Logger = i.log
@@ -425,7 +424,8 @@ func (i *Installer) Perform(kcontext string) error {
 	// Start
 	i.Report("install")
 
-	i.ShowWrapped(color.Info.Sprintf("Beginning AES Installation\n"))
+	i.show.Println("================================")
+	i.show.Println(beginningAESInstallation)
 
 	// Attempt to use kubectl
 	_, err := i.GetKubectlPath()
@@ -629,7 +629,7 @@ func (i *Installer) Perform(kcontext string) error {
 		return err
 	}
 	i.Report("cluster_accessible")
-	i.show.Println("Your AES installation's address is", chalk.Bold.TextStyle(i.address))
+	i.show.Println("Your AES installation's address is", color.Bold.Sprintf(i.address))
 
 	// Wait for Ambassador to be ready to serve ACME requests.
 	if err := i.loopUntil("AES to serve ACME", i.CheckAESServesACME, lc2); err != nil {
@@ -717,7 +717,7 @@ func (i *Installer) Perform(kcontext string) error {
 	}
 
 	i.hostname = string(content)
-	i.show.Println("-> Acquiring DNS name", chalk.Bold.TextStyle(i.hostname))
+	i.show.Println("-> Acquiring DNS name", color.Bold.Sprintf(i.hostname))
 
 	// Wait for DNS to propagate. This tries to avoid waiting for a ten
 	// minute error backoff if the ACME registration races ahead of the DNS
@@ -756,12 +756,12 @@ func (i *Installer) Perform(kcontext string) error {
 		return err
 	}
 
-	// Add a little color
+	i.show.Println("AES Installation Complete!")
+	i.show.Println("================================\n")
 
-	i.show.Println()
-	i.ShowWrapped(color.Info.Sprintf(fullSuccess,
-		chalk.Bold.TextStyle(i.hostname),
-		chalk.Bold.TextStyle("edgectl login "+i.hostname)))
+	i.ShowWrapped(fmt.Sprintf(fullSuccess,
+		color.Bold.Sprintf(i.hostname),
+		color.Bold.Sprintf("edgectl login "+i.hostname)))
 
 	i.show.Println()
 
@@ -977,6 +977,8 @@ spec:
     email: %s
 `
 
+const beginningAESInstallation = "Beginning Ambassador Edge Stack Installation"
+
 const emailAsk = `Please enter an email address. We'll use this email address to notify you prior to domain and certificate expiration. We also share this email address with Let's Encrypt to acquire your certificate for TLS.`
 
 const loginViaIP = `
@@ -1021,8 +1023,8 @@ The installer will now quit to avoid corrupting an existing (but undetected) ins
 const seeDocsURL = "https://www.getambassador.io/docs/latest/tutorials/getting-started/"
 const seeDocs    = "See " + seeDocsURL
 
-const phoneHomeDisabled  = "Info: phone-home is disabled by environment variable"
-const installAndTraceIDs = "Info: install_id = %s; trace_id = %s"
+const phoneHomeDisabled  = "INFO: phone-home is disabled by environment variable"
+const installAndTraceIDs = "INFO: install_id = %s; trace_id = %s"
 
 var validEmailAddress = regexp.MustCompile("^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$")
 

--- a/cmd/edgectl/aes_login.go
+++ b/cmd/edgectl/aes_login.go
@@ -99,7 +99,7 @@ func do_login(kubeinfo *k8s.KubeInfo, context, namespace, hostname string, justS
 		fmt.Println("Visit the following URL to access the Ambassador Edge Policy Console:")
 		fmt.Println("    ", url)
 	} else {
-		fmt.Println(color.Info.Sprintf("The Ambassador Edge Policy Console has been opened in your browser."))
+		fmt.Println("The Ambassador Edge Policy Console has been opened in your browser.")
 	}
 
 	if showToken {

--- a/cmd/edgectl/aes_login.go
+++ b/cmd/edgectl/aes_login.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/datawire/ambassador/pkg/k8s"
 	"github.com/dgrijalva/jwt-go"
+	"github.com/gookit/color"
 	"github.com/pkg/browser"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -23,7 +24,7 @@ type LoginClaimsV1 struct {
 }
 
 func aesLogin(cmd *cobra.Command, args []string) error {
-	fmt.Println("Connecting to the Ambassador Edge Policy Console in this cluster...")
+	fmt.Println(color.Info.Sprintf("Connecting to the Ambassador Edge Policy Console in this cluster..."))
 
 	// Grab options
 	context, _ := cmd.Flags().GetString("context")
@@ -98,7 +99,7 @@ func do_login(kubeinfo *k8s.KubeInfo, context, namespace, hostname string, justS
 		fmt.Println("Visit the following URL to access the Ambassador Edge Policy Console:")
 		fmt.Println("    ", url)
 	} else {
-		fmt.Println("The Ambassador Edge Policy Console has been opened in your browser.")
+		fmt.Println(color.Info.Sprintf("The Ambassador Edge Policy Console has been opened in your browser."))
 	}
 
 	if showToken {

--- a/cmd/edgectl/main.go
+++ b/cmd/edgectl/main.go
@@ -183,7 +183,7 @@ func getRootCommand() *cobra.Command {
 	}
 	loginCmd := &cobra.Command{
 		Use:   "login [flags] HOSTNAME",
-		Short: "Access the Ambassador Edge Policy Console",
+		Short: "Log in to the Ambassador Edge Policy Console web application",
 		Args:  cobra.ExactArgs(1),
 		RunE:  aesLogin,
 	}

--- a/cmd/edgectl/main.go
+++ b/cmd/edgectl/main.go
@@ -183,7 +183,7 @@ func getRootCommand() *cobra.Command {
 	}
 	loginCmd := &cobra.Command{
 		Use:   "login [flags] HOSTNAME",
-		Short: "Log in to the Ambassador Edge Policy Console web application",
+		Short: "Log in and open the Ambassador Edge Policy Console web application",
 		Args:  cobra.ExactArgs(1),
 		RunE:  aesLogin,
 	}

--- a/cmd/edgectl/main.go
+++ b/cmd/edgectl/main.go
@@ -183,7 +183,7 @@ func getRootCommand() *cobra.Command {
 	}
 	loginCmd := &cobra.Command{
 		Use:   "login [flags] HOSTNAME",
-		Short: "Log in and open the Ambassador Edge Policy Console web application",
+		Short: "Log in to the Ambassador Edge Policy Console",
 		Args:  cobra.ExactArgs(1),
 		RunE:  aesLogin,
 	}

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/golang/protobuf v1.3.2
 	github.com/google/shlex v0.0.0-20181106134648-c34317bd91bf
 	github.com/google/uuid v1.1.1
+	github.com/gookit/color v1.2.3
 	github.com/gorilla/websocket v1.4.0
 	github.com/hashicorp/consul/api v1.1.0
 	github.com/huandu/xstrings v1.2.0 // indirect
@@ -33,6 +34,7 @@ require (
 	github.com/spf13/cobra v0.0.5
 	github.com/spf13/pflag v1.0.3
 	github.com/stretchr/testify v1.4.0
+	github.com/ttacon/chalk v0.0.0-20160626202418-22c06c80ed31
 	golang.org/x/crypto v0.0.0-20190611184440-5c40567a22f8
 	golang.org/x/net v0.0.0-20190812203447-cdfb69ac37fc
 	golang.org/x/sys v0.0.0-20191024073052-e66fe6eb8e0c

--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,6 @@ require (
 	github.com/spf13/cobra v0.0.5
 	github.com/spf13/pflag v1.0.3
 	github.com/stretchr/testify v1.4.0
-	github.com/ttacon/chalk v0.0.0-20160626202418-22c06c80ed31
 	golang.org/x/crypto v0.0.0-20190611184440-5c40567a22f8
 	golang.org/x/net v0.0.0-20190812203447-cdfb69ac37fc
 	golang.org/x/sys v0.0.0-20191024073052-e66fe6eb8e0c

--- a/go.sum
+++ b/go.sum
@@ -122,6 +122,8 @@ github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gnostic v0.0.0-20170729233727-0c5108395e2d h1:7XGaL1e6bYS1yIonGp9761ExpPPV1ui0SAC59Yube9k=
 github.com/googleapis/gnostic v0.0.0-20170729233727-0c5108395e2d/go.mod h1:sJBsCZ4ayReDTBIg8b9dl28c5xFWyhBTVRp3pOg5EKY=
+github.com/gookit/color v1.2.3 h1:2Si0/JAEE2+1hkNYuTszu54Ti9wfp+M4JNNrknf9/D0=
+github.com/gookit/color v1.2.3/go.mod h1:AhIE+pS6D4Ql0SQWbBeXPHw7gY0/sjHoA4s/n1KB7xg=
 github.com/gophercloud/gophercloud v0.1.0 h1:P/nh25+rzXouhytV2pUHBb65fnds26Ghl8/391+sT5o=
 github.com/gophercloud/gophercloud v0.1.0/go.mod h1:vxM41WHh5uqHVBMZHzuwNOHh8XEoIEcSTewFxm1c5g8=
 github.com/gorilla/websocket v1.4.0 h1:WDFjx/TMzVgy9VdMMQi2K2Emtwi2QcUQsztZ/zLaH/Q=
@@ -269,6 +271,8 @@ github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXf
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+github.com/ttacon/chalk v0.0.0-20160626202418-22c06c80ed31 h1:OXcKh35JaYsGMRzpvFkLv/MEyPuL49CThT1pZ8aSml4=
+github.com/ttacon/chalk v0.0.0-20160626202418-22c06c80ed31/go.mod h1:onvgF043R+lC5RZ8IT9rBXDaEDnpnw/Cl+HFiw+v/7Q=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=

--- a/go.sum
+++ b/go.sum
@@ -271,8 +271,6 @@ github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXf
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
-github.com/ttacon/chalk v0.0.0-20160626202418-22c06c80ed31 h1:OXcKh35JaYsGMRzpvFkLv/MEyPuL49CThT1pZ8aSml4=
-github.com/ttacon/chalk v0.0.0-20160626202418-22c06c80ed31/go.mod h1:onvgF043R+lC5RZ8IT9rBXDaEDnpnw/Cl+HFiw+v/7Q=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=


### PR DESCRIPTION
Some improvements in the output during edgectl install, working on the Edgectl Install Improvements story, "Celebrate with the User".  I made a first pass on the following (from the story):

-_change the edgectl install success message printed to the terminal to a happier, more celebratory success message: bold? Capital letters? Distinguished spacing? This seems silly, but it turns out that a little design goes a long way in helping people like the product enough to put more time into evaluating it._. I colorized and restyled the text a bit.

- _add to the terminal message, some information about how to log back into the UI in the future._  Text was added for this.

-_change the edgectl --help message about login to be more clear that this is how one opens the UI._ Very minor change in the Cobra command definition.

I would appreciate some feedback on the language here.

![celebrate2](https://user-images.githubusercontent.com/635244/77939686-63864600-726c-11ea-871c-8cc8f0a34ad8.png)
