### PR TITLE
Traffic Agent: Listen on a single port set by env or default to 9900

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,12 @@ Format:
 --->
 
 <!--- CueAddReleaseNotes --->
+## Next release
+
+### Ambassador Edge Stack Only
+
+- Bugfix: The Traffic Agent binds to port 9900 by default. That port can be configured in the Agent's Pod spec.
+
 ## [1.4.1] April 15, 2020
 [1.4.1]: https://github.com/datawire/ambassador/compare/v1.4.0...v1.4.1
 

--- a/python/ambassador/constants.py
+++ b/python/ambassador/constants.py
@@ -3,3 +3,4 @@ class Constants:
     SERVICE_PORT_HTTPS = 8443
     ADMIN_PORT = 8001
     DIAG_PORT = 8877
+    SERVICE_PORT_AGENT = 9900


### PR DESCRIPTION
## Description
- Listen on a single port rather than two
- Make that port 9900 by default, so it doesn't stomp on the application running in the same container
- Make that port configurable
- Accept either cleartext or TLS, not both

## Related Issues
Fixes datawire/apro#1239

## Testing
Manual testing with and without TLS

## Tasks That Must Be Done
- [x] Did you update CHANGELOG.md?
- [x] Did you update documentation?
