### PR TITLE
[v1.4] Updating link to AWS load balancer annotations

### DIFF
--- a/docs/topics/running/ambassador-with-aws.md
+++ b/docs/topics/running/ambassador-with-aws.md
@@ -32,7 +32,7 @@ In Kubernetes, when using the AWS integration and a service of type `LoadBalance
 
 ## Load Balancer Annotations
 
-There are several `aws-load-balancer` annotations that can be configured in the Ambassador Edge Stack service to control the AWS load balancer it deploys. You can view all of them in the [Kubernetes documentation](https://kubernetes.io/docs/concepts/cluster-administration/cloud-providers/#load-balancers). This document will go over the subset that is most relevant when deploying Ambassador Edge Stack.
+Kubernetes on AWS exposes a mechanism to request certain load balancer configurations by annotating the `type: LoadBalancer` `Service`. The most complete set and explanations of these annotations can be found in this [Kubernetes document](https://kubernetes.io/docs/concepts/services-networking/service/#loadbalancer). This document will go over the subset that is most relevant when deploying Ambassador Edge Stack.
 
 - `service.beta.kubernetes.io/aws-load-balancer-ssl-cert`: 
     Configures the load balancer to use a valid certificate ARN to terminate TLS at the Load Balancer.


### PR DESCRIPTION
Fixes the following broken link:

> Page https://www.getambassador.io/docs/1.4/topics/running/ambassador-with-aws/ has a broken link: https://kubernetes.io/docs/concepts/cluster-administration/cloud-providers/#load-balancers (HTTP_404)
