### PR TITLE
diagd: Fix envoy validation TimeoutExpired error message

### DIFF
--- a/python/ambassador_diag/diagd.py
+++ b/python/ambassador_diag/diagd.py
@@ -1396,9 +1396,9 @@ class AmbassadorEventWatcher(threading.Thread):
                 break
             except subprocess.TimeoutExpired as e:
                 odict['exit_code'] = 1
-                odict['output'] = e.output
+                odict['output'] = e.output or ''
                 self.logger.warn("envoy configuration validation timed out after {} seconds{}\n{}",
-                    timeout, ', retrying...' if retry < retries - 1 else '', e.output)
+                    timeout, ', retrying...' if retry < retries - 1 else '', odict['output'])
                 continue
 
         if odict['exit_code'] == 0:


### PR DESCRIPTION
## Description
When envoy validation process is too long, the exception
subprocess.TimeoutExpired will be raised.
The error message is outputting e.output.
This value can be None, so the code has been changed to handle this
case.
Otherwise, the logging line will raise an exception:
TypeError: not all arguments converted during string formatting

## Related Issues
Bug introduced by this PR: https://github.com/datawire/ambassador/pull/1652
