### PR TITLE
Move service and endpoints processing to a separate processor

### DIFF
--- a/python/ambassador/fetch/fetcher.py
+++ b/python/ambassador/fetch/fetcher.py
@@ -64,7 +64,6 @@ class ResourceFetcher:
 
         self.k8s_processor = DeduplicatingKubernetesProcessor(AggregateKubernetesProcessor([
             CountingKubernetesProcessor(self.aconf, KubernetesGVK.for_knative_networking('Ingress'), 'knative_ingress'),
-            CountingKubernetesProcessor(self.aconf, KubernetesGVK.for_knative_networking('ClusterIngress'), 'knative_cluster_ingress'),
             AmbassadorProcessor(self.manager),
             ServiceProcessor(self.manager, watch_only=watch_only),
             KnativeIngressProcessor(self.manager),

--- a/python/ambassador/fetch/fetcher.py
+++ b/python/ambassador/fetch/fetcher.py
@@ -7,7 +7,7 @@ import yaml
 import re
 
 from ..config import ACResource, Config
-from ..utils import parse_yaml, dump_yaml
+from ..utils import parse_yaml
 
 from .resource import NormalizedResource, ResourceManager
 from .k8sobject import KubernetesGVK, KubernetesObject
@@ -18,6 +18,7 @@ from .k8sprocessor import (
     CountingKubernetesProcessor,
 )
 from .ambassador import AmbassadorProcessor
+from .service import ServiceProcessor
 from .knative import KnativeIngressProcessor
 
 AnyDict = Dict[str, Any]
@@ -60,21 +61,16 @@ class ResourceFetcher:
         self.aconf = aconf
         self.logger = logger
         self.manager = ResourceManager(self.logger, self.aconf)
-        self.watch_only = watch_only
 
         self.k8s_processor = DeduplicatingKubernetesProcessor(AggregateKubernetesProcessor([
             CountingKubernetesProcessor(self.aconf, KubernetesGVK.for_knative_networking('Ingress'), 'knative_ingress'),
             CountingKubernetesProcessor(self.aconf, KubernetesGVK.for_knative_networking('ClusterIngress'), 'knative_cluster_ingress'),
             AmbassadorProcessor(self.manager),
+            ServiceProcessor(self.manager, watch_only=watch_only),
             KnativeIngressProcessor(self.manager),
         ]))
-        self.k8s_endpoints: Dict[str, AnyDict] = {}
-        self.k8s_services: Dict[str, AnyDict] = {}
 
         self.alerted_about_labels = False
-
-        # Ugh. Should we worry about multiple Helm charts for a single Ambassador?
-        self.helm_chart: Optional[str] = None
 
         # For deduplicating objects coming in from watt
         self.k8s_parsed: Dict[str, bool] = {}
@@ -104,10 +100,6 @@ class ResourceFetcher:
     @property
     def elements(self) -> List[ACResource]:
         return self.manager.elements
-
-    @property
-    def services(self) -> Dict[str, Dict[str, Any]]:
-        return self.manager.services
 
     @property
     def location(self) -> str:
@@ -217,7 +209,7 @@ class ResourceFetcher:
 
         if os.path.isfile(os.path.join(basedir, '.ambassador_ignore_ingress')):
             self.aconf.post_error("Ambassador is not permitted to read Ingress resources. Please visit https://www.getambassador.io/user-guide/ingress-controller/ for more information. You can continue using Ambassador, but Ingress resources will be ignored...")
-        
+
         # Expand environment variables allowing interpolation in manifests.
         serialization = os.path.expandvars(serialization)
 
@@ -299,7 +291,7 @@ class ResourceFetcher:
         # self.logger.debug("handle_k8s obj %s" % json.dumps(obj, indent=4, sort_keys=True))
 
         try:
-            obj = KubernetesObject(raw_obj, default_namespace='default')
+            obj = KubernetesObject(raw_obj)
         except ValueError:
             # The object doesn't contain a kind, API version, or name, so we
             # can't process it.
@@ -457,7 +449,7 @@ class ResourceFetcher:
 
         parsed_ambassador_annotations = None
         if ambassador_annotations is not None:
-            self.manager.locations.current.mark_annotation()
+            self.manager.locations.mark_annotated()
 
             try:
                 parsed_ambassador_annotations = parse_yaml(ambassador_annotations)
@@ -632,254 +624,6 @@ class ResourceFetcher:
 
         return None
 
-    def is_ambassador_service(self, service_labels, service_selector):
-        # self.logger.info(f"is_ambassador_service checking {service_labels} - {service_selector}")
-
-        # Every Ambassador service must have the label 'app.kubernetes.io/component: ambassador-service'
-        if service_labels is None:
-            return False
-
-        if service_labels.get('app.kubernetes.io/component', "").lower() != 'ambassador-service':
-            return False
-
-        # Now that we have the Ambassador label, let's verify that this Ambassador service routes to this very
-        # Ambassador pod.
-        # We do this by checking that the pod's labels match the selector in the service.
-        for key, value in service_selector.items():
-            pod_label_value = self.aconf.pod_labels.get(key)
-            if pod_label_value != value:
-                return False
-
-        return True
-
-    def handle_k8s_endpoints(self, k8s_object: AnyDict) -> HandlerResult:
-        # Don't include Endpoints unless endpoint routing is enabled.
-        if not Config.enable_endpoints:
-            return None
-
-        metadata = k8s_object.get('metadata', None)
-        metadata_labels: Optional[Dict[str, str]] = metadata.get('labels')
-        resource_name = metadata.get('name') if metadata else None
-        resource_namespace = metadata.get('namespace', 'default') if metadata else None
-        resource_subsets = k8s_object.get('subsets', None)
-
-        skip = False
-
-        if not metadata:
-            self.logger.debug("ignoring K8s Endpoints with no metadata")
-            skip = True
-
-        if not resource_name:
-            self.logger.debug("ignoring K8s Endpoints with no name")
-            skip = True
-
-        if not resource_subsets:
-            self.logger.debug(f"ignoring K8s Endpoints {resource_name}.{resource_namespace} with no subsets")
-            skip = True
-
-        if skip:
-            return None
-
-        # We use this resource identifier as a key into self.k8s_services, and of course for logging .
-        resource_identifier = '{name}.{namespace}'.format(namespace=resource_namespace, name=resource_name)
-
-        # K8s Endpoints resources are _stupid_ in that they give you a vector of
-        # IP addresses and a vector of ports, and you have to assume that every
-        # IP address listens on every port, and that the semantics of each port
-        # are identical. The first is usually a good assumption. The second is not:
-        # people routinely list 80 and 443 for the same service, for example,
-        # despite the fact that one is HTTP and the other is HTTPS.
-        #
-        # By the time the ResourceFetcher is done, we want to be working with
-        # Ambassador Service resources, which have an array of address:port entries
-        # for endpoints. So we're going to extract the address and port numbers
-        # as arrays of tuples and stash them for later.
-        #
-        # In Kubernetes-speak, the Endpoints resource has some metadata and a set
-        # of "subsets" (though I've personally never seen more than one subset in
-        # one of these things).
-
-        for subset in resource_subsets:
-            # K8s subset addresses have some node info in with the IP address.
-            # May as well save that too.
-
-            addresses = []
-
-            for address in subset.get('addresses', []):
-                addr = {}
-
-                ip = address.get('ip', None)
-                if ip is not None:
-                    addr['ip'] = ip
-
-                node = address.get('nodeName', None)
-                if node is not None:
-                    addr['node'] = node
-
-                target_ref = address.get('targetRef', None)
-                if target_ref is not None:
-                    target_kind = target_ref.get('kind', None)
-                    if target_kind is not None:
-                        addr['target_kind'] = target_kind
-
-                    target_name = target_ref.get('name', None)
-                    if target_name is not None:
-                        addr['target_name'] = target_name
-
-                    target_namespace = target_ref.get('namespace', None)
-                    if target_namespace is not None:
-                        addr['target_namespace'] = target_namespace
-
-                if len(addr) > 0:
-                    addresses.append(addr)
-
-            # If we got no addresses, there's no point in messing with ports.
-            if len(addresses) == 0:
-                continue
-
-            ports = subset.get('ports', [])
-
-            # A service can reference a port either by name or by port number.
-            port_dict = {}
-
-            for port in ports:
-                port_name = port.get('name', None)
-                port_number = port.get('port', None)
-                port_proto = port.get('protocol', 'TCP').upper()
-
-                if port_proto != 'TCP':
-                    continue
-
-                if port_number is None:
-                    # WTFO.
-                    continue
-
-                port_dict[str(port_number)] = port_number
-
-                if port_name:
-                    port_dict[port_name] = port_number
-
-            if port_dict:
-                # We're not going to actually return this: we'll just stash it for our
-                # later resolution pass.
-
-                self.k8s_endpoints[resource_identifier] = {
-                    'name': resource_name,
-                    'namespace': resource_namespace,
-                    'addresses': addresses,
-                    'ports': port_dict
-                }
-
-                if metadata_labels:
-                    self.k8s_endpoints[resource_identifier]['metadata_labels'] = metadata_labels
-
-            else:
-                self.logger.debug(f"ignoring K8s Endpoints {resource_identifier} with no routable ports")
-
-        return None
-
-    def handle_k8s_service(self, k8s_object: AnyDict) -> HandlerResult:
-        # The annoying bit about K8s Service resources is that not only do we have to look
-        # inside them for Ambassador resources, but we also have to save their info for
-        # later endpoint resolution too.
-        #
-        # Again, we're trusting that the input isn't overly bloated on that latter bit.
-
-        metadata = k8s_object.get('metadata', None)
-        if not metadata:
-            self.logger.debug("ignoring K8s Service with no metadata")
-            return None
-
-        metadata_labels: Optional[Dict[str, str]] = metadata.get('labels')
-        resource_name = metadata.get('name') if metadata else None
-        resource_namespace = metadata.get('namespace', 'default') if metadata else None
-
-        annotations = metadata.get('annotations', None) if metadata else None
-        if annotations:
-            annotations = annotations.get('getambassador.io/config', None)
-
-        labels = metadata.get('labels')
-
-        if labels:
-            chart_version = labels.get('helm.sh/chart', None)
-
-            if chart_version and not self.helm_chart:
-                self.helm_chart = chart_version
-
-        skip = False
-
-        if not metadata:
-            self.logger.debug("ignoring K8s Service with no metadata")
-            skip = True
-
-        if not skip and not resource_name:
-            self.logger.debug("ignoring K8s Service with no name")
-            skip = True
-
-        if not skip and (Config.single_namespace and (resource_namespace != Config.ambassador_namespace)):
-            # This should never happen in actual usage, since we shouldn't be given things
-            # in the wrong namespace. However, in development, this can happen a lot.
-            self.logger.debug(f"ignoring K8s Service {resource_name}.{resource_namespace} in wrong namespace")
-            skip = True
-
-        if skip:
-            return None
-
-        # We use this resource identifier as a key into self.k8s_services, and of course for logging .
-        resource_identifier = f'{resource_name}.{resource_namespace}'
-
-        # Not skipping. First, if we have some actual ports, stash this in self.k8s_services
-        # for later resolution.
-
-        spec = k8s_object.get('spec', None)
-        ports = spec.get('ports', None) if spec else None
-
-        if spec and ports:
-            self.k8s_services[resource_identifier] = {
-                'name': resource_name,
-                'namespace': resource_namespace,
-                'ports': ports
-            }
-
-            if metadata_labels:
-                self.k8s_services[resource_identifier]['metadata_labels'] = metadata_labels
-
-            selector = spec.get('selector', {})
-
-            if self.is_ambassador_service(labels, selector):
-                self.logger.debug(f"Found Ambassador service: {resource_name}")
-                self.manager.ambassador_service = KubernetesObject(k8s_object, default_namespace='default')
-
-        else:
-            self.logger.debug(f"not saving K8s Service {resource_name}.{resource_namespace} with no ports")
-
-        result: List[Any] = []
-
-        if annotations:
-            self.manager.locations.current.mark_annotation()
-
-            try:
-                objects = parse_yaml(annotations)
-
-                for obj in objects:
-                    if not obj:
-                        self.logger.warning(f"empty YAML document found in ambassador service: {resource_name}.{resource_namespace}")
-                        continue
-                    if obj.get('metadata_labels') is None and metadata_labels:
-                        obj['metadata_labels'] = metadata_labels
-                    if obj.get('namespace') is None:
-                        obj['namespace'] = resource_namespace
-
-                    # Force validation of this object.
-                    obj['_force_validation'] = True
-
-                    result.append(obj)
-
-            except yaml.error.YAMLError as e:
-                self.logger.debug("could not parse YAML: %s" % e)
-
-        return resource_identifier, result
-
     # Handler for K8s Secret resources.
     def handle_k8s_secret(self, k8s_object: AnyDict) -> HandlerResult:
         # XXX Another one where we shouldn't be saving everything.
@@ -971,14 +715,7 @@ class ResourceFetcher:
         # Note that we currently trust the association ID to contain the datacenter name.
         # That's a function of the watch_hook putting it there.
 
-        svc = {
-            'apiVersion': 'getambassador.io/v2',
-            'ambassador_id': Config.ambassador_id,
-            'kind': 'Service',
-            'name': name,
-            'datacenter': consul_object.get('Id') or 'dc1',
-            'endpoints': {}
-        }
+        normalized_endpoints: Dict[str, List[Dict[str, Any]]] = {}
 
         for ep in endpoints:
             ep_addr = ep.get('Address')
@@ -990,220 +727,27 @@ class ResourceFetcher:
 
             # Consul services don't have the weird indirections that Kube services do, so just
             # lump all the endpoints together under the same source port of '*'.
-            svc_eps = svc['endpoints'].setdefault('*', [])
+            svc_eps = normalized_endpoints.setdefault('*', [])
             svc_eps.append({
                 'ip': ep_addr,
                 'port': ep_port,
                 'target_kind': 'Consul'
             })
 
-        # Once again: don't return this. Instead, save it in self.services.
-        self.services[f"consul-{name}-{svc['datacenter']}"] = svc
+        spec = {
+            'ambassador_id': Config.ambassador_id,
+            'datacenter': consul_object.get('Id') or 'dc1',
+            'endpoints': normalized_endpoints,
+        }
+
+        self.manager.emit(NormalizedResource.from_data(
+            kind='Service',
+            name=name,
+            spec=spec,
+            rkey=f"consul-{name}-{spec['datacenter']}",
+        ))
 
         return None
 
     def finalize(self) -> None:
-        # The point here is to sort out self.k8s_services and self.k8s_endpoints and
-        # turn them into proper Ambassador Service resources. This is a bit annoying,
-        # because of the annoyances of Kubernetes, but we'll give it a go.
-        #
-        # Here are the rules:
-        #
-        # 1. By the time we get here, we have a _complete_ set of Ambassador resources that
-        #    have passed muster by virtue of having the correct namespace, the correct
-        #    ambassador_id, etc. (They may have duplicate names at this point, admittedly.)
-        #    Any service not mentioned by name is out. Since the Ambassador resources in
-        #    self.elements are in fact AResources, we can farm this out to code for each
-        #    resource.
-        #
-        # 2. The check is, by design, permissive. If in doubt, write the check to leave
-        #    the resource in.
-        #
-        # 3. For any service that stays in, we vet its listed ports against self.k8s_endpoints.
-        #    Anything with no matching ports is _not_ dropped; it is assumed to use service
-        #    routing rather than endpoint routing.
-
-        # od = {
-        #     'elements': [ x.as_dict() for x in self.elements ],
-        #     'k8s_endpoints': self.k8s_endpoints,
-        #     'k8s_services': self.k8s_services,
-        #     'services': self.services
-        # }
-        #
-        # self.logger.debug("==== FINALIZE START\n%s" % json.dumps(od, sort_keys=True, indent=4))
-
-        for key, k8s_svc in self.k8s_services.items():
-            k8s_name = k8s_svc['name']
-            k8s_namespace = k8s_svc['namespace']
-            k8s_metadata_labels = k8s_svc.get('metadata_labels', None)
-
-            target_ports = {}
-            target_addrs = []
-            svc_endpoints = {}
-
-            if not self.watch_only:
-                # If we're not in watch mode, try to find endpoints for this service.
-
-                k8s_ep = self.k8s_endpoints.get(key, None)
-                k8s_ep_ports = k8s_ep.get('ports', None) if k8s_ep else None
-
-                # OK, Kube is weird. The way all this works goes like this:
-                #
-                # 1. When you create a Kube Service, Kube will allocate a clusterIP
-                #    for it and update DNS to resolve the name of the service to
-                #    that clusterIP.
-                # 2. Kube will look over the pods matched by the Service's selectors
-                #    and stick those pods' IP addresses into Endpoints for the Service.
-                # 3. The Service will have ports listed. These service.port entries can
-                #    contain:
-                #      port -- a port number you can talk to at the clusterIP
-                #      name -- a name for this port
-                #      targetPort -- a port number you can talk to at the _endpoint_ IP
-                #    We'll call the 'port' entry here the "service-port".
-                # 4. If you talk to clusterIP:service-port, you will get magically
-                #    proxied by the Kube CNI to a target port at one of the endpoint IPs.
-                #
-                # The $64K question is: how does Kube decide which target port to use?
-                #
-                # First, if there's only one endpoint port, that's the one that gets used.
-                #
-                # If there's more than one, if the Service's port entry has a targetPort
-                # number, it uses that. Otherwise it tries to find an endpoint port with
-                # the same name as the service port. Otherwise, I dunno, it punts and uses
-                # the service-port.
-                #
-                # So that's how Ambassador is going to do it, for each Service port entry.
-                #
-                # If we have no endpoints at all, Ambassador will end up routing using
-                # just the service name and port per the Mapping's service spec.
-
-                if not k8s_ep or not k8s_ep_ports:
-                    # No endpoints at all, so we're done with this service.
-                    self.logger.debug(f'{key}: no endpoints at all')
-                else:
-                    idx = -1
-
-                    for port in k8s_svc['ports']:
-                        idx += 1
-
-                        k8s_target: Optional[int] = None
-
-                        src_port = port.get('port', None)
-
-                        if not src_port:
-                            # WTFO. This is impossible.
-                            self.logger.error(f"Kubernetes service {key} has no port number at index {idx}?")
-                            continue
-
-                        if len(k8s_ep_ports) == 1:
-                            # Just one endpoint port. Done.
-                            k8s_target = list(k8s_ep_ports.values())[0]
-                            target_ports[src_port] = k8s_target
-
-                            self.logger.debug(f'{key} port {src_port}: single endpoint port {k8s_target}')
-                            continue
-
-                        # Hmmm, we need to try to actually map whatever ports are listed for
-                        # this service. Oh well.
-
-                        found_key = False
-                        fallback: Optional[int] = None
-
-                        for attr in [ 'targetPort', 'name', 'port' ]:
-                            port_key = port.get(attr)   # This could be a name or a number, in general.
-
-                            if port_key:
-                                found_key = True
-
-                                if not fallback and (port_key != 'name') and str(port_key).isdigit():
-                                    # fallback can only be digits.
-                                    fallback = port_key
-
-                                # Do we have a destination port for this?
-                                k8s_target = k8s_ep_ports.get(str(port_key), None)
-
-                                if k8s_target:
-                                    self.logger.debug(f'{key} port {src_port} #{idx}: {attr} {port_key} -> {k8s_target}')
-                                    break
-                                else:
-                                    self.logger.debug(f'{key} port {src_port} #{idx}: {attr} {port_key} -> miss')
-
-                        if not found_key:
-                            # WTFO. This is impossible.
-                            self.logger.error(f"Kubernetes service {key} port {src_port} has an empty port spec at index {idx}?")
-                            continue
-
-                        if not k8s_target:
-                            # This is most likely because we don't have endpoint info at all, so we'll do service
-                            # routing.
-                            #
-                            # It's actually impossible for fallback to be unset, but WTF.
-                            k8s_target = fallback or src_port
-
-                            self.logger.debug(f'{key} port {src_port} #{idx}: falling back to {k8s_target}')
-
-                        target_ports[src_port] = k8s_target
-
-                    if not target_ports:
-                        # WTFO. This is impossible. I guess we'll fall back to service routing.
-                        self.logger.error(f"Kubernetes service {key} has no routable ports at all?")
-
-                    # OK. Once _that's_ done we have to take the endpoint addresses into
-                    # account, or just use the service name if we don't have that.
-
-                    k8s_ep_addrs = k8s_ep.get('addresses', None)
-
-                    if k8s_ep_addrs:
-                        for addr in k8s_ep_addrs:
-                            ip = addr.get('ip', None)
-
-                            if ip:
-                                target_addrs.append(ip)
-
-            # OK! If we have no target addresses, just use service routing.
-            if not target_addrs:
-                if not self.watch_only:
-                    self.logger.debug(f'{key} falling back to service routing')
-                target_addrs = [ key ]
-
-            for src_port, target_port in target_ports.items():
-                svc_endpoints[src_port] = [ {
-                    'ip': target_addr,
-                    'port': target_port
-                } for target_addr in target_addrs ]
-
-            svc_resource = {
-                'apiVersion': 'getambassador.io/v2',
-                'ambassador_id': Config.ambassador_id,
-                'kind': 'Service',
-                'name': k8s_name,
-                'namespace': k8s_namespace,
-                'endpoints': svc_endpoints
-            }
-
-            if k8s_metadata_labels:
-                svc_resource['metadata_labels'] = k8s_metadata_labels
-
-            self.services[f'k8s-{k8s_name}-{k8s_namespace}'] = svc_resource
-
-        # OK. After all that, go turn all of the things in self.services into Ambassador
-        # Service resources.
-
-        for key, svc in self.services.items():
-            serialization = dump_yaml(svc, default_flow_style=False)
-
-            r = ACResource.from_dict(key, key, serialization, svc)
-
-            if self.helm_chart:
-                r['helm_chart'] = self.helm_chart
-
-            self.elements.append(r)
-
-        # od = {
-        #     'elements': [ x.as_dict() for x in self.elements ],
-        #     'k8s_endpoints': self.k8s_endpoints,
-        #     'k8s_services': self.k8s_services,
-        #     'services': self.services
-        # }
-
-        # self.logger.debug("==== FINALIZE END\n%s" % json.dumps(od, sort_keys=True, indent=4))
+        self.k8s_processor.finalize()

--- a/python/ambassador/fetch/k8sobject.py
+++ b/python/ambassador/fetch/k8sobject.py
@@ -127,7 +127,7 @@ class KubernetesObject (collections.abc.Mapping):
     @property
     def key(self) -> KubernetesObjectKey:
         try:
-            namespace = self.namespace
+            namespace: Optional[str] = self.namespace
         except AttributeError:
             namespace = None
 

--- a/python/ambassador/fetch/knative.py
+++ b/python/ambassador/fetch/knative.py
@@ -21,12 +21,7 @@ class KnativeIngressProcessor (ManagedKubernetesProcessor):
     INGRESS_CLASS: ClassVar[str] = 'ambassador.ingress.networking.knative.dev'
 
     def kinds(self) -> FrozenSet[KubernetesGVK]:
-        kinds = [
-            'Ingress',
-            'ClusterIngress',
-        ]
-
-        return frozenset([KubernetesGVK.for_knative_networking(kind) for kind in kinds])
+        return frozenset([KubernetesGVK.for_knative_networking('Ingress')])
 
     def _has_required_annotations(self, obj: KubernetesObject) -> bool:
         annotations = obj.annotations

--- a/python/ambassador/fetch/knative.py
+++ b/python/ambassador/fetch/knative.py
@@ -90,7 +90,7 @@ class KnativeIngressProcessor (ManagedKubernetesProcessor):
             mapping = NormalizedResource.from_data(
                 'Mapping',
                 mapping_identifier,
-                namespace=obj.namespace or 'default',
+                namespace=obj.namespace,
                 generation=obj.generation,
                 labels=obj.labels,
                 spec=spec,
@@ -154,7 +154,7 @@ class KnativeIngressProcessor (ManagedKubernetesProcessor):
             # the relevant domain by doing a DNS lookup on
             # kubernetes.default.svc, but this problem appears elsewhere in the
             # code as well and probably should just be fixed all at once.
-            current_lb_domain = f"{self.manager.ambassador_service.name}.{self.manager.ambassador_service.namespace or 'default'}.svc.cluster.local"
+            current_lb_domain = f"{self.manager.ambassador_service.name}.{self.manager.ambassador_service.namespace}.svc.cluster.local"
 
         observed_ingress: Dict[str, Any] = next(iter(obj.status.get('privateLoadBalancer', {}).get('ingress', [])), {})
         observed_lb_domain = observed_ingress.get('domainInternal')

--- a/python/ambassador/fetch/service.py
+++ b/python/ambassador/fetch/service.py
@@ -1,0 +1,392 @@
+from typing import Dict, FrozenSet, List, Optional
+
+import dataclasses
+
+from ..config import Config
+
+from .k8sobject import KubernetesGVK, KubernetesObjectKey, KubernetesObject
+from .k8sprocessor import AggregateKubernetesProcessor, ManagedKubernetesProcessor
+from .resource import NormalizedResource, ResourceManager
+
+
+@dataclasses.dataclass(frozen=True)
+class EndpointAddress:
+    """
+    A single address of an endpoint used internally to map back to Service
+    resources.
+    """
+
+    ip: str
+    node: Optional[str]
+    target: Optional[KubernetesObjectKey]
+
+
+@dataclasses.dataclass(frozen=True)
+class Endpoints:
+    """
+    A discovered set of endpoint addresses and ports used internally to map back
+    to Service resources.
+    """
+
+    addresses: List[EndpointAddress]
+    ports: Dict[str, int]
+    labels: Dict[str, str]
+
+
+class InternalServiceProcessor (ManagedKubernetesProcessor):
+    """
+    An internal Kubernetes object processor for services. Used by the
+    ServiceProcessor aggregate class.
+    """
+
+    helm_chart: Optional[str]
+    discovered_services: Dict[KubernetesObjectKey, KubernetesObject]
+
+    def __init__(self, manager: ResourceManager) -> None:
+        super().__init__(manager)
+
+        self.helm_chart = None
+        self.discovered_services = {}
+
+    def kinds(self) -> FrozenSet[KubernetesGVK]:
+        return frozenset([KubernetesGVK('v1', 'Service')])
+
+    def _is_ambassador_service(self, service_labels: Dict[str, str], service_selector: Dict[str, str]) -> bool:
+        # self.logger.info(f"is_ambassador_service checking {service_labels} - {service_selector}")
+
+        # Every Ambassador service must have the label 'app.kubernetes.io/component: ambassador-service'
+        if service_labels.get('app.kubernetes.io/component', "").lower() != 'ambassador-service':
+            return False
+
+        # Now that we have the Ambassador label, let's verify that this Ambassador service routes to this very
+        # Ambassador pod.
+        # We do this by checking that the pod's labels match the selector in the service.
+        for key, value in service_selector.items():
+            pod_label_value = self.aconf.pod_labels.get(key)
+            if pod_label_value == value:
+                return True
+
+        return False
+
+    def _process(self, obj: KubernetesObject) -> None:
+        # The annoying bit about K8s Service resources is that not only do we have to look
+        # inside them for Ambassador resources, but we also have to save their info for
+        # later endpoint resolution too.
+        #
+        # Again, we're trusting that the input isn't overly bloated on that latter bit.
+
+        chart_version = obj.labels.get('helm.sh/chart')
+        if chart_version and not self.helm_chart:
+            self.helm_chart = chart_version
+
+        if not obj.spec.get('ports'):
+            self.logger.debug(f"not saving Kubernetes Service {obj.name}.{obj.namespace} with no ports")
+        else:
+            self.discovered_services[obj.key] = obj
+
+            if self._is_ambassador_service(obj.labels, obj.spec.get('selector', {})):
+                self.logger.debug(f"Found Ambassador service: {obj.name}")
+                self.manager.ambassador_service = obj
+
+        # Although we can't emit this resource immediately, we can handle
+        # anything added as an annotation.
+        self.manager.emit_annotated(NormalizedResource.from_kubernetes_object_annotation(obj))
+
+
+class InternalEndpointsProcessor (ManagedKubernetesProcessor):
+    """
+    This processor discovers endpoints, extracts information we care about, and
+    stores the data for referencing by another processor.
+    """
+
+    discovered_endpoints: Dict[KubernetesObjectKey, Endpoints]
+
+    def __init__(self, manager: ResourceManager) -> None:
+        super().__init__(manager)
+
+        self.discovered_endpoints = {}
+
+    def kinds(self) -> FrozenSet[KubernetesGVK]:
+        return frozenset([KubernetesGVK('v1', 'Endpoints')])
+
+    def _process(self, obj: KubernetesObject) -> None:
+        resource_subsets = obj.get('subsets')
+        if not resource_subsets:
+            self.logger.debug(f"ignoring Kubernetes Endpoints {obj.name}.{obj.namespace} with no subsets")
+            return
+
+        # K8s Endpoints resources are _stupid_ in that they give you a vector of
+        # IP addresses and a vector of ports, and you have to assume that every
+        # IP address listens on every port, and that the semantics of each port
+        # are identical. The first is usually a good assumption. The second is not:
+        # people routinely list 80 and 443 for the same service, for example,
+        # despite the fact that one is HTTP and the other is HTTPS.
+        #
+        # By the time the ResourceFetcher is done, we want to be working with
+        # Ambassador Service resources, which have an array of address:port entries
+        # for endpoints. So we're going to extract the address and port numbers
+        # as arrays of tuples and stash them for later.
+        #
+        # In Kubernetes-speak, the Endpoints resource has some metadata and a set
+        # of "subsets" (though I've personally never seen more than one subset in
+        # one of these things).
+
+        for subset in resource_subsets:
+            # K8s subset addresses have some node info in with the IP address.
+            # May as well save that too.
+
+            addresses: List[EndpointAddress] = []
+
+            for address in subset.get('addresses', []):
+                ip = address.get('ip')
+                if not ip:
+                    continue
+
+                target_ref: Optional[KubernetesObjectKey] = None
+                try:
+                    target_ref = KubernetesObjectKey.from_object_reference(address.get('targetRef', {}))
+                except KeyError:
+                    pass
+
+                addresses.append(EndpointAddress(ip, node=address.get('nodeName'), target=target_ref))
+
+            # If we got no addresses, there's no point in messing with ports.
+            if len(addresses) == 0:
+                continue
+
+            ports = subset.get('ports', [])
+
+            # A service can reference a port either by name or by port number.
+            port_dict: Dict[str, int] = {}
+
+            for port in ports:
+                port_name = port.get('name', None)
+                port_number = port.get('port', None)
+                port_proto = port.get('protocol', 'TCP').upper()
+
+                if port_proto != 'TCP':
+                    continue
+
+                if port_number is None:
+                    # WTFO.
+                    continue
+
+                port_dict[str(port_number)] = port_number
+
+                if port_name:
+                    port_dict[port_name] = port_number
+
+            if not port_dict:
+                self.logger.debug(f"ignoring K8s Endpoints {obj.name}.{obj.namespace} with no routable ports")
+                continue
+
+            self.discovered_endpoints[obj.key] = Endpoints(addresses, port_dict, obj.labels)
+
+
+class ServiceProcessor (ManagedKubernetesProcessor):
+    """
+    This processor handles Service and Endpoints objects and creates relevant
+    Ambassador service resources.
+    """
+
+    services: InternalServiceProcessor
+    endpoints: InternalEndpointsProcessor
+    delegate: AggregateKubernetesProcessor
+    watch_only: bool
+
+    def __init__(self, manager: ResourceManager, watch_only: bool = False):
+        super().__init__(manager)
+
+        self.services = InternalServiceProcessor(manager)
+        self.endpoints = InternalEndpointsProcessor(manager)
+        self.delegate = AggregateKubernetesProcessor([self.services, self.endpoints])
+        self.watch_only = watch_only
+
+    def kinds(self) -> FrozenSet[KubernetesGVK]:
+        return self.delegate.kinds()
+
+    def _process(self, obj: KubernetesObject) -> None:
+        self.delegate.try_process(obj)
+
+    def finalize(self) -> None:
+        self.delegate.finalize()
+
+        # The point here is to sort out self.services.discovered_services and
+        # self.endpoints.discovered_endpoints and turn them into proper
+        # Ambassador Service resources. This is a bit annoying, because of the
+        # annoyances of Kubernetes, but we'll give it a go.
+        #
+        # Here are the rules:
+        #
+        # 1. By the time we get here, we have a _complete_ set of Ambassador
+        #    resources that have passed muster by virtue of having the correct
+        #    namespace, the correct ambassador_id, etc. (They may have duplicate
+        #    names at this point, admittedly.) Any service not mentioned by name
+        #    is out. Since the Ambassador resources in self.elements are in fact
+        #    AResources, we can farm this out to code for each resource.
+        #
+        # 2. The check is, by design, permissive. If in doubt, write the check
+        #    to leave the resource in.
+        #
+        # 3. For any service that stays in, we vet its listed ports against
+        #    self.k8s_endpoints. Anything with no matching ports is _not_
+        #    dropped; it is assumed to use service routing rather than endpoint
+        #    routing.
+
+        # od = {
+        #     'elements': [ x.as_dict() for x in self.elements ],
+        #     'k8s_endpoints': self.endpoints.discovered_endpoints,
+        #     'k8s_services': self.services.discovered_services,
+        # }
+        #
+        # self.logger.debug("==== FINALIZE START\n%s" % json.dumps(od, sort_keys=True, indent=4))
+
+        for k8s_svc in self.services.discovered_services.values():
+            key = f'{k8s_svc.name}.{k8s_svc.namespace}'
+
+            target_ports = {}
+            target_addrs = []
+            svc_endpoints = {}
+
+            if not self.watch_only:
+                # If we're not in watch mode, try to find endpoints for this service.
+                k8s_ep_key = KubernetesObjectKey(KubernetesGVK('v1', 'Endpoints'), k8s_svc.namespace, k8s_svc.name)
+                k8s_ep = self.endpoints.discovered_endpoints.get(k8s_ep_key)
+
+                # OK, Kube is weird. The way all this works goes like this:
+                #
+                # 1. When you create a Kube Service, Kube will allocate a clusterIP
+                #    for it and update DNS to resolve the name of the service to
+                #    that clusterIP.
+                # 2. Kube will look over the pods matched by the Service's selectors
+                #    and stick those pods' IP addresses into Endpoints for the Service.
+                # 3. The Service will have ports listed. These service.port entries can
+                #    contain:
+                #      port -- a port number you can talk to at the clusterIP
+                #      name -- a name for this port
+                #      targetPort -- a port number you can talk to at the _endpoint_ IP
+                #    We'll call the 'port' entry here the "service-port".
+                # 4. If you talk to clusterIP:service-port, you will get magically
+                #    proxied by the Kube CNI to a target port at one of the endpoint IPs.
+                #
+                # The $64K question is: how does Kube decide which target port to use?
+                #
+                # First, if there's only one endpoint port, that's the one that gets used.
+                #
+                # If there's more than one, if the Service's port entry has a targetPort
+                # number, it uses that. Otherwise it tries to find an endpoint port with
+                # the same name as the service port. Otherwise, I dunno, it punts and uses
+                # the service-port.
+                #
+                # So that's how Ambassador is going to do it, for each Service port entry.
+                #
+                # If we have no endpoints at all, Ambassador will end up routing using
+                # just the service name and port per the Mapping's service spec.
+
+                if not k8s_ep:
+                    # No endpoints at all, so we're done with this service.
+                    self.logger.debug(f'{key}: no endpoints at all')
+                else:
+                    idx = -1
+
+                    for port in k8s_svc.spec.get('ports', []):
+                        idx += 1
+
+                        k8s_target: Optional[int] = None
+
+                        src_port = port.get('port', None)
+
+                        if not src_port:
+                            # WTFO. This is impossible.
+                            self.logger.error(f"Kubernetes service {key} has no port number at index {idx}?")
+                            continue
+
+                        if len(k8s_ep.ports) == 1:
+                            # Just one endpoint port. Done.
+                            k8s_target = next(iter(k8s_ep.ports.values()))
+                            target_ports[src_port] = k8s_target
+
+                            self.logger.debug(f'{key} port {src_port}: single endpoint port {k8s_target}')
+                            continue
+
+                        # Hmmm, we need to try to actually map whatever ports are listed for
+                        # this service. Oh well.
+
+                        found_key = False
+                        fallback: Optional[int] = None
+
+                        for attr in ['targetPort', 'name', 'port']:
+                            port_key = port.get(attr)   # This could be a name or a number, in general.
+
+                            if port_key:
+                                found_key = True
+
+                                if not fallback and (port_key != 'name') and str(port_key).isdigit():
+                                    # fallback can only be digits.
+                                    fallback = port_key
+
+                                # Do we have a destination port for this?
+                                k8s_target = k8s_ep.ports.get(str(port_key), None)
+
+                                if k8s_target:
+                                    self.logger.debug(f'{key} port {src_port} #{idx}: {attr} {port_key} -> {k8s_target}')
+                                    break
+                                else:
+                                    self.logger.debug(f'{key} port {src_port} #{idx}: {attr} {port_key} -> miss')
+
+                        if not found_key:
+                            # WTFO. This is impossible.
+                            self.logger.error(f"Kubernetes service {key} port {src_port} has an empty port spec at index {idx}?")
+                            continue
+
+                        if not k8s_target:
+                            # This is most likely because we don't have endpoint info at all, so we'll do service
+                            # routing.
+                            #
+                            # It's actually impossible for fallback to be unset, but WTF.
+                            k8s_target = fallback or src_port
+
+                            self.logger.debug(f'{key} port {src_port} #{idx}: falling back to {k8s_target}')
+
+                        target_ports[src_port] = k8s_target
+
+                    if not target_ports:
+                        # WTFO. This is impossible. I guess we'll fall back to service routing.
+                        self.logger.error(f"Kubernetes service {key} has no routable ports at all?")
+
+                    # OK. Once _that's_ done we have to take the endpoint addresses into
+                    # account, or just use the service name if we don't have that.
+
+                    for addr in k8s_ep.addresses:
+                        target_addrs.append(addr.ip)
+
+            # OK! If we have no target addresses, just use service routing.
+            if not target_addrs:
+                if not self.watch_only:
+                    self.logger.debug(f'{key} falling back to service routing')
+                target_addrs = [key]
+
+            for src_port, target_port in target_ports.items():
+                svc_endpoints[src_port] = [{
+                    'ip': target_addr,
+                    'port': target_port
+                } for target_addr in target_addrs]
+
+            spec = {
+                'ambassador_id': Config.ambassador_id,
+                'endpoints': svc_endpoints,
+            }
+
+            if self.services.helm_chart:
+                spec['helm_chart'] = self.services.helm_chart
+
+            self.manager.emit(NormalizedResource.from_data(
+                kind='Service',
+                name=k8s_svc.name,
+                namespace=k8s_svc.namespace,
+                labels=k8s_svc.labels,
+                spec=spec,
+                rkey=f'k8s-{k8s_svc.name}-{k8s_svc.namespace}',
+            ))
+
+        # self.logger.debug("==== FINALIZE END\n%s" % json.dumps(od, sort_keys=True, indent=4))

--- a/python/ambassador/ir/ir.py
+++ b/python/ambassador/ir/ir.py
@@ -994,7 +994,7 @@ class IR:
         od['endpoint_routing_envoy_maglev_count'] = endpoint_routing_envoy_maglev_count
         od['endpoint_routing_envoy_lr_count'] = endpoint_routing_envoy_lr_count
 
-        od['cluster_ingress_count'] = self.aconf.get_count('knative_cluster_ingress')
+        od['cluster_ingress_count'] = 0  # Provided for backward compatibility only.
         od['knative_ingress_count'] = self.aconf.get_count('knative_ingress')
 
         od['k8s_ingress_count'] = len(self.aconf.k8s_ingresses)

--- a/python/tests/test_knative.py
+++ b/python/tests/test_knative.py
@@ -21,6 +21,7 @@ apiVersion: serving.knative.dev/v1alpha1
 kind: Service
 metadata:
  name: helloworld-go
+ namespace: default
 spec:
  template:
    spec:
@@ -36,6 +37,7 @@ apiVersion: networking.internal.knative.dev/v1alpha1
 kind: Ingress
 metadata:
   name: helloworld-go
+  namespace: default
 spec:
   rules:
   - hosts:


### PR DESCRIPTION
## Description
This change moves service processing from the resource fetcher to a separate processor, `ServiceProcessor`. The functionality should be exactly the same.

## Testing
This passes the automated test suite.

## Tasks That Must Be Done
- [ ] Did you update CHANGELOG.md?
- [x] Did you add or update tests?
- [ ] Did you update documentation?
- [ ] Were there any special dev tricks you had to use to work on this code efficiently?
  + [ ] Did you add them to DEVELOPING.md?
- [ ] Is this a build change?
  + [ ] If so, did you test on both Mac and Linux?
