### PR TITLE
Reordered index.md to put YAML, Helm at top

### DIFF
--- a/docs/topics/install/index.md
+++ b/docs/topics/install/index.md
@@ -6,18 +6,35 @@ import './index.less'
 <div class="index-dropdown">
   <button class="index-dropBtn">Jump to Installation Type</button>
   <div class="index-dropdownContent">
+    <a href="#index-installKubernetesYaml">Kubernetes YAML</a>
+    <a href="#index-installHelm">Helm</a>
     <a href="#index-installMac">Mac</a>
     <a href="#index-installLinux">Linux</a>
     <a href="#index-installWindows">Windows</a>
-    <a href="#index-installKubernetesYaml">Kubernetes YAML</a> 
     <a href="#index-installAmbassadorOperator">Ambassador Operator</a>
-    <a href="#index-installHelm">Helm</a>
     <a href="#index-installDocker">Docker</a>
     <a href="#index-installBareMetal">Bare Metal</a>
     <a href="#index-installUpgrade">Upgrade</a>
   </div>
 </div>
 </div>
+
+<p id="index-installKubernetesYaml"></p><br/>
+
+## Install via Kubernetes YAML
+
+Kubernetes via YAML is the most common approach to install Ambassador Edge Stack,
+especially in production environments, with our default, customizable manifest.
+So if you want complete configuration control over specific parameters of your
+installation, use the [manual YAML installation method](yaml-install).
+<p id="index-installHelm"></p><br/>
+
+## Install via Helm
+[![Helm](../../images/helm.png)](helm/)
+
+Helm, the package manager for Kubernetes, is another popular way to install
+Ambassador Edge Stack through the pre-packaged Helm chart. Full details, including
+the differences for Helm 2 and Helm3, are in the [Helm instructions.](helm/)
 
 <span id="index-installMac"></span><br/>
 
@@ -67,14 +84,6 @@ for a domain name, so you can get started right away.
 and provide you with an `edgestack.me` subdomain. The `edgestack.me` subdomain 
 allows the Ambassador Edge Stack to automatically provision TLS and HTTPS
 for a domain name, so you can get started right away.
-<p id="index-installKubernetesYaml"></p><br/>
-
-## Install via Kubernetes YAML
-
-Kubernetes via YAML is the most common approach to install Ambassador Edge Stack,
-especially in production environments, with our default, customizable manifest.
-So if you want complete configuration control over specific parameters of your
-installation, use the [manual YAML installation method](yaml-install).
 <p id="index-installAmbassadorOperator"></p><br/>
 
 ## Install via the Ambassador Operator
@@ -82,14 +91,6 @@ installation, use the [manual YAML installation method](yaml-install).
 The Ambassador Edge Stack Operator automates installs (day 1 operations) and
 updates (day 2 operations), among other actions. To use the powerful Ambassador
 Operator, [follow the Ambassador Edge Stack Operator instructions](aes-operator).
-<p id="index-installHelm"></p><br/>
-
-## Install via Helm
-[![Helm](../../images/helm.png)](helm/)
-
-Helm, the package manager for Kubernetes, is another popular way to install
-Ambassador Edge Stack through the pre-packaged Helm chart. Full details, including
-the differences for Helm 2 and Helm3, are in the [Helm instructions.](helm/)
 <p id="index-installDocker"></p><br/>
 
 ## Install Locally on Docker


### PR DESCRIPTION
Moves Kubernetes YAML and Helm options to top of installations instructions page.  Reorders selection options on page to reflect this change.

<img width="1433" alt="Yaml, Helm at top" src="https://user-images.githubusercontent.com/57576741/80521277-a0169180-893f-11ea-99d7-898c09bd2928.png">

## Testing
Tested on Mac (Chrome, Firefox, Safari, Maxthon) and Windows (Chrome, Firefox), also mobile (Samsung Galaxy 9).

## Tasks That Must Be Done
- [ ] Did you update CHANGELOG.md?
- [ ] Did you add or update tests?
- [ ] Did you update documentation?
- [ ] Were there any special dev tricks you had to use to work on this code efficiently?
  + [ ] Did you add them to DEVELOPING.md?
- [ ] Is this a build change?
  + [ ] If so, did you test on both Mac and Linux?

## Other
* If this is a documentation change for a particular release, please open the pull request against the release branch.
