### PR TITLE
Move Ambassador CRD handling to resource processor

### DIFF
--- a/python/ambassador/config/resourcefetcher.py
+++ b/python/ambassador/config/resourcefetcher.py
@@ -302,7 +302,7 @@ class ResourceFetcher:
                 # Nothing else to do.
                 return
 
-        handler_name = f'handle_k8s_{obj.gvk.kind.lower()}'
+        handler_name = f'handle_k8s_{obj.kind.lower()}'
         # self.logger.debug(f"looking for handler {handler_name} for K8s {kind} {name}")
         handler = getattr(self, handler_name, None)
 
@@ -310,7 +310,7 @@ class ResourceFetcher:
             self.logger.debug(f"{self.location}: skipping K8s {obj.gvk}")
             return
 
-        if not self.check_k8s_dup(obj.gvk.kind, obj.namespace, obj.name):
+        if not self.check_k8s_dup(obj.kind, obj.namespace, obj.name):
             return
 
         result = handler(raw_obj)

--- a/python/ambassador/config/resourcefetcher.py
+++ b/python/ambassador/config/resourcefetcher.py
@@ -234,6 +234,9 @@ class ResourceFetcher:
             # Then we add everything else to be processed.
             watt_k8s_keys += watt_k8s.keys()
 
+            # `dict.fromkeys(iterable)` is a convenient way to work around the
+            # lack of an ordered set collection type in Python. As Python 3.7,
+            # dicts are guaranteed to be insertion-ordered.
             for key in dict.fromkeys(watt_k8s_keys):
                 for obj in watt_k8s.get(key) or []:
                     # self.logger.debug(f"Handling Kubernetes {key}...")

--- a/python/ambassador/config/resourceprocessor.py
+++ b/python/ambassador/config/resourceprocessor.py
@@ -102,7 +102,7 @@ class NormalizedResource:
         ir_obj['namespace'] = namespace
         ir_obj['kind'] = kind
         ir_obj['generation'] = generation
-        ir_obj['labels'] = labels or {}
+        ir_obj['metadata_labels'] = labels or {}
 
         return cls(ir_obj, rkey)
 

--- a/python/tests/test_resourceprocessor.py
+++ b/python/tests/test_resourceprocessor.py
@@ -144,7 +144,7 @@ class TestNormalizedResource:
 
         assert resource.rkey == f'{valid_mapping.name}.{valid_mapping.namespace}'
         assert resource.object['apiVersion'] == valid_mapping.gvk.api_version
-        assert resource.object['kind'] == valid_mapping.gvk.kind
+        assert resource.object['kind'] == valid_mapping.kind
         assert resource.object['name'] == valid_mapping.name
         assert resource.object['namespace'] == valid_mapping.namespace
         assert resource.object['generation'] == valid_mapping.generation

--- a/python/tests/test_resourceprocessor.py
+++ b/python/tests/test_resourceprocessor.py
@@ -148,8 +148,8 @@ class TestNormalizedResource:
         assert resource.object['name'] == valid_mapping.name
         assert resource.object['namespace'] == valid_mapping.namespace
         assert resource.object['generation'] == valid_mapping.generation
-        assert len(resource.object['labels']) == 1
-        assert resource.object['labels']['ambassador_crd'] == resource.rkey
+        assert len(resource.object['metadata_labels']) == 1
+        assert resource.object['metadata_labels']['ambassador_crd'] == resource.rkey
         assert resource.object['prefix'] == valid_mapping.spec['prefix']
         assert resource.object['service'] == valid_mapping.spec['service']
 


### PR DESCRIPTION
## Description
This change removes the `handle_k8s_crd` method of the resource fetcher, instead delegating that work to the `AmbassadorProcessor` class introduced in a previous refactor. The generated IR remains the same.

## Testing
I've run this through the Python test suite for validation.

## Tasks That Must Be Done
- [ ] Did you update CHANGELOG.md?
- [ ] Did you add or update tests?
- [ ] Did you update documentation?
- [ ] Were there any special dev tricks you had to use to work on this code efficiently?
  + [ ] Did you add them to DEVELOPING.md?
- [ ] Is this a build change?
  + [ ] If so, did you test on both Mac and Linux?

## Other
* If this is a documentation change for a particular release, please open the pull request against the release branch.
