### PR TITLE
Add ambassador tutorial

### DIFF
--- a/docs/js/doc-links.yml
+++ b/docs/js/doc-links.yml
@@ -4,6 +4,8 @@
   items:
     - title: Quick Start
       link: /docs/latest/tutorials/getting-started
+    - title: Ambassador Walk-Through
+      link: /docs/latest/tutorials/quickstart-demo
 - title: Install Ambassador Edge Stack
   link: /docs/latest/topics/install/
   items: 

--- a/docs/js/doc-links.yml
+++ b/docs/js/doc-links.yml
@@ -4,7 +4,7 @@
   items:
     - title: Quick Start
       link: /docs/latest/tutorials/getting-started
-    - title: Ambassador Walk-Through
+    - title: Ambassador Tutorial
       link: /docs/latest/tutorials/quickstart-demo
 - title: Install Ambassador Edge Stack
   link: /docs/latest/topics/install/

--- a/docs/tutorials/quickstart-demo.md
+++ b/docs/tutorials/quickstart-demo.md
@@ -1,4 +1,6 @@
-# Installation Demo
+# Ambassador Tutorial
+
+In this tutorial, we'll walk through some of the key features and workflow of Ambassador.
 
 ## Create a Mapping
 


### PR DESCRIPTION
The ambassador tutorial was not in the TOC. This fixes it.