### PR TITLE
Documentation fixes

### DIFF
--- a/docs/about/faq.md
+++ b/docs/about/faq.md
@@ -64,7 +64,7 @@ To use a custom 404 landing page, simply insert your service and remove the rewr
 apiVersion: getambassador.io/v2
 kind: Mapping
 metadata:
-  name: "404 fallback"
+  name: "404-fallback"
 spec:
   prefix: "/"
   rewrite: "/404/" # This must not map to any existing prefix!

--- a/docs/howtos/basic-auth.md
+++ b/docs/howtos/basic-auth.md
@@ -1,16 +1,18 @@
 # Authentication
 
-Ambassador can authenticate incoming requests before routing them to a backing service. In this tutorial, we'll configure Ambassador to use an external third party authentication service. Note that if you're using the Ambassador Edge Stack, the [`External` filter](../../topics/using/filters) is a more powerful way to manage authentication. 
+IMPORTANT: This guide applies to the Ambassador API Gateway version of Ambassador, use of this guide on the Ambassador Edge Stack is not fully supported; use the [External Filter](../../topics/using/filters) instead.
+
+Ambassador can authenticate incoming requests before routing them to a backing service. In this tutorial, we'll configure Ambassador to use an external third party authentication service. Note that if you're using the Ambassador Edge Stack, the [`External` filter](../../topics/using/filters) is the supported way to manage authentication. 
 
 ## Before You Get Started
 
-This tutorial assumes you have already followed the Ambassador Edge Stack [Installation](../../topics/install) guide. If you haven't done that already, you should do that now.
+This tutorial assumes you have already followed the Ambassador API Gateway [Installation](../../topics/install/install-ambassador-oss.md) guide. If you haven't done that already, you should do so now.
 
-Once complete, you'll have a Kubernetes cluster running Ambassador Edge Stack. Let's walk through adding authentication to this setup.
+Once complete, you'll have a Kubernetes cluster running Ambassador. Let's walk through adding authentication to this setup.
 
 ## 1. Deploy the Authentication Service
 
-Ambassador Edge Stack delegates the actual authentication logic to a third party authentication service. We've written a [simple authentication service](https://github.com/datawire/ambassador-auth-service) that:
+Ambassador delegates the actual authentication logic to a third party authentication service. We've written a [simple authentication service](https://github.com/datawire/ambassador-auth-service) that:
 
 - listens for requests on port 3000;
 - expects all URLs to begin with `/extauth/`;
@@ -18,7 +20,7 @@ Ambassador Edge Stack delegates the actual authentication logic to a third party
 - accepts only user `username`, password `password`; and
 - makes sure that the `x-qotm-session` header is present, generating a new one if needed.
 
-Ambassador Edge Stack routes _all_ requests through the authentication service: it relies on the auth service to distinguish between requests that need authentication and those that do not. If Ambassador Edge Stack cannot contact the auth service, it will return a 503 for the request; as such, **it is very important to have the auth service running before configuring Ambassador Edge Stack to use it.**
+Ambassador routes _all_ requests through the authentication service: it relies on the auth service to distinguish between requests that need authentication and those that do not. If Ambassador cannot contact the auth service, it will return a 503 for the request; as such, **it is very important to have the auth service running before configuring Ambassador Edge Stack to use it.**
 
 Here's the YAML we'll start with:
 
@@ -66,7 +68,7 @@ spec:
             memory: 100Mi
 ```
 
-Note that the cluster does not yet contain any Ambassador Edge Stack AuthService definition. This is intentional: we want the service running before we tell Ambassador about it.
+Note that the cluster does not yet contain any Ambassador AuthService definition. This is intentional: we want the service running before we tell Ambassador about it.
 
 The YAML above is published at getambassador.io, so if you like, you can just do
 
@@ -85,9 +87,9 @@ example-auth-6c5855b98d-24clp   1/1       Running   0          4m
 ```
 Note that the `READY` field says `1/1` which means the pod is up and running.
 
-## 2. Configure Ambassador Edge Stack Authentication
+## 2. Configure Ambassador Authentication
 
-Once the auth service is running, we need to tell Ambassador Edge Stack about it. The easiest way to do that is to map the `example-auth` service with the following:
+Once the auth service is running, we need to tell Ambassador about it. The easiest way to do that is to map the `example-auth` service with the following:
 
 ```yaml
 ---
@@ -104,7 +106,7 @@ spec:
   - "x-qotm-session"
 ```
 
