### PR TITLE
docs: Fix problems with the 'rate-limit-service' page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,9 +36,9 @@ communicate with `AuthService`s and `RateLimitService`s:
 
 - In some future version of Ambassador, there will be settings to control which name is
   used; with the default being the current name; it will be opt-in to the new names.
-- In some future version of Ambassador after that, *no sooner than Ambassador 1.6.0*, the
-  default values of those setting swill change; making them opt-out from the new names.
 - In some future version of Ambassador after that, *no sooner than Ambassador 1.7.0*, the
+  default values of those settings will change; making them opt-out from the new names.
+- In some future version of Ambassador after that, *no sooner than Ambassador 1.8.0*, the
   settings will go away, and Ambassador will always use the new names.
 
 Note that Ambassador Edge Stack `External` Filters already unconditionally use the newer

--- a/docs/topics/running/services/rate-limit-service.md
+++ b/docs/topics/running/services/rate-limit-service.md
@@ -77,16 +77,16 @@ limiting service.
 >   opt-in to the new name.
 >
 > - In some future version of Ambassador after that, *no sooner than Ambassador
->   1.6.0*, the default value of that setting swill change; making it opt-out
+>   1.7.0*, the default value of that setting will change; making it opt-out
 >   from the new name.
 >
 > - In some future version of Ambassador after that, *no sooner than Ambassador
->   1.7.0*, the setting will go away, and Ambassador will always use the new
+>   1.8.0*, the setting will go away, and Ambassador will always use the new
 >   name.
 >
