### PR TITLE
Add circuit_breakers to TCP connections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,7 @@ Format:
 
 - Incorporate the [Envoy 1.14.2](https://www.envoyproxy.io/docs/envoy/v1.14.2/intro/version_history#june-8-2020) security update.
 - Upgrade the base Docker images used by several tests (thanks, [Daniel Sutton](https://github.com/ducksecops)!).
+- Feature: Add support for circuit breakers in TCP mapping
 
 ### Ambassador Edge Stack only
 

--- a/docs/topics/using/tcpmappings.md
+++ b/docs/topics/using/tcpmappings.md
@@ -17,6 +17,7 @@ Ambassador Edge Stack supports a number of attributes to configure and customize
 | `idle_timeout_ms` | (optional) the timeout, in milliseconds, after which the connection will be terminated if no traffic is seen -- if not present, no timeout is applied |
 | `enable_ipv4` | (optional) if true, enables IPv4 DNS lookups for this mapping's service (the default is set by the [`ambassador Module`](../../running/ambassador)) |
 | `enable_ipv6` | (optional) if true, enables IPv6 DNS lookups for this mapping's service (the default is set by the [`ambassador Module`](../../running/ambassador)) |
+| `circuit_breakers` | (optional) circuit breakers, as for [`HTTP mapping`](../circuit-breakers) (the default is set by the [`ambassador Module`](../../running/ambassador)) |
 
 If both `enable_ipv4` and `enable_ipv6` are set, Ambassador Edge Stack will prefer IPv6 to IPv4. See the [`ambassador Module`](../../running/ambassador) documentation for more information.
 

--- a/python/ambassador/ir/irambassador.py
+++ b/python/ambassador/ir/irambassador.py
@@ -5,6 +5,7 @@ from ..constants import Constants
 from ..config import Config
 
 from .irresource import IRResource
+from .irbasemapping import IRBaseMapping
 from .irhttpmapping import IRHTTPMapping
 from .irtls import IRAmbassadorTLS
 from .irtlscontext import IRTLSContext
@@ -258,7 +259,7 @@ class IRAmbassador (IRResource):
                 return False
 
         if self.get('circuit_breakers', None) is not None:
-            if not IRHTTPMapping.validate_circuit_breakers(self.ir, self['circuit_breakers']):
+            if not IRBaseMapping.validate_circuit_breakers(self.ir, self['circuit_breakers']):
                 self.post_error("Invalid circuit_breakers specified: {}".format(self['circuit_breakers']))
                 return False
 

--- a/python/ambassador/ir/irhttpmapping.py
+++ b/python/ambassador/ir/irhttpmapping.py
@@ -11,7 +11,6 @@ from .irhttpmappinggroup import IRHTTPMappingGroup
 from .ircors import IRCORS
 from .irretrypolicy import IRRetryPolicy
 
-import json
 import hashlib
 
 if TYPE_CHECKING:
@@ -339,56 +338,6 @@ class IRHTTPMapping (IRBaseMapping):
             if not self.validate_load_balancer(self['load_balancer']):
                 self.post_error("Invalid load_balancer specified: {}, invalidating mapping".format(self['load_balancer']))
                 return False
-
-        if self.get('circuit_breakers', None) is None:
-            self['circuit_breakers'] = ir.ambassador_module.circuit_breakers
-
-        if self.get('circuit_breakers', None) is not None:
-            if not self.validate_circuit_breakers(ir, self['circuit_breakers']):
-                self.post_error("Invalid circuit_breakers specified: {}, invalidating mapping".format(self['circuit_breakers']))
-                return False
-
-        return True
-
-    @staticmethod
-    def validate_circuit_breakers(ir: 'IR', circuit_breakers) -> bool:
-        if not isinstance(circuit_breakers, (list, tuple)):
-            return False
-
-        for circuit_breaker in circuit_breakers:
-            if '_name' in circuit_breaker:
-                # Already reconciled.
-                ir.logger.debug(f'Breaker validation: good breaker {circuit_breaker["_name"]}')
-                continue
-
-            ir.logger.debug(f'Breaker validation: {json.dumps(circuit_breakers, indent=4, sort_keys=True)}')
-
-            name_fields = [ 'cb' ]
-
-            if 'priority' in circuit_breaker:
-                prio = circuit_breaker.get('priority').lower()
-                if prio not in ['default', 'high']:
-                    return False
-
-                name_fields.append(prio[0])
-            else:
-                name_fields.append('n')
-
-            digit_fields = [ ( 'max_connections', 'c' ),
-                             ( 'max_pending_requests', 'p' ),
-                             ( 'max_requests', 'r' ),
-                             ( 'max_retries', 't' ) ]
-
-            for field, abbrev in digit_fields:
-                if field in circuit_breaker:
-                    try:
-                        value = int(circuit_breaker[field])
-                        name_fields.append(f'{abbrev}{value}')
-                    except ValueError:
-                        return False
-
-            circuit_breaker['_name'] = ''.join(name_fields)
-            ir.logger.debug(f'Breaker valid: {circuit_breaker["_name"]}')
 
         return True
 

--- a/python/ambassador/ir/irtcpmapping.py
+++ b/python/ambassador/ir/irtcpmapping.py
@@ -5,7 +5,6 @@ from ..config import Config
 
 from .irbasemapping import IRBaseMapping
 from .irbasemappinggroup import IRBaseMappingGroup
-from .irhttpmapping import IRHTTPMapping
 from .irtcpmappinggroup import IRTCPMappingGroup
 
 import hashlib
@@ -69,20 +68,6 @@ class IRTCPMapping (IRBaseMapping):
     @staticmethod
     def group_class() -> Type[IRBaseMappingGroup]:
         return IRTCPMappingGroup
-
-    def setup(self, ir: 'IR', aconf: Config) -> bool:
-        if not super().setup(ir, aconf):
-            return False
-
-        if self.get('circuit_breakers', None) is None:
-            self['circuit_breakers'] = ir.ambassador_module.circuit_breakers
-
-        if self.get('circuit_breakers', None) is not None:
-            if not IRHTTPMapping.validate_circuit_breakers(ir, self['circuit_breakers']):
-                self.post_error("Invalid circuit_breakers specified: {}, invalidating mapping".format(self['circuit_breakers']))
-                return False
-
-        return True
 
     def bind_to(self) -> str:
         bind_addr = self.get('address') or '0.0.0.0'

--- a/python/ambassador/ir/irtcpmappinggroup.py
+++ b/python/ambassador/ir/irtcpmappinggroup.py
@@ -25,6 +25,7 @@ class IRTCPMappingGroup (IRBaseMappingGroup):
 
     CoreMappingKeys: ClassVar[Dict[str, bool]] = {
         'address': True,
+        'circuit_breakers': True,
         'enable_ipv4': True,
         'enable_ipv6': True,
         'group_id': True,
@@ -123,6 +124,7 @@ class IRTCPMappingGroup (IRBaseMappingGroup):
                             host_rewrite=mapping.get('host_rewrite', False),
                             enable_ipv4=mapping.get('enable_ipv4', None),
                             enable_ipv6=mapping.get('enable_ipv6', None),
+                            circuit_breakers=mapping.get('circuit_breakers', None),
                             marker=marker,
                             allow_scheme=False)
 

--- a/python/schemas/v2/TCPMapping.schema
+++ b/python/schemas/v2/TCPMapping.schema
@@ -27,6 +27,23 @@
         "weight": { "type": "integer" },
         "enable_ipv4": { "type": "boolean" },
         "enable_ipv6": { "type": "boolean" },
+        "circuit_breakers": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "priority": {
+                        "type": "string",
+                        "enum": ["default", "high"]
+                    },
+                    "max_connections": { "type": "integer" },
+                    "max_pending_requests": { "type": "integer" },
+                    "max_requests": { "type": "integer" },
+                    "max_retries": { "type": "integer" }
+                },
+                "additionalProperties": false
+            }
+        },
         "resolver": { "type": "string" },
         "tls": { "type": [ "string", "boolean" ] },
         "cluster_tag": { "type": "string" },

