### PR TITLE
[v1.6] The website uses yarn now, not npm

### DIFF
--- a/.ci/website-preview-build
+++ b/.ci/website-preview-build
@@ -45,5 +45,5 @@ for submodule in latest 1.6; do
 	cp -prv $amb_dir/docs submodules/"$submodule"/docs
 done
 
-npm install
-npm run build
+yarn install
+yarn run build

--- a/.ci/website-prod-publish
+++ b/.ci/website-prod-publish
@@ -27,5 +27,5 @@ git clone -b master "$remote_url" /tmp/getambassador.io
 cd /tmp/getambassador.io
 git submodule update --init --reference="$git_workdir"
 
-npm run pull-docs
+yarn run pull-docs
 git push origin master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,6 +20,7 @@ commands:
     steps:
     - install-node:
         version: "11"
+    - install-yarn
     - install-python:
         executor-key: "201903-01"
         version: "3.7.0"
@@ -156,6 +157,13 @@ commands:
         command: |
           curl -L --fail -o /tmp/kubectl https://storage.googleapis.com/kubernetes-release/release/v<< parameters.version >>/bin/$(uname -s | tr A-Z a-z)/amd64/kubectl
           sudo install /tmp/kubectl /usr/local/bin/kubectl
+  install-yarn:
+    steps:
+    - run:
+        name: "Install Yarn"
+        command: |
+          curl -o- -L https://yarnpkg.com/install.sh | bash
+          echo 'PATH="$HOME/.yarn/bin:$HOME/.config/yarn/global/node_modules/.bin:$PATH"' >> "$BASH_ENV"
   install-python:
     parameters:
       version:

--- a/.circleci/config.yml.d/docs.yml
+++ b/.circleci/config.yml.d/docs.yml
@@ -18,6 +18,7 @@ commands:
     steps:
       - install-node:
           version: "11"
+      - install-yarn
       - install-python:
           executor-key: "201903-01"
           version: "3.7.0"

--- a/.circleci/config.yml.d/util.yml
+++ b/.circleci/config.yml.d/util.yml
@@ -72,6 +72,13 @@ commands:
             curl -L --fail -o /tmp/kubectl https://storage.googleapis.com/kubernetes-release/release/v<< parameters.version >>/bin/$(uname -s | tr A-Z a-z)/amd64/kubectl
             sudo install /tmp/kubectl /usr/local/bin/kubectl
 
+  "install-yarn":
+    steps:
+      - run:
+          name: "Install Yarn"
+          command: |
+            curl -o- -L https://yarnpkg.com/install.sh | bash
+            echo 'PATH="$HOME/.yarn/bin:$HOME/.config/yarn/global/node_modules/.bin:$PATH"' >> "$BASH_ENV"
   "install-python":
     parameters:
       "version":

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -86,7 +86,7 @@ and the CI will be green.
       - `CurrentVersion` is e.g. "0.78.0" -- no leading 'v' here
       - `BlogLink` is the full URL of the blog post (from Marketing), or "" if there is no blog post
    - Make your edits, submit a PR, get it merged. Done.
-      - If you want to test before submitting, use `npm install && npm start` and point a web browser to `localhost:8000`
+      - If you want to test before submitting, use `yarn install && yarn start` and point a web browser to `localhost:8000`
 
    Submit a PR to the Ambassador website repository to update the version on the homepage.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,9 @@ The Ambassador Edge Stack is a comprehensive, self-service edge stack and API Ga
 
 ## First Steps
 
-New to Ambassador Edge Stack? Start here! We've worked hard to make installing and using Ambassador Edge Stack as easy as possible.
+New to the Ambassador Edge Stack?  Start here!  We've worked hard to
+make installing and using the Ambassador Edge Stack as easy as
+possible.
 
 * The [Quick Start Guide](tutorials/getting-started)
 
@@ -28,6 +30,7 @@ We work hard at keeping our documentation useful for all of our users. Here's an
   * [Running Ambassador](topics/running) is for operators, site reliability engineers, and other Ambassador users who are responsible for running Ambassador in production.
 * [HOWTO Guides](howtos) are recipes for configuring Ambassador to address specific challenges such as Single Sign-On, rate limiting, or integrating with a service mesh. They assume some general knowledge of Ambassador.
 
-It's easy to get started with Ambassador Edge Stack. Get started now:
+It's easy to get started with the Ambassador Edge Stack.  Get started
+now:
 
 <Button color="orange" to="tutorials/getting-started/">Begin Quick Start</Button>

--- a/scripts/doc-publish
+++ b/scripts/doc-publish
@@ -63,7 +63,7 @@ cd "$WEBSITE_DIR"
 
 printf "${GRN}${BLD}==== Starting build${END}\n"
 
-npm run build
+yarn run build
 
 # From ./ambassador/.ci/website-preview-publish
 

--- a/scripts/doc-setup
+++ b/scripts/doc-setup
@@ -56,5 +56,5 @@ mkdir submodules/latest
 
 (cd "$source_dir" && bash ${root_dir}/doc-sync "${WEBSITE_DIR}")
 
-npm install
-npm run start
+yarn install
+yarn run start


### PR DESCRIPTION
## Description

Counterpart of https://github.com/datawire/getambassador.io/pull/329

This should fix the website previews from locking up.

This'll need to make its way to master, and to apro.git.  And to whichever `release/v1.Y` branches we expect to continue to update.

See the website preview in the CI checks? (I had to find something in `docs/` to proof-read to get it to build).  Click around in the docs, it doesn't lock up your browser like it was doing before.

## Tasks That Must Be Done
- [x] Is this a build change? - yes
  + [x] If so, did you test on both Mac and Linux? - nope!