### PR TITLE
Fixing broken rate limit service link in 1.6 docs

### DIFF
--- a/docs/js/doc-page.js
+++ b/docs/js/doc-page.js
@@ -244,7 +244,7 @@ export default ({ data, location }) => {
             </div>
           </main>
         </div>
-        <DocFooter page={page} branch="${versions.branch}" />
+        <DocFooter page={page} branch={versions.branch} />
       </Layout>
     </React.Fragment>
   );

--- a/docs/js/doc-page.js
+++ b/docs/js/doc-page.js
@@ -244,7 +244,7 @@ export default ({ data, location }) => {
             </div>
           </main>
         </div>
-        <DocFooter page={page} branch="release/v1.6" />
+        <DocFooter page={page} branch="$branch$" />
       </Layout>
     </React.Fragment>
   );

--- a/docs/js/doc-page.js
+++ b/docs/js/doc-page.js
@@ -244,7 +244,7 @@ export default ({ data, location }) => {
             </div>
           </main>
         </div>
-        <DocFooter page={page} branch="$branch$" />
+        <DocFooter page={page} branch="${versions.branch}" />
       </Layout>
     </React.Fragment>
   );

--- a/docs/js/versions.yml
+++ b/docs/js/versions.yml
@@ -2,3 +2,4 @@ version: 1.6.2
 aproVersion: 0.11.0
 qotmVersion: 1.7
 quoteVersion: 0.4.1
+branch: release/v1.6

--- a/docs/topics/running/services/rate-limit-service.md
+++ b/docs/topics/running/services/rate-limit-service.md
@@ -91,7 +91,7 @@ limiting service.
 >
 > ```diff
 >  import (
->  	envoy_ratelimit_v1 "github.com/datawire/ambassador/pkg/api/envoy/service/ratelimit/v1"
+>  	envoy_ratelimit_v1 "github.com/datawire/ambassador/pkg/api/pb/lyft/ratelimit"
 > +	envoy_ratelimit_v2 "github.com/datawire/ambassador/pkg/api/envoy/service/ratelimit/v2"
 >  )
 > ...
@@ -99,8 +99,8 @@ limiting service.
 > +	envoy_ratelimit_v2.RegisterRateLimitServiceServer(myGRPCServer, myRateLimitImplementation)
 > ```
 
-[`v1/rls.proto`]: https://github.com/datawire/ambassador/tree/master/api/envoy/service/ratelimit/v1/rls.proto
-[`v2/rls.proto`]: https://github.com/datawire/ambassador/tree/master/api/envoy/service/ratelimit/v2/rls.proto
+[`v1/rls.proto`]: https://github.com/datawire/ambassador/tree/$branch$/api/pb/lyft/ratelimit/rls.proto
+[`v2/rls.proto`]: https://github.com/datawire/ambassador/tree/$branch$/api/envoy/service/ratelimit/v2/rls.proto
 
 The Ambassador API Gateway generates a gRPC request to the external rate limit
 service and provides a list of labels on which the rate limit service can base

--- a/docs/topics/running/services/rate-limit-service.md
+++ b/docs/topics/running/services/rate-limit-service.md
@@ -91,7 +91,7 @@ limiting service.
 >
 > ```diff
 >  import (
->  	envoy_ratelimit_v1 "github.com/datawire/ambassador/pkg/api/pb/lyft/ratelimit"
+>  	envoy_ratelimit_v1 "github.com/datawire/ambassador/pkg/api/envoy/service/ratelimit/v1"
 > +	envoy_ratelimit_v2 "github.com/datawire/ambassador/pkg/api/envoy/service/ratelimit/v2"
 >  )
 > ...
@@ -99,7 +99,7 @@ limiting service.
 > +	envoy_ratelimit_v2.RegisterRateLimitServiceServer(myGRPCServer, myRateLimitImplementation)
 > ```
 
-[`v1/rls.proto`]: https://github.com/datawire/ambassador/tree/$branch$/api/pb/lyft/ratelimit/rls.proto
+[`v1/rls.proto`]: https://github.com/datawire/ambassador/tree/$branch$/api/envoy/service/ratelimit/v1/rls.proto
 [`v2/rls.proto`]: https://github.com/datawire/ambassador/tree/$branch$/api/envoy/service/ratelimit/v2/rls.proto
 
 The Ambassador API Gateway generates a gRPC request to the external rate limit


### PR DESCRIPTION
Fixes the following broken link:

> Page https://www.getambassador.io/docs/1.6/topics/running/services/rate-limit-service/ has a broken link: https://github.com/datawire/ambassador/tree/master/api/envoy/service/ratelimit/v1/rls.proto (HTTP_404)