### PR TITLE
QuickStart_add -lproduct to yaml code block

### DIFF
--- a/docs/tutorials/GettingStarted.js
+++ b/docs/tutorials/GettingStarted.js
@@ -196,6 +196,7 @@ class GettingStarted extends Component {
                     <span className="token plain"> </span>
                     <span className="token-plain">deploy</span>
                     <span className="token plain"> </span>
+                    <span className="token plain">-lproduct</span>
                     <span className="token-plain">=</span>
                     <span className="token-plain">aes</span>
                   </div>

--- a/docs/tutorials/GettingStarted.js
+++ b/docs/tutorials/GettingStarted.js
@@ -58,7 +58,7 @@ class GettingStarted extends Component {
               <div className="token-line">
                 <span className="token plain">sudo</span>
                 <span className="token plain"> </span>
-                <span className="token-plan">curl</span>
+                <span className="token-plain">curl</span>
                 <span className="token plain"> -fL https://metriton.datawire.io/downloads/darwin/edgectl <br/>   -o /usr/local/bin/edgectl </span>
                 <span className="token plain">&&</span><br/>
                 <span className="token plain">  </span>


### PR DESCRIPTION
## Description
Corrects the yaml instructions to match what is copied by the copy button.  Makes "token plain" the style applied to all code block code.

<img width="808" alt="yaml fix" src="https://user-images.githubusercontent.com/57576741/82369540-084f1500-99cc-11ea-8519-42900904a558.png">

## Related Issues
List related issues.

## Testing
A few sentences describing what testing you've done, e.g., manual tests, automated tests, deployed in production, etc.

## Tasks That Must Be Done
- [ ] Did you update CHANGELOG.md?
- [ ] Did you add or update tests?
- [ ] Did you update documentation?
- [ ] Were there any special dev tricks you had to use to work on this code efficiently?
  + [ ] Did you add them to DEVELOPING.md?
- [ ] Is this a build change?
  + [ ] If so, did you test on both Mac and Linux?

## Other
* If this is a documentation change for a particular release, please open the pull request against the release branch.
