### PR TITLE
Docs: reinstate mac, linux, windows install options using 'edgectl install'

### DIFF
--- a/docs/topics/install/index.md
+++ b/docs/topics/install/index.md
@@ -6,6 +6,9 @@ import './index.less'
 <div class="index-dropdown">
   <button class="index-dropBtn">Jump to Installation Type</button>
   <div class="index-dropdownContent">
+    <a href="#index-installMac">Mac</a>	
+    <a href="#index-installLinux">Linux</a>	
+    <a href="#index-installWindows">Windows</a>
     <a href="#index-installKubernetesYaml">Kubernetes YAML</a>
     <a href="#index-installHelm">Helm</a>
     <a href="#index-installDocker">Docker</a>
@@ -15,6 +18,56 @@ import './index.less'
   </div>
 </div>
 </div>
+
+<span id="index-installMac"></span><br/>	
+
+## <img class="os-logo" src="../../images/apple.png"/> Install from MacOS 	
+1. (1a) [Download the `edgectl` installer](https://metriton.datawire.io/downloads/darwin/edgectl) 	
+ or (1b) download it with a curl command:	
+
+    ```shell	
+    sudo curl -fL https://metriton.datawire.io/downloads/darwin/edgectl -o /usr/local/bin/edgectl && sudo chmod a+x /usr/local/bin/edgectl	
+    ```	
+
+    If you decide to download the file with (1b), you may encounter a security block. To continue, use this procedure:	
+    * Go to **System Preferences > Security & Privacy > General**.	
+    * Click the **Open Anyway** button.	
+    * On the new dialog, click the **Open** button.	
+
+2. Run the installer with `edgectl install`	
+
+3. The installer will provision a load balancer, configure TLS, 	
+and provide you with an `edgestack.me` subdomain. The `edgestack.me` subdomain 	
+allows the Ambassador Edge Stack to automatically provision TLS and HTTPS	
+for a domain name, so you can get started right away.	
+<span id="index-installLinux"></span><br/>	
+
+## <img class="os-logo" src="../../images/linux.png"/> Install from Linux 	
+
+1. (1a) [Download the `edgectl` installer](https://metriton.datawire.io/downloads/linux/edgectl) or	
+ (1b) download it with a curl	
+   command:	
+
+    ```shell	
+    sudo curl -fL https://metriton.datawire.io/downloads/linux/edgectl -o /usr/local/bin/edgectl && sudo chmod a+x /usr/local/bin/edgectl	
+    ```	
+2. Run the installer with `edgectl install`	
+
+3. The installer will provision a load balancer, configure TLS, 	
+and provide you with an `edgestack.me` subdomain. The `edgestack.me` subdomain 	
+allows the Ambassador Edge Stack to automatically provision TLS and HTTPS	
+for a domain name, so you can get started right away.	
+<p id="index-installWindows"></p><br/>	
+
+## <img class="os-logo" src="../../images/windows.png"/> Install from Windows 	
+
+1. [Download the `edgectl.exe` installer](https://metriton.datawire.io/downloads/windows/edgectl.exe).	
+2. Run the installer with `edgectl install`	
+3. The installer will provision a load balancer, configure TLS, 	
+and provide you with an `edgestack.me` subdomain. The `edgestack.me` subdomain 	
+allows the Ambassador Edge Stack to automatically provision TLS and HTTPS	
+for a domain name, so you can get started right away.	
+<p id="index-installKubernetesYaml"></p><br/>	
 
 ## <img class="os-logo" src="../../images/kubernetes.png"/> Install via Kubernetes YAML 
 Kubernetes via YAML is the most common approach to install Ambassador Edge Stack,

--- a/docs/tutorials/GettingStarted.js
+++ b/docs/tutorials/GettingStarted.js
@@ -64,7 +64,7 @@ class GettingStarted extends Component {
                 <span className="token plain">  -o /usr/local/bin/edgectl </span>	
                 <span className="token plain">&&</span>
                 <span className="token plain"> </span>
-                <span className="token-plain">\</span><br/>	
+                <span className="token plain">\</span><br/>	
                 <span className="token plain">sudo</span>	
                 <span className="token plain"> </span>	
                 <span className="token plain">chmod</span>	
@@ -89,7 +89,7 @@ class GettingStarted extends Component {
                 <span className="token plain">  -o /usr/local/bin/edgectl </span>	
                 <span className="token plain">&&</span>
                 <span className="token plain"> </span>
-                <span className="token-plain">\</span><br/>
+                <span className="token plain">\</span><br/>
                 <span className="token plain">sudo</span>	
                 <span className="token plain"> </span>	
                 <span className="token plain">chmod</span>	

--- a/docs/tutorials/GettingStarted.js
+++ b/docs/tutorials/GettingStarted.js
@@ -39,7 +39,90 @@ class GettingStarted extends Component {
     return (
     <div className="QS-grid">
 
-        <span className="QS-k8"><img className="QS-osLogo" src="../../images/kubernetes.png"/></span>
+    <div className="QS-os">	
+          <span id="QS-showMac" data-os="mac"><img className="QS-osLogo" src="../../images/apple.png" /></span>	
+
+          <span id="QS-showLinux" data-os="linux"><img className="QS-osLogo" src="../../images/linux.png" /></span>	
+
+          <span id="QS-showWindows" data-os="windows"><img className="QS-osLogo" src="../../images/windows.png" /></span>	
+        </div>	
+
+      <div className="QS-aside QS-aside1">	
+        <ul id="QS-asideBullets">	
+          <div id="QS-showMacAside1" data-os="mac" className="QS-asideText">	
+
+          <li>New user? Get Edgectl, the Ambassador CLI.</li>	
+          <div className="styles-module--CodeBlock--1UB4s">	
+            <div className="QS-codeblockInstall">	
+            <span className="QS-copyButton"><CopyButton content="sudo curl -fL https://metriton.datawire.io/downloads/darwin/edgectl -o /usr/local/bin/edgectl && sudo chmod a+x /usr/local/bin/edgectl">Copy</CopyButton></span>	
+              <div className="token-line">	
+                <span className="token plain">sudo</span>	
+                <span className="token plain"> </span>	
+                <span className="token-plain">curl</span>	
+                <span className="token plain"> -fL https://metriton.datawire.io/downloads/darwin/edgectl <br/>   -o /usr/local/bin/edgectl </span>	
+                <span className="token plain">&&</span><br/>	
+                <span className="token plain">  </span>	
+                <span className="token plain">sudo</span>	
+                <span className="token plain"> </span>	
+                <span className="token plain">chmod</span>	
+                <span className="token plain"> a+x /usr/local/bin/edgectl</span>	
+              </div>	
+            </div>	
+          </div>	
+        </div>	
+
+        <div id="QS-showLinuxAside1" data-os="linux" className="	
+        QS-asideText">	
+          <li>New user? Get Edgectl, the Ambassador CLI.</li>	
+          <div className="styles-module--CodeBlock--1UB4s">	
+            <div className="QS-codeblockInstall">	
+              <span className="QS-copyButton"><CopyButton content="sudo curl -fL https://metriton.datawire.io/downloads/linux/edgectl -o /usr/local/bin/edgectl && sudo chmod a+x /usr/local/bin/edgectl">Copy</CopyButton></span>	
+              <div className="token-line">	
+                <span className="token plain">sudo</span>	
+                <span className="token plain"> </span>	
+                <span className="token plain">curl</span>	
+                <span className="token plain"> -fL https://metriton.datawire.io/downloads/linux/edgectl <br/>   -o /usr/local/bin/edgectl </span>	
+                <span className="token plain">&&</span><br/>	
+                <span className="token plain">  </span>	
+                <span className="token plain">sudo</span>	
+                <span className="token plain"> </span>	
+                <span className="token plain">chmod</span>	
+                <span className="token plain"> a+x /usr/local/bin/edgectl</span>	
+              </div>	
+            </div>	
+          </div>	
+        </div>	
+
+        <div id="QS-showWindowsAside1" data-os="windows" className="QS-asideText">	
+          <li>New user? Get Edgectl, the Ambassador CLI.</li>	
+          <div className="styles-module--CodeBlock--1UB4s">	
+              <div className="QS-codeblockInstall">	
+                <button><a className="windowsDownloadButton" href="https://metriton.datawire.io/downloads/windows/edgectl.exe" rel="nofollow noopener noreferrer">Download edgectl.exe</a></button><span>&nbsp;</span>	
+                <div className="token-line">	
+                  <span className="token function"></span>	
+                </div>	
+              </div>	
+          </div>	
+        </div>	
+
+
+        <div className="QS-asideText">	
+          <li className="QS-asideNoBullets">Install Ambassador Edge Stack:</li>	
+            <div className="styles-module--CodeBlock--1UB4s">	
+              <div className="QS-codeblockInstall">	
+              <div className="QS-copyButton"><CopyButton content="edgectl install">Copy</CopyButton></div>	
+                <div className="token-line">	
+                  <span className="token plain">edgectl</span>	
+                  <span className="token plain"> </span>	
+                  <span className="token plain">install</span>	
+                </div>	
+              </div>	
+            </div>	
+        </div>	
+        </ul>	
+      </div>	
+
+      <span className="QS-k8"><img className="QS-osLogo" src="../../images/kubernetes.png"/></span>
 
       <div className="QS-aside QS-aside2">
         <div className="QS-asideText">

--- a/docs/tutorials/GettingStarted.js
+++ b/docs/tutorials/GettingStarted.js
@@ -51,7 +51,7 @@ class GettingStarted extends Component {
         <ul id="QS-asideBullets">	
           <div id="QS-showMacAside1" data-os="mac" className="QS-asideText">	
 
-          <li>New user? Get Edgectl, the Ambassador CLI:</li>	
+          <li>New user? Get Edgectl, the Ambassador CLI</li>	
           <div className="styles-module--CodeBlock--1UB4s">	
             <div className="QS-codeblockInstall">	
             <span className="QS-copyButton"><CopyButton content="sudo curl -fL https://metriton.datawire.io/downloads/darwin/edgectl -o /usr/local/bin/edgectl && sudo chmod a+x /usr/local/bin/edgectl">Copy</CopyButton></span>	
@@ -73,7 +73,7 @@ class GettingStarted extends Component {
 
         <div id="QS-showLinuxAside1" data-os="linux" className="	
         QS-asideText">	
-          <li>New user? Get Edgectl, the Ambassador CLI:</li>	
+          <li>New user? Get Edgectl, the Ambassador CLI</li>	
           <div className="styles-module--CodeBlock--1UB4s">	
             <div className="QS-codeblockInstall">	
               <span className="QS-copyButton"><CopyButton content="sudo curl -fL https://metriton.datawire.io/downloads/linux/edgectl -o /usr/local/bin/edgectl && sudo chmod a+x /usr/local/bin/edgectl">Copy</CopyButton></span>	
@@ -94,7 +94,7 @@ class GettingStarted extends Component {
         </div>	
 
         <div id="QS-showWindowsAside1" data-os="windows" className="QS-asideText">	
-          <li>New user? Get Edgectl, the Ambassador CLI:</li>	
+          <li>New user? Get Edgectl, the Ambassador CLI</li>	
           <div className="styles-module--CodeBlock--1UB4s">	
               <div className="QS-codeblockInstall">	
                 <button><a className="windowsDownloadButton" href="https://metriton.datawire.io/downloads/windows/edgectl.exe" rel="nofollow noopener noreferrer">Download edgectl.exe</a></button><span>&nbsp;</span>	
@@ -107,7 +107,7 @@ class GettingStarted extends Component {
 
 
         <div className="QS-asideText">	
-          <li className="QS-asideNoBullets">Install Ambassador Edge Stack:</li>	
+          <li className="QS-asideNoBullets">Install Ambassador Edge Stack</li>	
             <div className="styles-module--CodeBlock--1UB4s">	
               <div className="QS-codeblockInstall">	
               <div className="QS-copyButton"><CopyButton content="edgectl install">Copy</CopyButton></div>	
@@ -127,7 +127,7 @@ class GettingStarted extends Component {
       <div className="QS-aside QS-aside2">
         <div className="QS-asideText">
           <ul id="QS-asideBullets">
-            <li>Have Kubernetes? Deploy with YAML:</li>
+            <li>Have Kubernetes? Deploy with YAML</li>
               <div className="styles-module--CodeBlock--1UB4s">
                 <div className="QS-codeblockInstall">
                 <span className="QS-copyButton"><CopyButton content="
@@ -198,7 +198,7 @@ class GettingStarted extends Component {
                   </div>
                 </div>
               </div>
-            <li className="QS-asideNoBullets">Get your cluster's IP address:</li>
+            <li className="QS-asideNoBullets">Get your cluster's IP address</li>
               <div className="styles-module--CodeBlock--1UB4s">
                 <div className="QS-codeblockInstall">
                 <span className="QS-copyButton"><CopyButton content='
@@ -257,7 +257,7 @@ class GettingStarted extends Component {
         <div className="QS-aside QS-aside3">
           <div className="QS-asideText">
             <ul id="QS-asideBullets">
-              <li>Prefer Helm?  Add this repo to your Helm client:</li>
+              <li>Prefer Helm?  Add this repo to your Helm client</li>
                 <div className="styles-module--CodeBlock--1UB4s">
                   <div className="QS-codeblockInstall">
                   <span className="QS-copyButton"><CopyButton content="
@@ -276,7 +276,7 @@ class GettingStarted extends Component {
                   </div>
                 </div>
 
-              <li className="QS-asideNoBullets">Install the Ambassador Edge Stack chart:</li>
+              <li className="QS-asideNoBullets">Install the Ambassador Edge Stack chart</li>
                 <div id="helmVersionWrapper">
 
                   <div id="helm2Block">
@@ -356,7 +356,7 @@ class GettingStarted extends Component {
                   </div>
                 </div>
             
-              <li className="QS-asideNoBullets">Install Ambassador Edge Stack:</li>
+              <li className="QS-asideNoBullets">Install Ambassador Edge Stack</li>
                 <div className="styles-module--CodeBlock--1UB4s">
                     <div className="QS-codeblockInstall">
                     <div className="QS-copyButton"><CopyButton content="edgectl install">Copy</CopyButton></div>
@@ -384,14 +384,14 @@ class GettingStarted extends Component {
       <div className="QS-Spin">
        <div className="QS-asideText">
          Take it for a spin!<br/>
-          <span className="QS-spinText">➞ <a href="../../tutorials/quickstart-demo/">See how Ambassador works with a service</a>.</span><br/>
-          <span id="QS-customLink" className="QS-spinText">➞ <a href="../../topics/using/">Check out custom options and integrations</a>.</span><br/>
+          <span className="QS-spinText">➞ <a href="../../tutorials/quickstart-demo/">See how Ambassador works with a service</a></span><br/>
+          <span id="QS-customLink" className="QS-spinText">➞ <a href="../../topics/using/">Check out custom options and integrations</a></span><br/>
         </div>
        </div>
       
       <div className="QS-main">
 
-        <h2>Ambassador Edge Stack gives you:</h2>
+        <h2>Ambassador Edge Stack gives you</h2>
           <div id="QS-mainTextSmall">
             <ul>
               <li className="QS-mainBullet" id="QS-bullet1">First-in-class Kubernetes ingress support with CRD- based configuration</li>

--- a/docs/tutorials/GettingStarted.js
+++ b/docs/tutorials/GettingStarted.js
@@ -51,7 +51,7 @@ class GettingStarted extends Component {
         <ul id="QS-asideBullets">	
           <div id="QS-showMacAside1" data-os="mac" className="QS-asideText">	
 
-          <li>New user? Get Edgectl, the Ambassador CLI.</li>	
+          <li>New user? Get Edgectl, the Ambassador CLI:</li>	
           <div className="styles-module--CodeBlock--1UB4s">	
             <div className="QS-codeblockInstall">	
             <span className="QS-copyButton"><CopyButton content="sudo curl -fL https://metriton.datawire.io/downloads/darwin/edgectl -o /usr/local/bin/edgectl && sudo chmod a+x /usr/local/bin/edgectl">Copy</CopyButton></span>	
@@ -73,7 +73,7 @@ class GettingStarted extends Component {
 
         <div id="QS-showLinuxAside1" data-os="linux" className="	
         QS-asideText">	
-          <li>New user? Get Edgectl, the Ambassador CLI.</li>	
+          <li>New user? Get Edgectl, the Ambassador CLI:</li>	
           <div className="styles-module--CodeBlock--1UB4s">	
             <div className="QS-codeblockInstall">	
               <span className="QS-copyButton"><CopyButton content="sudo curl -fL https://metriton.datawire.io/downloads/linux/edgectl -o /usr/local/bin/edgectl && sudo chmod a+x /usr/local/bin/edgectl">Copy</CopyButton></span>	
@@ -94,7 +94,7 @@ class GettingStarted extends Component {
         </div>	
 
         <div id="QS-showWindowsAside1" data-os="windows" className="QS-asideText">	
-          <li>New user? Get Edgectl, the Ambassador CLI.</li>	
+          <li>New user? Get Edgectl, the Ambassador CLI:</li>	
           <div className="styles-module--CodeBlock--1UB4s">	
               <div className="QS-codeblockInstall">	
                 <button><a className="windowsDownloadButton" href="https://metriton.datawire.io/downloads/windows/edgectl.exe" rel="nofollow noopener noreferrer">Download edgectl.exe</a></button><span>&nbsp;</span>	

--- a/docs/tutorials/GettingStarted.js
+++ b/docs/tutorials/GettingStarted.js
@@ -56,12 +56,13 @@ class GettingStarted extends Component {
             <div className="QS-codeblockInstall">	
             <span className="QS-copyButton"><CopyButton content="sudo curl -fL https://metriton.datawire.io/downloads/darwin/edgectl -o /usr/local/bin/edgectl && sudo chmod a+x /usr/local/bin/edgectl">Copy</CopyButton></span>	
               <div className="token-line">	
-                <span className="token plain">sudo</span>	
-                <span className="token plain"> </span>	
-                <span className="token plain">curl</span>	
-                <span className="token plain"> -fL https://metriton.datawire.io/downloads/darwin/edgectl <br/>   -o /usr/local/bin/edgectl </span>	
+                <span className="token plain">sudo</span>
+                <span className="token plain"> </span>
+                <span className="token plain">curl</span>
+                <span className="token plain"> -fL https://metriton.datawire.io/downloads/darwin/edgectl</span>
+                <span className="token plain">\</span><br/>
+                <span className="token plain">  -o /usr/local/bin/edgectl</span>	
                 <span className="token plain">&&</span><br/>	
-                <span className="token plain">  </span>	
                 <span className="token plain">sudo</span>	
                 <span className="token plain"> </span>	
                 <span className="token plain">chmod</span>	
@@ -81,9 +82,10 @@ class GettingStarted extends Component {
                 <span className="token plain">sudo</span>	
                 <span className="token plain"> </span>	
                 <span className="token plain">curl</span>	
-                <span className="token plain"> -fL https://metriton.datawire.io/downloads/linux/edgectl <br/>   -o /usr/local/bin/edgectl </span>	
+                <span className="token plain"> -fL https://metriton.datawire.io/downloads/linux/edgectl</span>	
+                <span className="token plain">\</span><br/>
+                <span className="token plain">  -o /usr/local/bin/edgectl</span>	
                 <span className="token plain">&&</span><br/>	
-                <span className="token plain">  </span>	
                 <span className="token plain">sudo</span>	
                 <span className="token plain"> </span>	
                 <span className="token plain">chmod</span>	

--- a/docs/tutorials/GettingStarted.js
+++ b/docs/tutorials/GettingStarted.js
@@ -58,7 +58,7 @@ class GettingStarted extends Component {
               <div className="token-line">	
                 <span className="token plain">sudo</span>	
                 <span className="token plain"> </span>	
-                <span className="token-plain">curl</span>	
+                <span className="token plain">curl</span>	
                 <span className="token plain"> -fL https://metriton.datawire.io/downloads/darwin/edgectl <br/>   -o /usr/local/bin/edgectl </span>	
                 <span className="token plain">&&</span><br/>	
                 <span className="token plain">  </span>	
@@ -127,74 +127,74 @@ class GettingStarted extends Component {
       <div className="QS-aside QS-aside2">
         <div className="QS-asideText">
           <ul id="QS-asideBullets">
-            <li>Have Kubernetes? Deploy with yaml:</li>
+            <li>Have Kubernetes? Deploy with YAML:</li>
               <div className="styles-module--CodeBlock--1UB4s">
                 <div className="QS-codeblockInstall">
                 <span className="QS-copyButton"><CopyButton content="
                 kubectl apply -f https://www.getambassador.io/yaml/aes-crds.yaml && kubectl wait --for condition=established --timeout=90s crd -lproduct=aes && kubectl apply -f https://www.getambassador.io/yaml/aes.yaml && kubectl -n ambassador wait --for condition=available --timeout=90s deploy -lproduct=aes">Copy</CopyButton></span>
                   <div className="token-line">
-                    <span className="token-plain">kubectl</span>
+                    <span className="token plain">kubectl</span>
                     <span className="token plain"> </span>
-                    <span className="token-plain">apply</span>
+                    <span className="token plain">apply</span>
                     <span className="token plain"> </span>
-                    <span className="token-plain">-f https://www.getambassador.io/yaml/aes-crds.yaml</span>
+                    <span className="token plain">-f https://www.getambassador.io/yaml/aes-crds.yaml</span>
                     <span className="token plain"> </span>
                     <span className="token plain">&&</span>
                     <span className="token plain"> </span>
                     <span className="token plain">\</span><br/>
-                    <span className="token-plain">kubectl</span>
+                    <span className="token plain">kubectl</span>
                     <span className="token plain"> </span>
                     <span className="token plain">wait</span>
                     <span className="token plain"> </span>
-                    <span className="token-plain">--for</span>
+                    <span className="token plain">--for</span>
                     <span className="token plain"> </span>
                     <span className="token plain">condition</span>
                     <span className="token plain">=</span>
-                    <span className="token-plain">established</span>
+                    <span className="token plain">established</span>
                     <span className="token plain"> </span>
-                    <span className="token-plain">--timeout</span>
+                    <span className="token plain">--timeout</span>
                     <span className="token plain">=</span>
-                    <span className="token-plain">90s</span>
+                    <span className="token plain">90s</span>
                     <span className="token plain"> </span>
-                    <span className="token-plain">crd -lproduct</span>
+                    <span className="token plain">crd -lproduct</span>
                     <span className="token plain">=</span>
-                    <span className="token-plain">aes</span>
+                    <span className="token plain">aes</span>
                     <span className="token plain"> </span>
                     <span className="token plain">&&</span>
                     <span className="token plain"> </span>
-                    <span className="token-plain">\</span><br/>
-                    <span className="token-plain">kubectl</span>
+                    <span className="token plain">\</span><br/>
+                    <span className="token plain">kubectl</span>
                     <span className="token plain"> </span>
-                    <span className="token-plain">apply</span>
+                    <span className="token plain">apply</span>
                     <span className="token plain"> </span>
-                    <span className="token-plain">-f https://www.getambassador.io/yaml/aes.yaml</span>
+                    <span className="token plain">-f https://www.getambassador.io/yaml/aes.yaml</span>
                     <span className="token plain"> </span>
                     <span className="token plain">&&</span>
                     <span className="token plain"> </span>
-                    <span className="token-plain">\</span><br/>
-                    <span className="token-plain">kubectl</span>
+                    <span className="token plain">\</span><br/>
+                    <span className="token plain">kubectl</span>
                     <span className="token plain"> </span>
-                    <span className="token-plain">-n</span>
+                    <span className="token plain">-n</span>
                     <span className="token plain"> </span>
-                    <span className="token-plain">ambassador</span>
+                    <span className="token plain">ambassador</span>
                     <span className="token plain"> </span>
                     <span className="token plain">wait</span>
                     <span className="token plain"> </span>
-                    <span className="token-plain">--for</span>
+                    <span className="token plain">--for</span>
                     <span className="token plain"> </span>
                     <span className="token plain">condition</span>
                     <span className="token plain">=</span>
-                    <span className="token-plain">available</span>
+                    <span className="token plain">available</span>
                     <span className="token plain"> </span>
-                    <span className="token-plain">--timeout</span>
+                    <span className="token plain">--timeout</span>
                     <span className="token plain">=</span>
-                    <span className="token-plain">90s</span>
+                    <span className="token plain">90s</span>
                     <span className="token plain"> </span>
-                    <span className="token-plain">deploy</span>
+                    <span className="token plain">deploy</span>
                     <span className="token plain"> </span>
                     <span className="token plain">-lproduct</span>
-                    <span className="token-plain">=</span>
-                    <span className="token-plain">aes</span>
+                    <span className="token plain">=</span>
+                    <span className="token plain">aes</span>
                   </div>
                 </div>
               </div>
@@ -204,19 +204,19 @@ class GettingStarted extends Component {
                 <span className="QS-copyButton"><CopyButton content='
                 kubectl get -n ambassador service ambassador -o "go-template={{range .status.loadBalancer.ingress}}{{or .ip .hostname}}{{end}}"'>Copy</CopyButton></span>
                   <div className="token-line">
-                    <span className="token-plain">kubectl</span>
+                    <span className="token plain">kubectl</span>
                     <span className="token plain"> </span>
-                    <span className="token-plain">get</span>
+                    <span className="token plain">get</span>
                     <span className="token plain"> </span>
-                    <span className="token-plain">-n</span>
+                    <span className="token plain">-n</span>
                     <span className="token plain"> </span>
-                    <span className="token-plain">ambassador</span>
+                    <span className="token plain">ambassador</span>
                     <span className="token plain"> </span>
-                    <span className="token-plain">service</span>
+                    <span className="token plain">service</span>
                     <span className="token plain"> </span>
-                    <span className="token-plain">ambassador</span>
+                    <span className="token plain">ambassador</span>
                     <span className="token plain"> </span>
-                    <span className="token-plain">-o</span>
+                    <span className="token plain">-o</span>
                     <span className="token plain"> </span>
                     <span className="token plain">"go-template</span>
                     <span className="token plain">=</span>
@@ -257,15 +257,15 @@ class GettingStarted extends Component {
         <div className="QS-aside QS-aside3">
           <div className="QS-asideText">
             <ul id="QS-asideBullets">
-              <li>Prefer Helm?  Add this repo to your helm client:</li>
+              <li>Prefer Helm?  Add this repo to your Helm client:</li>
                 <div className="styles-module--CodeBlock--1UB4s">
                   <div className="QS-codeblockInstall">
                   <span className="QS-copyButton"><CopyButton content="
                   helm repo add datawire https://www.getambassador.io">Copy</CopyButton></span>
                     <div className="token-line">
-                      <span className="token-plain">helm</span>
+                      <span className="token plain">helm</span>
                       <span className="token plain"> </span>
-                      <span className="token-plain">repo</span>
+                      <span className="token plain">repo</span>
                       <span className="token plain"> </span>
                       <span className="token plain">add</span>
                       <span className="token plain"> </span>
@@ -288,30 +288,30 @@ class GettingStarted extends Component {
                         <span className="QS-copyButton"><CopyButton content="
                         kubectl create namespace ambassador && helm install --name ambassador --namespace ambassador datawire/ambassador">Copy</CopyButton></span>
                           <div className="token-line">
-                            <span className="token-plain">kubectl</span>
+                            <span className="token plain">kubectl</span>
                             <span className="token plain"> </span>
-                            <span className="token-plain">create</span>
+                            <span className="token plain">create</span>
                             <span className="token plain"> </span>
-                            <span className="token-plain">namespace</span>
+                            <span className="token plain">namespace</span>
                             <span className="token plain"> </span>
                             <span className="token plain">ambassador</span>
                             <span className="token plain"> </span>
                             <span className="token plain">&&</span>
                             <span className="token plain"> </span>
-                            <span className="token-plain">\</span><br/>
-                            <span className="token-plain">helm</span>
+                            <span className="token plain">\</span><br/>
+                            <span className="token plain">helm</span>
                             <span className="token plain"> </span>
-                            <span className="token-plain">install</span>
+                            <span className="token plain">install</span>
                             <span className="token plain"> </span>
-                            <span className="token-plain">--name</span>
+                            <span className="token plain">--name</span>
                             <span className="token plain"> </span>
-                            <span className="token-plain">ambassador</span>
+                            <span className="token plain">ambassador</span>
                             <span className="token plain"> </span>
                             <span className="token plain">--namespace</span>
                             <span className="token plain"> </span>
-                            <span className="token-plain">ambassador</span>
+                            <span className="token plain">ambassador</span>
                             <span className="token plain"> </span>
-                            <span className="token-plain">datawire/ambassador</span>
+                            <span className="token plain">datawire/ambassador</span>
                           </div>
                         </div>
                       </div>
@@ -327,28 +327,28 @@ class GettingStarted extends Component {
                         <span className="QS-copyButton"><CopyButton content="
                         kubectl create namespace ambassador && helm install ambassador --namespace ambassador datawire/ambassador">Copy</CopyButton></span>
                             <div className="token-line">
-                            <span className="token-plain">kubectl</span>
+                            <span className="token plain">kubectl</span>
                             <span className="token plain"> </span>
-                            <span className="token-plain">create</span>
+                            <span className="token plain">create</span>
                             <span className="token plain"> </span>
-                            <span className="token-plain">namespace</span>
+                            <span className="token plain">namespace</span>
                             <span className="token plain"> </span>
                             <span className="token plain">ambassador</span>
                             <span className="token plain"> </span>
                             <span className="token plain">&&</span>
                             <span className="token plain"> </span>
-                            <span className="token-plain">\</span><br/>
-                            <span className="token-plain">helm</span>
+                            <span className="token plain">\</span><br/>
+                            <span className="token plain">helm</span>
                             <span className="token plain"> </span>
-                            <span className="token-plain">install</span>
+                            <span className="token plain">install</span>
                             <span className="token plain"> </span>
-                            <span className="token-plain">ambassador</span>
+                            <span className="token plain">ambassador</span>
                             <span className="token plain"> </span>
                             <span className="token plain">--namespace</span>
                             <span className="token plain"> </span>
-                            <span className="token-plain">ambassador</span>
+                            <span className="token plain">ambassador</span>
                             <span className="token plain"> </span>
-                            <span className="token-plain">datawire/ambassador</span>
+                            <span className="token plain">datawire/ambassador</span>
                           </div>
                         </div>
                       </div>

--- a/docs/tutorials/GettingStarted.js
+++ b/docs/tutorials/GettingStarted.js
@@ -62,7 +62,9 @@ class GettingStarted extends Component {
                 <span className="token plain"> -fL https://metriton.datawire.io/downloads/darwin/edgectl </span>
                 <span className="token plain">\</span><br/>
                 <span className="token plain">  -o /usr/local/bin/edgectl </span>	
-                <span className="token plain">&&</span><br/>	
+                <span className="token plain">&&</span>
+                <span className="token plain"> </span>
+                <span className="token-plain">\</span><br/>	
                 <span className="token plain">sudo</span>	
                 <span className="token plain"> </span>	
                 <span className="token plain">chmod</span>	
@@ -85,7 +87,9 @@ class GettingStarted extends Component {
                 <span className="token plain"> -fL https://metriton.datawire.io/downloads/linux/edgectl </span>	
                 <span className="token plain">\</span><br/>
                 <span className="token plain">  -o /usr/local/bin/edgectl </span>	
-                <span className="token plain">&&</span><br/>	
+                <span className="token plain">&&</span>
+                <span className="token plain"> </span>
+                <span className="token-plain">\</span><br/>
                 <span className="token plain">sudo</span>	
                 <span className="token plain"> </span>	
                 <span className="token plain">chmod</span>	

--- a/docs/tutorials/GettingStarted.js
+++ b/docs/tutorials/GettingStarted.js
@@ -247,7 +247,7 @@ class GettingStarted extends Component {
                   </div>
                 </div>
               </div>
-            <li className="QS-asideNoBullets">Visit <code id="k8Code">http://your-IP-address</code> to login to the console.</li>
+            <li className="QS-asideNoBullets">Visit <code id="k8Code">http://your-IP-address</code> to login to the console</li>
             </ul>
           </div>
         </div>

--- a/docs/tutorials/GettingStarted.js
+++ b/docs/tutorials/GettingStarted.js
@@ -59,9 +59,9 @@ class GettingStarted extends Component {
                 <span className="token plain">sudo</span>
                 <span className="token plain"> </span>
                 <span className="token plain">curl</span>
-                <span className="token plain"> -fL https://metriton.datawire.io/downloads/darwin/edgectl</span>
+                <span className="token plain"> -fL https://metriton.datawire.io/downloads/darwin/edgectl </span>
                 <span className="token plain">\</span><br/>
-                <span className="token plain">  -o /usr/local/bin/edgectl</span>	
+                <span className="token plain">  -o /usr/local/bin/edgectl </span>	
                 <span className="token plain">&&</span><br/>	
                 <span className="token plain">sudo</span>	
                 <span className="token plain"> </span>	
@@ -82,9 +82,9 @@ class GettingStarted extends Component {
                 <span className="token plain">sudo</span>	
                 <span className="token plain"> </span>	
                 <span className="token plain">curl</span>	
-                <span className="token plain"> -fL https://metriton.datawire.io/downloads/linux/edgectl</span>	
+                <span className="token plain"> -fL https://metriton.datawire.io/downloads/linux/edgectl </span>	
                 <span className="token plain">\</span><br/>
-                <span className="token plain">  -o /usr/local/bin/edgectl</span>	
+                <span className="token plain">  -o /usr/local/bin/edgectl </span>	
                 <span className="token plain">&&</span><br/>	
                 <span className="token plain">sudo</span>	
                 <span className="token plain"> </span>	

--- a/docs/tutorials/getting-started.less
+++ b/docs/tutorials/getting-started.less
@@ -2,6 +2,7 @@
   display: grid;
   grid-template-columns: 50px auto;
   grid-template-areas:
+  "os sidebar1"  
   "k8 sidebar2"
   "helm sidebar3"
   "blank manual"


### PR DESCRIPTION
## Description
Install options using 'edgectl install' were temporarily removed during Quay outage.  This PR reinstates these install options on the QuickStart and full details installation pages.

## Related Issues
List related issues.

## Testing
A few sentences describing what testing you've done, e.g., manual tests, automated tests, deployed in production, etc.

## Tasks That Must Be Done
- [ ] Did you update CHANGELOG.md?
- [ ] Did you add or update tests?
- [ ] Did you update documentation?
- [ ] Were there any special dev tricks you had to use to work on this code efficiently?
  + [ ] Did you add them to DEVELOPING.md?
- [ ] Is this a build change?
  + [ ] If so, did you test on both Mac and Linux?

## Other
* If this is a documentation change for a particular release, please open the pull request against the release branch.
