### PR TITLE
Don't try to build the website if GH_TOKEN is unset.

### DIFF
--- a/.ci/pr-build-website-preview
+++ b/.ci/pr-build-website-preview
@@ -15,6 +15,14 @@
 # limitations under the License
 
 set -o errexit
+
+# Don't bother trying to build the website if GH_TOKEN is unset (as it will
+# be for a community PR).
+if [ -z "$GH_TOKEN" ]; then
+	echo '[pr-build-website-preview] skipping: GH_TOKEN is not set'
+	exit 0
+fi
+
 set -o nounset
 set -o xtrace
 


### PR DESCRIPTION
This seems to the cause of the recent spate of community-PR build failures

## Tasks That Must Be Done
- [ ] Did you update CHANGELOG.md? no, because it's not part of a release
- [x] Is this a build change? yes. Tested by hand on Mac, CI will test on Linux. 🙂 
