### PR TITLE
Fixing broken link to MicroK8s logo

### DIFF
--- a/docs/topics/install/ambassador-oss-community.md
+++ b/docs/topics/install/ambassador-oss-community.md
@@ -66,7 +66,7 @@ is currently available out-of-the-box in some Kubernetes installers and local en
     <tr>
       <td style="text-align:center">
         <a href="https://microk8s.io/" target="_blank">
-          <img width="75" src="https://admin.insights.ubuntu.com/wp-content/uploads/305a/microk8s-sticker.png"></img>
+          <img width="75" src="https://ubuntu.com/wp-content/uploads/305a/microk8s-sticker.png"></img>
         </a>
       </td>
       <td>


### PR DESCRIPTION
Fixes the following broken link:

> Page https://www.getambassador.io/docs/1.6/topics/install/ambassador-oss-community/ has a broken link: https://admin.insights.ubuntu.com/wp-content/uploads/305a/microk8s-sticker.png(HTTP_undefined)