### PR TITLE
Drop Kubestatus and raise the Envoy loglevel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,15 @@ Note that Ambassador Edge Stack `External` Filters already unconditionally use t
 
 ## Next Release
 
-(no changes yet)
+### Ambassador API Gateway + Ambassador Edge Stack
+
+- Bugfix: Allow disabling `Mapping`-status updates (RECOMMENDED: see below)
+
+We recommend that users not relying on `Mapping` status updates
+set `AMBASSADOR_UPDATE_MAPPING_STATUS=false` in the environment to
+tell Ambassador not to update `Mapping` statuses. The default value
+of `AMBASSADOR_UPDATE_MAPPING_STATUS` will change to `false` in 
+Ambassador 1.6.
 
 ## [1.5.3] June 16, 2020
 [1.5.3]: https://github.com/datawire/ambassador/compare/v1.5.2...v1.5.3

--- a/cmd/kubestatus/main.go
+++ b/cmd/kubestatus/main.go
@@ -57,10 +57,16 @@ func Main() {
 		}, func(w *k8s.Watcher) {
 			for _, rsrc := range w.List(kind) {
 				if *statusFile == "" {
+					// The user is asking for the status, so print it.
 					fmt.Println("Status of", rsrc.QName())
 					fmt.Printf("  %v\n", rsrc["status"])
 				} else {
-					fmt.Println("Updating", rsrc.QName())
+					// The user is asking for a status update.
+					// log.Debugf doesn't exist.
+					if false {
+						fmt.Println("Updating", rsrc.QName())
+					}
+
 					rsrc["status"] = status
 					_, err := w.UpdateStatus(rsrc)
 					if err != nil {

--- a/cmd/watt/invoker.go
+++ b/cmd/watt/invoker.go
@@ -138,7 +138,7 @@ func (a *invoker) gcSnapshots() {
 	for k := range a.invokedSnapshots {
 		if k <= a.id-10 {
 			delete(a.invokedSnapshots, k)
-			a.process.Logf("deleting snapshot %d", k)
+			a.process.Debugf("deleting snapshot %d", k)
 		}
 	}
 }

--- a/python/ambassador_diag/diagd.py
+++ b/python/ambassador_diag/diagd.py
@@ -1177,7 +1177,14 @@ class AmbassadorEventWatcher(threading.Thread):
 
                 app.kubestatus.post(kind, resource_name, namespace, text)
 
-        self.logger.info("configuration updated from snapshot %s" % snapshot)
+
+        group_count = len(app.ir.groups)
+        cluster_count = len(app.ir.clusters)
+        listener_count = len(app.ir.listeners)
+        service_count = len(app.ir.services)
+
+        self.logger.info("configuration updated from snapshot %s (S%d L%d G%d C%d)" % 
+                         (snapshot, service_count, listener_count, group_count, cluster_count))
         self._respond(rqueue, 200, 'configuration updated from snapshot %s' % snapshot)
 
         if app.health_checks and not app.stats_updater:

--- a/python/ambassador_diag/diagd.py
+++ b/python/ambassador_diag/diagd.py
@@ -776,7 +776,7 @@ class KubeStatus:
     def mark_live(self, kind: str, name: str, namespace: str) -> None:
         key = f"{kind}/{name}.{namespace}"
 
-        # print(f"KubeStatus MASTER {os.getpid()}: mark_live {key}")
+        # self.logger.debug(f"KubeStatus MASTER {os.getpid()}: mark_live {key}")
         self.live[key] = True
 
     def prune(self) -> None:
@@ -787,7 +787,7 @@ class KubeStatus:
                 drop.append(key)
 
         for key in drop:
-            # print(f"KubeStatus MASTER {os.getpid()}: prune {key}")
+            # self.logger.debug(f"KubeStatus MASTER {os.getpid()}: prune {key}")
             del(self.current_status[key])
 
         self.live = {}
@@ -797,10 +797,10 @@ class KubeStatus:
         extant = self.current_status.get(key, None)
 
         if extant == text:
-            # print(f"KubeStatus MASTER {os.getpid()}: {key} == {text}")
+            # self.logger.info(f"KubeStatus MASTER {os.getpid()}: {key} == {text}")
             pass
         else:
-            # print(f"KubeStatus MASTER {os.getpid()}: {key} needs {text}")
+            # self.logger.info(f"KubeStatus MASTER {os.getpid()}: {key} needs {text}")
 
             # For now we're going to assume that this works.
             self.current_status[key] = text

--- a/python/ambassador_diag/diagd.py
+++ b/python/ambassador_diag/diagd.py
@@ -748,7 +748,7 @@ class SystemStatus:
 
 
 class KubeStatusNoOp:
-    def __init__(self) -> None:
+    def __init__(self, app) -> None:
         pass
 
     def mark_live(self, kind: str, name: str, namespace: str) -> None:
@@ -764,10 +764,14 @@ class KubeStatusNoOp:
 class KubeStatus:
     pool: concurrent.futures.ProcessPoolExecutor
 
-    def __init__(self) -> None:
+    def __init__(self, app) -> None:
+        self.app = app
+        self.logger = app.logger
         self.live: Dict[str,  bool] = {}
         self.current_status: Dict[str, str] = {}
         self.pool = concurrent.futures.ProcessPoolExecutor(max_workers=5)
+
+        self.app.logger.info("WILL update Mapping status")
 
     def mark_live(self, kind: str, name: str, namespace: str) -> None:
         key = f"{kind}/{name}.{namespace}"

--- a/python/entrypoint.sh
+++ b/python/entrypoint.sh
@@ -115,7 +115,7 @@ fi
 # being in AMBASSADOR_CONFIG_BASE_DIR.
 envoy_config_file="${ENVOY_DIR}/envoy.json"         # not a typo, see above
 envoy_flags=('-c' "${ENVOY_BOOTSTRAP_FILE}" "--base-id" "${ENVOY_BASE_ID}")
-envoy_logging=('-l' 'warning')
+envoy_logging=('-l' 'error')
 
 if [ -n "$AGENT_SERVICE" ]; then
     # We are the intercept agent. Force Envoy's drain time very low.


### PR DESCRIPTION
Environment variable `AMBASSADOR_UPDATE_MAPPING_STATUS` now tells Ambassador whether or not to do updates to `Mapping` status. The current default is `true`; in 1.6 we plan to change it to `false`.

Also, push Envoy's log level to `error`, since Envoy's logging of known use of deprecated `v2` configuration elements is... excessive.

Finally, the `configuration updated` log line is now e.g.

```
INFO: configuration updated from snapshot 1 (S7 L1 G253 C2)
```

- `S7`: we found 7 services
- `L1`: we configured 1 Envoy `listener`
- `G253`: we found 253 mapping `Group`s (which is to say, 253 Envoy `route`s)
- `C2`: we're using 2 Envoy `cluster`s