### PR TITLE
Do not fail if a previous `edgectl install`ed installation has been found

### DIFF
--- a/cmd/edgectl/aes_install_messages.go
+++ b/cmd/edgectl/aes_install_messages.go
@@ -44,10 +44,6 @@ func (i *Installer) ShowAESExistingVersion(versionName string, method string) {
 	i.show.Println(fmt.Sprintf("-> Ambassador Edge Stack %s was already installed using %s", versionName, method))
 }
 
-func (i *Installer) ShowAESInstalledByHelm() {
-	i.show.Println("-> Ambassador was installed with Helm")
-}
-
 func (i *Installer) FindingRepositoriesAndVersions() {
 	i.show.Println("-> Finding repositories and chart versions")
 }


### PR DESCRIPTION
## Description

Do not fail if a previous `edgectl install`ed installation has been found. The installation will continue with the remaining steps after finding a previous `edgectl` installation.

On the first `edgectl install`:

![edgectl-install-first](https://user-images.githubusercontent.com/1841612/79130538-683c1580-7da7-11ea-9cff-0af863891e86.png)

then a second `edgectl install` produces:

![edgectl-install-second](https://user-images.githubusercontent.com/1841612/79130563-738f4100-7da7-11ea-92cb-f45659e34cd7.png)



## Testing

Install twice and check that the second time you get a nice, non-error message.