### PR TITLE
edgectl sends crash reports and logs to metriton

### DIFF
--- a/cmd/edgectl/aes_install.go
+++ b/cmd/edgectl/aes_install.go
@@ -1023,6 +1023,7 @@ func (i *Installer) generateCrashReport(sourceError error) {
 		return
 	}
 	i.log.Printf("uploading anonymous crash report and logs under report ID: %v", crashReport.ReportId)
+	i.Report("crash_report", ScoutMeta{"crash_report_id", crashReport.ReportId})
 	i.uploadCrashReportData(crashReport, i.gatherCrashReportData())
 }
 

--- a/cmd/edgectl/aes_install.go
+++ b/cmd/edgectl/aes_install.go
@@ -1008,6 +1008,15 @@ type kubernetesVersion struct {
 	Server k8sVersion.Info `json:"serverVersion"`
 }
 
+// registration is used to register edgestack.me domains
+type registration struct {
+	Email            string
+	Ip               string
+	Hostname         string
+	EdgectlInstallId string
+	AESInstallId     string
+}
+
 const hostManifest = `
 apiVersion: getambassador.io/v2
 kind: Host

--- a/cmd/edgectl/aes_install.go
+++ b/cmd/edgectl/aes_install.go
@@ -425,6 +425,7 @@ func (i *Installer) GetInstalledImageVersion() (string, error) {
 
 // Perform is the main function for the installer
 func (i *Installer) Perform(kcontext string) error {
+	// TODO: REMOVE!
 	return fmt.Errorf("Short circuit")
 
 	// Start

--- a/cmd/edgectl/aes_install_crash.go
+++ b/cmd/edgectl/aes_install_crash.go
@@ -104,15 +104,6 @@ func (i *Installer) uploadCrashReportData(crashReport crashReportCreationRespons
 	}
 }
 
-// registration is used to register edgestack.me domains
-type registration struct {
-	Email            string
-	Ip               string
-	Hostname         string
-	EdgectlInstallId string
-	AESInstallId     string
-}
-
 // crashReportCreationRequest is used to initiate a crash report request
 type crashReportCreationRequest struct {
 	Product         string

--- a/cmd/edgectl/aes_install_crash.go
+++ b/cmd/edgectl/aes_install_crash.go
@@ -1,0 +1,141 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+)
+
+func (i *Installer) generateCrashReport(sourceError error) {
+	// TODO: Use the live endpoint
+	//reportURL := "https://metriton.datawire.io/crash-report"
+	reportURL := "https://metriton.datawire.io/beta/crash-report"
+
+	report := &crashReportCreationRequest{
+		Product:         "edgectl",
+		Command:         "install",
+		ProductVersion:  displayVersion,
+		Error:           sourceError.Error(),
+		AESVersion:      i.version,
+		Address:         i.address,
+		Hostname:        i.hostname,
+		ClusterID:       i.clusterID,
+		InstallID:       i.scout.installID,
+		TraceID:         fmt.Sprintf("%v", i.scout.metadata["trace_id"]),
+		ClusterInfo:     fmt.Sprintf("%v", i.scout.metadata["cluster_info"]),
+		Managed:         fmt.Sprintf("%v", i.scout.metadata["managed"]),
+		KubectlVersion:  i.k8sVersion.Client.GitVersion,
+		KubectlPlatform: i.k8sVersion.Client.Platform,
+		K8sVersion:      i.k8sVersion.Server.GitVersion,
+		K8sPlatform:     i.k8sVersion.Server.Platform,
+	}
+	buf := new(bytes.Buffer)
+	_ = json.NewEncoder(buf).Encode(report)
+	resp, err := http.Post(reportURL, "application/json", buf)
+	if err != nil {
+		i.log.Printf("failed to initiate anonymous crash report due to error: %v", err.Error())
+		return
+	}
+	defer resp.Body.Close()
+	content, err := ioutil.ReadAll(resp.Body)
+	if resp.StatusCode != 201 {
+		i.log.Print("skipping anonymous crash report and log submission for this failure")
+		i.log.Printf("%v: %q", resp.StatusCode, string(content))
+		return
+	}
+	crashReport := crashReportCreationResponse{}
+	err = json.Unmarshal(content, &crashReport)
+	if err != nil {
+		i.log.Printf("failed to generate anonymous crash report due to error: %v", err.Error())
+		return
+	}
+	i.log.Printf("uploading anonymous crash report and logs under report ID: %v", crashReport.ReportId)
+	i.Report("crash_report", ScoutMeta{"crash_report_id", crashReport.ReportId})
+	i.uploadCrashReportData(crashReport, i.gatherCrashReportData())
+}
+
+func (i *Installer) gatherCrashReportData() []byte {
+	buffer := bytes.NewBuffer([]byte{})
+
+	buffer.WriteString("========== edgectl logs ==========\n")
+	fileContent, err := ioutil.ReadFile(i.logName)
+	if err != nil {
+		i.log.Printf("failed to read log file %v: %v", i.logName, err.Error())
+	}
+	buffer.Write(fileContent)
+
+	buffer.WriteString("\n========== kubectl describe ==========\n")
+	describe, err := i.SilentCaptureKubectl("describe ambassador namespace", "", "-n", "ambassador", "describe", "all")
+	if err != nil {
+		i.log.Printf("failed to describe ambassador resources: %v", err.Error())
+	}
+	buffer.WriteString(describe)
+
+	buffer.WriteString("\n========== kubectl logs ==========\n")
+	ambassadorLogs, err := i.SilentCaptureKubectl("read ambassador logs", "", "-n", "ambassador", "logs", "deployments/ambassador", "--tail=1000")
+	if err != nil {
+		i.log.Printf("failed to read ambassador logs: %v", err.Error())
+	}
+	buffer.WriteString(ambassadorLogs)
+
+	return buffer.Bytes()
+}
+
+func (i *Installer) uploadCrashReportData(crashReport crashReportCreationResponse, uploadContent []byte) {
+	client := &http.Client{}
+	req, err := http.NewRequest(crashReport.Method, crashReport.UploadURL, bytes.NewReader(uploadContent))
+	if err != nil {
+		i.log.Print(err.Error())
+		return
+	}
+
+	res, err := client.Do(req)
+	if err != nil {
+		i.log.Print(err.Error())
+		return
+	}
+	defer res.Body.Close()
+	_, err = ioutil.ReadAll(res.Body)
+	if err != nil {
+		i.log.Print(err.Error())
+		return
+	}
+}
+
+// registration is used to register edgestack.me domains
+type registration struct {
+	Email            string
+	Ip               string
+	Hostname         string
+	EdgectlInstallId string
+	AESInstallId     string
+}
+
+// crashReportCreationRequest is used to initiate a crash report request
+type crashReportCreationRequest struct {
+	Product         string
+	ProductVersion  string
+	Command         string
+	Error           string
+	AESVersion      string
+	Address         string
+	Hostname        string
+	ClusterID       string
+	InstallID       string
+	TraceID         string
+	ClusterInfo     string
+	Managed         string
+	KubectlVersion  string
+	KubectlPlatform string
+	K8sVersion      string
+	K8sPlatform     string
+}
+
+// crashReportCreationResponse is used to receive a crash report creation response
+type crashReportCreationResponse struct {
+	ReportId  string
+	Method    string
+	UploadURL string
+}

--- a/cmd/edgectl/aes_install_crash.go
+++ b/cmd/edgectl/aes_install_crash.go
@@ -9,9 +9,7 @@ import (
 )
 
 func (i *Installer) generateCrashReport(sourceError error) {
-	// TODO: Use the live endpoint
-	//reportURL := "https://metriton.datawire.io/crash-report"
-	reportURL := "https://metriton.datawire.io/beta/crash-report"
+	reportURL := "https://metriton.datawire.io/crash-report"
 
 	report := &crashReportCreationRequest{
 		Product:         "edgectl",

--- a/cmd/edgectl/main.go
+++ b/cmd/edgectl/main.go
@@ -123,6 +123,9 @@ func getRootCommand() *cobra.Command {
 		Long:         myHelp,
 		SilenceUsage: true, // https://github.com/spf13/cobra/issues/340
 	}
+	_ = rootCmd.PersistentFlags().Bool(
+		"no-report", false, "turn off anonymous crash reports and log submission on failure",
+	)
 
 	// Hidden/internal commands. These are called by Edge Control itself from
 	// the correct context and execute in-place immediately.


### PR DESCRIPTION
## Description
- `--no-report` cmd flag to skip uploading report and logs on failure.
- Call metriton to get a crash-report id and url for upload.
- Provides edgectl metadata, including versions and install ids.
- Provides edgectl logs, ambassador logs and ambassador resource description outputs.

## Related Issues
https://github.com/datawire/apro/issues/1162

## Testing
Manual tests

## Tasks That Must Be Done
- [ ] Did you update CHANGELOG.md?
- [ ] Did you add or update tests?
- [ ] Did you update documentation?
- [ ] Were there any special dev tricks you had to use to work on this code efficiently?
  + [ ] Did you add them to DEVELOPING.md?

## Other
* If this is a documentation change for a particular release, please open the pull request against the release branch.