-> In the mean-time, implementations of `RateLimitService` are encouraged to
-> respond to both both names--they are simply aliases of eachother, registering
-> the service under both names is usually a simple 1-or-2-line addition.  For
+> In the meantime, implementations of `RateLimitService` are encouraged to
+> respond to both names--they are simply aliases of eachother, registering the
+> service under both names is usually a simple 1-or-2-line addition.  For
 > example, in Go the change to support both names is:
 >
 > ```diff

--- a/docs/topics/running/services/rate-limit-service.md
+++ b/docs/topics/running/services/rate-limit-service.md
@@ -3,11 +3,12 @@
 Rate limiting is a powerful technique to improve the [availability and
 resilience of your
 services](https://blog.getambassador.io/rate-limiting-a-useful-tool-with-distributed-systems-6be2b1a4f5f4).
-In the Ambassador API Gateway, each request can have one or more *labels*. These
-labels are exposed to a third party service via a gRPC API. The third-party
-service can then rate limit requests based on the request labels.
+In the Ambassador API Gateway, each request can have one or more *labels*.
+These labels are exposed to a third-party service via a gRPC API.  The
+third-party service can then rate limit requests based on the request labels.
 
-**Note that `RateLimitService`is only applicable to the Ambassador API Gateway, and not the Edge Stack.**
+**Note that `RateLimitService` is only applicable to the Ambassador API Gateway,
+and not the Edge Stack.**
 
 ## Request Labels
 
@@ -53,7 +54,11 @@ spec:
 
 ## External Rate Limit Service
 
-In order for Ambassador Edge Stack to rate limit, you need to implement a gRPC `RateLimitService`, as defined in [Envoy's `rls.proto`][rls.proto] interface. If you do not have the time or resources to implement your own rate limit service, Ambassador Edge Stack integrates a high performance, rate limiting service.
+In order for Ambassador Edge Stack to rate limit, you need to implement a gRPC
+`RateLimitService`, as defined in [Envoy's `rls.proto`][rls.proto] interface.
+If you do not have the time or resources to implement your own rate limit
+service, Ambassador Edge Stack integrates a high-performance rate limiting
+service.
 
 [rls.proto]: https://github.com/datawire/ambassador/tree/master/api/envoy/service/ratelimit/v2/rls.proto
 

--- a/docs/topics/running/services/rate-limit-service.md
+++ b/docs/topics/running/services/rate-limit-service.md
@@ -61,12 +61,46 @@ spec:
 ## External Rate Limit Service
 
 In order for the Ambassador API Gateway to rate limit, you need to implement a
-gRPC `RateLimitService`, as defined in [Envoy's `rls.proto`][rls.proto]
+gRPC `RateLimitService`, as defined in [Envoy's `v1/rls.proto`][`v1/rls.proto`]
 interface.  If you do not have the time or resources to implement your own rate
 limit service, the Ambassador Edge Stack integrates a high-performance rate
 limiting service.
 
-[rls.proto]: https://github.com/datawire/ambassador/tree/master/api/envoy/service/ratelimit/v2/rls.proto
+> Note: *In a future version of Ambassador*, the Ambassador API Gateway will
+> change the version of the gRPC service name used to communicate
+> `RateLimitService`s from the one defined in [`v1/rls.proto`][]
+> (`pb.lyft.ratelimit.RateLimitService`) to the one defined in
+> [`v2/rls.proto`][] (`envoy.service.ratelimit.v2.RateLimitService`):
+>
+> - In some future version of Ambassador, there will be a setting to control
+>   which name is used; with the default being the current name; it will be
+>   opt-in to the new name.
+>
+> - In some future version of Ambassador after that, *no sooner than Ambassador
+>   1.6.0*, the default value of that setting swill change; making it opt-out
+>   from the new name.
+>
+> - In some future version of Ambassador after that, *no sooner than Ambassador
+>   1.7.0*, the setting will go away, and Ambassador will always use the new
+>   name.
+>
+> In the mean-time, implementations of `RateLimitService` are encouraged to
+> respond to both both names--they are simply aliases of eachother, registering
+> the service under both names is usually a simple 1-or-2-line addition.  For
+> example, in Go the change to support both names is:
+>
+> ```diff
+>  import (
+>  	envoy_ratelimit_v1 "github.com/datawire/ambassador/pkg/api/envoy/service/ratelimit/v1"
+> +	envoy_ratelimit_v2 "github.com/datawire/ambassador/pkg/api/envoy/service/ratelimit/v2"
+>  )
+> ...
+>  	envoy_ratelimit_v1.RegisterRateLimitServiceServer(myGRPCServer, myRateLimitImplementation)
+> +	envoy_ratelimit_v2.RegisterRateLimitServiceServer(myGRPCServer, myRateLimitImplementation)
+> ```
+
+[`v1/rls.proto`]: https://github.com/datawire/ambassador/tree/master/api/envoy/service/ratelimit/v1/rls.proto
+[`v2/rls.proto`]: https://github.com/datawire/ambassador/tree/master/api/envoy/service/ratelimit/v2/rls.proto
 
 The Ambassador API Gateway generates a gRPC request to the external rate limit
 service and provides a list of labels on which the rate limit service can base

--- a/docs/topics/running/services/rate-limit-service.md
+++ b/docs/topics/running/services/rate-limit-service.md
@@ -3,16 +3,18 @@
 Rate limiting is a powerful technique to improve the [availability and
 resilience of your
 services](https://blog.getambassador.io/rate-limiting-a-useful-tool-with-distributed-systems-6be2b1a4f5f4).
-In the Ambassador API Gateway, each request can have one or more *labels*.
-These labels are exposed to a third-party service via a gRPC API.  The
-third-party service can then rate limit requests based on the request labels.
+In Ambassador, each request can have one or more *labels*.  These labels are
+exposed to a third-party service via a gRPC API.  The third-party service can
+then rate limit requests based on the request labels.
 
 **Note that `RateLimitService` is only applicable to the Ambassador API Gateway,
-and not the Edge Stack.**
+and not the Ambassador Edge Stack, as the Ambassador Edge Stack includes a
+built-in rate limit service.**
 
 ## Request Labels
 
-Ambassador Edge Stack lets users add one or more labels to a given request. These labels are added as part of a `Mapping` object. For example:
+Ambassador lets users add one or more labels to a given request.  These labels
+are added as part of a `Mapping` object.  For example:
 
 ```yaml
 ---
