### PR TITLE
Read Knative generation information from the right place

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,10 @@ Format:
 <!--- CueAddReleaseNotes --->
 ## Next Release
 
+### Ambassador API Gateway + Ambassador Edge Stack
+
+- Bugfix: Read Knative ingress generation from the correct place in the Kubernetes object
+
 ## [1.5.2] June 10, 2020
 [1.5.2]: https://github.com/datawire/ambassador/compare/v1.5.1...v1.5.2
 

--- a/python/ambassador/fetch/knative.py
+++ b/python/ambassador/fetch/knative.py
@@ -137,8 +137,7 @@ class KnativeIngressProcessor (ManagedKubernetesProcessor):
         return status
 
     def _update_status(self, obj: KubernetesObject) -> None:
-        current_generation = obj.spec.get('generation', 1)
-        has_new_generation = current_generation > obj.status.get('observedGeneration', 0)
+        has_new_generation = obj.generation > obj.status.get('observedGeneration', 0)
 
         # Knative expects the load balancer information on the ingress, which it
         # then propagates to an ExternalName service for intra-cluster use. We
@@ -163,7 +162,7 @@ class KnativeIngressProcessor (ManagedKubernetesProcessor):
         has_new_lb_domain = current_lb_domain != observed_lb_domain
 
         if has_new_generation or has_new_lb_domain:
-            status = self._make_status(generation=current_generation, lb_domain=current_lb_domain)
+            status = self._make_status(generation=obj.generation, lb_domain=current_lb_domain)
             status_update = (obj.gvk.domain, obj.namespace, status)
 
             self.logger.info(f"Updating Knative {obj.kind} {obj.name} status to {status_update}")


### PR DESCRIPTION
## Description
We were accidentally trying to get the generation of a Knative ingress from the spec instead of metadata, which caused the observed generation to never update. This change uses the standardized `obj.generation` attribute instead.

## Testing
In addition to not impacting tests, this change fixed the issue for us in our production environment.

## Tasks That Must Be Done
- [x] Did you update CHANGELOG.md?
- [ ] Did you add or update tests?
- [ ] Did you update documentation?
- [ ] Were there any special dev tricks you had to use to work on this code efficiently?
  + [ ] Did you add them to DEVELOPING.md?
- [ ] Is this a build change?
  + [ ] If so, did you test on both Mac and Linux?
