### PR TITLE
Small improvement to Ambassador's Envoy development.

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -354,15 +354,21 @@ This is a bit more complex than anyone likes, but here goes:
    process.  The build happens in a Docker container; you can set
    `DOCKER_HOST` to point to a powerful machine if you like.
 
-   You can build and test Ambassador with the usual `make` commands,
+   * You can build and test **Ambassador** with the usual `make` commands,
    with the exception that you MUST run `make update-base` first
    whenever Envoy needs to be recompiled; it won't happen
    automatically.  So `make test` to build-and-test Ambassador would
    become `make update-base && make test`, and `make images` to just
    build Ambassador would become `make update-base && make images`.
 
-   You can run Envoy's test suite by running `make check-envoy`.  Be
-   warned that Envoy's test suite requires several hundred gigabytes
+   * For **Envoy** development, you can build and run **specific Envoy test** 
+   (i.e. unit tests in test/common/network/listener_impl_test.cc) by exporting Bazel label: 
+   `export ENVOY_TEST_LABEL='//test/common/network:listener_impl_test'` 
+   and running `make check-envoy`.
+   Once you are happy with your changes, it's advised to `unset ENVOY_TEST_LABEL`
+   and run Envoy's **test suite** by executing `make check-envoy`
+   again to make sure your change is not breaking Envoy.
+   Be warned that Envoy's **test suite** requires several hundred gigabytes
    of disk space to run.
 
    You can run `make envoy-shell` to get a Bash shell in the Docker

--- a/cxx/envoy.mk
+++ b/cxx/envoy.mk
@@ -4,6 +4,7 @@ include $(OSS_HOME)/build-aux/prelude.mk
 
 YES_I_AM_OK_WITH_COMPILING_ENVOY ?=
 YES_I_AM_UPDATING_THE_BASE_IMAGES ?=
+ENVOY_TEST_LABEL ?= //test/...
 
 _git_remote_urls := $(shell git remote | xargs -n1 git remote get-url --all)
 IS_PRIVATE ?= $(findstring private,$(_git_remote_urls))
@@ -137,9 +138,10 @@ $(OSS_HOME)/docker/base-envoy/envoy-static: $(ENVOY_BASH.deps) FORCE
 
 check-envoy: ## Run the Envoy test suite
 check-envoy: $(ENVOY_BASH.deps)
-	$(call ENVOY_BASH.cmd, \
-	    docker exec --workdir=/root/envoy $$(cat $(srcdir)/envoy-build-container.txt) /bin/bash -c 'export CC=/opt/llvm/bin/clang && export CXX=/opt/llvm/bin/clang++ && bazel test --config=clang --test_output=errors --verbose_failures -c dbg --test_env=ENVOY_IP_TEST_VERSIONS=v4only //test/...;' \
-	)
+	  @echo 'Testing envoy with Bazel label: "$(ENVOY_TEST_LABEL)"'; \
+	  $(call ENVOY_BASH.cmd, \
+	     docker exec --workdir=/root/envoy $$(cat $(srcdir)/envoy-build-container.txt) /bin/bash -c 'export CC=/opt/llvm/bin/clang && export CXX=/opt/llvm/bin/clang++ && bazel test --config=clang --test_output=errors --verbose_failures -c dbg --test_env=ENVOY_IP_TEST_VERSIONS=v4only $(ENVOY_TEST_LABEL);' \
+	 )
 .PHONY: check-envoy
 
 envoy-shell: ## Run a shell in the Envoy build container


### PR DESCRIPTION
This change introduced a new environment variable `ENVOY_TEST_LABEL`
to target specific Envoy test.

i.e. `export ENVOY_TEST_LABEL='//test/common/network:listener_impl_test'` to build and run only a subset of Envoy test suit. After exporting the variable you can run `make check-envoy`.
