### PR TITLE
Making community pages version-specific,

### DIFF
--- a/docs/js/doc-links.yml
+++ b/docs/js/doc-links.yml
@@ -251,6 +251,6 @@
 - title: Community
   items:
     - title: Contributor's Guide
-      link: https://github.com/datawire/ambassador/blob/master/DEVELOPING.md
+      link: https://github.com/datawire/ambassador/blob/release/v1.4/DEVELOPING.md
     - title: CHANGELOG
-      link: https://github.com/datawire/ambassador/blob/master/CHANGELOG.md
+      link: https://github.com/datawire/ambassador/blob/release/v1.4/CHANGELOG.md


### PR DESCRIPTION
Update the community page URLs to reference files in the branch associated with this version of the docs.