### PR TITLE
quick installer fixes

### DIFF
--- a/cmd/edgectl/aes_install.go
+++ b/cmd/edgectl/aes_install.go
@@ -754,7 +754,8 @@ func (i *Installer) Perform(kcontext string) Result {
 	// Show how to use edgectl login in the future
 	i.show.Println()
 
-	futureLogin := `In the future, to log in to the Ambassador Edge Policy Console, run %s`
+	futureLogin := `In the future, to log in to the Ambassador Edge Policy Console, run 
+%s`
 	i.ShowWrapped(fmt.Sprintf(futureLogin, color.Bold.Sprintf("edgectl login "+i.hostname)))
 
 	if err := i.CheckAESHealth(); err != nil {

--- a/cmd/edgectl/aes_install.go
+++ b/cmd/edgectl/aes_install.go
@@ -517,7 +517,7 @@ func (i *Installer) Perform(kcontext string) Result {
 		i.log.Printf("failed to read Kubernetes client and server versions: %v", err.Error())
 	}
 
-	i.k8sVersion = kubernetesVersion
+	i.k8sVersion = *kubernetesVersion
 	// Metriton tries to parse fields with `version` in their keys and discards them if it can't.
 	// Using _v to keep the version value as string since Kubernetes versions vary in formats.
 	i.SetMetadatum("kubectl Version", "kubectl_v", i.k8sVersion.Client.GitVersion)
@@ -773,7 +773,6 @@ type Installer struct {
 	kubeinfo   *k8s.KubeInfo
 	restConfig *rest.Config
 	coreClient *k8sClientCoreV1.CoreV1Client
-	k8sVersion *kubernetesVersion
 
 	// Reporting
 
@@ -791,10 +790,11 @@ type Installer struct {
 
 	// Install results
 
-	version   string // which AES is being installed
-	address   string // load balancer address
-	hostname  string // of the Host resource
-	clusterID string // the Ambassador unique clusterID
+	k8sVersion kubernetesVersion // cluster version information
+	version    string            // which AES is being installed
+	address    string            // load balancer address
+	hostname   string            // of the Host resource
+	clusterID  string            // the Ambassador unique clusterID
 }
 
 // NewInstaller returns an Installer object after setting up logging.

--- a/cmd/edgectl/aes_install.go
+++ b/cmd/edgectl/aes_install.go
@@ -754,7 +754,7 @@ func (i *Installer) Perform(kcontext string) Result {
 	// Show how to use edgectl login in the future
 	i.show.Println()
 
-	futureLogin := `In the future, to log in to the Ambassador Edge Policy Console, run\n$ %s`
+	futureLogin := `In the future, to log in to the Ambassador Edge Policy Console, run %s`
 	i.ShowWrapped(fmt.Sprintf(futureLogin, color.Bold.Sprintf("edgectl login "+i.hostname)))
 
 	if err := i.CheckAESHealth(); err != nil {

--- a/cmd/edgectl/aes_install.go
+++ b/cmd/edgectl/aes_install.go
@@ -612,10 +612,10 @@ func (i *Installer) Perform(kcontext string) Result {
 			i.ShowAESExistingVersion(i.version)
 		case installedVersion != "":
 			i.ShowAESExistingVersion(installedVersion)
-			return i.IncompatibleCRDVersionsError(err, installedVersion)
+			return i.IncompatibleCRDVersionsError(installedVersion)
 		default:
 			i.ShowAESCRDsButNoAESInstallation()
-			return i.ExistingCRDsError(err)
+			return i.ExistingCRDsError()
 		}
 	}
 

--- a/cmd/edgectl/aes_install.go
+++ b/cmd/edgectl/aes_install.go
@@ -96,7 +96,7 @@ func aesInstall(cmd *cobra.Command, args []string) error {
 	}
 
 	// Both printed and logged when verbose (Installer.log is responsible for --verbose)
-	i.log.Printf(fmt.Sprintf("INFO: install_id = #{i.scout.installID}; trace_id = #{i.scout.metadata['trace_id']}"))
+	i.log.Printf(fmt.Sprintf("INFO: install_id = %v; trace_id = %v", i.scout.installID, i.scout.metadata["trace_id"]))
 
 	sup := supervisor.WithContext(i.ctx)
 	sup.Logger = i.log

--- a/cmd/edgectl/aes_install_crash.go
+++ b/cmd/edgectl/aes_install_crash.go
@@ -64,6 +64,11 @@ func (i *Installer) gatherCrashReportData() []byte {
 	}
 	buffer.Write(fileContent)
 
+	if i.k8sVersion.Server.GitVersion == "" {
+		buffer.WriteString("\n\nNo kubectl or no cluster (see report)\n")
+		return buffer.Bytes()
+	}
+
 	buffer.WriteString("\n========== kubectl describe ==========\n")
 	describe, err := i.SilentCaptureKubectl("describe ambassador namespace", "", "-n", "ambassador", "describe", "all")
 	if err != nil {

--- a/cmd/edgectl/aes_install_errors.go
+++ b/cmd/edgectl/aes_install_errors.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+
 	"github.com/pkg/errors"
 )
 
@@ -114,7 +115,7 @@ func (i *Installer) ManifestParsingError(err error, matches []string) Result {
 }
 
 // Existing AES CRD's of incompatible version
-func (i *Installer) IncompatibleCRDVersionsError(err error, installedVersion string) Result {
+func (i *Installer) IncompatibleCRDVersionsError(installedVersion string) Result {
 	abortExisting := `
 This tool does not support upgrades/downgrades at this time.
 The installer will now quit to avoid corrupting an existing installation of AES.
@@ -127,12 +128,12 @@ The installer will now quit to avoid corrupting an existing installation of AES.
 	return Result{
 		URL:     "https://www.getambassador.io/docs/topics/install/help/incompatible-crd-versions",
 		Message: message,
-		Err:     err,
+		Err:     errors.Errorf("Ambassador Edge Stack %s already installed", installedVersion),
 	}
 }
 
 // Existing AES CRD's, unable to upgrade.
-func (i *Installer) ExistingCRDsError(err error) Result {
+func (i *Installer) ExistingCRDsError() Result {
 	abortCRDs := `You can manually remove installed CRDs if you are confident they are not in use by any installation. Removing the CRDs will cause your existing Ambassador Mappings and other resources to be deleted as well.
 
 <bold>$ kubectl delete crd -l product=aes</>
@@ -143,7 +144,7 @@ The installer will now quit to avoid corrupting an existing (but undetected) ins
 		Report:  "fail_existing_crds",
 		Message: abortCRDs,
 		URL:     "https://www.getambassador.io/docs/topics/install/help/existing-crds",
-		Err:     err,
+		Err:     errors.New("found Ambassador CRDs in your cluster, but no AES installation"),
 	}
 }
 
@@ -203,10 +204,10 @@ func (i *Installer) KnownLocalClusterResult() Result {
 	message += "\n\n"
 
 	return Result{
-		Report: "cluster_not_accessible",
+		Report:  "cluster_not_accessible",
 		Message: message,
-		URL:    seeDocsURL,
-		Err:    nil,
+		URL:     seeDocsURL,
+		Err:     nil,
 	}
 }
 
@@ -221,10 +222,10 @@ func (i *Installer) LoadBalancerError(err error) Result {
 
 	return Result{
 
-		Report: "fail_loadbalancer_timeout",
+		Report:  "fail_loadbalancer_timeout",
 		Message: message,
-		URL:    "https://www.getambassador.io/docs/topics/install/help/load-balancer",
-		Err:    err,
+		URL:     "https://www.getambassador.io/docs/topics/install/help/load-balancer",
+		Err:     err,
 	}
 }
 
@@ -238,10 +239,10 @@ func (i *Installer) AESACMEChallengeError(err error) Result {
 
 	return Result{
 		Report:   "aes_listening_timeout",
-		Message: message,
+		Message:  message,
 		TryAgain: true,
-		URL: "https://www.getambassador.io/docs/topics/install/help/aes-acme-challenge",
-		Err: err,
+		URL:      "https://www.getambassador.io/docs/topics/install/help/aes-acme-challenge",
+		Err:      err,
 	}
 }
 

--- a/cmd/edgectl/aes_install_messages.go
+++ b/cmd/edgectl/aes_install_messages.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+
 	"github.com/gookit/color"
 )
 
@@ -84,7 +85,7 @@ func (i *Installer) ShowAESInstallationComplete() {
 	i.show.Println()
 
 	// Show congratulations message
-	i.ShowWrapped(color.Bold.Sprintf("Congratulations! You've successfully installed the Ambassador Edge Stack in your Kubernetes cluster. Visit https://#{i.hostname}"))
+	i.ShowTemplated(color.Bold.Sprintf("Congratulations! You've successfully installed the Ambassador Edge Stack in your Kubernetes cluster. Visit https://{{.hostname}}/"))
 	i.show.Println()
 
 }

--- a/cmd/edgectl/aes_install_result.go
+++ b/cmd/edgectl/aes_install_result.go
@@ -47,7 +47,7 @@ func (i *Installer) ShowTemplated(text string, more ...AdditionalDatum) {
 	var k8sServerVersion = "unknown"
 
 	// Assign if we have k8sVersion available.
-	if i.k8sVersion != nil {
+	if i.k8sVersion.Server.GitVersion != "" {
 		k8sClientVersion = i.k8sVersion.Client.GitVersion
 		k8sServerVersion = i.k8sVersion.Server.GitVersion
 	}
@@ -145,4 +145,3 @@ func (i *Installer) ShowResult(r Result) {
 		}
 	}
 }
-


### PR DESCRIPTION
This PR addresses the following issues:
- confusion between success and failure in on failure case
- incorrect messaging template for some output
- a crash in one of the crash reports
- updated documentation links to point to latest
- incorrect formatting of install_id log