### PR TITLE
Service Preview org

### DIFF
--- a/docs/js/doc-links.yml
+++ b/docs/js/doc-links.yml
@@ -255,12 +255,12 @@
           link: /docs/latest/howtos/client-cert-validation
 - title: Service Preview
   items:
-  - title: Service Preview Quick Start
-    link: /docs/latest/topics/using/edgectl/service-preview-install
-  - title: Service Preview Tutorial
-    link: /docs/latest/topics/using/edgectl/service-preview-tutorial
   - title: Introduction to Service Preview
     link: /docs/latest/topics/using/edgectl/
+  - title: Installation
+    link: /docs/latest/topics/using/edgectl/service-preview-install
+  - title: Tutorial
+    link: /docs/latest/topics/using/edgectl/service-preview-tutorial
   - title: Service Preview Reference
     link: /docs/latest/topics/using/edgectl/service-preview-reference
   - title: Edge Control Reference

--- a/docs/js/doc-links.yml
+++ b/docs/js/doc-links.yml
@@ -254,10 +254,9 @@
         - title: Client Certificate Validation
           link: /docs/latest/howtos/client-cert-validation
 - title: Service Preview
+  link: /docs/latest/topics/using/edgectl/
   items:
-  - title: Introduction to Service Preview
-    link: /docs/latest/topics/using/edgectl/
-  - title: Installation
+  - title: Quick Start
     link: /docs/latest/topics/using/edgectl/service-preview-install
   - title: Tutorial
     link: /docs/latest/topics/using/edgectl/service-preview-tutorial

--- a/docs/topics/using/edgectl/index.md
+++ b/docs/topics/using/edgectl/index.md
@@ -2,31 +2,13 @@
 
 One of the challenges in adopting Kubernetes and microservices is the development and testing workflow. Creating and maintaining a full development environment with many microservices and their dependencies is complex and hard.
 
-Service Preview addresses this challenge by connecting your CI system or local development infrastructure to the Kubernetes cluster, and dynamically routing specific requests to your local environment.
+Service Preview, based on [Telepresence](https://www.telepresence.io), enables different developers to access different virtual versions of the same microservice. These virtual versions are deployed on your CI system or local development infrastructure, enabling fast development and testing workflows.
 
-## Installation
+## Getting started
 
-Service Preview and `edgectl` are addons to the Ambassador Edge Stack.
+To get started, follow the [installation](service-preview-install) instructions, and try the [tutorial](service-preview-tutorial).
 
-### Edge Control Install
-
-`edgectl` is a binary used to interact with the Ambassador Edge Stack and Service Preview.
-
-See [installing edge control](edge-control#installing-edge-control) to learn how to download and install `edgectl`
-
-### Service Preview Install
-
-Service Preview is installed as an additional deployment to Ambassador Edge Stack that runs in your Kubernetes cluster.
-
-See the [installing Service Preview Quick Start](service-preview-install) and [Service Preview tutorial](service-preview-tutorial) to learn how to install and use Service Preview.
-
-## Reference
-
-### Edge Control Commands
-
-`edgectl` is used for interacting with your cluster, Ambassador Edge Stack, and Service Preview. It can also be a powerful tool to use for CI/CD pipelines.
-
-See [Edge Control Commands](edge-control#edge-control-commands) for cli reference and [Edge Control in CI](edge-control-in-ci) for information on using `edgectl` in CI/CD pipelines.
+Service Preview runs on Mac OS X, Linux, and Windows via WSL2.
 
 ### Service Preview Components
 

--- a/docs/topics/using/edgectl/index.md
+++ b/docs/topics/using/edgectl/index.md
@@ -2,7 +2,7 @@
 
 One of the challenges in adopting Kubernetes and microservices is the development and testing workflow. Creating and maintaining a full development environment with many microservices and their dependencies is complex and hard.
 
-Service Preview, based on [Telepresence](https://www.telepresence.io), enables different developers to access different virtual versions of the same microservice. These virtual versions are deployed on your CI system or local development infrastructure, enabling fast development and testing workflows.
+Service Preview, based on [Telepresence](https://www.telepresence.io), enables different developers to run different virtual versions of the same microservice. These virtual versions are deployed on your CI system or local development infrastructure, enabling fast development and testing workflows.
 
 ## Getting started
 


### PR DESCRIPTION
- make the introduction the first page that people see when they get to the SP docs
- delete the ref material from the SP docs
- try to clarify the use case of SP