@@ -31,11 +33,15 @@ For more information on request labels, see the [Rate Limit reference](../../../
 
 ## Domains
 
-In Ambassador Edge Stack, each engineer (or team) can be assigned its own *domain*. A domain is a separate namespace for labels. By creating individual domains, each team can assign their own labels to a given request, and independently set the rate limits based on their own labels.
+In Ambassador, each engineer (or team) can be assigned its own *domain*.  A
+domain is a separate namespace for labels.  By creating individual domains, each
+team can assign their own labels to a given request, and independently set the
+rate limits based on their own labels.
 
 ## Default labels
 
-Ambassador Edge Stack allows setting a default label on every request. A default label is set on the `ambassador Module`. For example:
+Ambassador allows setting a default label on every request.  A default label is
+set on the `ambassador Module`.  For example:
 
 ```yaml
 ---
@@ -54,15 +60,17 @@ spec:
 
 ## External Rate Limit Service
 
-In order for Ambassador Edge Stack to rate limit, you need to implement a gRPC
-`RateLimitService`, as defined in [Envoy's `rls.proto`][rls.proto] interface.
-If you do not have the time or resources to implement your own rate limit
-service, Ambassador Edge Stack integrates a high-performance rate limiting
-service.
+In order for the Ambassador API Gateway to rate limit, you need to implement a
+gRPC `RateLimitService`, as defined in [Envoy's `rls.proto`][rls.proto]
+interface.  If you do not have the time or resources to implement your own rate
+limit service, the Ambassador Edge Stack integrates a high-performance rate
+limiting service.
 
 [rls.proto]: https://github.com/datawire/ambassador/tree/master/api/envoy/service/ratelimit/v2/rls.proto
 
-Ambassador Edge Stack generates a gRPC request to the external rate limit service and provides a list of labels on which the rate limit service can base its decision to accept or reject the request:
+The Ambassador API Gateway generates a gRPC request to the external rate limit
+service and provides a list of labels on which the rate limit service can base
+its decision to accept or reject the request:
 
 ```
 [
@@ -74,18 +82,29 @@ Ambassador Edge Stack generates a gRPC request to the external rate limit servic
 ]
 ```
 
-If Ambassador Edge Stack cannot contact the rate limit service, it will allow the request to be processed as if there were no rate limit service configuration.
+If the Ambassador API Gateway cannot contact the rate limit service, it will
+allow the request to be processed as if there were no rate limit service
+configuration.
 
-It is the external rate limit service's responsibility to determine whether rate limiting should take place, depending on custom business logic. The rate limit service must simply respond to the request with an `OK` or `OVER_LIMIT` code:
+It is the external rate limit service's responsibility to determine whether rate
+limiting should take place, depending on custom business logic.  The rate limit
+service must simply respond to the request with an `OK` or `OVER_LIMIT` code:
 
-* If Envoy receives an `OK` response from the rate limit service, then Ambassador Edge Stack allows the client request to resume being processed by the normal Ambassador Envoy flow.
-* If Envoy receives an `OVER_LIMIT` response, then the Ambassador Edge Stack will return an HTTP 429 response to the client and will end the transaction flow, preventing the request from reaching the backing service.
+* If Envoy receives an `OK` response from the rate limit service, then the
+  Ambassador API Gateway allows the client request to resume being processed by
+  the normal flow.
+* If Envoy receives an `OVER_LIMIT` response, then the Ambassador API Gateway
+  will return an HTTP 429 response to the client and will end the transaction
+  flow, preventing the request from reaching the backing service.
 
-The headers injected by the [AuthService](../auth-service) can also be passed to the rate limit service since the `AuthService` is invoked before the `RateLimitService`.
+The headers injected by the [AuthService](../auth-service) can also be passed to
+the rate limit service since the `AuthService` is invoked before the
+`RateLimitService`.
 
 ## Configuring the Rate Limit Service
 
-A `RateLimitService` manifest configures Ambassador Edge Stack to use an external service to check and enforce rate limits for incoming requests:
+A `RateLimitService` manifest configures the Ambassador API Gateway to use an
+external service to check and enforce rate limits for incoming requests:
 
 ```yaml
 ---
@@ -103,13 +122,21 @@ You may only use a single `RateLimitService` manifest.
 
 ## Rate Limit Service and TLS
 
-You can tell Ambassador Edge Stack to use TLS to talk to your service by using a `RateLimitService` with an `https://` prefix. However, you may also provide a `tls` attribute: if `tls` is present and `true`, Ambassador Edge Stack will originate TLS even if the `service` does not have the `https://` prefix.
+You can tell the Ambassador API Gateway to use TLS to talk to your service by
+using a `RateLimitService` with an `https://` prefix.  However, you may also
+provide a `tls` attribute: if `tls` is present and `true`, the Ambassador API
+Gateway will originate TLS even if the `service` does not have the `https://`
+prefix.
 
 If `tls` is present with a value that is not `true`, the value is assumed to be the name of a defined TLS context, which will determine the certificate presented to the upstream service.
 
 ## Example
 
-The [Ambassador Edge Stack Rate Limiting Tutorial](../../../../howtos/rate-limiting-tutorial) has a simple rate limiting example. For a more advanced example, read the [advanced rate limiting tutorial](../../../../howtos/advanced-rate-limiting) with Ambassador Edge Stack tutorial.
+The [Ambassador API Gateway Rate Limiting
+Tutorial](../../../../howtos/rate-limiting-tutorial) has a simple rate limiting
+example.  For a more advanced example, read the [advanced rate limiting
+tutorial](../../../../howtos/advanced-rate-limiting), which uses the rate limit
+service that is integrated with the Ambassador Edge Stack.
 
 ## Further Reading
 


### PR DESCRIPTION
- Fix punctuation
- Proof-read for "Ambassador" vs "the Ambassador API Gateway" vs "the Ambassador Edge Stack"
- Clarify what's going on with `v1/rls.proto` vs `v2/rls.proto`

Fixes https://github.com/datawire/ambassador/issues/2828