### PR TITLE
fix install link click area, k8 codeblock text at smallest width

### DIFF
--- a/docs/tutorials/GettingStarted.js
+++ b/docs/tutorials/GettingStarted.js
@@ -133,7 +133,7 @@ class GettingStarted extends Component {
           <ul id="QS-asideBullets">
             <li>Have Kubernetes? Deploy with yaml:</li>
               <div className="styles-module--CodeBlock--1UB4s">
-                <div className="QS-codeblockInstall QS-Aside2-codeblockInstall">
+                <div className="QS-codeblockInstall">
                 <span className="QS-copyButton"><CopyButton content="
                 kubectl apply -f https://www.getambassador.io/yaml/aes-crds.yaml && \kubectl wait --for condition=established --timeout=90s crd -lproduct=aes && \kubectl apply -f https://www.getambassador.io/yaml/aes.yaml && \kubectl -n ambassador wait --for condition=available --timeout=90s deploy -lproduct=aes">Copy</CopyButton></span>
                   <div className="token-line">

--- a/docs/tutorials/getting-started.less
+++ b/docs/tutorials/getting-started.less
@@ -171,7 +171,7 @@ summary#helmVersions {
 #QS-fullManual a{
   color: darkgrey;
   text-decoration: underline;
-  padding-bottom: 3px;
+  padding-bottom: 10px;
 }
 #QS-fullManual:hover a {
   text-decoration: none;

--- a/docs/tutorials/getting-started.less
+++ b/docs/tutorials/getting-started.less
@@ -5,7 +5,7 @@
   "os sidebar1"
   "k8 sidebar2"
   "helm sidebar3"
-  "manual manual"
+  "manual0 manual"
   "main main";
   grid-gap: 15px;
   margin-left: -125px;
@@ -167,7 +167,6 @@ summary#helmVersions {
   display: flex;
   font-size: 1.2em;
   font-weight: 600;
-  margin-left: 60px;
 }
 #QS-fullManual a{
   color: darkgrey;

--- a/docs/tutorials/getting-started.less
+++ b/docs/tutorials/getting-started.less
@@ -171,6 +171,7 @@ summary#helmVersions {
 #QS-fullManual a{
   color: darkgrey;
   text-decoration: underline;
+  padding-bottom: 3px;
 }
 #QS-fullManual:hover a {
   text-decoration: none;


### PR DESCRIPTION
Fixes grid assignment on QuickStart page that makes link to full detailed instructions easier to click.  Makes kubernetes yaml code block font size smaller on mobile width.

## Related Issues
Relates to improvement of QuickStart page (PR#2660)

## Testing
Tested on Chrome, Firefox, Safari, Maxthon browsers

## Tasks That Must Be Done
- [ ] Did you update CHANGELOG.md?
- [ ] Did you add or update tests?
- [ ] Did you update documentation?
- [ ] Were there any special dev tricks you had to use to work on this code efficiently?
  + [ ] Did you add them to DEVELOPING.md?
- [ ] Is this a build change?
  + [ ] If so, did you test on both Mac and Linux?

## Other
* If this is a documentation change for a particular release, please open the pull request against the release branch.
