### PR TITLE
Fixup capabilities_wrapper

### DIFF
--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -130,7 +130,7 @@ RUN setcap cap_net_bind_service=ei /usr/local/bin/envoy
 # Our Go binaries. See envoy section for setcap info.
 COPY --from=artifacts /opt/ambassador /opt/ambassador
 RUN ln -s /opt/ambassador/bin/* /usr/local/bin/
-RUN setcap cap_net_bind_service=p /usr/local/bin/wrapper
+RUN setcap cap_net_bind_service=p /opt/ambassador/bin/wrapper
 
 # Our Python code
 COPY --from=artifacts /buildroot/ambassador/python /buildroot/ambassador/python

--- a/cmd/capabilities_wrapper/capset_linux.go
+++ b/cmd/capabilities_wrapper/capset_linux.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+func capset() error {
+	header := unix.CapUserHeader{unix.LINUX_CAPABILITY_VERSION_3, int32(os.Getpid())}
+	data := unix.CapUserData{}
+	if err := unix.Capget(&header, &data); err != nil {
+		return err
+	}
+
+	data.Inheritable = (1 << unix.CAP_NET_BIND_SERVICE)
+
+	if err := unix.Capset(&header, &data); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/cmd/capabilities_wrapper/capset_other.go
+++ b/cmd/capabilities_wrapper/capset_other.go
@@ -1,0 +1,11 @@
+// +build !linux
+
+package main
+
+import (
+	"errors"
+)
+
+func capset() error {
+	return errors.New("setcap is only implemented on GOOS=linux")
+}

--- a/cmd/capabilities_wrapper/wrapper.go
+++ b/cmd/capabilities_wrapper/wrapper.go
@@ -4,22 +4,12 @@ import (
 	"log"
 	"os"
 	"syscall"
-
-	"golang.org/x/sys/unix"
 )
 
 func main() {
 	log.Println("Starting Envoy with CAP_NET_BIND_SERVICE capability")
 
-	header := unix.CapUserHeader{unix.LINUX_CAPABILITY_VERSION_3, int32(os.Getpid())}
-	data := unix.CapUserData{}
-	if err := unix.Capget(&header, &data); err != nil {
-		log.Fatal(err)
-	}
-
-	data.Inheritable = (1 << unix.CAP_NET_BIND_SERVICE)
-
-	if err := unix.Capset(&header, &data); err != nil {
+	if err := capset(); err != nil {
 		log.Fatal(err)
 	}
 


### PR DESCRIPTION
## Description

- Stub out the linux-only stuff in `cmd/capabilities_wrapper`, so that it compiles on things other than `GOOS=linux`, and stops causing headaches for macOS-using developers. (#2589)
- Fix the filesystem capabilities on the wrapper binary in the final Docker image; they weren't getting set.  This was a regression in 1.3.0.

## Related Issues

#2589

## Testing

- `go build ./cmd/capabilities_wrapper` ran fine on on a macincloud
- `make images && docker run --rm -it --entrypoint=sh ambassador:latest -c 'apk add attr && getfattr -d -m - /usr/local/bin/wrapper'` verified that it now has the `security.capability` xattr set.

## Tasks That Must Be Done
- [x] Did you update CHANGELOG.md? - no applicable changes; #2050 hasn't landed yet
- [ ] Did you add or update tests? - no, should I?
- [x] Did you update documentation? - no applicable changes
- [x] Were there any special dev tricks you had to use to work on this code efficiently? - no
- [x] Is this a build change? - yes
  + [x] If so, did you test on both Mac and Linux? - yes
