### PR TITLE
Cakuros/cert manager docs

### DIFF
--- a/docs/howtos/cert-manager.md
+++ b/docs/howtos/cert-manager.md
@@ -55,7 +55,7 @@ The DNS-01 challenge verifies domain ownership by proving you have control over 
 
 2. Note the `accessKeyID` and create a `secret` named `prod-route53-credentials-secret` in the cert-manager namespace that has a key value: `secret-access-key` from your AWS IaM credentials.
 
-3. Create and apply a `ClusterIssuer`.  Make sure that the `Issuer` and the `secret` are in the same namespace.
+3. Create and apply a `ClusterIssuer`. 
 
     ```yaml
     ---
@@ -137,7 +137,7 @@ The HTTP-01 challenge verifies ownership of the domain by sending a request for 
           selector: {}
     ```
 
-2. Create and apply a `Certificate`.  Make sure the `Certificate` is in the same namespace as Ambassador.
+2. Create and apply a `Certificate`.
 
     ```yaml
     ---

--- a/docs/howtos/cert-manager.md
+++ b/docs/howtos/cert-manager.md
@@ -12,7 +12,7 @@ Note: Ambassador Edge Stack will automatically create and renew TLS certificates
 
 ## Install Cert-Manager
 
-There are many different ways to [install cert-manager](https://docs.cert-manager.io/en/latest/getting-started/install.html). For simplicity, we will use Helm.
+There are many different ways to [install cert-manager](https://docs.cert-manager.io/en/latest/getting-started/install.html). For simplicity, we will use Helm v3.
 
 1. Add the `jetstack` repository.
     ```bash

--- a/docs/howtos/cert-manager.md
+++ b/docs/howtos/cert-manager.md
@@ -184,9 +184,9 @@ The HTTP-01 challenge verifies ownership of the domain by sending a request for 
 
 4. Create a Mapping for the `/.well-known/acme-challenge/` route.
 
-cert-manager uses an `Ingress` resource to issue the challenge to `/.well-known/acme-challenge/` but, since Ambassador is not an `Ingress`, we will need to create a `Mapping` so the cert-manager can reach the temporary pod.
+    cert-manager uses an `Ingress` resource to issue the challenge to `/.well-known/acme-challenge/` but, since Ambassador is not an `Ingress`, we will need to create a `Mapping` so the cert-manager can reach the temporary pod.
  
-```yaml
+    ```yaml
     ---
     apiVersion: getambassador.io/v2
     kind: Mapping
@@ -208,9 +208,9 @@ cert-manager uses an `Ingress` resource to issue the challenge to `/.well-known/
         targetPort: 8089
       selector:
         acme.cert-manager.io/http01-solver: "true"
-```
+    ```
 
-Apply the YAML and wait a couple of minutes. cert-manager will retry the challenge and issue the certificate.
+    Apply the YAML and wait a couple of minutes. cert-manager will retry the challenge and issue the certificate.
 
 5. Verify the secret is created:
 

--- a/docs/howtos/cert-manager.md
+++ b/docs/howtos/cert-manager.md
@@ -1,10 +1,8 @@
 # Cert-Manager and Ambassador Edge Stack
 
-**Note:** The Ambassador Edge Stack can issue and manage certificate with the ACME HTTP-01 challenge.
+**Note:** Cert-manager release v0.15 removed legacy CRD support.  This document has been updated to use CRD standards specified in v0.15.
 
 cert-manager is still required for DNS-01 challenges for wildcard domains and when using Ambassador OSS. 
-
-**Note:** Cert-manager release v0.15 removed legacy CRD support.  This document has been updated to use CRD standards specified in v0.15 and tested with Ambassador v1.4.2.
 
 ---
 
@@ -17,16 +15,16 @@ Note: Ambassador Edge Stack will automatically create and renew TLS certificates
 There are many different ways to [install cert-manager](https://docs.cert-manager.io/en/latest/getting-started/install.html). For simplicity, we will use Helm.
 
 1. Add the `jetstack` repository.
-  ```bash
-  helm repo add jetstack https://charts.jetstack.io && helm repo update
-  ```
+    ```bash
+    helm repo add jetstack https://charts.jetstack.io && helm repo update
+    ```
 
 2. Install cert-manager
 
-  ```
-  kubectl create ns cert-manager
-  helm install cert-manager --namespace cert-manager --set installCRDs=true
-  ```
+    ```
+    kubectl create ns cert-manager
+    helm install cert-manager --namespace cert-manager --set installCRDs=true
+    ```
 
 ## Issuing Certificates
 
@@ -42,7 +40,7 @@ A [Certificate](https://cert-manager.readthedocs.io/en/latest/reference/certific
 
 By duplicating issuers, certificates, and secrets one can support multiple domains with [SNI](../../topics/running/tls/sni).
 
-### Challenge
+## Challenge
 
 cert-manager supports two kinds of ACME challenges that verify domain ownership in different ways: HTTP-01 and DNS-01.
 
@@ -116,7 +114,7 @@ The DNS-01 challenge verifies domain ownership by proving you have control over 
     default-token-4l772      kubernetes.io/service-account-token   3         2h
     ```
 
-#### HTTP-01 Challenge
+### HTTP-01 Challenge
 
 The HTTP-01 challenge verifies ownership of the domain by sending a request for a specific file on that domain. cert-manager accomplishes this by sending a request to a temporary pod with the prefix `/.well-known/acme-challenge/`. To perform this challenge:
 

--- a/docs/howtos/grpc.md
+++ b/docs/howtos/grpc.md
@@ -8,7 +8,7 @@ There are many examples and walkthroughs on how to write gRPC applications so th
 
 This document will use the [gRPC python helloworld example](https://github.com/grpc/grpc/tree/master/examples/python/helloworld) to demonstrate how to configure a gRPC service with Ambassador Edge Stack.
 
-Follow the example up through [Run a gRPC application](https://grpc.io/docs/quickstart/python.html#run-a-grpc-application) to get started.
+Follow the example up through [Run a gRPC application](https://grpc.io/docs/languages/python/quickstart/#run-a-grpc-application) to get started.
 
 ### Dockerize
 


### PR DESCRIPTION
Cert manager documentation updates.  Changed documentation to reflect cert-manager v0.15's deprecation of old CRD's.  Both DNS-01 challenge and HTTP-01 challenge tested on Ambassador API Gateway and Edge Stack on GKE.