### PR TITLE
Making community pages version-specific

### DIFF
--- a/docs/js/doc-links.yml
+++ b/docs/js/doc-links.yml
@@ -249,6 +249,6 @@
 - title: Community
   items:
     - title: Contributor's Guide
-      link: https://github.com/datawire/ambassador/blob/master/DEVELOPING.md
+      link: https://github.com/datawire/ambassador/blob/release/v1.3/DEVELOPING.md
     - title: CHANGELOG
-      link: https://github.com/datawire/ambassador/blob/master/CHANGELOG.md
+      link: https://github.com/datawire/ambassador/blob/release/v1.3/CHANGELOG.md


### PR DESCRIPTION
Update the community page URLs to reference files in the branch associated with this version of the docs.