### PR TITLE
Fix and reword path_prefix docs for better clarity

### DIFF
--- a/docs/topics/using/filters/external.md
+++ b/docs/topics/using/filters/external.md
@@ -59,7 +59,7 @@ spec:
 
 The following fields are only used if `proto: http`; they are ignored if `proto: grpc`:
 
- - `path_prefix` (optional) prepends a string to the request path of the request when sending it to the external auth service.  By default this is empty, and nothing is prepended.  For example, if the client makes a request to `/foo`, and `path_prefix: /bar`, then the path in the request made to the external auth service will be `/foo/bar`.
+ - `path_prefix` (optional) prepends a string to the path of the original request when sending it to the external auth service. By default this is empty, and the path is not changed. For example, if the client makes a request to `/path`, and the external auth service is configured with `path_prefix: /auth`, then the path in the request made to the external auth service will be `/auth/path`.
 
  - `allowed_request_headers` (optional) lists the headers that will be sent copied from the incoming request to the request made to the external auth service (case-insensitive).  In addition to the headers listed in this field, the following headers are always included:
     * `Authorization`


### PR DESCRIPTION
## Description
There was a mistake in "External Filters" documentation around `path_prefix`. This PR fixes it and slightly modifies the language for better clarity.

## Related Issues
None.

## Testing
N/A

## Tasks That Must Be Done
- [ ] Did you update CHANGELOG.md?
- [ ] Did you add or update tests?
- [x] Did you update documentation?
- [ ] Were there any special dev tricks you had to use to work on this code efficiently?
  + [ ] Did you add them to DEVELOPING.md?
- [ ] Is this a build change?
  + [ ] If so, did you test on both Mac and Linux?

## Other
* If this is a documentation change for a particular release, please open the pull request against the release branch.
