### PR TITLE
WIP: Update Istio docs for Istio 1.5

### DIFF
--- a/docs/howtos/istio.md
+++ b/docs/howtos/istio.md
@@ -608,3 +608,36 @@ envoy_cluster_manager_active_clusters{job="ambassador"}
 Now let's save the changes:
 
 * Click on Save Dashboard in the Top Right corner
+
+## FAQ
+
+### How to test Istio Certificate Rotation
+
+Istio mTLS certificates, by default, will be valid for a max of 90 days but will be rotated every day.
+
+Ambassador will watch and update the mTLS certificates as they rotate so you will not need to worry about certificate expiration. 
+
+To test that Ambassador is properly rotating certificates you can shorten the TTL of the Istio certificates so you can verify that Ambassador is using the new certificates.
+
+In **Istio 1.5 and above**, you can configure that by setting the following environment variables in the `istiod` container.
+
+```yaml
+env:
+- name: DEFAULT_WORKLOAD_CERT_TTL
+  value: 30m
+- name: MAX_WORKLOAD_CERT_TTL
+  value: 1h
+```
+
+In **Istio 1.4 and below**, you can configure this by passing the following arguments to the `istio-citadel` container
+
+```yaml
+      containers:
+      - name: citadel
+        ...
+        args:
+          - --workload-cert-ttl=1h # Lifetime of certificates issued to workloads in Kubernetes.
+          - --max-workload-cert-ttl=48h # Maximum lifetime of certificates issued to workloads by Citadel.
+```
+
+This will make the certificates Istio issues expire in one hour so testing certificate rotation is much easier.

--- a/docs/howtos/istio.md
+++ b/docs/howtos/istio.md
@@ -611,7 +611,7 @@ Now let's save the changes:
 
 ## FAQ
 
-### How to test Istio Certificate Rotation
+### How to Test Istio Certificate Rotation
 
 Istio mTLS certificates, by default, will be valid for a max of 90 days but will be rotated every day.
 

--- a/docs/js/versions.yml
+++ b/docs/js/versions.yml
@@ -1,4 +1,4 @@
 version: 1.5.0
 aproVersion: 0.11.0
 qotmVersion: 1.7
-quoteVersion: 0.3.0
+quoteVersion: 0.4.1

--- a/docs/yaml/backends/quote.yaml
+++ b/docs/yaml/backends/quote.yaml
@@ -15,7 +15,10 @@ spec:
   ports:
   - name: http
     port: 80
-    targetPort: 8080
+    targetPort: 8000
+  - name: https
+    port: 443
+    targetPort: 8000
   selector:
     app: quote
 ---
@@ -40,7 +43,10 @@ spec:
         image: docker.io/datawire/quote:$quoteVersion$
         ports:
         - name: http
-          containerPort: 8080
+          containerPort: 8000
+        env:
+        - name: PORT
+          value: 8000
         resources:
           limits:
             cpu: "0.1"


### PR DESCRIPTION
Istio 1.5 moved istio away from their microservice architecture and towards a monolithic control plane. As part of this move, the method of storing mTLS certificates in kubernetes namespaces was removed in favor of the `istio-proxy`s grabbing these certificates directly from `istiod`. This doc updates our documentation on how to install Ambassador with Istio to support this new approach.