### PR TITLE
Support custom json log format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,7 @@ Format:
 - Bugfix: The websocket library used by the test suite has been upgraded to incorporate security fixes (thanks, [Andrew Allbright](https://github.com/aallbrig)!)
 - Bugfix: Fixed evaluation of label selectors causing the wrong IP to be put in to Ingress resource statuses
 - Bugfix: The `watt` (port 8002) and `ambex` (port 8003) components now bind to localhost instead of 0.0.0.0, so they are no longer erroneously available from outside the Pod
+- Feature: Customizable JSON access logging format 
 
 ## [1.4.3] May 14, 2020
 [1.4.3]: https://github.com/datawire/ambassador/compare/v1.4.2...v1.4.3

--- a/docs/topics/running/ambassador.md
+++ b/docs/topics/running/ambassador.md
@@ -31,9 +31,9 @@ spec:
 | `enable_http10` | Should we enable http/1.0 protocol? | `enable_http10: false` |
 | `enable_ipv4`| Should we do IPv4 DNS lookups when contacting services? Defaults to true, but can be overridden in a [`Mapping`](../../using/mappings). | `enable_ipv4: true` |
 | `enable_ipv6` | Should we do IPv6 DNS lookups when contacting services? Defaults to false, but can be overridden in a [`Mapping`](../../using/mappings). | `enable_ipv6: false` |
-| `envoy_log_format` | Defines the envoy log line format. See [this page](https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/access_log) for a complete list of operators | See [this page](https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#default-format-string) for the standard log format. |
+| `envoy_log_format` | Defines the envoy log json or line format. See [this page](https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/access_log) for a complete list of operators | See [this page](https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#default-format-string) for the standard log format. |
 | `envoy_log_path` | Defines the path of log envoy will use. By default this is standard output | `envoy_log_path: /dev/fd/1` |
-| `envoy_log_type` | Defines the type of log envoy will use, currently only support json or text | `envoy_log_type: text` |
+| `envoy_log_type` | Defines the type of log envoy will use, currently supports `json`, `typed_json`, or `text` | `envoy_log_type: text` |
 | `listener_idle_timeout_ms` | Controls how Envoy configures the tcp idle timeout on the http listener. Default is no timeout (TCP connection may remain idle indefinitely). | `listener_idle_timeout_ms: 30000` |
 | `lua_scripts` | Run a custom lua script on every request. see below for more details. |  |
 | `proper_case` | Should we enable upper casing for response headers? For more information, see [the Envoy docs](https://www.envoyproxy.io/docs/envoy/latest/api-v2/api/v2/core/protocol.proto#envoy-api-msg-core-http1protocoloptions-headerkeyformat) | `proper_case: false` |

--- a/python/tests/gold/envoyjsonlogtest/bootstrap-ads.json
+++ b/python/tests/gold/envoyjsonlogtest/bootstrap-ads.json
@@ -1,0 +1,77 @@
+{
+    "admin": {
+        "access_log_path": "/tmp/admin_access_log",
+        "address": {
+            "socket_address": {
+                "address": "127.0.0.1",
+                "port_value": 8001
+            }
+        }
+    },
+    "dynamic_resources": {
+        "ads_config": {
+            "api_type": "GRPC",
+            "grpc_services": [
+                {
+                    "envoy_grpc": {
+                        "cluster_name": "xds_cluster"
+                    }
+                }
+            ]
+        },
+        "cds_config": {
+            "ads": {}
+        },
+        "lds_config": {
+            "ads": {}
+        }
+    },
+    "layered_runtime": {
+        "layers": [
+            {
+                "name": "static_layer",
+                "static_layer": {
+                    "envoy.deprecated_features:envoy.api.v2.route.HeaderMatcher.regex_match": true,
+                    "envoy.deprecated_features:envoy.api.v2.route.RouteMatch.regex": true,
+                    "envoy.deprecated_features:envoy.config.filter.http.ext_authz.v2.ExtAuthz.use_alpha": true,
+                    "envoy.deprecated_features:envoy.config.trace.v2.ZipkinConfig.HTTP_JSON_V1": true
+                }
+            }
+        ]
+    },
+    "node": {
+        "cluster": "envoyjsonlogtest-default",
+        "id": "test-id"
+    },
+    "static_resources": {
+        "clusters": [
+            {
+                "connect_timeout": "1s",
+                "dns_lookup_family": "V4_ONLY",
+                "http2_protocol_options": {},
+                "lb_policy": "ROUND_ROBIN",
+                "load_assignment": {
+                    "cluster_name": "cluster_127_0_0_1_8003",
+                    "endpoints": [
+                        {
+                            "lb_endpoints": [
+                                {
+                                    "endpoint": {
+                                        "address": {
+                                            "socket_address": {
+                                                "address": "127.0.0.1",
+                                                "port_value": 8003,
+                                                "protocol": "TCP"
+                                            }
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                "name": "xds_cluster"
+            }
+        ]
+    }
+}

--- a/python/tests/gold/envoyjsonlogtest/snapshots/aconf.json
+++ b/python/tests/gold/envoyjsonlogtest/snapshots/aconf.json
@@ -1,0 +1,156 @@
+{
+    "_errors": {},
+    "_notices": {},
+    "_sources": {
+        "--diagnostics--": {
+            "_referenced_by": {},
+            "apiVersion": "getambassador.io/v0",
+            "description": "The '--diagnostics--' source marks objects created by Ambassador to assist with diagnostic output.",
+            "kind": "Diagnostics",
+            "location": "--diagnostics--",
+            "name": "Ambassador Diagnostics",
+            "namespace": null,
+            "rkey": "--diagnostics--",
+            "serialization": null,
+            "version": "getambassador.io/v0"
+        },
+        "--internal--": {
+            "_referenced_by": {},
+            "apiVersion": "getambassador.io/v0",
+            "description": "The '--internal--' source marks objects created by Ambassador's internal logic.",
+            "kind": "Internal",
+            "location": "--internal--",
+            "name": "Ambassador Internals",
+            "namespace": null,
+            "rkey": "--internal--",
+            "serialization": null,
+            "version": "getambassador.io/v0"
+        },
+        "envoyjsonlogtest.default.1": {
+            "_referenced_by": {},
+            "ambassador_id": "envoyjsonlogtest",
+            "apiVersion": "getambassador.io/v1",
+            "config": {
+                "envoy_log_type": "json",
+                "envoy_log_format": "{\"response_code\":\"%RESPONSE_CODE%\",\"authority\":\"%REQ(:AUTHORITY)%\",\"user_agent\":\"%REQ(USER-AGENT)%\",\"request_id\":\"%REQ(X-REQUEST-ID)%\",\"upstream_host\":\"%UPSTREAM_HOST%\"}",
+                "envoy_log_path": "/tmp/ambassador/ambassador_log.jsonl"
+            },
+            "kind": "Module",
+            "location": "envoyjsonlogtest.default.1",
+            "metadata_labels": {
+                "app.kubernetes.io/component": "ambassador-service",
+                "kat-ambassador-id": "envoyjsonlogtest",
+                "scope": "AmbassadorTest"
+            },
+            "name": "ambassador",
+            "namespace": "default",
+            "rkey": "envoyjsonlogtest.default.1",
+            "serialization": "ambassador_id: envoyjsonlogtest\napiVersion: ambassador/v1\nconfig:\n  envoy_log_type: json\n  envoy_log_format: {\"response_code\":\"%RESPONSE_CODE%\",\"authority\":\"%REQ(:AUTHORITY)%\",\"user_agent\":\"%REQ(USER-AGENT)%\",\"request_id\":\"%REQ(X-REQUEST-ID)%\",\"upstream_host\":\"%UPSTREAM_HOST%\"}\n  envoy_log_path: /tmp/ambassador/ambassador_log.jsonl\nkind: Module\nmetadata_labels:\n  app.kubernetes.io/component: ambassador-service\n  kat-ambassador-id: envoyjsonlogtest\n  scope: AmbassadorTest\nname: ambassador\nnamespace: default\n"
+        },
+        "k8s-envoyjsonlogtest-admin-default": {
+            "_referenced_by": {},
+            "ambassador_id": "envoyjsonlogtest",
+            "apiVersion": "getambassador.io/v2",
+            "endpoints": {},
+            "kind": "Service",
+            "location": "k8s-envoyjsonlogtest-admin-default",
+            "metadata_labels": {
+                "kat-ambassador-id": "envoyjsonlogtest",
+                "scope": "AmbassadorTest",
+                "service": "envoyjsonlogtest-admin"
+            },
+            "name": "envoyjsonlogtest-admin",
+            "namespace": "default",
+            "rkey": "k8s-envoyjsonlogtest-admin-default",
+            "serialization": "ambassador_id: envoyjsonlogtest\napiVersion: getambassador.io/v2\nendpoints: {}\nkind: Service\nmetadata_labels:\n  kat-ambassador-id: envoyjsonlogtest\n  scope: AmbassadorTest\n  service: envoyjsonlogtest-admin\nname: envoyjsonlogtest-admin\nnamespace: default\n"
+        },
+        "k8s-envoyjsonlogtest-default": {
+            "_referenced_by": {},
+            "ambassador_id": "envoyjsonlogtest",
+            "apiVersion": "getambassador.io/v2",
+            "endpoints": {},
+            "kind": "Service",
+            "location": "k8s-envoyjsonlogtest-default",
+            "metadata_labels": {
+                "app.kubernetes.io/component": "ambassador-service",
+                "kat-ambassador-id": "envoyjsonlogtest",
+                "scope": "AmbassadorTest"
+            },
+            "name": "envoyjsonlogtest",
+            "namespace": "default",
+            "rkey": "k8s-envoyjsonlogtest-default",
+            "serialization": "ambassador_id: envoyjsonlogtest\napiVersion: getambassador.io/v2\nendpoints: {}\nkind: Service\nmetadata_labels:\n  app.kubernetes.io/component: ambassador-service\n  kat-ambassador-id: envoyjsonlogtest\n  scope: AmbassadorTest\nname: envoyjsonlogtest\nnamespace: default\n"
+        },
+        "k8s-envoyjsonlogtest-http-default": {
+            "_referenced_by": {},
+            "ambassador_id": "envoyjsonlogtest",
+            "apiVersion": "getambassador.io/v2",
+            "endpoints": {},
+            "kind": "Service",
+            "location": "k8s-envoyjsonlogtest-http-default",
+            "metadata_labels": {
+                "kat-ambassador-id": "envoyjsonlogtest",
+                "scope": "AmbassadorTest"
+            },
+            "name": "envoyjsonlogtest-http",
+            "namespace": "default",
+            "rkey": "k8s-envoyjsonlogtest-http-default",
+            "serialization": "ambassador_id: envoyjsonlogtest\napiVersion: getambassador.io/v2\nendpoints: {}\nkind: Service\nmetadata_labels:\n  kat-ambassador-id: envoyjsonlogtest\n  scope: AmbassadorTest\nname: envoyjsonlogtest-http\nnamespace: default\n"
+        }
+    },
+    "modules": {
+        "ambassador": {
+            "apiVersion": "getambassador.io/v1",
+            "envoy_log_format": "{\"response_code\":\"%RESPONSE_CODE%\",\"authority\":\"%REQ(:AUTHORITY)%\",\"user_agent\":\"%REQ(USER-AGENT)%\",\"request_id\":\"%REQ(X-REQUEST-ID)%\",\"upstream_host\":\"%UPSTREAM_HOST%\"}",
+            "envoy_log_path": "/tmp/ambassador/ambassador.log",
+            "kind": "Module",
+            "metadata_labels": {
+                "app.kubernetes.io/component": "ambassador-service",
+                "kat-ambassador-id": "envoyjsonlogtest",
+                "scope": "AmbassadorTest"
+            },
+            "name": "ambassador",
+            "namespace": "default"
+        }
+    },
+    "service": {
+        "k8s-envoyjsonlogtest-admin-default": {
+            "ambassador_id": "envoyjsonlogtest",
+            "apiVersion": "getambassador.io/v2",
+            "endpoints": {},
+            "kind": "Service",
+            "metadata_labels": {
+                "kat-ambassador-id": "envoyjsonlogtest",
+                "scope": "AmbassadorTest",
+                "service": "envoyjsonlogtest-admin"
+            },
+            "name": "envoyjsonlogtest-admin",
+            "namespace": "default"
+        },
+        "k8s-envoyjsonlogtest-default": {
+            "ambassador_id": "envoyjsonlogtest",
+            "apiVersion": "getambassador.io/v2",
+            "endpoints": {},
+            "kind": "Service",
+            "metadata_labels": {
+                "app.kubernetes.io/component": "ambassador-service",
+                "kat-ambassador-id": "envoyjsonlogtest",
+                "scope": "AmbassadorTest"
+            },
+            "name": "envoyjsonlogtest",
+            "namespace": "default"
+        },
+        "k8s-envoyjsonlogtest-http-default": {
+            "ambassador_id": "envoyjsonlogtest",
+            "apiVersion": "getambassador.io/v2",
+            "endpoints": {},
+            "kind": "Service",
+            "metadata_labels": {
+                "kat-ambassador-id": "envoyjsonlogtest",
+                "scope": "AmbassadorTest"
+            },
+            "name": "envoyjsonlogtest-http",
+            "namespace": "default"
+        }
+    }
+}

--- a/python/tests/gold/envoyjsonlogtest/snapshots/econf.json
+++ b/python/tests/gold/envoyjsonlogtest/snapshots/econf.json
@@ -1,0 +1,249 @@
+{
+    "layered_runtime": {
+        "layers": [
+            {
+                "name": "static_layer",
+                "static_layer": {
+                    "envoy.deprecated_features:envoy.api.v2.route.HeaderMatcher.regex_match": true,
+                    "envoy.deprecated_features:envoy.api.v2.route.RouteMatch.regex": true,
+                    "envoy.deprecated_features:envoy.config.filter.http.ext_authz.v2.ExtAuthz.use_alpha": true,
+                    "envoy.deprecated_features:envoy.config.trace.v2.ZipkinConfig.HTTP_JSON_V1": true
+                }
+            }
+        ]
+    },
+    "static_resources": {
+        "clusters": [
+            {
+                "connect_timeout": "3.000s",
+                "dns_lookup_family": "V4_ONLY",
+                "lb_policy": "ROUND_ROBIN",
+                "load_assignment": {
+                    "cluster_name": "cluster_127_0_0_1_8877_default",
+                    "endpoints": [
+                        {
+                            "lb_endpoints": [
+                                {
+                                    "endpoint": {
+                                        "address": {
+                                            "socket_address": {
+                                                "address": "127.0.0.1",
+                                                "port_value": 8877,
+                                                "protocol": "TCP"
+                                            }
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                "name": "cluster_127_0_0_1_8877_default",
+                "type": "STRICT_DNS"
+            }
+        ],
+        "listeners": [
+            {
+                "address": {
+                    "socket_address": {
+                        "address": "0.0.0.0",
+                        "port_value": 8080,
+                        "protocol": "TCP"
+                    }
+                },
+                "filter_chains": [
+                    {
+                        "filter_chain_match": {},
+                        "filters": [
+                            {
+                                "name": "envoy.http_connection_manager",
+                                "typed_config": {
+                                    "@type": "type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager",
+                                    "access_log": [
+                                        {
+                                            "name": "envoy.file_access_log",
+                                            "typed_config": {
+                                                "@type": "type.googleapis.com/envoy.config.accesslog.v2.FileAccessLog",
+                                                "json_format": {
+                                                    "authority": "%REQ(:AUTHORITY)%",
+                                                    "request_id": "%REQ(X-REQUEST-ID)%",
+                                                    "response_code": "%RESPONSE_CODE%",
+                                                    "upstream_host": "%UPSTREAM_HOST%",
+                                                    "user_agent": "%REQ(USER-AGENT)%"
+                                                },
+                                                "path": "/tmp/ambassador/ambassador_log.jsonl"
+                                            }
+                                        }
+                                    ],
+                                    "http_filters": [
+                                        {
+                                            "name": "envoy.cors"
+                                        },
+                                        {
+                                            "name": "envoy.router"
+                                        }
+                                    ],
+                                    "http_protocol_options": {
+                                        "accept_http_10": false
+                                    },
+                                    "normalize_path": true,
+                                    "route_config": {
+                                        "virtual_hosts": [
+                                            {
+                                                "domains": [
+                                                    "*"
+                                                ],
+                                                "name": "ambassador-listener-8080-*",
+                                                "routes": [
+                                                    {
+                                                        "match": {
+                                                            "case_sensitive": true,
+                                                            "headers": [
+                                                                {
+                                                                    "exact_match": "https",
+                                                                    "name": "x-forwarded-proto"
+                                                                }
+                                                            ],
+                                                            "prefix": "/ambassador/v0/check_ready",
+                                                            "runtime_fraction": {
+                                                                "default_value": {
+                                                                    "denominator": "HUNDRED",
+                                                                    "numerator": 100
+                                                                },
+                                                                "runtime_key": "routing.traffic_shift.cluster_127_0_0_1_8877_default"
+                                                            }
+                                                        },
+                                                        "route": {
+                                                            "cluster": "cluster_127_0_0_1_8877_default",
+                                                            "prefix_rewrite": "/ambassador/v0/check_ready",
+                                                            "priority": null,
+                                                            "timeout": "10.000s"
+                                                        }
+                                                    },
+                                                    {
+                                                        "match": {
+                                                            "case_sensitive": true,
+                                                            "prefix": "/ambassador/v0/check_ready",
+                                                            "runtime_fraction": {
+                                                                "default_value": {
+                                                                    "denominator": "HUNDRED",
+                                                                    "numerator": 100
+                                                                },
+                                                                "runtime_key": "routing.traffic_shift.cluster_127_0_0_1_8877_default"
+                                                            }
+                                                        },
+                                                        "route": {
+                                                            "cluster": "cluster_127_0_0_1_8877_default",
+                                                            "prefix_rewrite": "/ambassador/v0/check_ready",
+                                                            "priority": null,
+                                                            "timeout": "10.000s"
+                                                        }
+                                                    },
+                                                    {
+                                                        "match": {
+                                                            "case_sensitive": true,
+                                                            "headers": [
+                                                                {
+                                                                    "exact_match": "https",
+                                                                    "name": "x-forwarded-proto"
+                                                                }
+                                                            ],
+                                                            "prefix": "/ambassador/v0/check_alive",
+                                                            "runtime_fraction": {
+                                                                "default_value": {
+                                                                    "denominator": "HUNDRED",
+                                                                    "numerator": 100
+                                                                },
+                                                                "runtime_key": "routing.traffic_shift.cluster_127_0_0_1_8877_default"
+                                                            }
+                                                        },
+                                                        "route": {
+                                                            "cluster": "cluster_127_0_0_1_8877_default",
+                                                            "prefix_rewrite": "/ambassador/v0/check_alive",
+                                                            "priority": null,
+                                                            "timeout": "10.000s"
+                                                        }
+                                                    },
+                                                    {
+                                                        "match": {
+                                                            "case_sensitive": true,
+                                                            "prefix": "/ambassador/v0/check_alive",
+                                                            "runtime_fraction": {
+                                                                "default_value": {
+                                                                    "denominator": "HUNDRED",
+                                                                    "numerator": 100
+                                                                },
+                                                                "runtime_key": "routing.traffic_shift.cluster_127_0_0_1_8877_default"
+                                                            }
+                                                        },
+                                                        "route": {
+                                                            "cluster": "cluster_127_0_0_1_8877_default",
+                                                            "prefix_rewrite": "/ambassador/v0/check_alive",
+                                                            "priority": null,
+                                                            "timeout": "10.000s"
+                                                        }
+                                                    },
+                                                    {
+                                                        "match": {
+                                                            "case_sensitive": true,
+                                                            "headers": [
+                                                                {
+                                                                    "exact_match": "https",
+                                                                    "name": "x-forwarded-proto"
+                                                                }
+                                                            ],
+                                                            "prefix": "/ambassador/v0/",
+                                                            "runtime_fraction": {
+                                                                "default_value": {
+                                                                    "denominator": "HUNDRED",
+                                                                    "numerator": 100
+                                                                },
+                                                                "runtime_key": "routing.traffic_shift.cluster_127_0_0_1_8877_default"
+                                                            }
+                                                        },
+                                                        "route": {
+                                                            "cluster": "cluster_127_0_0_1_8877_default",
+                                                            "prefix_rewrite": "/ambassador/v0/",
+                                                            "priority": null,
+                                                            "timeout": "10.000s"
+                                                        }
+                                                    },
+                                                    {
+                                                        "match": {
+                                                            "case_sensitive": true,
+                                                            "prefix": "/ambassador/v0/",
+                                                            "runtime_fraction": {
+                                                                "default_value": {
+                                                                    "denominator": "HUNDRED",
+                                                                    "numerator": 100
+                                                                },
+                                                                "runtime_key": "routing.traffic_shift.cluster_127_0_0_1_8877_default"
+                                                            }
+                                                        },
+                                                        "route": {
+                                                            "cluster": "cluster_127_0_0_1_8877_default",
+                                                            "prefix_rewrite": "/ambassador/v0/",
+                                                            "priority": null,
+                                                            "timeout": "10.000s"
+                                                        }
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "server_name": "envoy",
+                                    "stat_prefix": "ingress_http",
+                                    "use_remote_address": true,
+                                    "xff_num_trusted_hops": 0
+                                }
+                            }
+                        ]
+                    }
+                ],
+                "listener_filters": [],
+                "name": "ambassador-listener-8080",
+                "traffic_direction": "UNSPECIFIED"
+            }
+        ]
+    }
+}

--- a/python/tests/gold/envoyjsonlogtest/snapshots/ir.json
+++ b/python/tests/gold/envoyjsonlogtest/snapshots/ir.json
@@ -1,0 +1,465 @@
+{
+    "ambassador": {
+        "_active": true,
+        "_errored": false,
+        "_finalized": true,
+        "_referenced_by": [
+            "envoyjsonlogtest.default.1"
+        ],
+        "_rkey": "envoyjsonlogtest.default.1",
+        "admin_port": 8001,
+        "debug_mode": false,
+        "default_label_domain": "ambassador",
+        "default_labels": {},
+        "diag_port": 8877,
+        "diagnostics": {
+            "enabled": true,
+            "prefix": "/ambassador/v0/",
+            "rewrite": "/ambassador/v0/",
+            "service": "127.0.0.1:8877"
+        },
+        "enable_http10": false,
+        "enable_ipv4": true,
+        "enable_ipv6": false,
+        "envoy_log_format": "{\"response_code\":\"%RESPONSE_CODE%\",\"authority\":\"%REQ(:AUTHORITY)%\",\"user_agent\":\"%REQ(USER-AGENT)%\",\"request_id\":\"%REQ(X-REQUEST-ID)%\",\"upstream_host\":\"%UPSTREAM_HOST%\"}",
+        "envoy_log_path": "/tmp/ambassador/ambassador_log.jsonl",
+        "envoy_log_type": "json",
+        "kind": "IRAmbassador",
+        "liveness_probe": {
+            "enabled": true,
+            "prefix": "/ambassador/v0/check_alive",
+            "rewrite": "/ambassador/v0/check_alive",
+            "service": "127.0.0.1:8877"
+        },
+        "location": "envoyjsonlogtest.default.1",
+        "name": "ir.ambassador",
+        "namespace": "default",
+        "proper_case": false,
+        "readiness_probe": {
+            "enabled": true,
+            "prefix": "/ambassador/v0/check_ready",
+            "rewrite": "/ambassador/v0/check_ready",
+            "service": "127.0.0.1:8877"
+        },
+        "server_name": "envoy",
+        "service_port": 8080,
+        "use_ambassador_namespace_for_service_resolution": false,
+        "use_proxy_proto": false,
+        "use_remote_address": true,
+        "x_forwarded_proto_redirect": false,
+        "xff_num_trusted_hops": 0
+    },
+    "clusters": {
+        "cluster_127_0_0_1_8877_default": {
+            "_active": true,
+            "_errored": false,
+            "_hostname": "127.0.0.1",
+            "_is_sidecar": false,
+            "_namespace": "default",
+            "_port": 8877,
+            "_referenced_by": [
+                "envoyjsonlogtest.default.1"
+            ],
+            "_resolver": "kubernetes-service",
+            "_rkey": "cluster_127_0_0_1_8877_default",
+            "connect_timeout_ms": 3000,
+            "enable_endpoints": false,
+            "enable_ipv4": true,
+            "enable_ipv6": false,
+            "ignore_cluster": false,
+            "kind": "IRCluster",
+            "lb_type": "round_robin",
+            "location": "envoyjsonlogtest.default.1",
+            "name": "cluster_127_0_0_1_8877_default",
+            "namespace": "default",
+            "service": "127.0.0.1:8877",
+            "targets": [
+                {
+                    "ip": "127.0.0.1",
+                    "port": 8877,
+                    "target_kind": "IPaddr"
+                }
+            ],
+            "type": "strict_dns",
+            "urls": [
+                "tcp://127.0.0.1:8877"
+            ]
+        }
+    },
+    "filters": [
+        {
+            "_active": true,
+            "_errored": false,
+            "_rkey": "ir.cors",
+            "config": {},
+            "kind": "ir.cors",
+            "location": "--internal--",
+            "name": "cors",
+            "namespace": "default"
+        },
+        {
+            "_active": true,
+            "_errored": false,
+            "_rkey": "ir.router",
+            "config": {},
+            "kind": "ir.router",
+            "location": "--internal--",
+            "name": "router",
+            "namespace": "default",
+            "type": "decoder"
+        }
+    ],
+    "groups": [
+        {
+            "_active": true,
+            "_errored": false,
+            "_referenced_by": [
+                "envoyjsonlogtest.default.1"
+            ],
+            "_rkey": "envoyjsonlogtest.default.1",
+            "group_id": "b4db12f5b638f1750062dd4220911c4f6f44fc57",
+            "group_weight": [
+                0,
+                26,
+                0,
+                "/ambassador/v0/check_ready",
+                "GET"
+            ],
+            "headers": [],
+            "kind": "IRHTTPMappingGroup",
+            "location": "envoyjsonlogtest.default.1",
+            "mappings": [
+                {
+                    "_active": true,
+                    "_errored": false,
+                    "_referenced_by": [
+                        "envoyjsonlogtest.default.1"
+                    ],
+                    "_rkey": "envoyjsonlogtest.default.1",
+                    "add_request_headers": {},
+                    "cluster": {
+                        "_active": true,
+                        "_errored": false,
+                        "_hostname": "127.0.0.1",
+                        "_is_sidecar": false,
+                        "_namespace": "default",
+                        "_port": 8877,
+                        "_referenced_by": [
+                            "envoyjsonlogtest.default.1"
+                        ],
+                        "_resolver": "kubernetes-service",
+                        "_rkey": "cluster_127_0_0_1_8877_default",
+                        "connect_timeout_ms": 3000,
+                        "enable_endpoints": false,
+                        "enable_ipv4": true,
+                        "enable_ipv6": false,
+                        "ignore_cluster": false,
+                        "kind": "IRCluster",
+                        "lb_type": "round_robin",
+                        "location": "envoyjsonlogtest.default.1",
+                        "name": "cluster_127_0_0_1_8877_default",
+                        "namespace": "default",
+                        "service": "127.0.0.1:8877",
+                        "targets": [
+                            {
+                                "ip": "127.0.0.1",
+                                "port": 8877,
+                                "target_kind": "IPaddr"
+                            }
+                        ],
+                        "type": "strict_dns",
+                        "urls": [
+                            "tcp://127.0.0.1:8877"
+                        ]
+                    },
+                    "group_id": "b4db12f5b638f1750062dd4220911c4f6f44fc57",
+                    "headers": [],
+                    "kind": "IRHTTPMapping",
+                    "location": "envoyjsonlogtest.default.1",
+                    "name": "internal_readiness_probe_mapping",
+                    "namespace": "default",
+                    "precedence": 0,
+                    "prefix": "/ambassador/v0/check_ready",
+                    "resolver": "kubernetes-service",
+                    "rewrite": "/ambassador/v0/check_ready",
+                    "route_weight": [
+                        0,
+                        26,
+                        0,
+                        "/ambassador/v0/check_ready",
+                        "GET"
+                    ],
+                    "service": "127.0.0.1:8877",
+                    "timeout_ms": 10000,
+                    "weight": 100
+                }
+            ],
+            "name": "GROUP: internal_readiness_probe_mapping",
+            "namespace": "default",
+            "precedence": 0,
+            "prefix": "/ambassador/v0/check_ready",
+            "rewrite": "/ambassador/v0/check_ready",
+            "timeout_ms": 10000
+        },
+        {
+            "_active": true,
+            "_errored": false,
+            "_referenced_by": [
+                "envoyjsonlogtest.default.1"
+            ],
+            "_rkey": "envoyjsonlogtest.default.1",
+            "group_id": "7df546235997704c909d473af2cbcb5e606d20de",
+            "group_weight": [
+                0,
+                26,
+                0,
+                "/ambassador/v0/check_alive",
+                "GET"
+            ],
+            "headers": [],
+            "kind": "IRHTTPMappingGroup",
+            "location": "envoyjsonlogtest.default.1",
+            "mappings": [
+                {
+                    "_active": true,
+                    "_errored": false,
+                    "_referenced_by": [
+                        "envoyjsonlogtest.default.1"
+                    ],
+                    "_rkey": "envoyjsonlogtest.default.1",
+                    "add_request_headers": {},
+                    "cluster": {
+                        "_active": true,
+                        "_errored": false,
+                        "_hostname": "127.0.0.1",
+                        "_is_sidecar": false,
+                        "_namespace": "default",
+                        "_port": 8877,
+                        "_referenced_by": [
+                            "envoyjsonlogtest.default.1"
+                        ],
+                        "_resolver": "kubernetes-service",
+                        "_rkey": "cluster_127_0_0_1_8877_default",
+                        "connect_timeout_ms": 3000,
+                        "enable_endpoints": false,
+                        "enable_ipv4": true,
+                        "enable_ipv6": false,
+                        "ignore_cluster": false,
+                        "kind": "IRCluster",
+                        "lb_type": "round_robin",
+                        "location": "envoyjsonlogtest.default.1",
+                        "name": "cluster_127_0_0_1_8877_default",
+                        "namespace": "default",
+                        "service": "127.0.0.1:8877",
+                        "targets": [
+                            {
+                                "ip": "127.0.0.1",
+                                "port": 8877,
+                                "target_kind": "IPaddr"
+                            }
+                        ],
+                        "type": "strict_dns",
+                        "urls": [
+                            "tcp://127.0.0.1:8877"
+                        ]
+                    },
+                    "group_id": "7df546235997704c909d473af2cbcb5e606d20de",
+                    "headers": [],
+                    "kind": "IRHTTPMapping",
+                    "location": "envoyjsonlogtest.default.1",
+                    "name": "internal_liveness_probe_mapping",
+                    "namespace": "default",
+                    "precedence": 0,
+                    "prefix": "/ambassador/v0/check_alive",
+                    "resolver": "kubernetes-service",
+                    "rewrite": "/ambassador/v0/check_alive",
+                    "route_weight": [
+                        0,
+                        26,
+                        0,
+                        "/ambassador/v0/check_alive",
+                        "GET"
+                    ],
+                    "service": "127.0.0.1:8877",
+                    "timeout_ms": 10000,
+                    "weight": 100
+                }
+            ],
+            "name": "GROUP: internal_liveness_probe_mapping",
+            "namespace": "default",
+            "precedence": 0,
+            "prefix": "/ambassador/v0/check_alive",
+            "rewrite": "/ambassador/v0/check_alive",
+            "timeout_ms": 10000
+        },
+        {
+            "_active": true,
+            "_errored": false,
+            "_referenced_by": [
+                "envoyjsonlogtest.default.1"
+            ],
+            "_rkey": "envoyjsonlogtest.default.1",
+            "group_id": "8de18501d2044fe30db225289b318d5fda913b64",
+            "group_weight": [
+                0,
+                15,
+                0,
+                "/ambassador/v0/",
+                "GET"
+            ],
+            "headers": [],
+            "kind": "IRHTTPMappingGroup",
+            "location": "envoyjsonlogtest.default.1",
+            "mappings": [
+                {
+                    "_active": true,
+                    "_errored": false,
+                    "_referenced_by": [
+                        "envoyjsonlogtest.default.1"
+                    ],
+                    "_rkey": "envoyjsonlogtest.default.1",
+                    "add_request_headers": {},
+                    "cluster": {
+                        "_active": true,
+                        "_errored": false,
+                        "_hostname": "127.0.0.1",
+                        "_is_sidecar": false,
+                        "_namespace": "default",
+                        "_port": 8877,
+                        "_referenced_by": [
+                            "envoyjsonlogtest.default.1"
+                        ],
+                        "_resolver": "kubernetes-service",
+                        "_rkey": "cluster_127_0_0_1_8877_default",
+                        "connect_timeout_ms": 3000,
+                        "enable_endpoints": false,
+                        "enable_ipv4": true,
+                        "enable_ipv6": false,
+                        "ignore_cluster": false,
+                        "kind": "IRCluster",
+                        "lb_type": "round_robin",
+                        "location": "envoyjsonlogtest.default.1",
+                        "name": "cluster_127_0_0_1_8877_default",
+                        "namespace": "default",
+                        "service": "127.0.0.1:8877",
+                        "targets": [
+                            {
+                                "ip": "127.0.0.1",
+                                "port": 8877,
+                                "target_kind": "IPaddr"
+                            }
+                        ],
+                        "type": "strict_dns",
+                        "urls": [
+                            "tcp://127.0.0.1:8877"
+                        ]
+                    },
+                    "group_id": "8de18501d2044fe30db225289b318d5fda913b64",
+                    "headers": [],
+                    "kind": "IRHTTPMapping",
+                    "location": "envoyjsonlogtest.default.1",
+                    "name": "internal_diagnostics_probe_mapping",
+                    "namespace": "default",
+                    "precedence": 0,
+                    "prefix": "/ambassador/v0/",
+                    "resolver": "kubernetes-service",
+                    "rewrite": "/ambassador/v0/",
+                    "route_weight": [
+                        0,
+                        15,
+                        0,
+                        "/ambassador/v0/",
+                        "GET"
+                    ],
+                    "service": "127.0.0.1:8877",
+                    "timeout_ms": 10000,
+                    "weight": 100
+                }
+            ],
+            "name": "GROUP: internal_diagnostics_probe_mapping",
+            "namespace": "default",
+            "precedence": 0,
+            "prefix": "/ambassador/v0/",
+            "rewrite": "/ambassador/v0/",
+            "timeout_ms": 10000
+        }
+    ],
+    "grpc_services": {},
+    "hosts": [],
+    "identity": {
+        "ambassador_id": "envoyjsonlogtest",
+        "ambassador_namespace": "default",
+        "ambassador_nodename": "envoyjsonlogtest-default"
+    },
+    "k8s_status_updates": {},
+    "listeners": [
+        {
+            "_active": true,
+            "_errored": false,
+            "_rkey": "ir.listener",
+            "hostname": "*",
+            "insecure_action": "Route",
+            "kind": "IRListener",
+            "location": "envoyjsonlogtest.default.1",
+            "name": "ir.listener",
+            "namespace": "default",
+            "redirect_listener": false,
+            "secure_action": "Route",
+            "service_port": 8080,
+            "use_proxy_proto": false
+        }
+    ],
+    "services": {
+        "k8s-envoyjsonlogtest-admin-default": {
+            "_referenced_by": {},
+            "ambassador_id": "envoyjsonlogtest",
+            "apiVersion": "getambassador.io/v2",
+            "endpoints": {},
+            "kind": "Service",
+            "location": "k8s-envoyjsonlogtest-admin-default",
+            "metadata_labels": {
+                "kat-ambassador-id": "envoyjsonlogtest",
+                "scope": "AmbassadorTest",
+                "service": "envoyjsonlogtest-admin"
+            },
+            "name": "envoyjsonlogtest-admin",
+            "namespace": "default",
+            "rkey": "k8s-envoyjsonlogtest-admin-default",
+            "serialization": "ambassador_id: envoyjsonlogtest\napiVersion: getambassador.io/v2\nendpoints: {}\nkind: Service\nmetadata_labels:\n  kat-ambassador-id: envoyjsonlogtest\n  scope: AmbassadorTest\n  service: envoyjsonlogtest-admin\nname: envoyjsonlogtest-admin\nnamespace: default\n"
+        },
+        "k8s-envoyjsonlogtest-default": {
+            "_referenced_by": {},
+            "ambassador_id": "envoyjsonlogtest",
+            "apiVersion": "getambassador.io/v2",
+            "endpoints": {},
+            "kind": "Service",
+            "location": "k8s-envoyjsonlogtest-default",
+            "metadata_labels": {
+                "app.kubernetes.io/component": "ambassador-service",
+                "kat-ambassador-id": "envoyjsonlogtest",
+                "scope": "AmbassadorTest"
+            },
+            "name": "envoyjsonlogtest",
+            "namespace": "default",
+            "rkey": "k8s-envoyjsonlogtest-default",
+            "serialization": "ambassador_id: envoyjsonlogtest\napiVersion: getambassador.io/v2\nendpoints: {}\nkind: Service\nmetadata_labels:\n  app.kubernetes.io/component: ambassador-service\n  kat-ambassador-id: envoyjsonlogtest\n  scope: AmbassadorTest\nname: envoyjsonlogtest\nnamespace: default\n"
+        },
+        "k8s-envoyjsonlogtest-http-default": {
+            "_referenced_by": {},
+            "ambassador_id": "envoyjsonlogtest",
+            "apiVersion": "getambassador.io/v2",
+            "endpoints": {},
+            "kind": "Service",
+            "location": "k8s-envoyjsonlogtest-http-default",
+            "metadata_labels": {
+                "kat-ambassador-id": "envoyjsonlogtest",
+                "scope": "AmbassadorTest"
+            },
+            "name": "envoyjsonlogtest-http",
+            "namespace": "default",
+            "rkey": "k8s-envoyjsonlogtest-http-default",
+            "serialization": "ambassador_id: envoyjsonlogtest\napiVersion: getambassador.io/v2\nendpoints: {}\nkind: Service\nmetadata_labels:\n  kat-ambassador-id: envoyjsonlogtest\n  scope: AmbassadorTest\nname: envoyjsonlogtest-http\nnamespace: default\n"
+        }
+    },
+    "tls_contexts": []
+}

--- a/python/tests/gold/envoyjsonlogtest/snapshots/snapshot.yaml
+++ b/python/tests/gold/envoyjsonlogtest/snapshots/snapshot.yaml
@@ -1,0 +1,154 @@
+{
+    "Consul": {},
+    "Kubernetes": {
+        "AuthService": null,
+        "ConsulResolver": null,
+        "Host": null,
+        "KubernetesEndpointResolver": null,
+        "KubernetesServiceResolver": null,
+        "LogService": null,
+        "Mapping": null,
+        "Module": null,
+        "RateLimitService": null,
+        "TCPMapping": null,
+        "TLSContext": null,
+        "TracingService": null,
+        "ingresses": null,
+        "service": [
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "getambassador.io/config": "---\napiVersion: ambassador/v1\nkind: Module\nname: ambassador\nambassador_id: envoyjsonlogtest\nconfig:\n  envoy_log_path: /tmp/ambassador/ambassador.log\n  envoy_log_format: MY_REQUEST %RESPONSE_CODE% \"%REQ(:AUTHORITY)%\" \"%REQ(USER-AGENT)%\"\n    \"%REQ(X-REQUEST-ID)%\" \"%UPSTREAM_HOST%\"\n",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{\"getambassador.io/config\":\"---\\napiVersion: ambassador/v1\\nkind: Module\\nname: ambassador\\nambassador_id: envoyjsonlogtest\\nconfig:\\n  envoy_log_path: /tmp/ambassador/ambassador.log\\n  envoy_log_format: MY_REQUEST %RESPONSE_CODE% \\\"%REQ(:AUTHORITY)%\\\" \\\"%REQ(USER-AGENT)%\\\"\\n    \\\"%REQ(X-REQUEST-ID)%\\\" \\\"%UPSTREAM_HOST%\\\"\\n\"},\"labels\":{\"app.kubernetes.io/component\":\"ambassador-service\",\"kat-ambassador-id\":\"envoyjsonlogtest\",\"scope\":\"AmbassadorTest\"},\"name\":\"envoyjsonlogtest\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8080},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8443}],\"selector\":{\"service\":\"envoyjsonlogtest\"},\"type\":\"NodePort\"}}\n"
+                    },
+                    "creationTimestamp": "2020-02-26T15:54:11Z",
+                    "labels": {
+                        "app.kubernetes.io/component": "ambassador-service",
+                        "kat-ambassador-id": "envoyjsonlogtest",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "envoyjsonlogtest",
+                    "namespace": "default",
+                    "resourceVersion": "68869",
+                    "selfLink": "/api/v1/namespaces/default/services/envoyjsonlogtest",
+                    "uid": "3b17b103-58b0-11ea-86d6-0e674b3ff44f"
+                },
+                "spec": {
+                    "clusterIP": "10.100.90.219",
+                    "externalTrafficPolicy": "Cluster",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "nodePort": 30720,
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8080
+                        },
+                        {
+                            "name": "https",
+                            "nodePort": 32196,
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8443
+                        }
+                    ],
+                    "selector": {
+                        "service": "envoyjsonlogtest"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "NodePort"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"envoyjsonlogtest\",\"scope\":\"AmbassadorTest\",\"service\":\"envoyjsonlogtest-admin\"},\"name\":\"envoyjsonlogtest-admin\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"envoyjsonlogtest-admin\",\"port\":8877,\"targetPort\":8877}],\"selector\":{\"service\":\"envoyjsonlogtest\"},\"type\":\"NodePort\"}}\n"
+                    },
+                    "creationTimestamp": "2020-02-26T15:54:13Z",
+                    "labels": {
+                        "kat-ambassador-id": "envoyjsonlogtest",
+                        "scope": "AmbassadorTest",
+                        "service": "envoyjsonlogtest-admin"
+                    },
+                    "name": "envoyjsonlogtest-admin",
+                    "namespace": "default",
+                    "resourceVersion": "68882",
+                    "selfLink": "/api/v1/namespaces/default/services/envoyjsonlogtest-admin",
+                    "uid": "3bebcab2-58b0-11ea-86d6-0e674b3ff44f"
+                },
+                "spec": {
+                    "clusterIP": "10.106.95.236",
+                    "externalTrafficPolicy": "Cluster",
+                    "ports": [
+                        {
+                            "name": "envoyjsonlogtest-admin",
+                            "nodePort": 30347,
+                            "port": 8877,
+                            "protocol": "TCP",
+                            "targetPort": 8877
+                        }
+                    ],
+                    "selector": {
+                        "service": "envoyjsonlogtest"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "NodePort"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                    "annotations": {
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"kat-ambassador-id\":\"envoyjsonlogtest\",\"scope\":\"AmbassadorTest\"},\"name\":\"envoyjsonlogtest-http\",\"namespace\":\"default\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":8138},{\"name\":\"https\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":8501}],\"selector\":{\"backend\":\"superpod-default\"}}}\n"
+                    },
+                    "creationTimestamp": "2020-02-26T15:54:14Z",
+                    "labels": {
+                        "kat-ambassador-id": "envoyjsonlogtest",
+                        "scope": "AmbassadorTest"
+                    },
+                    "name": "envoyjsonlogtest-http",
+                    "namespace": "default",
+                    "resourceVersion": "68889",
+                    "selfLink": "/api/v1/namespaces/default/services/envoyjsonlogtest-http",
+                    "uid": "3c87e9bc-58b0-11ea-86d6-0e674b3ff44f"
+                },
+                "spec": {
+                    "clusterIP": "10.104.209.18",
+                    "ports": [
+                        {
+                            "name": "http",
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 8138
+                        },
+                        {
+                            "name": "https",
+                            "port": 443,
+                            "protocol": "TCP",
+                            "targetPort": 8501
+                        }
+                    ],
+                    "selector": {
+                        "backend": "superpod-default"
+                    },
+                    "sessionAffinity": "None",
+                    "type": "ClusterIP"
+                },
+                "status": {
+                    "loadBalancer": {}
+                }
+            }
+        ]
+    }
+}

--- a/python/tests/t_envoy_logs.py
+++ b/python/tests/t_envoy_logs.py
@@ -6,7 +6,7 @@ from kat.utils import ShellCommand
 from abstract_tests import AmbassadorTest, ServiceType, HTTP
 
 access_log_entry_regex = re.compile('^MY_REQUEST 200 .*')
-
+access_log_json_entry_regex = re.compile('.*"response_code":.*"200".*')
 
 class EnvoyLogTest(AmbassadorTest):
     target: ServiceType
@@ -39,3 +39,37 @@ config:
 
         for line in cmd.stdout.splitlines():
             assert access_log_entry_regex.match(line), f"{line} does not match {access_log_entry_regex}"
+
+class EnvoyJsonLogTest(AmbassadorTest):
+    target: ServiceType
+    log_path: str
+    log_format: str
+
+    def init(self):
+        if EDGE_STACK:
+            self.xfail = "Not yet supported in Edge Stack"
+
+        self.target = HTTP()
+        self.log_path = '/tmp/ambassador/ambassador_log.jsonl'
+        self.log_format = '{"response_code":"%RESPONSE_CODE%","authority":"%REQ(:AUTHORITY)%","user_agent":"%REQ(USER-AGENT)%","request_id":"%REQ(X-REQUEST-ID)%","upstream_host":"%UPSTREAM_HOST%"}'
+
+    def config(self):
+        yield self, self.format("""
+---
+apiVersion: ambassador/v1
+kind: Module
+name: ambassador
+ambassador_id: {self.ambassador_id}
+config:
+  envoy_log_path: {self.log_path}
+  envoy_log_type: json
+  envoy_log_format: '{self.log_format}'
+""")
+
+    def check(self):
+        cmd = ShellCommand("kubectl", "exec", self.path.k8s, "cat", self.log_path)
+        if not cmd.check("check envoy access log"):
+            pytest.exit("envoy access log does not exist")
+
+        for line in cmd.stdout.splitlines():
+            assert access_log_json_entry_regex.match(line), f"{line} does not match {access_log_json_entry_regex}"


### PR DESCRIPTION
## Description
This adds capability to use envoy's custom json log formatting using `envoy_log_type` and `envoy_log_format` config entries.

## Related Issues
#2593

## Testing
Added test similar to existing EnvoyLogTest

## Tasks That Must Be Done
- [X] Did you update CHANGELOG.md?
- [X] Did you add or update tests?
- [X] Did you update documentation?

