### PR TITLE
Update 1.3 docs pages' canonical URLs

### DIFF
--- a/docs/js/doc-page.js
+++ b/docs/js/doc-page.js
@@ -17,6 +17,10 @@ import template from '../../../../src/utils/template';
 import docLinks from './doc-links.yml';
 import versions from './versions.yml';
 
+function removeDoubleSlashes(str) {
+  return str.replace(/\/{2,}/g, '/');
+}
+
 export default ({ data, location }) => {
   const page = data.mdx || {};
   const title =
@@ -25,8 +29,26 @@ export default ({ data, location }) => {
   const aesPage = isAesPage(page.fields.slug);
   const apiGatewayPage = isApiGatewayPage(page.fields.slug);
 
-  const canonicalLink = `https://www.getambassador.io${location.pathname}`;
-  const metaDescription = page.frontmatter ? page.frontmatter.description : null;
+  const metaDescription = page.frontmatter
+    ? page.frontmatter.description
+    : null;
+
+  // docs/version/path/to/page
+  const slug = data.mdx.fields.slug || location.pathname;
+
+  // we don't need the version, which is the first element of the array
+  const [, ...rest] = slug
+    // remove the docs part
+    .replace(/(\/docs\/)|(docs\/)/, '')
+    // get the parts of the path by splitting it
+    .split('/');
+
+  // Finally, build the canonical URL: we know the initial part (docs/latest)
+  // and need to append the rest of the original slug to it
+  const canonicalUrl = `https://www.getambassador.io/docs/latest${removeDoubleSlashes(
+    // Also, we can add a trailing slash to make sure we're pointing to the right URL
+    `/${rest.join('/')}/`,
+  )}`;
 
   return (
     <React.Fragment>
@@ -34,21 +56,38 @@ export default ({ data, location }) => {
         <title>{title} | Ambassador</title>
         <meta name="og:title" content={`${title} | Ambassador`} />
         <meta name="og:type" content="article" />
-        <link rel="canonical" href={canonicalLink} />
-        { metaDescription && <meta name="description" content={metaDescription} /> }
+        <link rel="canonical" href={canonicalUrl} />
+        {metaDescription && (
+          <meta name="description" content={metaDescription} />
+        )}
       </Helmet>
       <Layout location={location}>
         <Sidebar location={location} prefix="" items={docLinks} />
         <div className="doc-body">
           <main className="main-body">
             <div className="doc-tags">
-              { aesPage && <Link className="doc-tag aes" to="/editions">Ambassador Edge Stack</Link> }
-              { apiGatewayPage && <Link className="doc-tag api" to="/editions/">Ambassador API Gateway</Link> }
+              {aesPage && (
+                <Link className="doc-tag aes" to="/editions">
+                  Ambassador Edge Stack
+                </Link>
+              )}
+              {apiGatewayPage && (
+                <Link className="doc-tag api" to="/editions/">
+                  Ambassador API Gateway
+                </Link>
+              )}
             </div>
-            <MDXRenderer slug={page.fields.slug}>{template(page.body, versions)}</MDXRenderer>
+            <MDXRenderer slug={page.fields.slug}>
+              {template(page.body, versions)}
+            </MDXRenderer>
             <div>
               <h2>Questions?</h2>
-              <p>We’re here to help. If you have questions, <a href="http://d6e.co/slack">join our Slack</a>, <a href="/contact/">contact us</a>, or <a href="/demo/">request a demo</a>.</p>
+              <p>
+                We’re here to help. If you have questions,{' '}
+                <a href="http://d6e.co/slack">join our Slack</a>,{' '}
+                <a href="/contact/">contact us</a>, or{' '}
+                <a href="/demo/">request a demo</a>.
+              </p>
             </div>
           </main>
         </div>


### PR DESCRIPTION
One file PR that changes the `rel="canonical"` link in 1.3 docs pages to point to the corresponding `/latest/` version to prevent content duplication in Google.