### PR TITLE
Correct branch variable and make more use of it (on master)

### DIFF
--- a/docs/js/doc-page.js
+++ b/docs/js/doc-page.js
@@ -244,7 +244,7 @@ export default ({ data, location }) => {
             </div>
           </main>
         </div>
-        <DocFooter page={page} branch="master" />
+        <DocFooter page={page} branch={versions.branch} />
       </Layout>
     </React.Fragment>
   );

--- a/docs/js/versions.yml
+++ b/docs/js/versions.yml
@@ -2,4 +2,4 @@ version: 1.7.0
 aproVersion: 0.11.0
 qotmVersion: 1.7
 quoteVersion: 0.4.1
-branch: release/v1.7
+branch: master

--- a/docs/topics/running/services/rate-limit-service.md
+++ b/docs/topics/running/services/rate-limit-service.md
@@ -69,8 +69,8 @@ limiting service.
 > +	envoy_ratelimit_v2.RegisterRateLimitServiceServer(myGRPCServer, myRateLimitImplementation)
 > ```
 
-[`v1/rls.proto`]: https://github.com/datawire/ambassador/tree/master/api/pb/lyft/ratelimit/rls.proto
-[`v2/rls.proto`]: https://github.com/datawire/ambassador/tree/master/api/envoy/service/ratelimit/v2/rls.proto
+[`v1/rls.proto`]: https://github.com/datawire/ambassador/tree/$branch$/api/pb/lyft/ratelimit/rls.proto
+[`v2/rls.proto`]: https://github.com/datawire/ambassador/tree/$branch$/api/envoy/service/ratelimit/v2/rls.proto
 
 The Ambassador API Gateway generates a gRPC request to the external rate limit
 service and provides a list of labels on which the rate limit service can base


### PR DESCRIPTION
Corrects the value of the `branch` variable (for docs) and makes use of it for rate limit service page and docs page footers.