### PR TITLE
Fix the BLC not actually running

### DIFF
--- a/.ci/website-preview-blc
+++ b/.ci/website-preview-blc
@@ -35,6 +35,10 @@ pushd "${WEBSITE_DIR:-/tmp/getambassador.io}/public"
 python3 -m http.server 2>/dev/null &
 trap "kill $! 2>/dev/null" EXIT
 popd
+while ! curl --fail http://localhost:8000/; do
+	echo 'waiting for http server to start...'
+	sleep 1
+done
 
 cd /tmp/getambassador.io-blc
 ./blc.js http://localhost:8000/ > /tmp/blc.txt

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -235,6 +235,9 @@ jobs:
     - attach_workspace:
         at: /tmp/getambassador.io
     - run: ./.ci/website-preview-blc
+    - store_artifacts:
+        path: /tmp/blc.txt
+        destination: blc.txt
   "website-preview-for-smoketest":
     !!merge <<: *website-job
     steps:

--- a/.circleci/config.yml.d/docs.yml
+++ b/.circleci/config.yml.d/docs.yml
@@ -54,6 +54,9 @@ jobs:
       - attach_workspace:
           at: /tmp/getambassador.io
       - run: ./.ci/website-preview-blc
+      - store_artifacts:
+          path: /tmp/blc.txt
+          destination: blc.txt
 
   "website-preview-for-smoketest":
     <<: *website-job


### PR DESCRIPTION
It was starting up before `python3 -m http.server` started up, and so immediately exited with an error. So block until it's ready.

Also save the `blc.txt` log as an artifact so we can check for if weird things happen, like this.