### PR TITLE
Added link to release blog with Ingress in k8s 1.18 samples

### DIFF
--- a/docs/topics/running/ingress-controller.md
+++ b/docs/topics/running/ingress-controller.md
@@ -17,6 +17,7 @@ If you're new to the Ambassador Edge Stack and to Kubernetes, we'd recommend you
    Kubernetes 1.18 introduced the `IngressClass` resource to the existing `networking.k8s.io/v1beta1` api.
 
    **Note:** If you are using 1.14 and above, it is recommended to use `apiVersion: networking.k8s.io/v1beta1` when defining `Ingresses`. Since both are still supported in all 1.14+ versions of Kubernetes, this document will use `extensions/v1beta1` for compatibility reasons.
+   If you are using 1.18 and above, sample usage of the `IngressClass` resource and `pathType` field are [available on our blog](https://blog.getambassador.io/new-kubernetes-1-18-extends-ingress-c34abdc2f064).
 
 - You will need RBAC permissions to create `Ingress` resources in either
   the `extensions` `apiGroup` (present in all supported versions of


### PR DESCRIPTION
## Description
Added link to release blog with Ingress in k8s 1.18 samples.
This is targeting `release/v1.4` since it can be published immediately.

## Related Issues
https://github.com/datawire/apro/issues/1041

## Testing
Documentation changes only.

## Tasks That Must Be Done
- [ ] Did you update CHANGELOG.md?
- [ ] Did you add or update tests?
- [x] Did you update documentation?
- [ ] Were there any special dev tricks you had to use to work on this code efficiently?
  + [ ] Did you add them to DEVELOPING.md?

## Other
* If this is a documentation change for a particular release, please open the pull request against the release branch.
