### PR TITLE
Include warning and workaround from Prom Operator bundle not working with kube 1.14 and below

### DIFF
--- a/docs/howtos/prometheus.md
+++ b/docs/howtos/prometheus.md
@@ -58,6 +58,14 @@ In this section, we will deploy the Prometheus Operator using the standard YAML 
     kubectl apply -f https://raw.githubusercontent.com/coreos/prometheus-operator/master/bundle.yaml
     ```
 
+    **Note:** The YAML assumes Kubernetes 1.15 and above. If running a lower version, you will need to run the following command to install the CRDs with the right API version:
+
+    ```
+    curl -sL https://raw.githubusercontent.com/coreos/prometheus-operator/master/bundle.yaml \
+      | sed 's|apiVersion: apiextensions.k8s.io/v1|apiVersion: apiextensions.k8s.io/v1beta1|' \
+      | kubectl apply -f -
+    ```
+
 2. Deploy Prometheus by creating a `Prometheus` CRD
 
     First, create RBAC resources for your Prometheus instance


### PR DESCRIPTION
Prometheus operator yaml uses new crd apiVersion

The prometheus operator publishes yaml updates frequently and we would
like to be up to date in out documentation. This means we install the
same bundle.yaml file that they keep up to dote.

The bundle.yaml file diverged and changed the apiVersion of the CRD to
apiextensions.k8s.io/v1 which does not exist in 1.14 and below. Google
defaults to using 1.14 so we need to have a workaround in our
documentation.
