### PR TITLE
diagd: Move estats update to its own thread

### DIFF
--- a/python/ambassador_diag/diagd.py
+++ b/python/ambassador_diag/diagd.py
@@ -177,6 +177,13 @@ class DiagApp (Flask):
     def check_scout(self, what: str) -> None:
         self.watcher.post("SCOUT", (what, self.ir))
 
+    def update_estats(self) -> None:
+        try:
+            self.estats.update()
+        except Exception as e:
+            self.logger.error("could not update estats: %s" % e)
+            self.logger.exception(e)
+
 
 # get the "templates" directory, or raise "FileNotFoundError" if not found
 def get_templates_dir():
@@ -835,9 +842,6 @@ class AmbassadorEventWatcher(threading.Thread):
 
         return rqueue.get()
 
-    def update_estats(self) -> None:
-        self.post('ESTATS', '')
-
     def run(self):
         self.logger.info("starting Scout checker")
         self.app.scout_checker = PeriodicTrigger(lambda: self.check_scout("checkin"), period=86400)     # Yup, one day.
@@ -848,16 +852,7 @@ class AmbassadorEventWatcher(threading.Thread):
             cmd, arg, rqueue = self.events.get()
             # self.logger.info("EVENT: %s" % cmd)
 
-            if cmd == 'ESTATS':
-                # self.logger.info("updating estats")
-                try:
-                    self._respond(rqueue, 200, 'updating')
-                    self.app.estats.update()
-                except Exception as e:
-                    self.logger.error("could not update estats: %s" % e)
-                    self.logger.exception(e)
-                    self._respond(rqueue, 500, 'Envoy stats update failed')
-            elif cmd == 'CONFIG_FS':
+            if cmd == 'CONFIG_FS':
                 try:
                     self.load_config_fs(rqueue, arg)
                 except Exception as e:
@@ -1157,7 +1152,7 @@ class AmbassadorEventWatcher(threading.Thread):
 
         if app.health_checks and not app.stats_updater:
             app.logger.info("starting Envoy status updater")
-            app.stats_updater = PeriodicTrigger(app.watcher.update_estats, period=5)
+            app.stats_updater = PeriodicTrigger(app.update_estats, period=5)
 
         # Check our environment...
         self.check_environment()


### PR DESCRIPTION
The estat update thread was just posting a message to the
AmbassadorEventWatcher thread.
Then this AmbassadorEventWatcher thread was processing sequentially all
the message.
This thread is also updating the config. This message can take some
time, more than 20 seconds.
20 seconds is the delay used by ambassador to declare envoy dead when it
could not get an update status from envoy.
But when the config takes more than 20 seconds, this blocks the message
doing this envoy update status, and then ambassador alive endpoint is
starting to return 503.
Then, at the k8s level, the liveness probe is failing and the container
is restarted.

In order to prevent this lag in the envoy update state, the timer which
was posting the update message is now directly doing the update itself.

## Description
A few sentences describing the overall goals of the pull request's commits.

## Related Issues
List related issues.

## Testing
A few sentences describing what testing you've done, e.g., manual tests, automated tests, deployed in production, etc.

## Tasks That Must Be Done
- [ ] Did you update CHANGELOG.md?
- [ ] Did you add or update tests?
- [ ] Did you update documentation?
- [ ] Were there any special dev tricks you had to use to work on this code efficiently?
  + [ ] Did you add them to DEVELOPING.md?

## Other
* If this is a documentation change for a particular release, please open the pull request against the release branch.
