### PR TITLE
Intercept: Restore regex support

### DIFF
--- a/cmd/edgectl/cli.go
+++ b/cmd/edgectl/cli.go
@@ -235,7 +235,7 @@ func (d *Daemon) getRootCommand(p *supervisor.Process, out *Emitter, data *Clien
 	})
 	intercept := InterceptInfo{}
 	interceptAddCmd := &cobra.Command{
-		Use:   "add DEPLOYMENT [--namespace NAMESPACE] [-p PREFIX] -t [HOST:]PORT -m HEADER=REGEX ...",
+		Use:   "add DEPLOYMENT -t [HOST:]PORT -m HEADER=REGEX ...",
 		Short: "Add a deployment intercept",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {

--- a/cmd/edgectl/cli.go
+++ b/cmd/edgectl/cli.go
@@ -87,7 +87,7 @@ func (d *Daemon) getRootCommand(p *supervisor.Process, out *Emitter, data *Clien
 			d.network = nil
 
 			out.Println("Network overrides paused.")
-			out.Println("Used \"edgectl resume\" to reestablish network overrides.")
+			out.Println("Use \"edgectl resume\" to reestablish network overrides.")
 			out.Send("paused", true)
 
 			return out.Err()

--- a/cmd/edgectl/intercept.go
+++ b/cmd/edgectl/intercept.go
@@ -285,7 +285,7 @@ type mappingSpec struct {
 	AmbassadorID []string          `json:"ambassador_id"`
 	Prefix       string            `json:"prefix"`
 	Service      string            `json:"service"`
-	Headers      map[string]string `json:"headers"`
+	RegexHeaders map[string]string `json:"regex_headers"`
 }
 
 type interceptMapping struct {
@@ -322,7 +322,7 @@ func MakeIntercept(p *supervisor.Process, out *Emitter, tm *TrafficManager, clus
 			AmbassadorID: []string{fmt.Sprintf("intercept-%s", ii.Deployment)},
 			Prefix:       ii.Prefix,
 			Service:      fmt.Sprintf("telepresence-proxy.%s:%d", tm.namespace, port),
-			Headers:      ii.Patterns,
+			RegexHeaders: ii.Patterns,
 		},
 	}
 

--- a/cmd/edgectl/intercept.go
+++ b/cmd/edgectl/intercept.go
@@ -377,9 +377,11 @@ func (cept *Intercept) quit(p *supervisor.Process) error {
 
 	p.Logf("cept.Quit removing %v", cept.ii.Name)
 
-	cept.removeMapping(p)
-
-	p.Logf("cept.Quit removed %v", cept.ii.Name)
+	if err := cept.removeMapping(p); err != nil {
+		p.Logf("cept.Quit failed to remove %v: %+v", cept.ii.Name, err)
+	} else {
+		p.Logf("cept.Quit removed %v", cept.ii.Name)
+	}
 
 	if cept.crc != nil {
 		_ = cept.crc.Close()


### PR DESCRIPTION
Regular expression matching was unintentionally broken in the transition to using AES as the Agent. This PR restores that feature.

Fixes https://github.com/datawire/apro/issues/1185

```console
$ edgectl intercept add echo -m :path=.*ark3.* -t localhost:9000
Using deployment cept-1586022949 in namespace default
cept-1586022949: applying intercept mapping in namespace default
cept-1586022949: starting SSH tunnel
Added intercept "cept-1586022949"

$ curl -s echo | head -n 2
Request served by echo-6466548f88-lgzrn


$ curl -s echo/foo/ark3/bar | head -n 2
<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN"
        "http://www.w3.org/TR/html4/strict.dtd">

$ edgectl intercept list
   1. cept-1586022949
      Intercepting requests to echo when
      - :path: .*ark3.*
      and redirecting them to localhost:9000

$ edgectl intercept add --help
Add a deployment intercept

Usage:
  edgectl intercept add DEPLOYMENT -t [HOST:]PORT -m HEADER=REGEX ... [flags]

Flags:
  -h, --help                   help for add
  -m, --match stringToString   match expression (HEADER=REGEX) (default [])
  -n, --name string            a name for this intercept
      --namespace string       Kubernetes namespace in which to create mapping for intercept
  -p, --prefix string          prefix to intercept (default /)
  -t, --target string          the [HOST:]PORT to forward to

Global Flags:
      --no-report   turn off anonymous crash reports and log submission on failure

$
```