### PR TITLE
Service Preview TOC

### DIFF
--- a/docs/js/doc-links.yml
+++ b/docs/js/doc-links.yml
@@ -113,14 +113,6 @@
               link: /docs/latest/topics/using/filters/external
             - title: Plugin Filter
               link: /docs/latest/topics/using/filters/plugin
-        - title: Service Preview and Edge Control
-          items:
-            - title: Introduction to Service Preview and Edge Control
-              link: /docs/latest/topics/using/edgectl/
-            - title: Edge Control
-              link: /docs/latest/topics/using/edgectl/edge-control
-            - title: Using Edge Control in CI
-              link: /docs/latest/topics/using/edgectl/edge-control-in-ci
         - title: Developer Portal
           link: /docs/latest/topics/using/dev-portal
         - title: Edge Policy Console
@@ -261,6 +253,14 @@
           link: /docs/latest/howtos/cert-manager
         - title: Client Certificate Validation
           link: /docs/latest/howtos/client-cert-validation
+- title: Service Preview and Edge Control
+  items:
+    - title: Introduction to Service Preview and Edge Control
+      link: /docs/latest/topics/using/edgectl/
+    - title: Edge Control
+      link: /docs/latest/topics/using/edgectl/edge-control
+    - title: Using Edge Control in CI
+      link: /docs/latest/topics/using/edgectl/edge-control-in-ci
 - title: Frequently Asked Questions
   link: /docs/latest/about/faq
 - title: Community


### PR DESCRIPTION
Move service preview docs to a top-level, instead of being buried in the Ambassador docs