-This configuration tells Ambassador Edge Stack about the auth service, notably that it needs the `/extauth` prefix, and that it's OK for it to pass back the `x-qotm-session` header. Note that `path_prefix` and `allowed_headers` are optional.
+This configuration tells Ambassador about the auth service, notably that it needs the `/extauth` prefix, and that it's OK for it to pass back the `x-qotm-session` header. Note that `path_prefix` and `allowed_headers` are optional.
 
 If the auth service uses a framework like [Gorilla Toolkit](http://www.gorillatoolkit.org) which enforces strict slashes as HTTP path separators, it is possible to end up with an infinite redirect where the auth service's framework redirects any request with non-conformant slashing. This would arise if the above example had ```path_prefix: "/extauth/"```, the auth service would see a request for ```/extauth//backend/get-quote/``` which would then be redirected to ```/extauth/backend/get-quote/``` rather than actually be handled by the authentication handler. For this reason, remember that the full path of the incoming request including the leading slash, will be appended to ```path_prefix``` regardless of non-conformant slashing.
 
@@ -116,7 +118,7 @@ kubectl apply -f https://www.getambassador.io/yaml/demo/demo-auth-enable.yaml
 
 or, again, apply it from a local file if you prefer.
 
-Note that the cluster does not yet contain any Ambassador Edge Stack AuthService definition.
+Note that the cluster does not yet contain any Ambassador AuthService definition.
 
 ## 3. Test Authentication
 

--- a/docs/howtos/basic-auth.md
+++ b/docs/howtos/basic-auth.md
@@ -1,6 +1,6 @@
 # Authentication
 
-IMPORTANT: This guide applies to the Ambassador API Gateway version of Ambassador, use of this guide on the Ambassador Edge Stack is not fully supported; use the [External Filter](../../topics/using/filters) instead.
+IMPORTANT: This guide applies to Ambassador API Gateway, use of this guide on the Ambassador Edge Stack is not fully supported.  Use the [External Filter](../../topics/using/filters) instead.
 
 Ambassador can authenticate incoming requests before routing them to a backing service. In this tutorial, we'll configure Ambassador to use an external third party authentication service.
 

--- a/docs/howtos/basic-auth.md
+++ b/docs/howtos/basic-auth.md
@@ -2,7 +2,7 @@
 
 IMPORTANT: This guide applies to the Ambassador API Gateway version of Ambassador, use of this guide on the Ambassador Edge Stack is not fully supported; use the [External Filter](../../topics/using/filters) instead.
 
-Ambassador can authenticate incoming requests before routing them to a backing service. In this tutorial, we'll configure Ambassador to use an external third party authentication service. Note that if you're using the Ambassador Edge Stack, the [`External` filter](../../topics/using/filters) is the supported way to manage authentication. 
+Ambassador can authenticate incoming requests before routing them to a backing service. In this tutorial, we'll configure Ambassador to use an external third party authentication service.
 
 ## Before You Get Started
 
@@ -20,7 +20,7 @@ Ambassador delegates the actual authentication logic to a third party authentica
 - accepts only user `username`, password `password`; and
 - makes sure that the `x-qotm-session` header is present, generating a new one if needed.
 
-Ambassador routes _all_ requests through the authentication service: it relies on the auth service to distinguish between requests that need authentication and those that do not. If Ambassador cannot contact the auth service, it will return a 503 for the request; as such, **it is very important to have the auth service running before configuring Ambassador Edge Stack to use it.**
+Ambassador routes _all_ requests through the authentication service: it relies on the auth service to distinguish between requests that need authentication and those that do not. If Ambassador cannot contact the auth service, it will return a 503 for the request; as such, **it is very important to have the auth service running before configuring Ambassador to use it.**
 
 Here's the YAML we'll start with:
 

--- a/docs/howtos/rate-limiting-tutorial.md
+++ b/docs/howtos/rate-limiting-tutorial.md
@@ -1,6 +1,6 @@
 # Rate Limiting
 
-IMPORTANT: This guide applies to the Ambassador API Gateway version of Ambassador, use of this guide on the Ambassador Edge Stack is not fully supported; use the existing [RateLimitService](../../topics/using/rate-limits/) instead.
+IMPORTANT: This guide applies to the Ambassador API Gateway version of Ambassador, use of this guide on the Ambassador Edge Stack is not fully supported.  Use the existing [RateLimitService](../../topics/using/rate-limits/) instead.
 
 Ambassador can validate incoming requests before routing them to a backing service. In this tutorial, we'll configure the Ambassador API Gateway to use a simple third party rate limit service. If you don't want to implement your own rate limiting service, the Ambassador Edge Stack integrates a [powerful, flexible rate limiting service](../../topics/using/rate-limits/).
 
@@ -12,7 +12,7 @@ Once completed, you'll have a Kubernetes cluster running Ambassador and the Quot
 
 ## 1. Deploy the Rate Limit Service
 
-The Ambassador Edge Stack delegates the actual rate limit logic to a third party service. We've written a [simple rate limit service](https://github.com/datawire/ambassador/tree/master/docker/test-ratelimit) that:
+Ambassador delegates the actual rate limit logic to a third party service. We've written a [simple rate limit service](https://github.com/datawire/ambassador/tree/master/docker/test-ratelimit) that:
 
 - listens for requests on port 5000;
 - handles gRPC `shouldRateLimit` requests;
@@ -72,9 +72,9 @@ spec:
             memory: 100Mi
 ```
 
-This configuration tells the Ambassador Edge Stack about the rate limit service, notably that it is serving requests at `example-rate-limit:5000`.
+This configuration tells Ambassador about the rate limit service, notably that it is serving requests at `example-rate-limit:5000`.
 
-The Ambassador will see the RateLimitService and reconfigure itself within a few seconds. Note that the v2 API is available for the Ambassador.
+Ambassador will see the RateLimitService and reconfigure itself within a few seconds. Note that the v2 API is available for the Ambassador.
 
 ## 2. Configure Ambassador Mappings
 
@@ -156,7 +156,7 @@ spec:
       - "x-ambassador-test-allow"
 ```
 
-This configuration tells the Ambassador Edge Stack about the rate limit rules to apply, notably that it needs the `x-ambassador-test-allow` header, and that it should set "A test case" as the `generic_key` descriptor when performing the gRPC request.
+This configuration tells Ambassador about the rate limit rules to apply, notably that it needs the `x-ambassador-test-allow` header, and that it should set "A test case" as the `generic_key` descriptor when performing the gRPC request.
 
 Note that both `descriptor` and `headers` are optional. However, if `headers` are defined, **they must be part of the request in order to be rate limited**.
 

--- a/docs/howtos/rate-limiting-tutorial.md
+++ b/docs/howtos/rate-limiting-tutorial.md
@@ -1,10 +1,12 @@
 # Rate Limiting
 
-The Ambassador Edge Stack can validate incoming requests before routing them to a backing service. In this tutorial, we'll configure the Ambassador Edge Stack to use a simple third party rate limit service. If you don't want to implement your own rate limiting service, the Ambassador Edge Stack integrates a [powerful, flexible rate limiting service](../../topics/using/rate-limits/).
+IMPORTANT: This guide applies to the Ambassador API Gateway version of Ambassador, use of this guide on the Ambassador Edge Stack is not fully supported; use the existing [RateLimitService](../../topics/using/rate-limits/) instead.
+
+Ambassador can validate incoming requests before routing them to a backing service. In this tutorial, we'll configure the Ambassador API Gateway to use a simple third party rate limit service. If you don't want to implement your own rate limiting service, the Ambassador Edge Stack integrates a [powerful, flexible rate limiting service](../../topics/using/rate-limits/).
 
 ## Before You Get Started
 
-This tutorial assumes you have already followed the Ambassador Edge Stack [Getting Started](../../tutorials/getting-started) guide. If you haven't done that already, you should do that now.
+This tutorial assumes you have already followed the Ambassador API Gateway [Installation](../../topics/install/install-ambassador-oss.md) and [Quickstart Tutorial](../../tutorials/quickstart-demo.md) guides. If you haven't done that already, you should do so now.
 
 Once completed, you'll have a Kubernetes cluster running Ambassador and the Quote of the Moment service. Let's walk through adding rate limiting to this setup.
 
@@ -72,11 +74,11 @@ spec:
 
 This configuration tells the Ambassador Edge Stack about the rate limit service, notably that it is serving requests at `example-rate-limit:5000`.
 
-The Ambassador Edge Stack will see the RateLimitService and reconfigure itself within a few seconds. Note that the v2 API is available for the Ambassador Edge Stack.
+The Ambassador will see the RateLimitService and reconfigure itself within a few seconds. Note that the v2 API is available for the Ambassador.
 
-## 2. Configure Ambassador Edge Stack Mappings
+## 2. Configure Ambassador Mappings
 
-The Ambassador Edge Stack only validates requests on Mappings which set rate limiting descriptors. If Ambassador cannot contact the rate limit service, it will allow the request to be processed as if there were no rate limit service configuration.
+Ambassador only validates requests on Mappings which set rate limiting descriptors. If Ambassador cannot contact the rate limit service, it will allow the request to be processed as if there were no rate limit service configuration.
 
 ### v0 API
 
@@ -122,24 +124,6 @@ apiVersion: v1
 kind: Service
 metadata:
   name: quote
-  annotations:
-    getambassador.io/config: |
-      ---
-      apiVersion: ambassador/v2
-      kind: Mapping
-      name: quote-backend
-      prefix: /
-      service: quote:5000
-      ---
-      apiVersion: ambassador/v2
-      kind: Mapping
-      name: quote-backend
-      prefix: /backend/
-      service: quote
-      rate_limits:
-        - descriptor: A test case
-          headers:
-            - "x-ambassador-test-allow"
 spec:
   ports:
   - name: ui
@@ -150,13 +134,33 @@ spec:
     targetPort: 8080
   selector:
     app: backend
+---
+apiVersion: getambassador.io/v2
+kind: Mapping
+metadata:
+  name: quote-backend
+spec:
+  prefix: /
+  service: quote:5000
+---
+apiVersion: getambassador.io/v2
+kind: Mapping
+metadata:
+  name: quote-backend
+spec:
+  prefix: /backend/
+  service: quote
+  rate_limits:
+  - descriptor: A test case
+    headers:
+      - "x-ambassador-test-allow"
 ```
 
 This configuration tells the Ambassador Edge Stack about the rate limit rules to apply, notably that it needs the `x-ambassador-test-allow` header, and that it should set "A test case" as the `generic_key` descriptor when performing the gRPC request.
 
 Note that both `descriptor` and `headers` are optional. However, if `headers` are defined, **they must be part of the request in order to be rate limited**.
 
-Ambassador Edge Stack would also perform multiple requests to `example-rate-limit:5000` if we had defined multiple `rate_limits` rules on the mapping.
+Ambassador would also perform multiple requests to `example-rate-limit:5000` if we had defined multiple `rate_limits` rules on the mapping.
 
 ## 3. Test Rate Limiting
 

--- a/docs/howtos/rate-limiting-tutorial.md
+++ b/docs/howtos/rate-limiting-tutorial.md
@@ -1,6 +1,6 @@
 # Rate Limiting
 
-IMPORTANT: This guide applies to the Ambassador API Gateway version of Ambassador, use of this guide on the Ambassador Edge Stack is not fully supported.  Use the existing [RateLimitService](../../topics/using/rate-limits/) instead.
+IMPORTANT: This guide applies to Ambassador API Gateway, use of this guide on the Ambassador Edge Stack is not fully supported.  Use the existing [RateLimitService](../../topics/using/rate-limits/) instead.
 
 Ambassador can validate incoming requests before routing them to a backing service. In this tutorial, we'll configure the Ambassador API Gateway to use a simple third party rate limit service. If you don't want to implement your own rate limiting service, the Ambassador Edge Stack integrates a [powerful, flexible rate limiting service](../../topics/using/rate-limits/).
 

--- a/docs/topics/install/helm.md
+++ b/docs/topics/install/helm.md
@@ -41,8 +41,8 @@ deploy it with either version of the tool.
    helm install --name ambassador --namespace ambassador datawire/ambassador
    ```
 
-4. Finish the installation by running the following command: `edgectl install` \*
-5. Provide an email address when prompted to receive notices if your domain or TLS certificate is about to expire.
+4. Finish the installation by running the following command: `edgectl install` (optional) \*
+5. Provide an email address when prompted to receive notices if your domain or TLS certificate is about to expire. (optional)
 
 Your terminal should print something similar to the following:
 ```

--- a/docs/topics/install/helm.md
+++ b/docs/topics/install/helm.md
@@ -41,7 +41,7 @@ deploy it with either version of the tool.
    helm install --name ambassador --namespace ambassador datawire/ambassador
    ```
 
-4. Finish the installation by running the following command: `edgectl install`
+4. Finish the installation by running the following command: `edgectl install` \*
 5. Provide an email address when prompted to receive notices if your domain or TLS certificate is about to expire.
 
 Your terminal should print something similar to the following:
@@ -56,7 +56,7 @@ Your terminal should print something similar to the following:
    Congratulations, you’ve successfully installed the Ambassador Edge Stack in your Kubernetes cluster. Visit https://random-word.edgestack.me to access your Edge Stack installation and for additional configuration.
 ```
 
-[Edge Control](../../using/edgectl/edge-control) (`edgectl`) automatically configures TLS for your instance and provisions a domain name for your Ambassador Edge Stack.
+\* [Edge Control](../../using/edgectl/edge-control) (`edgectl`) automatically configures TLS for your instance and provisions a domain name for your Ambassador Edge Stack.  This is not necessary if you already have a domain name and certificates.
 
 This will install the necessary deployments, RBAC, Custom Resource Definitions, etc. for the Ambassador Edge Stack to route traffic. Details on how to configure Ambassador using the Helm chart can be found in the Helm chart [README](https://github.com/datawire/ambassador-chart/tree/master).
 


### PR DESCRIPTION
Included doc changes
- In the FAQ, the space in the name of the mapping is technically a naming violation, even if it is intended to be a placeholder
- In the Helm Install, making it more clear that the edgectl install portion of the document is optional, and that
- Scrubbed Edge Stack from the basic auth and basic rate limiting howtos, since they are specific to API Gateway only, also made a note at the top reinforcing that these howtos are not supported by AES.
  - Also pulled some yaml annotations out of the service definition in the RL howto.

This PR only addresses v1.6 documentation, if PR is accepted I will create more for 1.3-1.5.