### PR TITLE
Add download error page to index

### DIFF
--- a/docs/topics/install/help/index.md
+++ b/docs/topics/install/help/index.md
@@ -7,6 +7,7 @@ We recommend edgectl for [installing Ambassador Edge Stack](../../../tutorials/g
 - [Failed to create a Host resource in your cluster](host-resource-creation)
 - [Failed to download AES manifests](aes-manifests)
 - [Failed to download CRD manifests](aes-crd-manifests)
+- [Failed to download Helm chart](download-error)
 - [Failed to log in to the cluster](aes-login)
 - [Failed to parse AES manifests](manifest-parsing)
 - [Failed to register DNS name for the current installation](dns-name-body)


### PR DESCRIPTION
One of the recently added pages was missing from the help page index. This pull request adds it.