### PR TITLE
[kale] Supporting code for AES telemetry

### DIFF
--- a/cmd/edgectl/scout.go
+++ b/cmd/edgectl/scout.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/google/uuid"
@@ -65,7 +66,7 @@ func (s *Scout) Report(action string, meta ...ScoutMeta) error {
 		metadata[metaItem.Key] = metaItem.Value
 	}
 
-	_, err := s.reporter.Report(metadata)
+	_, err := s.reporter.Report(context.TODO(), metadata)
 	if err != nil {
 		return errors.Wrap(err, "scout report")
 	}

--- a/cmd/edgectl/scout.go
+++ b/cmd/edgectl/scout.go
@@ -1,22 +1,17 @@
 package main
 
 import (
-	"bytes"
-	"encoding/json"
 	"fmt"
-	"io/ioutil"
-	"net/http"
-	"os"
-	"path/filepath"
 
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
+
+	"github.com/datawire/ambassador/pkg/metriton"
 )
 
 type Scout struct {
-	installID string
-	index     int
-	metadata  map[string]interface{}
+	index    int
+	reporter *metriton.Reporter
 }
 
 type ScoutMeta struct {
@@ -25,70 +20,37 @@ type ScoutMeta struct {
 }
 
 func NewScout(mode string) (s *Scout) {
-	// Fixed (growing) metadata passed with every report
-	metadata := make(map[string]interface{})
-	metadata["mode"] = mode
-	metadata["trace_id"] = uuid.New().String()
-
-	// The result
-	s = &Scout{metadata: metadata}
-
-	// Get or create the persistent install ID for Edge Control
-	err := func() error {
-		// We store the persistent ID in ~/.config/edgectl/id to be consistent
-		// with Telepresence. We could instead use os.UserConfigDir() as the
-		// root of the destination, which may be the same on Linux, but is
-		// definitely different on MacOS.
-		home, err := os.UserHomeDir()
-		if err != nil {
-			return err
-		}
-		configDir := filepath.Join(home, ".config", "edgectl")
-		if err := os.MkdirAll(configDir, 0755); err != nil {
-			return err
-		}
-		idFilename := filepath.Join(configDir, "id")
-
-		// Try to read an existing install ID
-		if installIDBytes, err := ioutil.ReadFile(idFilename); err == nil {
-			s.installID = string(installIDBytes)
-			// Validate UUID format
-			if _, err := uuid.Parse(s.installID); err == nil {
-				metadata["new_install"] = false
-				return nil
-			} // else the value is not a UUID
-		} // else file doesn't exist, etc.
-
-		// Try to create a new install ID
-		s.installID = uuid.New().String()
-		metadata["new_install"] = true
-		if err := ioutil.WriteFile(idFilename, []byte(s.installID), 0755); err != nil {
-			return err
-		}
-		return nil
-	}()
-	if err != nil {
-		s.installID = "00000000-0000-0000-0000-000000000000"
-		metadata["new_install"] = true
-		metadata["install_id_error"] = err.Error()
+	return &Scout{
+		reporter: &metriton.Reporter{
+			Application: "edgectl",
+			Version:     Version,
+			GetInstallID: func(r *metriton.Reporter) (string, error) {
+				id, err := metriton.InstallIDFromFilesystem(r)
+				if err != nil {
+					id = "00000000-0000-0000-0000-000000000000"
+					r.BaseMetadata["new_install"] = true
+					r.BaseMetadata["install_id_error"] = err.Error()
+				}
+				return id, nil
+			},
+			// Fixed (growing) metadata passed with every report
+			BaseMetadata: map[string]interface{}{
+				"mode":     mode,
+				"trace_id": uuid.New().String(),
+			},
+		},
 	}
-
-	return
 }
 
 func (s *Scout) SetMetadatum(key string, value interface{}) {
-	oldValue, ok := s.metadata[key]
+	oldValue, ok := s.reporter.BaseMetadata[key]
 	if ok {
 		panic(fmt.Sprintf("trying to replace metadata[%q] = %q with %q", key, oldValue, value))
 	}
-	s.metadata[key] = value
+	s.reporter.BaseMetadata[key] = value
 }
 
 func (s *Scout) Report(action string, meta ...ScoutMeta) error {
-	if os.Getenv("SCOUT_DISABLE") != "" {
-		return nil
-	}
-
 	// Construct the report's metadata. Include the fixed (growing) set of
 	// metadata in the Scout structure and the pairs passed as arguments to this
 	// call. Also include and increment the index, which can be used to
@@ -99,33 +61,16 @@ func (s *Scout) Report(action string, meta ...ScoutMeta) error {
 		"action": action,
 		"index":  s.index,
 	}
-	for metaKey, metaValue := range s.metadata {
-		metadata[metaKey] = metaValue
-	}
 	for _, metaItem := range meta {
 		metadata[metaItem.Key] = metaItem.Value
 	}
 
-	data := map[string]interface{}{
-		"application": "edgectl",
-		"install_id":  s.installID,
-		"version":     Version,
-		"metadata":    metadata,
-	}
-
-	body, err := json.MarshalIndent(data, "", "  ")
-	if err != nil {
-		panic(err)
-	}
-	metritonEndpoint := "https://metriton.datawire.io/scout"
-	resp, err := http.Post(metritonEndpoint, "application/json", bytes.NewBuffer(body))
+	_, err := s.reporter.Report(metadata)
 	if err != nil {
 		return errors.Wrap(err, "scout report")
 	}
-
-	// TODO: Do something useful (?) with the response?
-	_, _ = ioutil.ReadAll(resp.Body)
-	_ = resp.Body.Close()
+	// TODO: Do something useful (alert the user if there's an available
+	// upgrade?) with the response (discarded as "_" above)?
 
 	return nil
 }

--- a/pkg/metriton/install_id.go
+++ b/pkg/metriton/install_id.go
@@ -1,0 +1,73 @@
+package metriton
+
+import (
+	"errors"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"github.com/google/uuid"
+)
+
+// StaticInstallID is returns an install-ID-getter that always returns
+// a fixed install ID.
+func StaticInstallID(id string) func(*Reporter) (string, error) {
+	return func(*Reporter) (string, error) {
+		return id, nil
+	}
+}
+
+// This is the same as os.UserConfigDir() on GOOS=linux.  We Use this
+// instead of os.UserConfigDir() because on we want the GOOS=linux
+// behavior on macOS, because:
+//
+//  - For consistency with Telepresence; as that's what scout.py does,
+//    and Telepresence uses scout.py
+//  - This is what existing versions of edgectl do (for consistency
+//    with Telepresence)
+//  - It's what many macOS users expect any way; they expect XDG file
+//    paths to work, because other cross-platform unix-y applications
+//    (like gcloud & pgcli) use them.
+//
+// That said, neither Telepresence nor existing versions of edgectl
+// obey XDG_CONFIG_HOME.
+func userConfigDir() (string, error) {
+	var dir string
+	dir = os.Getenv("XDG_CONFIG_HOME")
+	if dir == "" {
+		dir = os.Getenv("HOME")
+		if dir == "" {
+			return "", errors.New("neither $XDG_CONFIG_HOME nor $HOME are defined")
+		}
+		dir += "/.config"
+	}
+	return dir, nil
+}
+
+// InstallIDFromFilesystem is an install-ID-getter that tracks the
+// install ID in the filesystem (à la `telepresence` or `edgectl`).
+func InstallIDFromFilesystem(reporter *Reporter) (string, error) {
+	dir, err := userConfigDir()
+	if err != nil {
+		return "", err
+	}
+
+	idFilename := filepath.Join(dir, reporter.Application, "id")
+	if idBytes, err := ioutil.ReadFile(idFilename); err == nil {
+		reporter.BaseMetadata["new_install"] = false
+		return string(idBytes), nil
+	} else if !os.IsNotExist(err) {
+		return "", err
+	}
+
+	id := uuid.New().String()
+	reporter.BaseMetadata["new_install"] = true
+
+	if err := os.MkdirAll(filepath.Dir(idFilename), 0755); err != nil {
+		return "", err
+	}
+	if err := ioutil.WriteFile(idFilename, []byte(id), 0644); err != nil {
+		return "", err
+	}
+	return id, nil
+}

--- a/pkg/metriton/protocol.go
+++ b/pkg/metriton/protocol.go
@@ -60,6 +60,15 @@ type Response struct {
 
 	// Only set for .Application=="aes"
 	HardLimit bool `json:"hard_limit"`
+
+	// Disable submitting any more telemetry for the remaining
+	// lifetime of this process.
+	//
+	// This way, if we ever make another release that turns out to
+	// effectively DDoS Metriton, we can adjust the Metriton
+	// server's `api.py:handle_report()` to be able to tell the
+	// offending processes to shut up.
+	DisableScout bool `json:"disable_scout"`
 }
 
 // AppInfo is the information that Metriton knows about an

--- a/pkg/metriton/protocol.go
+++ b/pkg/metriton/protocol.go
@@ -1,0 +1,84 @@
+package metriton
+
+import (
+	"bytes"
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+)
+
+// Report is a telemetry report to submit to Metriton.
+//
+// See: https://github.com/datawire/metriton/blob/master/metriton/scout/jsonschema.py
+type Report struct {
+	Application string                 `json:"application"` // (required) The name of the application reporting the event
+	InstallID   string                 `json:"install_id"`  // (required) Application installation ID (usually a UUID, but technically an opaque string)
+	Version     string                 `json:"version"`     // (required) Application version number
+	Metadata    map[string]interface{} `json:"metadata"`    // (optional) Additional metadata about the application
+}
+
+// Send the report to the given Metriton endpoint using the given
+// httpClient.
+//
+// The returned *Response may be nil even if there is no error, if
+// Metriton has not yet been configured to know about the Report's
+// `.Application`; i.e. a Response is only returned for known
+// applications.
+func (r Report) Send(httpClient *http.Client, endpoint string) (*Response, error) {
+	body, err := json.MarshalIndent(r, "", "  ")
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := httpClient.Post(endpoint, "application/json", bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	respBytes, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(respBytes) == 0 {
+		// not a recognized .Application
+		return nil, nil
+	}
+
+	var parsedResp Response
+	if err := json.Unmarshal(respBytes, &parsedResp); err != nil {
+		return nil, err
+	}
+	return &parsedResp, nil
+}
+
+// Response is a response from Metriton, after submitting a Report to
+// it.
+type Response struct {
+	AppInfo
+
+	// Only set for .Application=="aes"
+	HardLimit bool `json:"hard_limit"`
+}
+
+// AppInfo is the information that Metriton knows about an
+// application.
+//
+// There isn't really an otherwise fixed schema for this; Metriton
+// returns whatever it reads from
+// f"s3://scout-datawire-io/{report.application}/app.json".  However,
+// looking at all of the existing app.json files, they all agree on
+// the schema
+type AppInfo struct {
+	Application   string   `json:"application"`
+	LatestVersion string   `json:"latest_version"`
+	Notices       []Notice `json:"notices"`
+}
+
+// Notice is a notice that should be displayed to the user.
+//
+// I have no idea what the schema for Notice is, there are none
+// currently, and reverse-engineering it from what diagd.py consumes
+// isn't worth the effort at this time.
+type Notice interface{}

--- a/pkg/metriton/reporter.go
+++ b/pkg/metriton/reporter.go
@@ -1,0 +1,197 @@
+// Package metriton implements submitting telemetry data to the Metriton database.
+//
+// Metriton replaced Scout, and was originally going to have its own telemetry API and a
+// Scout-compatibility endpoint during the migration.  But now the Scout-compatible API is
+// the only thing we use.
+//
+// See also: The old scout.py package <https://pypi.org/project/scout.py/> /
+// <https://github.com/datawire/scout.py>.
+//
+// Things that are in scout.py, but are intentionally left of this package:
+//  - automatically setting the HTTP client user-agent string
+//  - a InstallIDFromConfigMap getter
+package metriton
+
+import (
+	"errors"
+	"net/http"
+	"net/url"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+)
+
+var (
+	// The endpoint you should use by default
+	DefaultEndpoint = "https://metriton.datawire.io/scout"
+	// Use BetaEndpoint for testing purposes without polluting production data
+	BetaEndpoint = "https://kubernaut.io/beta/scout"
+	// ScoutPyEndpoint is the default endpoint used by scout.py; it obeys the
+	// SCOUT_HOST and SCOUT_HTTPS environment variables.  I'm not sure when you should
+	// use it instead of DefaultEndpoint, but I'm putting it in Go so that I never
+	// have to look at scout.py again.
+	ScoutPyEndpoint = endpointFromEnv()
+)
+
+func getenvDefault(varname, def string) string {
+	ret := os.Getenv(varname)
+	if ret == "" {
+		ret = def
+	}
+	return ret
+}
+
+func endpointFromEnv() string {
+	host := getenvDefault("SCOUT_HOST", "kubernaut.io")
+	useHTTPS, _ := strconv.ParseBool(getenvDefault("SCOUT_HTTPS", "1"))
+	ret := &url.URL{
+		Scheme: "http",
+		Host:   host,
+		Path:   "/scout",
+	}
+	if useHTTPS {
+		ret.Scheme = "https"
+	}
+	return ret.String()
+}
+
+// Reporter is a client to
+type Reporter struct {
+	// Information about the application submitting telemetry.
+	Application string
+	Version     string
+	// GetInstallID is a function, instead of a fixed 'InstallID' string, in order to
+	// facilitate getting it lazily; and possibly updating the BaseMetadata based on
+	// the journey to getting the install ID.  See StaticInstallID and
+	// InstallIDFromFilesystem.
+	GetInstallID func(*Reporter) (string, error)
+	// BaseMetadata will be merged in to the data passed to each call to .Report().
+	// If the data passed to .Report() and BaseMetadata have a key in common, the
+	// value passed as an argument to .Report() wins.
+	BaseMetadata map[string]interface{}
+
+	// The HTTP client used to to submit the request; if this is nil, then
+	// http.DefaultClient is used.
+	Client *http.Client
+	// The endpoint URL to submit to; if this is empty, then DefaultEndpoint is used.
+	Endpoint string
+
+	mu          sync.Mutex
+	initialized bool
+	disabled    bool
+	installID   string
+}
+
+func (r *Reporter) ensureInitialized() error {
+	if r.Application == "" {
+		return errors.New("Reporter.Application may not be empty")
+	}
+	if r.Version == "" {
+		return errors.New("Reporter.Version may not be empty")
+	}
+	if r.GetInstallID == nil {
+		return errors.New("Reporter.GetInstallID may not be nil")
+	}
+
+	if r.initialized {
+		return nil
+	}
+
+	if r.BaseMetadata == nil {
+		r.BaseMetadata = make(map[string]interface{})
+	}
+
+	r.disabled = IsDisabledByUser()
+	if r.disabled {
+		r.initialized = true
+		return nil
+	}
+
+	installID, err := r.GetInstallID(r)
+	if err != nil {
+		return err
+	}
+	r.installID = installID
+
+	r.initialized = true
+
+	return nil
+}
+
+// IsDisabledByUser returns whether telemetry reporting is disabled by the user.
+func IsDisabledByUser() bool {
+	// From scout.py
+	if strings.HasPrefix(os.Getenv("TRAVIS_REPO_SLUG"), "datawire/") {
+		return true
+	}
+
+	// This mimics the existing ad-hoc Go clients, rather than scout.py; it is a more
+	// sensitive trigger than scout.py's __is_disabled() (which only accepts "1",
+	// "true", "yes"; case-insensitive).
+	return os.Getenv("SCOUT_DISABLE") != ""
+}
+
+// Report submits a telemetry report to Metriton.  It is safe to call .Report() from
+// different goroutines.  It is NOT safe to mutate the public fields in the Reporter while
+// .Report() is being called.
+func (r *Reporter) Report(metadata map[string]interface{}) (*Response, error) {
+	r.mu.Lock()
+
+	if err := r.ensureInitialized(); err != nil {
+		r.mu.Unlock()
+		return nil, err
+	}
+
+	var resp *Response
+	var err error
+
+	if r.disabled {
+		r.mu.Unlock()
+	} else {
+		client := r.Client
+		if client == nil {
+			client = http.DefaultClient
+		}
+
+		endpoint := r.Endpoint
+		if endpoint == "" {
+			endpoint = DefaultEndpoint
+		}
+
+		mergedMetadata := make(map[string]interface{}, len(r.BaseMetadata)+len(metadata))
+		// FWIW, the resolution of conflicts between 'r.BaseMetadata' and 'metadata'
+		// mimics scout.py; I'm not sure whether that aspect of scout.py's API is
+		// intentional or incidental.
+		for k, v := range r.BaseMetadata {
+			mergedMetadata[k] = v
+		}
+		for k, v := range metadata {
+			mergedMetadata[k] = v
+		}
+
+		report := Report{
+			Application: r.Application,
+			InstallID:   r.installID,
+			Version:     r.Version,
+			Metadata:    mergedMetadata,
+		}
+
+		r.mu.Unlock()
+		resp, err = report.Send(client, endpoint)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if resp == nil {
+		// This mimics scout.py
+		resp = &Response{
+			AppInfo: AppInfo{
+				LatestVersion: r.Version,
+			},
+		}
+	}
+
+	return resp, nil
+}

--- a/pkg/metriton/reporter.go
+++ b/pkg/metriton/reporter.go
@@ -13,6 +13,7 @@
 package metriton
 
 import (
+	"context"
 	"errors"
 	"net/http"
 	"net/url"
@@ -135,7 +136,7 @@ func IsDisabledByUser() bool {
 // Report submits a telemetry report to Metriton.  It is safe to call .Report() from
 // different goroutines.  It is NOT safe to mutate the public fields in the Reporter while
 // .Report() is being called.
-func (r *Reporter) Report(metadata map[string]interface{}) (*Response, error) {
+func (r *Reporter) Report(ctx context.Context, metadata map[string]interface{}) (*Response, error) {
 	r.mu.Lock()
 
 	if err := r.ensureInitialized(); err != nil {
@@ -178,7 +179,7 @@ func (r *Reporter) Report(metadata map[string]interface{}) (*Response, error) {
 		}
 
 		r.mu.Unlock()
-		resp, err = report.Send(client, endpoint)
+		resp, err = report.Send(ctx, client, endpoint)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/metriton/reporter.go
+++ b/pkg/metriton/reporter.go
@@ -193,5 +193,11 @@ func (r *Reporter) Report(metadata map[string]interface{}) (*Response, error) {
 		}
 	}
 
+	if resp != nil && resp.DisableScout {
+		r.mu.Lock()
+		r.disabled = true
+		r.mu.Unlock()
+	}
+
 	return resp, nil
 }


### PR DESCRIPTION
## Description

This creates a `pkg/metriton` Go library that mostly mimics `scout.py`, and consolidates code from `edgectl` and `amb-sidecar`.  It also adds the feature that it includes a mechanism for the Metriton server to say "please don't talk to me anymore".

## Testing

I've been using this to record route-to-code telemetry in to Metriton.  I've been querying that data; it is properly submitted.

## Tasks That Must Be Done
- [x] Did you update CHANGELOG.md? - no applicable changes
- [ ] Did you add or update tests? - *sigh* no
- [x] Did you update documentation? - There's docs in the added package
- [x] Were there any special dev tricks you had to use to work on this code efficiently? - not really

I'm not really sure what kind of tests I should be adding.