### PR TITLE
Fix wrong changelog entry done in #2789

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,9 @@ Note that Ambassador Edge Stack `External` Filters already unconditionally use t
 
 ## Next Release
 
-(no changes yet)
+### Ambassador API Gateway + Ambassador Edge Stack
+
+- Feature: Add support for circuit breakers in TCP mapping
 
 ## [1.5.3] June 16, 2020
 [1.5.3]: https://github.com/datawire/ambassador/compare/v1.5.2...v1.5.3
@@ -73,7 +75,6 @@ Note that Ambassador Edge Stack `External` Filters already unconditionally use t
 
 - Incorporate the [Envoy 1.14.2](https://www.envoyproxy.io/docs/envoy/v1.14.2/intro/version_history#june-8-2020) security update.
 - Upgrade the base Docker images used by several tests (thanks, [Daniel Sutton](https://github.com/ducksecops)!).
-- Feature: Add support for circuit breakers in TCP mapping
 
 ### Ambassador Edge Stack only
 


### PR DESCRIPTION
##  Description

In #2789 I wrongly added the Changelog entry to the released version 1.5.2.
This PR move it to "Next Release".

## Tasks That Must Be Done
- [x] Did you update CHANGELOG.md? (and correctly this time :))
- [ ] Did you add or update tests?
- [ ] Did you update documentation?
- [ ] Were there any special dev tricks you had to use to work on this code efficiently?
  + [ ] Did you add them to DEVELOPING.md?
- [ ] Is this a build change?
  + [ ] If so, did you test on both Mac and Linux?
