### PR TITLE
Installer: Every exit emits (or can emit) useful output

### DIFF
--- a/cmd/edgectl/aes_install.go
+++ b/cmd/edgectl/aes_install.go
@@ -120,6 +120,7 @@ func aesInstall(cmd *cobra.Command, args []string) error {
 		Work: func(p *supervisor.Process) error {
 			defer i.Quit()
 			result := i.Perform(kcontext)
+			i.ShowResult(result)
 			return result.Err
 		},
 	})
@@ -617,11 +618,12 @@ func (i *Installer) Perform(kcontext string) Result {
 			i.Report("fail_existing_aes", ScoutMeta{"installing", i.version}, ScoutMeta{"found", installedVersion})
 			return UnhandledErrResult(errors.Errorf("existing AES %s found when installing AES %s", installedVersion, i.version))
 		default:
-			i.ShowWrapped(abortCRDs)
-			i.show.Println()
-			i.ShowWrapped(seeDocs)
-			i.Report("fail_existing_crds")
-			return UnhandledErrResult(errors.New("CRDs found"))
+			return Result{
+				Report:  "fail_existing_crds",
+				Message: abortCRDs,
+				URL:     seeDocsURL,
+				Err:     errors.New("CRDs found"),
+			}
 		}
 	}
 

--- a/cmd/edgectl/aes_install.go
+++ b/cmd/edgectl/aes_install.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/pkg/browser"
 	"io"
 	"io/ioutil"
 	"log"
