### PR TITLE
Installer: Suggest login if an existing Host points to an existing AES

### DIFF
--- a/cmd/edgectl/aes_install.go
+++ b/cmd/edgectl/aes_install.go
@@ -752,6 +752,26 @@ func (i *Installer) Perform(kcontext string) Result {
 		return i.AESACMEChallengeError(err)
 	}
 	i.Report("aes_listening")
+
+	if installedVersion != "" {
+		i.show.Printf("-> Looking for a Host resource in the existing installation")
+		hostResource, err := i.FindMatchingHostResource()
+		if err != nil {
+			i.log.Printf("Failed to look for Hosts: %+v", err)
+			hostResource = nil
+		}
+		if hostResource != nil {
+			i.hostname = hostResource.Spec().GetString("hostname")
+			i.ShowWrapped("", fmt.Sprintf(
+				"Found an existing Host resource: Host %s in namespace %s",
+				hostResource.Name(),
+				hostResource.Namespace(),
+			))
+			i.ShowAESAlreadyInstalled()
+			return i.AESAlreadyInstalledResult()
+		}
+	}
+
 	i.ShowAESConfiguringTLS()
 
 	// Send a request to acquire a DNS name for this cluster's load balancer

--- a/cmd/edgectl/aes_install.go
+++ b/cmd/edgectl/aes_install.go
@@ -377,6 +377,84 @@ func (i *Installer) CheckHostnameFound() error {
 	return err
 }
 
