### PR TITLE
StaleBot: Mark issues as stale, but don't close them

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,8 +1,9 @@
 # Number of days of inactivity before an issue becomes stale
 daysUntilStale: 60
 
-# Number of days of inactivity before a stale issue is closed
-daysUntilClose: 7
+# Number of days of inactivity before a stale issue is closed; false
+# to disable automatic closing of stale issues.
+daysUntilClose: false
 
 # Issues with these labels will never be considered stale
 exemptLabels:


### PR DESCRIPTION
I don't like stalebot closing things.
Marking them as stale, sure. Prodding a human to either update them or close them, sure.
"Where'd that old PR go that I'd like to update during this cooldown?"
"Where'd that old tech debt issue go I'd like to address during this cooldown?"
"Where'd that ticket go for the exact issue that that a user is now hitting, that I'd like to be able to link them to?