### PR TITLE
Revamped edgectl install flow when DNS is not available

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 .coverage
 .dmypy
 .dmypy.json
+.golangci.yml
 .python-version
 .DS_Store
 .skip_test_warning

--- a/cmd/edgectl/aes_install_errors.go
+++ b/cmd/edgectl/aes_install_errors.go
@@ -362,7 +362,7 @@ func (i *Installer) AESLoginError(err error) Result {
 func (i *Installer) AESInstalledNoDNSResult(statusCode int, dnsMessage string, hostIP string) Result {
 	i.Report("dns_name_failure", ScoutMeta{"code", statusCode}, ScoutMeta{"err", dnsMessage})
 
-	message := "In the future, the following command will open the Edge Policy Console once you accept a self-signed certificate in your browser.\n"
+	message := "In the future, the following command will log in to the Ambassador Edge Policy Console once you accept a self-signed certificate in your browser.\n"
 	message += color.Bold.Sprintf("$ edgectl login " + hostIP)
 
 	return Result{
@@ -373,7 +373,7 @@ func (i *Installer) AESInstalledNoDNSResult(statusCode int, dnsMessage string, h
 
 // AES login successful!
 func (i *Installer) AESInstalledResult(hostname string) Result {
-	message := "In the future, to log in to the Ambassador Edge Policy Console, run\n"
+	message := "In the future, the following command will log in to the Ambassador Edge Policy Console.\n"
 	message += color.Bold.Sprintf("$ edgectl login " + hostname)
 
 	return Result{

--- a/cmd/edgectl/aes_install_errors.go
+++ b/cmd/edgectl/aes_install_errors.go
@@ -362,7 +362,7 @@ func (i *Installer) AESLoginError(err error) Result {
 func (i *Installer) AESInstalledNoDNSResult(statusCode int, dnsMessage string, hostIP string) Result {
 	i.Report("dns_name_failure", ScoutMeta{"code", statusCode}, ScoutMeta{"err", dnsMessage})
 
-	message := "In the future, to log in to the Ambassador Edge Policy Console, run\n"
+	message := "In the future, the following command will open the Edge Policy Console once you accept a self-signed certificate in your browser.\n"
 	message += color.Bold.Sprintf("$ edgectl login " + hostIP)
 
 	return Result{

--- a/cmd/edgectl/aes_install_errors.go
+++ b/cmd/edgectl/aes_install_errors.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"fmt"
+
+	"github.com/gookit/color"
 	"github.com/pkg/errors"
 )
 
@@ -294,7 +296,6 @@ func (i *Installer) AESInstalledNoDNSResult(statusCode int, dnsName string) Resu
 	message := "<bold>Congratulations! You've successfully installed the Ambassador Edge Stack in your Kubernetes cluster. However, we cannot connect to your cluster from the Internet, so we could not configure TLS automatically.</>\n\n"
 	message += "If the IP address is reachable from your computer, you can access your installation without a DNS name. The following command will open the Edge Policy Console once you accept a self-signed certificate in your browser.\n"
 	message += "<bold>$ edgectl login -n ambassador {{ .address }}</>\n\n"
-	message += fmt.Sprintf("Find a more detailed explanation and step-by-step instructions about addressing this issue at %v", url)
 
 	return Result{
 		Message: message,
@@ -373,8 +374,12 @@ func (i *Installer) AESLoginError(err error) Result {
 }
 
 // AES login successful!
-func (i *Installer) AESLoginSuccessResult() Result {
+func (i *Installer) AESLoginSuccessResult(hostname string) Result {
+	message := "In the future, to log in to the Ambassador Edge Policy Console, run\n"
+	message += color.Bold.Sprintf("$ edgectl login " + hostname)
+
 	return Result{
-		Err: nil,
+		Message: message,
+		Err:     nil,
 	}
 }

--- a/cmd/edgectl/aes_install_errors.go
+++ b/cmd/edgectl/aes_install_errors.go
@@ -288,21 +288,6 @@ func (i *Installer) DNSNameBodyError(err error) Result {
 	}
 }
 
-// Successful installation but no DNS.
-func (i *Installer) AESInstalledNoDNSResult(statusCode int, dnsName string) Result {
-	url := "https://www.getambassador.io/docs/latest/tutorials/getting-started/"
-	i.Report("dns_name_failure", ScoutMeta{"code", statusCode}, ScoutMeta{"err", dnsName})
-
-	message := "<bold>Congratulations! You've successfully installed the Ambassador Edge Stack in your Kubernetes cluster. However, we cannot connect to your cluster from the Internet, so we could not configure TLS automatically.</>\n\n"
-	message += "If the IP address is reachable from your computer, you can access your installation without a DNS name. The following command will open the Edge Policy Console once you accept a self-signed certificate in your browser.\n"
-	message += "<bold>$ edgectl login -n ambassador {{ .address }}</>\n\n"
-
-	return Result{
-		Message: message,
-		URL:     url,
-	}
-}
-
 // The DNS name propagation timed out, so unable to resolve the name.
 func (i *Installer) DNSPropagationError(err error) Result {
 	url := "https://www.getambassador.io/docs/latest/topics/install/help/dns-propagation"
@@ -373,8 +358,21 @@ func (i *Installer) AESLoginError(err error) Result {
 	}
 }
 
+// Successful installation but no DNS.
+func (i *Installer) AESInstalledNoDNSResult(statusCode int, dnsMessage string, hostIP string) Result {
+	i.Report("dns_name_failure", ScoutMeta{"code", statusCode}, ScoutMeta{"err", dnsMessage})
+
+	message := "In the future, to log in to the Ambassador Edge Policy Console, run\n"
+	message += color.Bold.Sprintf("$ edgectl login " + hostIP)
+
+	return Result{
+		Message: message,
+		Err:     nil,
+	}
+}
+
 // AES login successful!
-func (i *Installer) AESLoginSuccessResult(hostname string) Result {
+func (i *Installer) AESInstalledResult(hostname string) Result {
 	message := "In the future, to log in to the Ambassador Edge Policy Console, run\n"
 	message += color.Bold.Sprintf("$ edgectl login " + hostname)
 

--- a/cmd/edgectl/aes_install_messages.go
+++ b/cmd/edgectl/aes_install_messages.go
@@ -124,11 +124,19 @@ func (i *Installer) ShowTLSConfiguredSuccessfully() {
 	i.show.Println("-> TLS configured successfully")
 }
 
-// AES installation partially complete -- other instructions follow.
-func (i *Installer) ShowAESInstallationPartiallyComplete() {
+// AES installation complete, but no DNS.
+func (i *Installer) ShowAESInstallationCompleteNoDNS() {
 	i.show.Println()
 	i.show.Println("Ambassador Edge Stack Installation Complete!")
 	i.show.Println("========================================================================")
+
+	// Show congratulations message
+	i.show.Println()
+	message := "<bold>Congratulations! You've successfully installed the Ambassador Edge Stack in your Kubernetes cluster. However, we cannot connect to your cluster from the Internet, so we could not configure TLS automatically.</>\n\n"
+	message += "If the IP address is reachable from your computer, you can access your installation without a DNS name. The following command will open the Edge Policy Console once you accept a self-signed certificate in your browser.\n"
+	message += "<bold>$ edgectl login -n ambassador {{ .address }}</>\n\n"
+	i.ShowTemplated(message)
+	i.show.Println()
 }
 
 // AES installation complete!
@@ -139,6 +147,7 @@ func (i *Installer) ShowAESInstallationComplete() {
 
 	// Show congratulations message
 	i.show.Println()
-	i.ShowTemplated(color.Bold.Sprintf("Congratulations! You've successfully installed the Ambassador Edge Stack in your Kubernetes cluster. You can find it at your custom URL: https://{{.hostname}}/"))
+	message := color.Bold.Sprintf("Congratulations! You've successfully installed the Ambassador Edge Stack in your Kubernetes cluster. You can find it at your custom URL: https://{{.hostname}}/")
+	i.ShowTemplated(message)
 	i.show.Println()
 }

--- a/cmd/edgectl/aes_install_messages.go
+++ b/cmd/edgectl/aes_install_messages.go
@@ -124,6 +124,13 @@ func (i *Installer) ShowTLSConfiguredSuccessfully() {
 	i.show.Println("-> TLS configured successfully")
 }
 
+// AES installation partially complete -- other instructions follow.
+func (i *Installer) ShowAESInstallationPartiallyComplete() {
+	i.show.Println()
+	i.show.Println("Ambassador Edge Stack Installation Complete!")
+	i.show.Println("========================================================================")
+}
+
 // AES installation complete, but no DNS.
 func (i *Installer) ShowAESInstallationCompleteNoDNS() {
 	i.show.Println()

--- a/cmd/edgectl/aes_install_messages.go
+++ b/cmd/edgectl/aes_install_messages.go
@@ -139,9 +139,8 @@ func (i *Installer) ShowAESInstallationCompleteNoDNS() {
 
 	// Show congratulations message
 	i.show.Println()
-	message := "<bold>Congratulations! You've successfully installed the Ambassador Edge Stack in your Kubernetes cluster. However, we cannot connect to your cluster from the Internet, so we could not configure TLS automatically.</>\n\n"
-	message += "If the IP address is reachable from your computer, you can access your installation without a DNS name. The following command will open the Edge Policy Console once you accept a self-signed certificate in your browser.\n"
-	message += "<bold>$ edgectl login -n ambassador {{ .address }}</>\n\n"
+	message := "<bold>Congratulations! You've successfully installed the Ambassador Edge Stack in your Kubernetes cluster. However, we cannot connect to your cluster from the Internet, so we could not configure TLS automatically. "
+	message += "If the IP address is reachable from your computer, you can access your installation without a DNS name.</>\n"
 	i.ShowTemplated(message)
 	i.show.Println()
 }

--- a/cmd/edgectl/aes_install_messages.go
+++ b/cmd/edgectl/aes_install_messages.go
@@ -108,8 +108,8 @@ func (i *Installer) ShowAESConfiguringTLS() {
 	i.show.Println("-> Automatically configuring TLS")
 }
 
-func (i *Installer) ShowFailedToCreateDNSName(dnsName string) {
-	i.show.Println("-> Failed to create a DNS name:", dnsName)
+func (i *Installer) ShowFailedToCreateDNSName(message string) {
+	i.show.Println("   Failed to create a DNS name:", message)
 }
 
 func (i *Installer) ShowAcquiringDNSName(hostname string) {
@@ -142,11 +142,3 @@ func (i *Installer) ShowAESInstallationComplete() {
 	i.ShowTemplated(color.Bold.Sprintf("Congratulations! You've successfully installed the Ambassador Edge Stack in your Kubernetes cluster. You can find it at your custom URL: https://{{.hostname}}/"))
 	i.show.Println()
 }
-
-// Show how to use edgectl login in the future
-func (i *Installer) ShowFutureLogin(hostname string) {
-	i.show.Println()
-	futureLogin := "In the future, to log in to the Ambassador Edge Policy Console, run\n%s"
-	i.ShowWrapped(fmt.Sprintf(futureLogin, color.Bold.Sprintf("$ edgectl login " + hostname)))
-}
-

--- a/cmd/edgectl/aes_login.go
+++ b/cmd/edgectl/aes_login.go
@@ -3,8 +3,9 @@ package main
 import (
 	"crypto/rsa"
 	"fmt"
-	"github.com/pkg/browser"
 	"time"
+
+	"github.com/pkg/browser"
 
 	"github.com/datawire/ambassador/pkg/k8s"
 	"github.com/dgrijalva/jwt-go"
@@ -119,7 +120,6 @@ func do_login(kubeinfo *k8s.KubeInfo, context, namespace, hostname string, openI
 		fmt.Println("The login token is")
 		fmt.Println("    ", tokenString)
 	}
-
 
 	return err
 }


### PR DESCRIPTION
New flow for  the case that DNS is not available during `edgectl install`. After warning the user that DNS was not available, the AES Edge Policy Console is opened and the installer gives the user the appropriate login command with the IP address instead of the hostname.

**Console text when DNS is available:**

![withDNS flow](https://user-images.githubusercontent.com/635244/79376686-60978080-7f0f-11ea-9b1a-0f6f66b3e60a.png)

**Console text when DNS is not available:** note that a real error message would be given rather than the DNS name -- for testing the DNS name was in fact retrieved but the failure branch was executed instead.

![noDNS flow](https://user-images.githubusercontent.com/635244/79376716-6d1bd900-7f0f-11ea-8321-2ceeedac185f.png)

Webpage after accepting "insecure" URL:

![noDNS AES Console](https://user-images.githubusercontent.com/635244/79376802-8c1a6b00-7f0f-11ea-9d82-f1562400fd15.png)


