### PR TITLE
update links for new doc org

### DIFF
--- a/python/templates/overview.html
+++ b/python/templates/overview.html
@@ -100,20 +100,20 @@ limitations under the License
                 </thead>
                 <tbody>
                   <tr>
-                    <td><a href="https://www.getambassador.io/concepts/architecture?utm_source=diagnostics">Ambassador Architecture</a></td>
-                    <td><a href="https://www.getambassador.io/reference/configuration?utm_source=diagnostics">Configuration Reference</a></td>
+                    <td><a href="https://www.getambassador.io/docs/latest/topics/concepts/architecture/?utm_source=diagnostics">Ambassador Architecture</a></td>
+                    <td><a href="https://www.getambassador.io/docs/latest/topics/using/intro-mappings/?utm_source=diagnostics">Configuration Reference</a></td>
                   </tr>
                   <tr>
-                    <td><a href="https://www.getambassador.io/reference/running?utm_source=diagnostics">Running Ambassador</a></td>
-                    <td><a href="https://www.getambassador.io/user-guide/oauth-oidc-auth?utm_source=diagnostics">Single Sign-On with OAuth/OIDC</a></td>
+                    <td><a href="https://www.getambassador.io/docs/latest/topics/running/?utm_source=diagnostics">Running Ambassador in Production</a></td>
+                    <td><a href="https://www.getambassador.io/docs/latest/topics/using/filters/oauth2/?utm_source=diagnostics">Single Sign-On with OAuth/OIDC</a></td>
                   </tr>
                   <tr>
-                    <td><a href="https://www.getambassador.io/reference/statistics?utm_source=diagnostics">Statistics and Monitoring</a></td>
-                    <td><a href="https://www.getambassador.io/reference/filter-reference?utm_source=diagnostics">Custom Filters</a></td>
+                    <td><a href="https://www.getambassador.io/docs/latest/topics/running/statistics/?utm_source=diagnostics">Statistics and Monitoring</a></td>
+                    <td><a href="https://www.getambassador.io/docs/latest/topics/using/filters/?utm_source=diagnostics">Filters and Authentication</a></td>
                   </tr>
                   <tr>
-                    <td><a href="https://www.getambassador.io/reference/debugging?utm_source=diagnostics">Troubleshooting Ambassador</a></td>
-                    <td><a href="https://www.getambassador.io/user-guide/advanced-rate-limiting?utm_source=diagnostics">Rate Limiting</a></td>
+                    <td><a href="https://www.getambassador.io/docs/latest/topics/running/debugging/?utm_source=diagnostics">Troubleshooting Ambassador</a></td>
+                    <td><a href="https://www.getambassador.io/docs/latest/topics/using/rate-limits/rate-limits/?utm_source=diagnostics">Rate Limiting</a></td>
                   </tr>
                 </tbody>
               </table>


### PR DESCRIPTION
We moved the docs around, and the diag UI still points to the old links. This updates diag to point to new links.