### PR TITLE
updated ubuntu to 18.04

### DIFF
--- a/docker/test-auth/Dockerfile
+++ b/docker/test-auth/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License
 
-FROM ubuntu:14.04
+FROM ubuntu:18.04
 
 MAINTAINER Datawire <flynn@datawire.io>
 LABEL PROJECT_REPO_URL         = "git@github.com:datawire/ambassador.git" \

--- a/docker/test-shadow/Dockerfile
+++ b/docker/test-shadow/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License
 
-FROM ubuntu:14.04
+FROM ubuntu:18.04
 
 MAINTAINER Datawire <flynn@datawire.io>
 LABEL PROJECT_REPO_URL         = "git@github.com:datawire/ambassador.git" \


### PR DESCRIPTION
## Description
Update tests to use ubuntu 18.04 instead of 14.04

## Related Issues
Ubuntu 14.04 was end of life on 30th April 2019