### PR TITLE
Fix: waiting for the wrong version when overriding with AES_IMAGE_TAG

### DIFF
--- a/cmd/edgectl/aes_install.go
+++ b/cmd/edgectl/aes_install.go
@@ -564,6 +564,7 @@ func (i *Installer) Perform(kcontext string) Result {
 		if it := os.Getenv(defEnvVarImageTag); it != "" {
 			i.ShowOverridingImageTag(defEnvVarImageTag, it)
 			strvals.ParseInto(fmt.Sprintf("image.tag=%s", it), chartValues)
+			i.version = it
 		}
 	}
 
@@ -596,8 +597,10 @@ func (i *Installer) Perform(kcontext string) Result {
 	}
 	defer func() { _ = chartDown.Cleanup() }()
 
-	// the AES version we have downloaded
-	i.version = strings.Trim(chartDown.GetChart().AppVersion, "\n")
+	if i.version == "" {
+		// set the AES version to the version in the Chart we have downloaded
+		i.version = strings.Trim(chartDown.GetChart().AppVersion, "\n")
+	}
 
 	if installedInfo.Method == instHelm ||  installedInfo.Method == instEdgectl {
 		// if a previous installation was found, check that the installed version matches


### PR DESCRIPTION
## Description

Fix: waiting for the wrong version when overriding with AES_IMAGE_TAG

![Screenshot from 2020-04-15 10 29 54](https://user-images.githubusercontent.com/1841612/79316054-178dff00-7f04-11ea-80b5-009af1e768f7.png)
