### PR TITLE
edgectl adds some installation info as labels in the Deployment

### DIFF
--- a/cmd/edgectl/main.go
+++ b/cmd/edgectl/main.go
@@ -11,8 +11,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const UnknownVersion = "(unknown version)"
+
 // Version is inserted at build using --ldflags -X
-var Version = "(unknown version)"
+var Version = UnknownVersion
 
 const (
 	socketName = "/var/run/edgectl.socket"


### PR DESCRIPTION
## Description

Add some installation info as labels in the `Deployment`. For example:

```yaml
apiVersion: apps/v1
kind: Deployment
  ...
spec:
  progressDeadlineSeconds: 600
  replicas: 1
  revisionHistoryLimit: 10
  template:
    metadata:
      labels:
        app.kubernetes.io/instance: ambassador
        app.kubernetes.io/managed-by: edgectl
        app.kubernetes.io/name: ambassador
        app.kubernetes.io/part-of: ambassador
        getambassador.io/install-cluster-type: K3D
        getambassador.io/install-date: 2020-04-10.23-09-21
        getambassador.io/installer-arch: amd64
        getambassador.io/installer-os: linux
        getambassador.io/installer-version: 1.4.0a-11-g4e4877715-dirty
        product: aes

```