@@ -20,6 +19,8 @@ import (
 	"strings"
 	"syscall"
 	"time"
+
+	"github.com/pkg/browser"
 
 	"github.com/datawire/ambassador/pkg/k8s"
 	"github.com/datawire/ambassador/pkg/supervisor"
@@ -437,7 +438,7 @@ func (i *Installer) Perform(kcontext string) error {
 	i.show.Println(color.Bold.Sprintf(welcomeInstall))
 
 	// Attempt to grab a reasonable default for the user's email address
-	defaultEmail, err := i.Capture("get email", true,"", "git", "config", "--global", "user.email")
+	defaultEmail, err := i.Capture("get email", true, "", "git", "config", "--global", "user.email")
 	if err != nil {
 		i.log.Print(err)
 		defaultEmail = ""
@@ -475,7 +476,7 @@ func (i *Installer) Perform(kcontext string) error {
 
 	// Attempt to use kubectl
 	_, err = i.GetKubectlPath()
-	//err = errors.New("early error for testing")  // TODO: remove for production
+	// err = errors.New("early error for testing")  // TODO: remove for production
 	if err != nil {
 		i.Report("fail_no_kubectl")
 		err = browser.OpenURL(noKubectlURL)
@@ -746,7 +747,7 @@ func (i *Installer) Perform(kcontext string) error {
 		i.show.Println()
 		i.ShowWrapped(color.Bold.Sprintf(noTlsSuccess))
 		i.show.Println()
-		
+
 		i.ShowWrapped("If this IP address is reachable from here, you can access your installation without a DNS name.")
 		i.ShowWrapped(loginViaIP)
 		i.show.Println(color.Bold.Sprintf("$ edgectl login -n ambassador %s", i.address))

--- a/cmd/edgectl/aes_install.go
+++ b/cmd/edgectl/aes_install.go
@@ -125,6 +125,11 @@ func aesInstall(cmd *cobra.Command, args []string) error {
 		},
 	})
 
+	// Don't allow messages emitted while opening the browser to mess up our
+	// carefully-crafted terminal output
+	browser.Stdout = ioutil.Discard
+	browser.Stderr = ioutil.Discard
+
 	runErrors := sup.Run()
 	if len(runErrors) > 1 { // This shouldn't happen...
 		for _, err := range runErrors {

--- a/cmd/edgectl/aes_install.go
+++ b/cmd/edgectl/aes_install.go
@@ -747,22 +747,22 @@ func (i *Installer) Perform(kcontext string) Result {
 		message := strings.TrimSpace(string(content))
 		i.Report("dns_name_failure", ScoutMeta{"code", resp.StatusCode}, ScoutMeta{"err", message})
 		i.show.Println("-> Failed to create a DNS name:", message)
-		i.show.Println()
-		i.ShowWrapped(color.Bold.Sprintf(noTlsSuccess))
-		i.show.Println()
 
-		i.ShowWrapped("If this IP address is reachable from here, you can access your installation without a DNS name.")
-		i.ShowWrapped(loginViaIP)
-		i.show.Println(color.Bold.Sprintf("$ edgectl login -n ambassador %s", i.address))
+		userMessage := `
+<bold>Congratulations! You've successfully installed the Ambassador Edge Stack in your Kubernetes cluster. However, we cannot connect to your cluster from the Internet, so we could not configure TLS automatically.</>
 
-		i.show.Println()
-		i.ShowWrapped(loginViaPortForward)
-		i.show.Println(color.Bold.Sprintf("$ kubectl -n ambassador port-forward deploy/ambassador 8443 &"))
-		i.show.Println(color.Bold.Sprintf("$ edgectl login -n ambassador 127.0.0.1:8443"))
-		i.show.Println()
+If this IP address is reachable from here, you can access your installation without a DNS name. The following command will open the Edge Policy Console once you accept a self-signed certificate in your browser.
+<bold>$ edgectl login -n ambassador {{ .address }}</>
 
-		i.ShowWrapped(seeDocs)
-		return UnhandledErrResult(nil)
+You can use port forwarding to access your Edge Stack installation and the Edge Policy Console.  You will need to accept a self-signed certificate in your browser.
+<bold>$ kubectl -n ambassador port-forward deploy/ambassador 8443 &</>
+<bold>$ edgectl login -n ambassador 127.0.0.1:8443</>
+`
+		return Result{
+			Message: userMessage,
+			Report:  "",         // FIXME: reported above due to additional metadata required
+			URL:     seeDocsURL, // FIXME: this will be ignored
+		}
 	}
 
 	i.hostname = string(content)

--- a/cmd/edgectl/aes_install.go
+++ b/cmd/edgectl/aes_install.go
@@ -760,8 +760,8 @@ You can use port forwarding to access your Edge Stack installation and the Edge 
 `
 		return Result{
 			Message: userMessage,
-			Report:  "",         // FIXME: reported above due to additional metadata required
-			URL:     seeDocsURL, // FIXME: this will be ignored
+			URL:     seeDocsURL,
+			Report:  "", // FIXME: reported above due to additional metadata required
 		}
 	}
 

--- a/cmd/edgectl/aes_install_result.go
+++ b/cmd/edgectl/aes_install_result.go
@@ -1,8 +1,11 @@
 package main
 
 import (
+	"bytes"
 	"fmt"
+	"text/template"
 
+	"github.com/gookit/color"
 	"github.com/pkg/browser"
 )
 
@@ -10,7 +13,7 @@ import (
 type Result struct {
 	Report   string // Action to report to Metriton
 	Message  string // Message to show to the user
-	TryAgain bool   // Whether to show the "try again" message
+	TryAgain bool   // Whether to show the "try again" message (TODO: Is this necessary?)
 	URL      string // Docs URL to show and open
 	Err      error  // Error condition (nil -> successful installation)
 }
@@ -40,7 +43,6 @@ func (i *Installer) ShowResult(r Result) {
 			i.show.Println("AES Installation Unsuccessful")
 			i.show.Println("========================================================================")
 			i.show.Println()
-			// i.ShowWrapped(color.Bold.Print(r.Message))
 			i.ShowWrapped(r.Message)
 
 			if r.URL != "" {
@@ -70,8 +72,7 @@ func (i *Installer) ShowResult(r Result) {
 			i.show.Println("AES Installation Complete!")
 			i.show.Println("========================================================================")
 			i.show.Println()
-			// i.ShowWrapped(color.Bold.Print(r.Message))
-			i.ShowWrapped(r.Message)
+			i.ShowTemplated(r.Message)
 
 			// Assume there is no URL to open automatically. The login code may
 			// be invoked; it opens the browser itself.
@@ -79,4 +80,41 @@ func (i *Installer) ShowResult(r Result) {
 			// Assume there's no need to show the "try again" message.
 		}
 	}
+}
+
+// AdditionalDatum represents a key-value pair that may be used in template
+// expansion
+type AdditionalDatum struct {
+	key   string
+	value interface{}
+}
+
+// ShowTemplated displays a string to the user (using ShowWrapped) after
+// rendering the supplied text as a template using values from the installer
+// object and the additional parameters. It also processes color tags.
+// TODO: Fix color tag processing so it is effective on Windows.
+func (i *Installer) ShowTemplated(text string, more ...AdditionalDatum) {
+	t := template.New("installer")
+	template.Must(t.Parse(text))
+
+	data := map[string]interface{}{
+		"version":   i.version,
+		"address":   i.address,
+		"hostname":  i.hostname,
+		"clusterID": i.clusterID,
+		"kubectl":   i.k8sVersion.Client.GitVersion,
+		"k8s":       i.k8sVersion.Server.GitVersion,
+	}
+	for _, ad := range more {
+		data[ad.key] = ad.value
+	}
+
+	templateBuffer := &bytes.Buffer{}
+	if err := t.Execute(templateBuffer, data); err != nil {
+		//i.log.Printf("WARNING: failed to render template: %+v", err)
+		//return text
+		panic(err) // An error here indicates a bug in our code
+	}
+
+	i.ShowWrapped(color.Render(templateBuffer.String()))
 }

--- a/cmd/edgectl/aes_install_result.go
+++ b/cmd/edgectl/aes_install_result.go
@@ -1,0 +1,19 @@
+package main
+
+import "fmt"
+
+type Result struct {
+	Report   string
+	Message  string
+	TryAgain bool
+	URL      string
+	Err      error
+}
+
+func UnhandledErrResult(err error) Result {
+	return Result{
+		Report:  "",
+		Message: "",
+		Err:     err,
+	}
+}

--- a/cmd/edgectl/aes_install_result.go
+++ b/cmd/edgectl/aes_install_result.go
@@ -1,19 +1,82 @@
 package main
 
-import "fmt"
+import (
+	"fmt"
 
+	"github.com/pkg/browser"
+)
+
+// Result represents the result of an installation attempt
 type Result struct {
-	Report   string
-	Message  string
-	TryAgain bool
-	URL      string
-	Err      error
+	Report   string // Action to report to Metriton
+	Message  string // Message to show to the user
+	TryAgain bool   // Whether to show the "try again" message
+	URL      string // Docs URL to show and open
+	Err      error  // Error condition (nil -> successful installation)
 }
 
+// UnhandledErrResult returns a minimal Result that passes along an error but
+// otherwise does not do anything. It is intended for transitional use, until
+// *every* error is handled explicitly to yield a meaningful Result.
 func UnhandledErrResult(err error) Result {
 	return Result{
-		Report:  "",
-		Message: "",
-		Err:     err,
+		Err: err,
+	}
+}
+
+func (i *Installer) ShowResult(r Result) {
+	if r.Err != nil {
+		// Failure
+
+		i.log.Printf("Result: Installation failed")
+		i.log.Printf(" Error: %+v", r.Err)
+
+		if r.Report != "" {
+			i.Report(r.Report, ScoutMeta{"err", r.Err.Error()})
+		}
+
+		if r.Message != "" {
+			i.show.Println()
+			i.show.Println("AES Installation Unsuccessful")
+			i.show.Println("========================================================================")
+			i.show.Println()
+			// i.ShowWrapped(color.Bold.Print(r.Message))
+			i.ShowWrapped(r.Message)
+
+			if r.URL != "" {
+				i.show.Println()
+				i.ShowWrapped(fmt.Sprintf("Visit %s for more information and instructions.", r.URL))
+
+				if err := browser.OpenURL(r.URL); err != nil {
+					i.log.Printf("Failed to open browser: %+v", err)
+				}
+			}
+
+			if r.TryAgain {
+				i.show.Println()
+				i.ShowWrapped(tryAgain)
+			}
+		}
+
+	} else {
+		// Success
+
+		if r.Report != "" {
+			i.Report(r.Report)
+		}
+
+		if r.Message != "" {
+			i.show.Println()
+			i.show.Println("AES Installation Complete!")
+			i.show.Println("========================================================================")
+			i.show.Println()
+			// i.ShowWrapped(color.Bold.Print(r.Message))
+			i.ShowWrapped(r.Message)
+
+			// Assume there is no URL to open automatically. The login code may
+			// be invoked; it opens the browser itself.
+
+			// Assume there's no need to show the "try again" message.
+		}
 	}
 }

--- a/cmd/edgectl/aes_install_result.go
+++ b/cmd/edgectl/aes_install_result.go
@@ -28,6 +28,14 @@ func UnhandledErrResult(err error) Result {
 }
 
 func (i *Installer) ShowResult(r Result) {
+	templateData := []AdditionalDatum{
+		AdditionalDatum{key: "Report", value: r.Report},
+		AdditionalDatum{key: "Message", value: r.Message},
+		AdditionalDatum{key: "TryAgain", value: r.TryAgain},
+		AdditionalDatum{key: "URL", value: r.URL},
+		AdditionalDatum{key: "Err", value: r.Err},
+	}
+
 	if r.Err != nil {
 		// Failure
 
@@ -43,7 +51,7 @@ func (i *Installer) ShowResult(r Result) {
 			i.show.Println("AES Installation Unsuccessful")
 			i.show.Println("========================================================================")
 			i.show.Println()
-			i.ShowWrapped(r.Message)
+			i.ShowTemplated(r.Message, templateData...)
 
 			if r.URL != "" {
 				i.show.Println()
@@ -72,10 +80,19 @@ func (i *Installer) ShowResult(r Result) {
 			i.show.Println("AES Installation Complete!")
 			i.show.Println("========================================================================")
 			i.show.Println()
-			i.ShowTemplated(r.Message)
+			i.ShowTemplated(r.Message, templateData...)
 
-			// Assume there is no URL to open automatically. The login code may
-			// be invoked; it opens the browser itself.
+			if r.URL != "" {
+				// TODO: Consider leaving out this fixed "visit" message.
+				// Instead, it may be better to let Result.Message offer useful
+				// context for visiting a URL.
+				i.show.Println()
+				i.ShowWrapped(fmt.Sprintf("Visit %s for more information and instructions.", r.URL))
+
+				if err := browser.OpenURL(r.URL); err != nil {
+					i.log.Printf("Failed to open browser: %+v", err)
+				}
+			}
 
 			// Assume there's no need to show the "try again" message.
 		}


### PR DESCRIPTION
The goal is to ensure every exit from the installer has 
- a Metriton report
- a clear message to the user
- the relevant error logged (if applicable)
- a URL displayed and opened in the browser (if applicable)

This PR makes achieving the above goal much simpler by modifying the main body of the installer (`Perform()`) to replace the `error` return type with a `Result` struct. 

Key benefits for us:
- we can do all four of the above in a single place per exit
- code the misses doing the above stands out because it uses the (temporary) `UnhandledErrResult` helper
- there is one place to enforce additional requirements for every exit
- we can adjust the exit UX in one place

Key benefit for the user: It's much more likely that we'll get every exit addressed, meaning the user will have a clear end state in more cases.
