### PR TITLE
Correct prometheus operator install information

### DIFF
--- a/docs/howtos/prometheus.md
+++ b/docs/howtos/prometheus.md
@@ -58,11 +58,12 @@ In this section, we will deploy the Prometheus Operator using the standard YAML 
     kubectl apply -f https://raw.githubusercontent.com/coreos/prometheus-operator/master/bundle.yaml
     ```
 
-    **Note:** The YAML assumes Kubernetes 1.15 and above. If running a lower version, you will need to run the following command to install the CRDs with the right API version:
+    **Note:** The YAML assumes Kubernetes 1.16 and above. If running a lower version, you will need to run the following command to install the CRDs with the right API version:
 
     ```
     curl -sL https://raw.githubusercontent.com/coreos/prometheus-operator/master/bundle.yaml \
       | sed 's|apiVersion: apiextensions.k8s.io/v1|apiVersion: apiextensions.k8s.io/v1beta1|' \
+      | sed 's|jsonPath|JSONPath|' \
       | kubectl apply -f -
     ```
 


### PR DESCRIPTION
From a conversation in Slack, it looks like #2863 was not correct. 

1. `apiextensions.k8s.io/v1` is added in 1.16

2. The sed command was fat fingered and left out another needed string replacement.

Sorry for the confusion this caused. I am glad it was caught in the `pre-release` docs.