--- a/python/tests/t_circuitbreaker.py
+++ b/python/tests/t_circuitbreaker.py
@@ -312,26 +312,26 @@ circuit_breakers:
         if len(self.results) != 400:
             failures.append(f'wanted 400 results, got {len(self.results)}')
         else:
-            normal_mapping_results = self.results[0:200]
-            low_mapping_results = self.results[200:400]
+            default_limit_result = self.results[0:200]
+            low_limit_results = self.results[200:400]
 
-            normal_overloaded = 0
+            default_limit_failure = 0
 
-            for result in normal_mapping_results:
+            for result in default_limit_result:
                 if result.error:
-                    normal_overloaded += 1
+                    default_limit_failure += 1
 
-            if normal_overloaded != 0:
-              failures.append(f'[GCR] expected no normal overloaded, got {normal_overloaded}')
+            if default_limit_failure != 0:
+              failures.append(f'expected no failure with default limit, got {normal_overloaded}')
 
-            low_overloaded = 0
+            low_limit_failure = 0
 
-            for result in low_mapping_results:
+            for result in low_limit_results:
                 if result.error:
-                    low_overloaded += 1
+                    low_limit_failure += 1
 
-            if not 100 < low_overloaded < 200:
-                failures.append(f'[GCF] expected 100-200 low_overloaded, got {low_overloaded}')
+            if not 100 < low_limit_failure < 200:
+                failures.append(f'expected 100-200 failure with low limit, got {low_overloaded}')
 
         if failures:
             pytest.xfail("failed:\n  %s" % "\n  ".join(failures))

