### PR TITLE
Intercept: Avoid bugs triggered by misfeatures in older code

### DIFF
--- a/cmd/edgectl/intercept.go
+++ b/cmd/edgectl/intercept.go
@@ -173,7 +173,7 @@ func (d *Daemon) AddIntercept(p *supervisor.Process, out *Emitter, ii *Intercept
 
 		switch len(matches) {
 		case 0:
-			out.Printf("No interceptable deployment matching %s found", ii.Name)
+			out.Printf("No interceptable deployment matching %s found\n", ii.Deployment)
 			out.Send("failed", "no interceptable deployment matches")
 			out.SendExit(1)
 			return nil
@@ -181,7 +181,7 @@ func (d *Daemon) AddIntercept(p *supervisor.Process, out *Emitter, ii *Intercept
 		case 1:
 			// Good to go.
 			ii.Namespace = matches[0].Namespace
-			out.Printf("Using deployment %s in namespace %s\n", ii.Name, ii.Namespace)
+			out.Printf("Using deployment %s in namespace %s\n", ii.Deployment, ii.Namespace)
 
 		default:
 			out.Printf("Found more than one possible match:\n")


### PR DESCRIPTION
- `InterceptInfo` uses `.Deployment` and `.Namespace` to describe the deployment;
  `.Name` is the user's description of the intercept.
- The last `out.Print` or `out.Printf` must have a newline. Otherwise
  `out.SendExit(...)` doesn't work correctly.
