### PR TITLE
New doc Schema (v1) for master

### DIFF
--- a/docs/js/doc-page.js
+++ b/docs/js/doc-page.js
@@ -21,6 +21,104 @@ function removeDoubleSlashes(str) {
   return str.replace(/\/{2,}/g, '/');
 }
 
+function getPathFromSlug(str) {
+  return removeDoubleSlashes(`/${str}/`);
+}
+
+function relativeToAbsUrl(url) {
+  if (url.startsWith('http') || url.startsWith('mailto')) {
+    return url;
+  } else
+    return 'https://www.getambassador.io' + removeDoubleSlashes(`/${url}/`);
+}
+
+const getDocPageSchema = ({
+  slug,
+  // an array of { title, slug } relative to parent pages (only if applicable)
+  // This doesn't include the root docs page nor the page itself
+  breadcrumbs = [],
+  // the doc page title (required)
+  title,
+  // the current docs version (required)
+  version,
+  // the current sidebar section (only if applicable)
+  section,
+  isFAQ,
+  isLatest,
+}) => ({
+  '@context': 'http://schema.org',
+  '@type': isFAQ ? 'FAQPage' : 'WebPage',
+  '@id': relativeToAbsUrl(slug),
+  // Not every search engine has assemblyVersion figured out (see below),
+  // we want to separate this doc page from others of different versions 😉
+  version,
+  breadcrumb: {
+    '@type': 'BreadcrumbList',
+    itemListElement: [
+      // Every doc page will have this as the root
+      {
+        '@type': 'ListItem',
+        position: 1,
+        item: {
+          // be sure to update this /latest with the current version
+          '@id': isLatest
+            ? relativeToAbsUrl('/docs/latest/')
+            : relativeToAbsUrl(`/docs/${version}/`),
+          name: 'Ambassador Docs',
+        },
+      },
+      ...breadcrumbs.map((crumb, i) => ({
+        '@type': 'ListItem',
+        // start at position 2
+        position: i + 2,
+        item: {
+          '@id': relativeToAbsUrl(crumb.slug),
+          name: crumb.title,
+        },
+      })),
+      {
+        '@type': 'ListItem',
+        position: 1 + breadcrumbs.length + 1,
+        item: {
+          '@id': relativeToAbsUrl(slug),
+          name: title,
+        },
+      },
+    ],
+  },
+  mainEntity: {
+    '@type': 'APIReference',
+    headline: title,
+    inLanguage: 'en',
+    isPartOf: 'https://www.getambassador.io/#software',
+    // the current docs version
+    assemblyVersion: version,
+    // the sidebar section, if applicable,
+    articleSection: section,
+    // @TODO: check this license
+    license: 'Apache-2.0',
+    // @TODO: check this programmingModel
+    programmingModel: 'unmanaged',
+    // @TODO: adding keywords related to this doc page would be optimal
+    keywords:
+      'Kubernertes,API Gateway,Edge Stack,Envoy Proxy,Kubernetes Ingress,Load Balancer,Identity Aware Proxy,Developer Portal, microservices, open source',
+  },
+});
+
+// Used to get a flat array of *all* links with their corresponding parents
+function flatAllLinks(links, parent) {
+  return links.reduce((acc, cur) => {
+    let link = cur;
+    if (parent) {
+      link = { ...cur, parent };
+    }
+    if (!link.items) {
+      return [...acc, link];
+    }
+    return [...acc, link, ...flatAllLinks(link.items, link)];
+  }, []);
+}
+
 export default ({ data, location }) => {
   const page = data.mdx || {};
   const title =
@@ -50,6 +148,36 @@ export default ({ data, location }) => {
     `/${rest.join('/')}/`,
   )}`;
 
+  // For Schema purposes, we want to make the relationship between pages and their parents explicit
+  // So we flat all links (see flatAllLinks above)
+  const flatLinks = flatAllLinks(docLinks);
+  // Find the current expanded link
+  const expandedLink = flatLinks.find(
+    (l) => getPathFromSlug(l.link) === getPathFromSlug(slug),
+  );
+  let breadcrumbs = [];
+  let section;
+  // And check to see if it has any parent
+  if (expandedLink && expandedLink.parent) {
+    if (expandedLink.parent.link) {
+      // If it does, that's the Schema section and part of the breadcrumbs
+      section = expandedLink.parent.title;
+      breadcrumbs.push({
+        title: expandedLink.parent.title,
+        slug: expandedLink.parent.link,
+      });
+    }
+    // If the parent also has a parent, then that's also part of the breadcrumbs
+    if (expandedLink.parent.parent && expandedLink.parent.parent.link) {
+      breadcrumbs = [
+        {
+          title: expandedLink.parent.parent.title,
+          slug: expandedLink.parent.parent.link,
+        },
+        ...breadcrumbs,
+      ];
+    }
+  }
   return (
     <React.Fragment>
       <Helmet>
@@ -60,6 +188,19 @@ export default ({ data, location }) => {
         {metaDescription && (
           <meta name="description" content={metaDescription} />
         )}
+        <script type="application/ld+json">
+          {JSON.stringify(
+            getDocPageSchema({
+              isLatest: slug.includes('docs/latest'),
+              slug,
+              title,
+              version: versions.version,
+              isFAQ: slug.includes('about/faq/'),
+              breadcrumbs,
+              section,
+            }),
+          )}
+        </script>
       </Helmet>
       <Layout location={location}>
         <Sidebar location={location} prefix="" items={docLinks} />

--- a/docs/js/doc-page.js
+++ b/docs/js/doc-page.js
@@ -31,8 +31,8 @@ function relativeToAbsUrl(slug) {
 
 function getMainDocsUrl(slug) {
   // All doc pages slugs follow the pattern /docs/{VERSION}/{PATH}
-  // This regex extracts the /docs/{VERSION}/ part to find the current page's main docs slug
-  const mainDocsSlug = getPathFromSlug(slug).match(/\/docs\/[\d\.(latest)]*/)
+  // This regex extracts the /docs/{VERSION} part to find the current page's main docs slug
+  const mainDocsSlug = getPathFromSlug(slug).match(/\/docs\/[^/]*/)
   // If, for some reason, we can't find this part (regex matches nothing in the slug string), we assume /docs/latest/
   return relativeToAbsUrl(mainDocsSlug ? mainDocsSlug[0] : '/docs/latest/')
 }


### PR DESCRIPTION
## Description
Adds Schema.org declarations to doc pages for richer search results.

## Testing
I've tested it manually by changing the file in my local copy of the website repo and ran the resulting schemas through [Google's Structured Data Testing Tool](https://search.google.com/structured-data/testing-tool/u/0/).


## This is a provisional PR

This is related to #2826 and although it's highly positive for the docs SEO right off the batch, it's not a final solution. Eventually we'll want to go back to polish the code based on the following questions:

- [ ] Define the license in the Schema. Right now I'm using Apache-2.0 following this repo's license, can we go through with it or is the subject more nuanced?
- [ ] Can we use "unmanaged" as the ["programmingModel"](https://schema.org/programmingModel) in  the Schema?
- [ ] Can we move parts of the code to another file to make it neater? `docs/js/doc-page.js` is currently 261 lines long.