+// FindMatchingHostResource returns a Host resource from the cluster that
+// matches the load balancer's address. The Host resource must refer to a
+// *.edgestack.me domain and be in the Ready state.
+func (i *Installer) FindMatchingHostResource() (*k8s.Resource, error) {
+	client, err := k8s.NewClient(i.kubeinfo)
+	if err != nil {
+		return nil, err
+	}
+
+	resources, err := client.List("Host")
+	if err != nil {
+		return nil, err
+	}
+
+	for _, resource := range resources {
+		i.log.Printf("Considering Host %q in ns %q", resource.Name(), resource.Namespace())
+
+		hostname := resource.Spec().GetString("hostname")
+		if !strings.HasSuffix(strings.ToLower(hostname), ".edgestack.me") {
+			i.log.Printf("--> hostname %q is not a *.edgestack.me address", hostname)
+			continue
+		}
+
+		state := resource.Status().GetString("state")
+		if state != "Ready" {
+			i.log.Printf("--> state %q is not Ready", state)
+			continue
+		}
+
+		if !i.HostnameMatchesLBAddress(hostname) {
+			i.log.Printf("--> name does not match load balancer address")
+			continue
+		}
+
+		i.log.Printf("--> success (hostname is %q)", hostname)
+		return &resource, nil
+	}
+
+	return nil, nil
+}
+
+// HostnameMatchesLBAddress returns whether a *.edgestack.me hostname matches a
+// load balancer address, which may be a name or an IP.
+func (i *Installer) HostnameMatchesLBAddress(hostname string) bool {
+	i.log.Printf("--> Matching hostname %q with LB address %q", hostname, i.address)
+	if ip := net.ParseIP(i.address); ip != nil {
+		// Address is an IP address, so hostname should have a DNS A (Address)
+		// record that points to this IP address
+		hostnameIPs, err := net.LookupIP(hostname)
+		if err != nil {
+			i.log.Printf("    --> hostname IP lookup failed: %+v", err)
+			return false
+		}
+		if len(hostnameIPs) != 1 {
+			i.log.Printf("    --> Got %d results instead of 1: %q", len(hostnameIPs), hostnameIPs)
+			return false
+		}
+		if !ip.Equal(hostnameIPs[0]) {
+			i.log.Printf("    --> hostname IP %q did not match address IP %q", hostnameIPs[0], ip)
+			return false
+		}
+	} else {
+		// Address is a DNS name, so hostname should have a DNS CNAME (Canonical
+		// Name) record that points to this DNS name
+		cname, err := net.LookupCNAME(hostname)
+		if err != nil {
+			i.log.Printf("    --> hostname CNAME lookup failed: %+v", err)
+			return false
+		}
+		if !strings.EqualFold(cname, i.address) {
+			i.log.Printf("    --> hostname CNAME %q did not match address %q", cname, i.address)
+			return false
+		}
+	}
+	i.log.Printf("    --> matched")
+	return true
+}
+
 // CheckACMEIsDone queries the Host object and succeeds if its state is Ready.
 func (i *Installer) CheckACMEIsDone() error {
 	state, err := i.CaptureKubectl("get Host state", "", "get", "host", i.hostname, "-o", "go-template={{.status.state}}")

--- a/cmd/edgectl/aes_install.go
+++ b/cmd/edgectl/aes_install.go
@@ -754,7 +754,7 @@ func (i *Installer) Perform(kcontext string) Result {
 	i.Report("aes_listening")
 
 	if installedVersion != "" {
-		i.show.Printf("-> Looking for a Host resource in the existing installation")
+		i.ShowLookingForExistingHost()
 		hostResource, err := i.FindMatchingHostResource()
 		if err != nil {
 			i.log.Printf("Failed to look for Hosts: %+v", err)
@@ -762,11 +762,7 @@ func (i *Installer) Perform(kcontext string) Result {
 		}
 		if hostResource != nil {
 			i.hostname = hostResource.Spec().GetString("hostname")
-			i.ShowWrapped("", fmt.Sprintf(
-				"Found an existing Host resource: Host %s in namespace %s",
-				hostResource.Name(),
-				hostResource.Namespace(),
-			))
+			i.ShowExistingHostFound(hostResource.Name(), hostResource.Namespace())
 			i.ShowAESAlreadyInstalled()
 			return i.AESAlreadyInstalledResult()
 		}

--- a/cmd/edgectl/aes_install_errors.go
+++ b/cmd/edgectl/aes_install_errors.go
@@ -381,3 +381,14 @@ func (i *Installer) AESInstalledResult(hostname string) Result {
 		Err:     nil,
 	}
 }
+
+// AES already installed. Suggest using "edgectl login" instead.
+func (i *Installer) AESAlreadyInstalledResult() Result {
+	message := "Use the following command to open the Ambassador Edge Policy Console:\n"
+	message += color.Bold.Sprintf("$ edgectl login {{.hostname}}")
+
+	return Result{
+		Message: message,
+		Err:     nil,
+	}
+}

--- a/cmd/edgectl/aes_install_messages.go
+++ b/cmd/edgectl/aes_install_messages.go
@@ -157,3 +157,15 @@ func (i *Installer) ShowAESInstallationComplete() {
 	i.ShowTemplated(message)
 	i.show.Println()
 }
+
+// AES already installed
+func (i *Installer) ShowAESAlreadyInstalled() {
+	i.show.Println()
+	i.show.Println("Ambassador Edge Stack Already Installed")
+	i.show.Println("========================================================================")
+
+	// Show congratulations message
+	i.show.Println()
+	message := color.Bold.Sprintf("Congratulations! The Ambassador Edge Stack is already installed in your Kubernetes cluster. You can find it at your custom URL: https://{{.hostname}}/")
+	i.ShowTemplated(message)
+}

--- a/cmd/edgectl/aes_install_messages.go
+++ b/cmd/edgectl/aes_install_messages.go
@@ -104,6 +104,14 @@ func (i *Installer) ShowTimedOut(what string) {
 	i.show.Printf("   Timed out waiting for %s (or interrupted)", what)
 }
 
+func (i *Installer) ShowLookingForExistingHost() {
+	i.show.Printf("-> Looking for a Host resource in the existing installation")
+}
+
+func (i *Installer) ShowExistingHostFound(name, namespace string) {
+	i.show.Printf("   Found %s in the %s namespace", name, namespace)
+}
+
 func (i *Installer) ShowAESConfiguringTLS() {
 	i.show.Println("-> Automatically configuring TLS")
 }


### PR DESCRIPTION
## Goals

1. Don't behave any differently for users doing a fresh install
2. Precisely figure out that an installation already exists
3. Don't change anything in the cluster if an installation already exists

This PR addresses those goals for the full success case where the installer has (in a prior invocation) already set up DNS and created a Host object. 

This PR does not address those goals for the no-DNS success case. However, the installer already suggests login rather than doing the login automatically for that success case. We should think about whether we want to change things for that case, but that's outside the scope of this PR.

I don't think performance is a goal here, but with my laptop and GKE cluster, I can run the "already installed" scenario in under ten seconds.

## Review Questions

- Does this PR achieve goal 1 above? That's really important!
- Does the heuristic implemented in this PR (existing Host resource points to the LB address) correctly achieve goal 2?
- Does the existing code (not touched by the PR) achieve goal 3?

## Screenshots

Install a second time (new flow at the end):
![image](https://user-images.githubusercontent.com/1765854/79483846-d0c20700-7fe0-11ea-812d-72068df97438.png)

Install a second time after nuking the existing Host object (unchanged from before, except that one line was added, "Looking for a Host resource..."):
![image](https://user-images.githubusercontent.com/1765854/79483946-f7803d80-7fe0-11ea-9c44-4a7309382913.png)

Install for the first time is unchanged.
