### PR TITLE
Honor AES_IMAGE_REPOSITORY override when grabbing GrabAESInstallID

### DIFF
--- a/cmd/edgectl/aes_install.go
+++ b/cmd/edgectl/aes_install.go
@@ -243,7 +243,7 @@ func (i *Installer) loopUntil(what string, how func() error, lc *loopConfig) err
 // the Pod is Running (though not necessarily Ready). This should be good enough
 // to report the "deploy" status to metrics.
 func (i *Installer) GrabAESInstallID() error {
-	aesImage := "quay.io/datawire/aes:" + i.version
+	aesImage := i.imageRepo + ":" + i.version
 	i.log.Printf("> aesImage = %s", aesImage)
 	podName := ""
 	containerName := ""
@@ -637,6 +637,9 @@ func (i *Installer) Perform(kcontext string) Result {
 		if ir := os.Getenv(defEnvVarImageRepo); ir != "" {
 			i.ShowOverridingImageRepo(defEnvVarImageRepo, ir)
 			strvals.ParseInto(fmt.Sprintf("image.repository=%s", ir), chartValues)
+			i.imageRepo = ir
+		} else {
+			i.imageRepo = "quay.io/datawire/aes"
 		}
 
 		if it := os.Getenv(defEnvVarImageTag); it != "" {
@@ -906,7 +909,8 @@ type Installer struct {
 	// Install results
 
 	k8sVersion kubernetesVersion // cluster version information
-	version    string            // which AES is being installed
+	imageRepo  string            // from which docker repo is AES being installed
+	version    string            // which AES version is being installed
 	address    string            // load balancer address
 	hostname   string            // of the Host resource
 	clusterID  string            // the Ambassador unique clusterID


### PR DESCRIPTION
## Description
Honor AES_IMAGE_REPOSITORY override when grabbing GrabAESInstallID

## Related Issues
None

## Testing
Manual test with a custom AES image, therefore using `AES_IMAGE_REPOSITORY`

## Tasks That Must Be Done
- [ ] Did you update CHANGELOG.md?
- [ ] Did you add or update tests?
- [ ] Did you update documentation?
- [ ] Were there any special dev tricks you had to use to work on this code efficiently?
  + [ ] Did you add them to DEVELOPING.md?
- [ ] Is this a build change?
  + [ ] If so, did you test on both Mac and Linux?

## Other
* If this is a documentation change for a particular release, please open the pull request against the release branch.
