### PR TITLE
Project quickstart, added RBAC manifest for manual install.

### DIFF
--- a/docs/tutorials/projects.md
+++ b/docs/tutorials/projects.md
@@ -29,7 +29,7 @@ the project controller by running the following command:
 kubectl apply -f https://www.getambassador.io/yaml/projects.yaml
 ```
 
-**Note:** RBAC changes need to be made to fully activate the projects after manual project install:  Copy the following to add the RBAC permissions and restart the Ambassador Pods for the changes to take effect.
+**Note:** RBAC changes need to be made to fully activate the projects after manual project install:  Apply the following to add the RBAC permissions and restart the Ambassador Pods for the changes to take effect.
    ```yaml
    ---
    apiVersion: rbac.authorization.k8s.io/v1beta1

--- a/docs/tutorials/projects.md
+++ b/docs/tutorials/projects.md
@@ -35,46 +35,46 @@ kubectl apply -f https://www.getambassador.io/yaml/projects.yaml
    apiVersion: rbac.authorization.k8s.io/v1beta1
    kind: ClusterRole
    metadata:
-   name: ambassador-projects
-   labels:
-      app.kubernetes.io/name: ambassador
-      app.kubernetes.io/instance: ambassador
-      product: aes
+     name: ambassador-projects
+     labels:
+       app.kubernetes.io/name: ambassador
+       app.kubernetes.io/instance: ambassador
+       product: aes
    rules:
    - apiGroups: [""]
-   resources: [ "secrets", "services" ]
-   verbs: [ "get", "list", "create", "patch", "delete", "watch" ]
+     resources: [ "secrets", "services" ]
+     verbs: [ "get", "list", "create", "patch", "delete", "watch" ]
    - apiGroups: ["apps"]
-   resources: [ "deployments" ]
-   verbs: [ "get", "list", "create", "patch", "delete", "watch" ]
+     resources: [ "deployments" ]
+     verbs: [ "get", "list", "create", "patch", "delete", "watch" ]
    - apiGroups: ["batch"]
-   resources: [ "jobs" ]
-   verbs: [ "get", "list", "create", "patch", "delete", "watch" ]
+     resources: [ "jobs" ]
+     verbs: [ "get", "list", "create", "patch", "delete", "watch" ]
    - apiGroups: [""]
-   resources: [ "pods" ]
-   verbs: [ "get", "list", "watch" ]
+     resources: [ "pods" ]
+     verbs: [ "get", "list", "watch" ]
    - apiGroups: [""]
-   resources: [ "pods/log" ]
-   verbs: [ "get" ]
+     resources: [ "pods/log" ]
+     verbs: [ "get" ]
    ---
    apiVersion: rbac.authorization.k8s.io/v1beta1
    kind: ClusterRoleBinding
    metadata:
-   name: ambassador-projects
-   namespace: ambassador
-   labels:
-      app.kubernetes.io/name: ambassador
-      app.kubernetes.io/part-of: ambassador
-      app.kubernetes.io/instance: ambassador
-      product: aes
+     name: ambassador-projects
+     namespace: ambassador
+     labels:
+       app.kubernetes.io/name: ambassador
+       app.kubernetes.io/part-of: ambassador
+       app.kubernetes.io/instance: ambassador
+       product: aes
    roleRef:
-   apiGroup: rbac.authorization.k8s.io
-   kind: ClusterRole
-   name: ambassador-projects
+     apiGroup: rbac.authorization.k8s.io
+     kind: ClusterRole
+     name: ambassador-projects
    subjects:
    - name: ambassador
-      namespace: ambassador
-      kind: ServiceAccount
+     namespace: ambassador
+     kind: ServiceAccount
    ```
 
 If you use Helm to install Ambassador, you can get the equivalent by

--- a/docs/tutorials/projects.md
+++ b/docs/tutorials/projects.md
@@ -29,6 +29,54 @@ the project controller by running the following command:
 kubectl apply -f https://www.getambassador.io/yaml/projects.yaml
 ```
 
+**Note:** RBAC changes need to be made to fully activate the projects after manual project install:  Copy the following to add the RBAC permissions and restart the Ambassador Pods for the changes to take effect.
+   ```yaml
+   ---
+   apiVersion: rbac.authorization.k8s.io/v1beta1
+   kind: ClusterRole
+   metadata:
+   name: ambassador-projects
+   labels:
+      app.kubernetes.io/name: ambassador
+      app.kubernetes.io/instance: ambassador
+      product: aes
+   rules:
+   - apiGroups: [""]
+   resources: [ "secrets", "services" ]
+   verbs: [ "get", "list", "create", "patch", "delete", "watch" ]
+   - apiGroups: ["apps"]
+   resources: [ "deployments" ]
+   verbs: [ "get", "list", "create", "patch", "delete", "watch" ]
+   - apiGroups: ["batch"]
+   resources: [ "jobs" ]
+   verbs: [ "get", "list", "create", "patch", "delete", "watch" ]
+   - apiGroups: [""]
+   resources: [ "pods" ]
+   verbs: [ "get", "list", "watch" ]
+   - apiGroups: [""]
+   resources: [ "pods/log" ]
+   verbs: [ "get" ]
+   ---
+   apiVersion: rbac.authorization.k8s.io/v1beta1
+   kind: ClusterRoleBinding
+   metadata:
+   name: ambassador-projects
+   namespace: ambassador
+   labels:
+      app.kubernetes.io/name: ambassador
+      app.kubernetes.io/part-of: ambassador
+      app.kubernetes.io/instance: ambassador
+      product: aes
+   roleRef:
+   apiGroup: rbac.authorization.k8s.io
+   kind: ClusterRole
+   name: ambassador-projects
+   subjects:
+   - name: ambassador
+      namespace: ambassador
+      kind: ServiceAccount
+   ```
+
 If you use Helm to install Ambassador, you can get the equivalent by
 setting the `registry.create` option to true in your `values.yaml`
 file:
@@ -37,8 +85,6 @@ file:
 registry:
   create: true
 ```
-
-**Note:** The above installs an update to Ambassador RBAC permissions required to run Micro CD. You must restart the Ambassador Pods for this change to take effect.
 
 ## Project Quick Start
 


### PR DESCRIPTION
It's not immediately clear that after applying `kubectl apply -f https://getambassador.io/yaml/projects.yaml` that you also have to update the RBAC and restart the pods for it to take effect.  In the most apparant scenario, running `edgectl install` and then `kubectl apply -f https://getambassador.io/yaml/projects.yaml` results in the `ambassador` service account not getting the proper RBAC updates.  This would also likely occur if someone ran `helm install ambassador -n ambassador datawire/ambassador` without setting the registry flag and then applying the `projects` yaml.

Acts as a temporary fix for #2889 