### PR TITLE
Add ability to use query parameters in Mappings

### DIFF
--- a/docs/topics/using/index.md
+++ b/docs/topics/using/index.md
@@ -15,6 +15,7 @@ Application development teams use Ambassador to manage edge policies associated 
     * [Adding Response Headers](headers/add_response_headers)
     * [Removing Request Headers](headers/remove_request_headers)
     * [Remove Response Headers](headers/remove_response_headers)
+  * [Query Parameter Based Routing](query_parameters)
   * [Keepalive](keepalive)
   * Protocols
     * [TCP](tcpmappings)

--- a/docs/topics/using/mappings.md
+++ b/docs/topics/using/mappings.md
@@ -6,7 +6,7 @@ Ambassador Edge Stack _must_ have one or more mappings defined to provide access
 
 ## Mapping Evaluation Order
 
-Ambassador Edge Stack sorts mappings such that those that are more highly constrained are evaluated before those less highly constrained. The prefix length, the request method, and the constraint headers are all taken into account.
+Ambassador Edge Stack sorts mappings such that those that are more highly constrained are evaluated before those less highly constrained. The prefix length, the request method, constraint headers, and query parameters are all taken into account.
 
 If absolutely necessary, you can manually set a `precedence` on the mapping (see below). In general, you should not need to use this feature unless you're using the `regex_headers` or `host_regex` matching features. If there's any question about how Ambassador Edge Stack is ordering rules, the diagnostic service is a good first place to look: the order in which mappings appear in the diagnostic service is the order in which they are evaluated.
 

--- a/docs/topics/using/query_parameters.md
+++ b/docs/topics/using/query_parameters.md
@@ -54,7 +54,7 @@ will send requests that contain the `quote-mode` query parameter to the `quote-m
 
 ## `regex_query_parameters`
 
-The following mapping will route mobile requests from Android and iPhones to a mobile service:
+The following mapping will route requests with the `quote-mode` header that contain values that match the regex:
 
 ```yaml
 ---
@@ -64,7 +64,7 @@ metadata:
   name:  quote-backend
 spec:
   regex_query_parameters:
-    user-agent: "^(?=.*\\bAndroid\\b)(?=.*\\b(m|M)obile\\b).*|(?=.*\\biPhone\\b)(?=.*\\b(m|M)obile\\b).*$"
+    quote-mode: "^[a-z].*"
   prefix: /backend/
   service: quote
 ```

--- a/docs/topics/using/query_parameters.md
+++ b/docs/topics/using/query_parameters.md
@@ -1,0 +1,70 @@
+# Query Parameter based Routing
+
+Ambassador Edge Stack can route to target services based on HTTP query parameters with the `query_parameters` and `regex_query_parameters` specifications. Multiple mappings with different annotations can be applied to construct more complex routing rules.
+
+## The `query_parameters` Annotation
+
+The `query_parameters` attribute is a dictionary of `query_parameter`: `value` pairs. Ambassador Edge Stack will only allow requests that match the specified `query_parameter`: `value` pairs to reach the target service.
+
+You can also set the `value` of a query parameter to `true` to test for the existence of a query parameter.
+
+### A Basic Example
+
+```yaml
+---
+apiVersion: getambassador.io/v2
+kind:  Mapping
+metadata:
+  name:  quote-backend
+spec:
+  prefix: /backend/
+  service: quote
+  query_parameters:
+    quote-mode: backend
+    random-query-parameter: datawire
+```
+
+will allow requests to /backend/ to succeed only if the `quote-mode` query paraameter has the value `backend` and the `random-query-parameter` has the value `datawire`.
+
+### A Conditional Example
+
+```yaml
+---
+apiVersion: getambassador.io/v2
+kind:  Mapping
+metadata:
+  name:  quote-mode
+spec:
+  prefix: /backend/
+  service: quote-mode
+  query_parameters:
+    quote-mode: true
+
+---
+apiVersion: getambassador.io/v2
+kind:  Mapping
+metadata:
+  name:  quote-regular
+spec:
+  prefix: /backend/
+  service: quote-regular
+```
+
+will send requests that contain the `quote-mode` query parameter to the `quote-mode` target, while routing all other requests to the `quote-regular` target.
+
+## `regex_query_parameters`
+
+The following mapping will route mobile requests from Android and iPhones to a mobile service:
+
+```yaml
+---
+apiVersion: getambassador.io/v2
+kind:  Mapping
+metadata:
+  name:  quote-backend
+spec:
+  regex_query_parameters:
+    user-agent: "^(?=.*\\bAndroid\\b)(?=.*\\b(m|M)obile\\b).*|(?=.*\\biPhone\\b)(?=.*\\b(m|M)obile\\b).*$"
+  prefix: /backend/
+  service: quote
+```

--- a/python/ambassador/envoy/v2/v2route.py
+++ b/python/ambassador/envoy/v2/v2route.py
@@ -109,9 +109,12 @@ class V2Route(dict):
                 match.update(regex_matcher(config, route_prefix))
 
         headers = self.generate_headers(config, group)
-
         if len(headers) > 0:
             match['headers'] = headers
+
+        query_parameters = self.generate_query_parameters(config, group)
+        if len(query_parameters) > 0:
+            match['query_parameters'] = query_parameters
 
         self['match'] = match
 
@@ -290,6 +293,34 @@ class V2Route(dict):
             headers.append(header)
 
         return headers
+
+    @staticmethod
+    def generate_query_parameters(config: 'V2Config', mapping_group: IRHTTPMappingGroup) -> List[dict]:
+        query_parameters = []
+
+        group_query_parameters = mapping_group.get('query_parameters', [])
+
+        for group_query_parameter in group_query_parameters:
+            query_parameter = { 'name': group_query_parameter.get('name') }
+
+            if group_query_parameter.get('regex'):
+                query_parameter.update({
+                    'string_match': regex_matcher(
+                        config,
+                        group_query_parameter.get('value'),
+                        key='regex'
+                    )
+                })
+            else:
+                query_parameter.update({
+                    'string_match': {
+                        'exact': group_query_parameter.get('value')
+                    }
+                })
+
+            query_parameters.append(query_parameter)
+
+        return query_parameters
 
     @staticmethod
     def generate_hash_policy(mapping_group: IRHTTPMappingGroup) -> dict:

--- a/python/ambassador/envoy/v2/v2route.py
+++ b/python/ambassador/envoy/v2/v2route.py
@@ -312,11 +312,17 @@ class V2Route(dict):
                     )
                 })
             else:
-                query_parameter.update({
-                    'string_match': {
-                        'exact': group_query_parameter.get('value')
-                    }
-                })
+                value = group_query_parameter.get('value', None)
+                if value is not None:
+                    query_parameter.update({
+                        'string_match': {
+                            'exact': group_query_parameter.get('value')
+                        }
+                    })
+                else:
+                    query_parameter.update({
+                        'present_match': True
+                    })
 
             query_parameters.append(query_parameter)
 

--- a/python/schemas/v2/Mapping.schema
+++ b/python/schemas/v2/Mapping.schema
@@ -164,7 +164,9 @@
             },
             "required": ["policy"],
             "additionalProperties": false
-        }
+        },
+        "query_parameters": { "$ref": "#/definitions/mapStrStr" },
+        "regex_query_parameters": { "$ref": "#/definitions/mapStrStr" }
     },
     "definitions": {
         "mapStrStr": {

--- a/python/tests/t_queryparameter_routing.py
+++ b/python/tests/t_queryparameter_routing.py
@@ -1,0 +1,66 @@
+from kat.harness import variants, Query
+from abstract_tests import AmbassadorTest, ServiceType, HTTP
+
+class QueryParameterRoutingTest(AmbassadorTest):
+    target1: ServiceType
+    target2: ServiceType
+
+    def init(self):
+        self.target1 = HTTP(name="target1")
+        self.target2 = HTTP(name="target2")
+
+    def config(self):
+        yield self.target1, self.format("""
+---
+apiVersion: ambassador/v2
+kind:  Mapping
+name:  {self.name}-target1
+prefix: /target/
+service: http://{self.target1.path.fqdn}
+""")
+        yield self.target2, self.format("""
+---
+apiVersion: ambassador/v2
+kind:  Mapping
+name:  {self.name}-target2
+prefix: /target/
+service: http://{self.target2.path.fqdn}
+query_parameters:
+    test_param: target2
+""")
+
+    def queries(self):
+        yield Query(self.url("target/"), expected=200)
+        yield Query(self.url("target/?test_param=target2"), expected=200)
+
+    def check(self):
+        assert self.results[0].backend.name == self.target1.path.k8s, f"r0 wanted {self.target1.path.k8s} got {self.results[0].backend.name}"
+        assert self.results[1].backend.name == self.target2.path.k8s, f"r1 wanted {self.target2.path.k8s} got {self.results[1].backend.name}"
+
+class QueryParameterRoutingWithRegexTest(AmbassadorTest):
+    target: ServiceType
+
+    def init(self):
+        self.target = HTTP(name="target")
+
+    def config(self):
+        yield self.target, self.format("""
+---
+apiVersion: ambassador/v2
+kind:  Mapping
+name:  {self.name}-target
+prefix: /target/
+service: http://{self.target.path.fqdn}
+regex_query_parameters:
+    test_param: "^[a-z].*"
+""")
+
+    def queries(self):
+        yield Query(self.url("target/?test_param=hello"), expected=200)
+
+        # These should not match the regex and therefore not be found
+        yield Query(self.url("target/"), expected=404)
+        yield Query(self.url("target/?test_param=HeLlO"), expected=404)
+
+    def check(self):
+        assert self.results[0].backend.name == self.target.path.k8s, f"r0 wanted {self.target.path.k8s} got {self.results[0].backend.name}"

--- a/python/tests/test_ambassador.py
+++ b/python/tests/test_ambassador.py
@@ -34,6 +34,7 @@ import t_envoy_logs
 import t_ingress
 import t_listeneridletimeout
 import t_cluster_tag
+import t_queryparameter_routing
 
 # pytest will find this because Runner is a toplevel callable object in a file
 # that pytest is willing to look inside.


### PR DESCRIPTION
## Description

Adds the ability to use [query parameters](https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/route/v3/route_components.proto.html?highlight=routematch#config-route-v3-routematch) in `Mapping` objects.

Please note that while I linked to the latest envoy docs the behavior of query parameters is the same as the datawire envoy fork. All tests were performed on the datawire envoy fork.

## Testing

I have added python tests to verify this functionality. I based them on the similar header tests since it behaves in a similar fashion.

## Tasks That Must Be Done
- [X] Did you add or update tests?
- [x] Did you update documentation?