### PR TITLE
Refactor out from the build.mk the ingresstest target

### DIFF
--- a/builder/builder.mk
+++ b/builder/builder.mk
@@ -285,7 +285,7 @@ ingresstest:
 		printf "$(CYN)==> $(GRN)We are done. You should destroy the cluster with 'kind delete cluster'.$(END)\n"; \
 	fi
 
-test: ingresstest gotest pytest
+test: gotest pytest
 .PHONY: test
 
 shell:

--- a/releng/travis-script.sh
+++ b/releng/travis-script.sh
@@ -84,7 +84,7 @@ case "$COMMIT_TYPE" in
     *)
         docker login -u="$DOCKER_BUILD_USERNAME" --password-stdin "${DEV_REGISTRY}" <<<"$DOCKER_BUILD_PASSWORD"
 
-        make test
+        make test ingresstest
         ;;
 esac
 


### PR DESCRIPTION
## Description

We should not run `ingresstest` as part of `test` in the `builder.mk`, as it leads to some other errors.
