### PR TITLE
CI: Fix running on non-master branches

### DIFF
--- a/.github/workflows/circleci-branches.yml
+++ b/.github/workflows/circleci-branches.yml
@@ -20,8 +20,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Trigger CircleCI pipeline
+      env:
+        CIRCLECI_TOKEN: ${{ secrets.CIRCLECI_TOKEN }}
       run: |
-        curl -u "$CIRCLECI_TOKEN:" -X POST https://circleci.com/api/v2/project/github/${GITHUB_REPOSITORY}/pipeline \
+        # https://stackoverflow.com/a/22508743
+        post() {
+          [ "$(set -x; curl -s -i -w '%{http_code}' -o /dev/stderr -X POST "$@")" = 201 ]
+        }
+        post https://circleci.com/api/v2/project/github/${GITHUB_REPOSITORY}/pipeline \
+          -u "$CIRCLECI_TOKEN:" \
           -H 'Content-Type: application/json' \
           -H 'Accept: application/json' \
           --data "{ \"branch\": \"${GITHUB_REF#refs/heads/}\" }"


### PR DESCRIPTION
This fixes CI running on the `release/*` and `shared/*` branches.  You can tell because:
 - A GH action will appear on this PR
- The action will turn green
- The logs for the action will show an HTTP code of 201 "Created".