--- a/python/tests/t_circuitbreaker.py
+++ b/python/tests/t_circuitbreaker.py
@@ -262,3 +262,76 @@ config:
 
         if failures:
             pytest.xfail("failed:\n  %s" % "\n  ".join(failures))
+
+class CircuitBreakingTCPTest(AmbassadorTest):
+    extra_ports = [ 6789, 6790 ]
+
+    target1: ServiceType
+    target2: ServiceType
+
+    def init(self):
+      self.target1 = HTTP(name="target1")
+      self.target2 = HTTP(name="target2")
+
+    # config() must _yield_ tuples of Node, Ambassador-YAML where the
+    # Ambassador-YAML will be annotated onto the Node.
+
+    def config(self):
+        yield self.target1, self.format("""
+---
+apiVersion: ambassador/v2
+kind:  TCPMapping
+name:  {self.name}-1
+port: 6789
+service: {self.target1.path.fqdn}:80
+""")
+        yield self.target2, self.format("""
+---
+apiVersion: ambassador/v2
+kind:  TCPMapping
+name:  {self.name}-2
+port: 6790
+service: {self.target2.path.fqdn}:80
+circuit_breakers:
+- priority: default
+  max_pending_requests: 1
+  max_connections: 1
+""")
+
+    def queries(self):
+        for i in range(200):
+            yield Query(self.url(self.name, port=6789) , headers={ "Requested-Backend-Delay": "1000" },
+                        ignore_result=True, phase=1)
+        for i in range(200):
+            yield Query(self.url(self.name, port=6790) , headers={ "Requested-Backend-Delay": "1000" },
+                        ignore_result=True, phase=1)
+
+    def check(self):
+        failures = []
+
+        if len(self.results) != 400:
+            failures.append(f'wanted 400 results, got {len(self.results)}')
+        else:
+            normal_mapping_results = self.results[0:200]
+            low_mapping_results = self.results[200:400]
+
+            normal_overloaded = 0
+
+            for result in normal_mapping_results:
+                if result.error:
+                    normal_overloaded += 1
+
+            if normal_overloaded != 0:
+              failures.append(f'[GCR] expected no normal overloaded, got {normal_overloaded}')
+
+            low_overloaded = 0
+
+            for result in low_mapping_results:
+                if result.error:
+                    low_overloaded += 1
+
+            if not 100 < low_overloaded < 200:
+                failures.append(f'[GCF] expected 100-200 low_overloaded, got {low_overloaded}')
+
+        if failures:
+            pytest.xfail("failed:\n  %s" % "\n  ".join(failures))

--- a/python/tests/test_ambassador.py
+++ b/python/tests/test_ambassador.py
@@ -29,7 +29,7 @@ import t_tls
 import t_tracing
 import t_retrypolicy
 import t_consul
-#import t_circuitbreaker
+import t_circuitbreaker
 import t_envoy_logs
 import t_ingress
 import t_listeneridletimeout


### PR DESCRIPTION
## Description

Circuit breaker were not supported on TCP mapping, making impossible to have more than 1024 connections per ambassador/envoy. This PR add circuit_breakers to TCP mapping (it reuse exactly what is done in HTTP mapping).

More than 1024 TCP connections is important when the TCP service exposed is using persistent connection that are long lived and you expect more than 1024 client.

## Related Issues
It's the PR for #2193

## Testing

A testing step present in #2193 still apply.

## Tasks That Must Be Done
- [x] Did you update CHANGELOG.md?
- [ ] Did you add or update tests?
- [x] Did you update documentation?
- [ ] Were there any special dev tricks you had to use to work on this code efficiently?
  + [ ] Did you add them to DEVELOPING.md?
- [ ] Is this a build change?
  + [ ] If so, did you test on both Mac and Linux?


