### PR TITLE
Minor addition to Timeouts + Module page Formatting

### DIFF
--- a/docs/topics/running/ambassador.md
+++ b/docs/topics/running/ambassador.md
@@ -196,7 +196,7 @@ readiness_probe:
   rewrite: /backend/health
 ```
 
-The liveness and readiness probe both support `prefix`, `rewrite`, and `service`, with the same meanings as for [mappings](../../using/mappings). Additionally, the `enabled` boolean may be set to `false` to disable support for the probe entirely.
+The liveness and readiness probes both support `prefix`, `rewrite`, and `service`, with the same meanings as for [mappings](../../using/mappings). Additionally, the `enabled` boolean may be set to `false` to disable API support for the probe.  It will, however, remain accessible on port 8877.
 
 ### Lua Scripts (`lua_scripts`)
 

--- a/docs/topics/running/ambassador.md
+++ b/docs/topics/running/ambassador.md
@@ -25,9 +25,9 @@ spec:
 | `admin_port` | The port where Ambassador's Envoy will listen for low-level admin requests. You should almost never need to change this. | `admin_port: 8001` |
 | `ambassador_id` | Use only if you are using multiple ambassadors in the same cluster. [Learn more](#ambassador_id). | `ambassador_id: "<ambassador_id>"` |
 | `cluster_idle_timeout_ms` | Set the default upstream-connection idle timeout. Default is 1 hour. | `cluster_idle_timeout_ms: 30000` |
-| `default_label_domain  and default_labels` | Set a default domain and request labels to every request for use by rate limiting. For more on how to use these, see the Rate Limit reference. | Empty |
-| `defaults` | The `defaults` element allows setting system-wide defaults that will be applied to various Ambassador resources. See [using defaults](../../using/defaults) for more information. | Empty |
-| `diagnostics.enabled` | Enable or disable the [Edge Policy Console](../../using/edge-policy-console) and `/ambassador/v0/diag/` endpoints. | `diagnostics.enabled: true` |
+| `default_label_domain  and default_labels` | Set a default domain and request labels to every request for use by rate limiting. For more on how to use these, see the [Rate Limit reference](../../using/rate-limits/rate-limits##an-example-with-global-labels-and-groups). | None |
+| `defaults` | The `defaults` element allows setting system-wide defaults that will be applied to various Ambassador resources. See [using defaults](../../using/defaults) for more information. | None |
+| `diagnostics.enabled` | Enable or disable the [Edge Policy Console](../../using/edge-policy-console) and `/ambassador/v0/diag/` endpoints.  See below for more details. | None |
 | `enable_grpc_http11_bridge` | Should we enable the gRPC-http11 bridge? | `enable_grpc_http11_bridge: false` |
 | `enable_grpc_web` | Should we enable the grpc-Web protocol? | `enable_grpc_web: false` |
 | `enable_http10` | Should we enable http/1.0 protocol? | `enable_http10: false` |
@@ -37,13 +37,13 @@ spec:
 | `envoy_log_path` | Defines the path of log envoy will use. By default this is standard output. | `envoy_log_path: /dev/fd/1` |
 | `envoy_log_type` | Defines the type of log envoy will use, currently only support json or text. | `envoy_log_type: text` |
 | `listener_idle_timeout_ms` | Controls how Envoy configures the tcp idle timeout on the http listener. Default is 1 hour. | `listener_idle_timeout_ms: 30000` |
-| `lua_scripts` | Run a custom lua script on every request. see below for more details. | Empty |
+| `lua_scripts` | Run a custom lua script on every request. see below for more details. | None |
 | `proper_case` | Should we enable upper casing for response headers? For more information, see [the Envoy docs](https://www.envoyproxy.io/docs/envoy/latest/api-v2/api/v2/core/protocol.proto#envoy-api-msg-core-http1protocoloptions-headerkeyformat). | `proper_case: false` |
 | `regex_max_size` | This field controls the RE2 "program size" which is a rough estimate of how complex a compiled regex is to evaluate. A regex that has a program size greater than the configured value will fail to compile.    | `regex_max_size: 200` |
 | `regex_type` | Set which regular expression engine to use. See the "Regular Expressions" section below. | `regex_type: safe` |
-| `server_name` | By default Envoy sets server_name response header to `envoy`. Override it with this variable. | `envoy` |
-| `service_port` | If present, service_port will be the port Ambassador listens on for microservice access. If not present, Ambassador will use 8443 if TLS is configured, 8080 otherwise. | `8080` |
-| `statsd` | Configures Ambassador statistics. These values can be set in the Ambassador module or in an environment variable. For more information, see the [Statistics reference](../statistics#exposing-statistics-via-statsd). | Empty |
+| `server_name` | By default Envoy sets server_name response header to `envoy`. Override it with this variable. | `server_name: envoy` |
+| `service_port` | If present, service_port will be the port Ambassador listens on for microservice access. If not present, Ambassador will use 8443 if TLS is configured, 8080 otherwise. | `service_port: 8080` |
+| `statsd` | Configures Ambassador statistics. These values can be set in the Ambassador module or in an environment variable. For more information, see the [Statistics reference](../statistics#exposing-statistics-via-statsd). | None |
 | `use_proxy_proto` | Controls whether Envoy will honor the PROXY protocol on incoming requests. | `use_proxy_proto: false` |
 | `use_remote_address` | Controls whether Envoy will trust the remote address of incoming connections or rely exclusively on the X-Forwarded-For header. | `use_remote_address: true` |
 | `use_ambassador_namespace_for_service_resolution` | Controls whether Ambassador will resolve upstream services assuming they are in the same namespace as the element referring to them, e.g. a Mapping in namespace `foo` will look for its service in namespace `foo`. If `true`, Ambassador will resolve the upstream services assuming they are in the same namespace as Ambassador, unless the service explicitly mentions a different namespace. | `use_ambassador_namespace_for_service_resolution: false` |

--- a/docs/topics/running/ambassador.md
+++ b/docs/topics/running/ambassador.md
@@ -1,8 +1,10 @@
 # Global Configuration
 
-## The `ambassador Module`
+## The Ambassador `Module`
 
-If present, the `ambassador Module` defines system-wide configuration. This module can be applied to any Kubernetes service (the `ambassador` service itself is a common choice). **You may very well not need this Module.** The defaults in the `ambassador Module` are:
+If present, the `Module` defines system-wide configuration. This module can be applied to any Kubernetes service (the `ambassador` service itself is a common choice). **You may very well not need this Module.** To apply the `Module` to an Ambassador `Service`, it MUST be named 'ambassador', otherwise it will be ignored.  To create multiple `ambassador Modules` in the same namespace, they should be put in the annotations of each separate Ambassador `Service`.
+
+The defaults in the `Module` are:
 
 ```yaml
 apiVersion: getambassador.io/v2
@@ -23,37 +25,37 @@ spec:
 | `admin_port` | The port where Ambassador's Envoy will listen for low-level admin requests. You should almost never need to change this. | `admin_port: 8001` |
 | `ambassador_id` | Use only if you are using multiple ambassadors in the same cluster. [Learn more](#ambassador_id). | `ambassador_id: "<ambassador_id>"` |
 | `cluster_idle_timeout_ms` | Set the default upstream-connection idle timeout. Default is 1 hour. | `cluster_idle_timeout_ms: 30000` |
-| `default_label_domain  and default_labels` | Set a default domain and request labels to every request for use by rate limiting. For more on how to use these, see the Rate Limit reference. |  |
-| `defaults` | The `defaults` element allows setting system-wide defaults that will be applied to various Ambassador resources. See [using defaults](../../using/defaults) for more information. | None | 
-| `enable_grpc_http11_bridge` | Should we enable the gRPC-http11 bridge? | `enable_grpc_http11_bridge: false `|
+| `default_label_domain  and default_labels` | Set a default domain and request labels to every request for use by rate limiting. For more on how to use these, see the Rate Limit reference. | Empty |
+| `defaults` | The `defaults` element allows setting system-wide defaults that will be applied to various Ambassador resources. See [using defaults](../../using/defaults) for more information. | Empty |
+| `diagnostics.enabled` | Enable or disable the [Edge Policy Console](../../using/edge-policy-console) and `/ambassador/v0/diag/` endpoints. | `diagnostics.enabled: true` |
+| `enable_grpc_http11_bridge` | Should we enable the gRPC-http11 bridge? | `enable_grpc_http11_bridge: false` |
 | `enable_grpc_web` | Should we enable the grpc-Web protocol? | `enable_grpc_web: false` |
 | `enable_http10` | Should we enable http/1.0 protocol? | `enable_http10: false` |
 | `enable_ipv4`| Should we do IPv4 DNS lookups when contacting services? Defaults to true, but can be overridden in a [`Mapping`](../../using/mappings). | `enable_ipv4: true` |
 | `enable_ipv6` | Should we do IPv6 DNS lookups when contacting services? Defaults to false, but can be overridden in a [`Mapping`](../../using/mappings). | `enable_ipv6: false` |
-| `envoy_log_format` | Defines the envoy log line format. See [this page](https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/access_log) for a complete list of operators | See [this page](https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#default-format-string) for the standard log format. |
-| `envoy_log_path` | Defines the path of log envoy will use. By default this is standard output | `envoy_log_path: /dev/fd/1` |
-| `envoy_log_type` | Defines the type of log envoy will use, currently only support json or text | `envoy_log_type: text` |
+| `envoy_log_format` | Defines the envoy log line format. See [this page](https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/access_log) for a complete list of operators. | See [this page](https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#default-format-string) for the standard log format. |
+| `envoy_log_path` | Defines the path of log envoy will use. By default this is standard output. | `envoy_log_path: /dev/fd/1` |
+| `envoy_log_type` | Defines the type of log envoy will use, currently only support json or text. | `envoy_log_type: text` |
 | `listener_idle_timeout_ms` | Controls how Envoy configures the tcp idle timeout on the http listener. Default is 1 hour. | `listener_idle_timeout_ms: 30000` |
-| `lua_scripts` | Run a custom lua script on every request. see below for more details. |  |
-| `proper_case` | Should we enable upper casing for response headers? For more information, see [the Envoy docs](https://www.envoyproxy.io/docs/envoy/latest/api-v2/api/v2/core/protocol.proto#envoy-api-msg-core-http1protocoloptions-headerkeyformat) | `proper_case: false` |
-| `regex_max_size` | This field controls the RE2 "program size" which is a rough estimate of how complex a compiled regex is to evaluate. A regex that has a program size greater than the configured value will fail to compile    | `regex_max_size: 200` |
+| `lua_scripts` | Run a custom lua script on every request. see below for more details. | Empty |
+| `proper_case` | Should we enable upper casing for response headers? For more information, see [the Envoy docs](https://www.envoyproxy.io/docs/envoy/latest/api-v2/api/v2/core/protocol.proto#envoy-api-msg-core-http1protocoloptions-headerkeyformat). | `proper_case: false` |
+| `regex_max_size` | This field controls the RE2 "program size" which is a rough estimate of how complex a compiled regex is to evaluate. A regex that has a program size greater than the configured value will fail to compile.    | `regex_max_size: 200` |
 | `regex_type` | Set which regular expression engine to use. See the "Regular Expressions" section below. | `regex_type: safe` |
-| `server_name: envoy` | By default Envoy sets server_name response header to `envoy`. Override it with this variable |  |
-| `service_port: 8080` | If present, service_port will be the port Ambassador listens on for microservice access. If not present, Ambassador will use 8443 if TLS is configured, 8080 otherwise. |  |
-| `statsd` | Configures Ambassador statistics. These values can be set in the Ambassador module or in an environment variable. For more information, see the [Statistics reference](../statistics#exposing-statistics-via-statsd). |  |
+| `server_name` | By default Envoy sets server_name response header to `envoy`. Override it with this variable. | `envoy` |
+| `service_port` | If present, service_port will be the port Ambassador listens on for microservice access. If not present, Ambassador will use 8443 if TLS is configured, 8080 otherwise. | `8080` |
+| `statsd` | Configures Ambassador statistics. These values can be set in the Ambassador module or in an environment variable. For more information, see the [Statistics reference](../statistics#exposing-statistics-via-statsd). | Empty |
 | `use_proxy_proto` | Controls whether Envoy will honor the PROXY protocol on incoming requests. | `use_proxy_proto: false` |
-| `use_remote_address` | Controls whether Envoy will trust the remote address of incoming connections or rely exclusively on the X-Forwarded_For header. | `use_remote_address: true` |
+| `use_remote_address` | Controls whether Envoy will trust the remote address of incoming connections or rely exclusively on the X-Forwarded-For header. | `use_remote_address: true` |
 | `use_ambassador_namespace_for_service_resolution` | Controls whether Ambassador will resolve upstream services assuming they are in the same namespace as the element referring to them, e.g. a Mapping in namespace `foo` will look for its service in namespace `foo`. If `true`, Ambassador will resolve the upstream services assuming they are in the same namespace as Ambassador, unless the service explicitly mentions a different namespace. | `use_ambassador_namespace_for_service_resolution: false` |
 | `x_forwarded_proto_redirect` | Ambassador lets through only the HTTP requests with `X-FORWARDED-PROTO: https` header set, and redirects all the other requests to HTTPS if this field is set to true. Note that `use_remote_address` must be set to false for this feature to work as expected. | `x_forwarded_proto_redirect: false` |
 | `xff_num_trusted_hops` | Controls the how Envoy sets the trusted client IP address of a request. If you have a proxy in front of Ambassador, Envoy will set the trusted client IP to the address of that proxy. To preserve the orginal client IP address, setting `x_num_trusted_hops: 1` will tell Envoy to use the client IP address in `X-Forwarded-For`. Please see the [Envoy documentation](https://www.envoyproxy.io/docs/envoy/v1.11.2/configuration/http_conn_man/headers#x-forwarded-for) for more information. | `xff_num_trusted_hops: 0` |
-| `preserve_external_request_id` | Controls whether to override the `X-REQUEST-ID` header or keep it as it is coming from incomming request. Note that `preserve_external_request_id` must be set to true for this feature to work. Default value will be false. | `preserve_external_request_id: true` |
-
-### Using `defaults`
-
-The `defaults` element is a dictionary of default values that will be applied to various 
-Ambassador resources. See [using defaults](../../using/defaults) for more information.
+| `preserve_external_request_id` | Controls whether to override the `X-REQUEST-ID` header or keep it as it is coming from incomming request. Note that `preserve_external_request_id` must be set to true for this feature to work. Default value will be false. | `preserve_external_request_id: false` |
 
 ### Additional `config` Field Examples
+
+The Ambassador `Module` can set global configurations for circuit-breaking, cors, keepalive, load-balancing, and retry policy. Setting any of these values in a `Mapping` will overwrite this behavior.
+
+#### Circuit Breaking
 
 `circuit_breakers` sets the global circuit breaking configuration that Ambassador will use for all mappings, unless overridden in a mapping. More information at the [circuit breaking reference](../../using/circuit-breakers).
 
@@ -63,6 +65,8 @@ circuit_breakers
   ...
 ```
 
+#### Cross Origin Resource Sharing (CORS)
+
 `cors` sets the default CORS configuration for all mappings in the cluster. See the [CORS syntax](../../using/cors).
 
 ```
@@ -70,10 +74,53 @@ cors:
   origins: http://foo.example,http://bar.example
   methods: POST, GET, OPTIONS
   ...
+```
+
+#### Keepalive
+
+`keepalive` sets the global keepalive settings. Ambassador will use for all mappings unless overridden in a mapping. No default value is provided by Ambassador. More information at https://www.envoyproxy.io/docs/envoy/latest/api-v2/api/v2/core/address.proto#envoy-api-msg-core-tcpkeepalive.
+
+```
+keepalive:
+  time: 2
+  interval: 2
+  probes: 100
+...
+```
+
+#### Load Balancer
+
+`load_balancer` sets the global load balancing type and policy that Ambassador will use for all mappings unless overridden in a mapping. Defaults to round-robin with Kubernetes. More information at the [load balancer reference](../load-balancer).
+
+```
+load_balancer:
+  policy: round_robin/least_request/ring_hash/maglev
   ...
 ```
 
-`diagnostics` configures Ambassador's diagnostics services.
+#### Retry Policy
+
+`retry_policy` lets you add resilience to your services in case of request failures by performing automatic retries.
+
+```
+retry_policy:
+  retry_on: "5xx"
+  ...
+```
+
+### Linkerd Interoperability (`add_linkerd_headers`)
+
+When using Linkerd, requests going to an upstream service need to include the `l5d-dst-override` header to ensure that Linkerd will route them correctly. Setting `add_linkerd_headers` does this automatically; see the [Mapping](../../using/mappings) documentation for more details.
+
+### Upstream Idle Timeout (`cluster_idle_timeout_ms`)
+
+If set, `cluster_idle_timeout_ms` specifies the timeout (in milliseconds) after which an idle connection upstream is closed. If no `cluster_idle_timeout_ms` is specified, upstream connections will never be closed due to idling.
+
+### Defaults (`defaults`)
+
+The `defaults` element is a dictionary of default values that will be applied to various Ambassador resources. See [using defaults](../../using/defaults) for more information.
+
+### Diagnostics (`diagnostics`)
 
 - Both the API Gateway and the Edge Stack provide low-level diagnostics at `/ambassador/v0/diag/`.
 - The Ambassador Edge Stack also provides the higher-level Edge Policy Console at `/edge_stack/admin/`.
@@ -98,107 +145,7 @@ When configured this way, diagnostics are only available from inside the Ambassa
 kubectl port-forward -n ambassador deploy/ambassador 8877
 ```
 
-`keepalive` sets the global keepalive settings.
-Ambassador will use for all mappings unless overridden in a
-mapping. No default value is provided by Ambassador.
-More information at https://www.envoyproxy.io/docs/envoy/latest/api-v2/api/v2/core/address.proto#envoy-api-msg-core-tcpkeepalive
-
-```
-keepalive:
-  time: 2
-  interval: 2
-  probes: 100
-```
-
-`liveness_probe` defaults on, but you can disable the API route.  It
-will remain accessible on port 8877.
-
-```
-liveness_probe:
-      enabled: true
-```
-
-`load_balancer` sets the global load balancing type and policy that Ambassador will use for all mappings unless overridden in a mapping. Defaults to round-robin with Kubernetes. More information at the [load balancer reference](../load-balancer).
-
-```
-load_balancer:
-  policy: round_robin/least_request/ring_hash/maglev
-  ...
-```
-
-`readiness_probe` defaults on, but you can disable the API route.  It
-will remain accessible on port 8877.
-
-```
-readiness_probe:
-  enabled: true
-```
-
-`retry_policy` lets you add resilience to your services in case of request failures by performing automatic retries.
-```
-retry_policy:
-  retry_on: "5xx"
-  ...
-```
-
-### Overriding Default Ports
-
-By default, Ambassador Edge Stack listens for HTTP or HTTPS traffic on ports 8080 or 8443 respectively. This value can be overridden by setting the `service_port` in the Ambassador `Module`:
-
-```yaml
----
-apiVersion: getambassador.io/v2
-kind: Module
-metadata:
-  name: ambassador
-spec:
-  config:
-    service_port: 4567
-```
-
-This will configure Ambassador Edge Stack to listen for traffic on port 4567 instead of 8080.
-
-### Regular Expressions (`regex_type`)
-
-If `regex_type` is unset (the default), or is set to any value other than `unsafe`, Ambassador Edge Stack will use the [RE2](https://github.com/google/re2/wiki/Syntax) regular expression engine. This engine is designed to support most regular expressions, but keep bounds on execution time. **RE2 is the recommended regular expression engine.**
-
-If `regex_type` is set to `unsafe`, Ambassador Edge Stack will use the [modified ECMAScript](https://en.cppreference.com/w/cpp/regex/ecmascript) regular expression engine. **This is not recommended** since the modified ECMAScript engine can consume unbounded CPU in some cases (mostly relating to backreferences and lookahead); it is provided for backward compatibility if necessary.
-
-### Lua Scripts (`lua_scripts`)
-
-Ambassador Edge Stack supports the ability to inline Lua scripts that get run on every request. This is useful for simple use cases that mutate requests or responses, e.g., add a custom header. Here is a sample:
-
-```yaml
----
-apiVersion: getambassador.io/v2
-kind: Module
-metadata:
-  name: ambassador
-spec:
-  config:
-    lua_scripts: |
-      function envoy_on_response(response_handle)
-        response_handle:headers():add("Lua-Scripts-Enabled", "Processed")
-      end
-```
-
-For more details on the Lua API, see the [Envoy Lua filter documentation](https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_filters/lua_filter.html).
-
-Some caveats around the embedded scripts:
-
-* They run in-process, so any bugs in your Lua script can break every request
-* They're inlined in the Ambassador Edge Stack YAML, so you likely won't want to write complex logic in here
-* They're run on every request/response to every URL
-
-If you need more flexible and configurable options, Ambassador Edge Stack supports a [pluggable Filter system](../../using/filters/).
-
-### Linkerd Interoperability (`add_linkerd_headers`)
-
-When using Linkerd, requests going to an upstream service need to include the `l5d-dst-override` header to ensure that Linkerd will route them correctly. Setting `add_linkerd_headers` does this automatically; see the [Mapping](../../using/mappings) documentation for more details.
-
-### Upstream Idle Timeout (`cluster_idle_timeout_ms`)
-
-If set, `cluster_idle_timeout_ms` specifies the timeout (in milliseconds) after which an idle connection upstream is closed. If no `cluster_idle_timeout_ms` is specified, upstream connections will never be closed due to idling.
+If you want to expose the diagnostics page but control them via `Host` based routing, you can set `diagnostics.enabled` to false and create mappings as specified in the [FAQ](../../../about/faq#how-do-i-disable-the-default-admin-mappings).
 
 ### gRPC HTTP/1.1 bridge (`enable_grpc_http11_bridge`)
 
@@ -214,18 +161,29 @@ The gRPC-Web specification requires a server-side proxy to translate between gRP
 
 Enable/disable the handling of incoming HTTP/1.0 and HTTP 0.9 requests.
 
-### Listener Idle Timeout (`listener_idle_timeout_ms`)
-
-Controls how Envoy configures the tcp idle timeout on the http listener. Default is no timeout (TCP connection may remain idle indefinitely). This is useful if you have proxies and/or firewalls in front of Ambassador and need to control how Ambassador initiates closing an idle TCP connection. Please see the [Envoy documentation](https://www.envoyproxy.io/docs/envoy/v1.12.2/api-v2/api/v2/core/protocol.proto#envoy-api-msg-core-httpprotocoloptions) for more information.
-
 ### `enable_ivp4` and `enable_ipv6`
 
 If both IPv4 and IPv6 are enabled, Ambassador Edge Stack will prefer IPv6. This can have strange effects if Ambassador Edge Stack receives `AAAA` records from a DNS lookup, but the underlying network of the pod doesn't actually support IPv6 traffic. For this reason, the default is IPv4 only.
 
 A `Mapping` can override both `enable_ipv4` and `enable_ipv6`, but if either is not stated explicitly in a `Mapping`, the values here are used. Most Ambassador Edge Stack installations will probably be able to avoid overriding these settings in `Mapping`s.
 
-### `proper_case`
-To enable upper casing of response headers by proper casing words: the first character and any character following a special character will be capitalized if it’s an alpha character. For example, “content-type” becomes “Content-Type”. Please see the [Envoy documentation](https://www.envoyproxy.io/docs/envoy/latest/api-v2/api/v2/core/protocol.proto#envoy-api-msg-core-http1protocoloptions-headerkeyformat)
+### Envoy Access Logs (`envoy_log_format`, `envoy_log_path`, and `envoy_log_type`)
+
+Ambassador allows for two types of logging output, json and text (`envoy_log_type`). These logs can be formatted using Envoy [operators](https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators) to display specific information about an incoming request. For example, a log of type `json` could use the following to show only the protocol and duration of a request:
+
+```
+envoy_log_format:
+  {
+    "protocol": "%PROTOCOL%",
+    "duration": "%DURATION%"
+  }
+```
+
+Additionally, a file path can be specified to output logs instead of standard out using `envoy_log_path`.
+
+### Listener Idle Timeout (`listener_idle_timeout_ms`)
+
+Controls how Envoy configures the tcp idle timeout on the http listener. Default is no timeout (TCP connection may remain idle indefinitely). This is useful if you have proxies and/or firewalls in front of Ambassador and need to control how Ambassador initiates closing an idle TCP connection. Please see the [Envoy documentation](https://www.envoyproxy.io/docs/envoy/v1.12.2/api-v2/api/v2/core/protocol.proto#envoy-api-msg-core-httpprotocoloptions) for more information.
 
 ### Readiness and Liveness probes (`readiness_probe` and `liveness_probe`)
 
@@ -233,25 +191,65 @@ The default liveness and readiness probes map `/ambassador/v0/check_alive` and `
 
 ```yaml
 readiness_probe:
+  enabled: true
   service: quote
   rewrite: /backend/health
 ```
 
-The liveness and readiness probe both support `prefix`, `rewrite`, and `service`, with the same meanings as for [mappings](../../using/mappings). Additionally, the `enabled` boolean may be set to `false` (as in the commented-out examples above) to disable support for the probe entirely.
+The liveness and readiness probe both support `prefix`, `rewrite`, and `service`, with the same meanings as for [mappings](../../using/mappings). Additionally, the `enabled` boolean may be set to `false` to disable support for the probe entirely.
 
-**Note well** that configuring the probes in the `ambassador Module` only means that Ambassador Edge Stack will respond to the probes. You must still configure Kubernetes to perform the checks, as shown in the Datawire-provided YAML files.
+### Lua Scripts (`lua_scripts`)
 
-### `use_remote_address`
+Ambassador Edge Stack supports the ability to inline Lua scripts that get run on every request. This is useful for simple use cases that mutate requests or responses, e.g., add a custom header. Here is a sample:
 
-In Ambassador 0.50 and later, the default value for `use_remote_address` to `true`. When set to `true`, Ambassador Edge Stack will append to the `X-Forwarded-For` header its IP address so upstream clients of Ambassador Edge Stack can get the full set of IP addresses that have propagated a request.  You may also need to set `externalTrafficPolicy: Local` on your `LoadBalancer` as well to propagate the original source IP address.  See the [Envoy documentation](https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_conn_man/headers) and the [Kubernetes documentation](https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip) for more details.
+```yaml
+lua_scripts: |
+  function envoy_on_response(response_handle)
+    response_handle:headers():add("Lua-Scripts-Enabled", "Processed")
+  end
+```
 
-**Note well** that if you need to use `X-Forwarded-Proto`, you **must** set `use_remote_address` to `false`.
+For more details on the Lua API, see the [Envoy Lua filter documentation](https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_filters/lua_filter.html).
 
-### `use_proxy_proto`
+**Some caveats around the embedded scripts:**
+
+* They run in-process, so any bugs in your Lua script can break every request
+* They're inlined in the Ambassador Edge Stack YAML, so you likely won't want to write complex logic in here
+* They're run on every request/response to every URL
+
+If you need more flexible and configurable options, Ambassador Edge Stack supports a [pluggable Filter system](../../using/filters/).
+
+### Header Case (`proper_case`)
+
+To enable upper casing of response headers by proper casing words: the first character and any character following a special character will be capitalized if it’s an alpha character. For example, “content-type” becomes “Content-Type”. Please see the [Envoy documentation](https://www.envoyproxy.io/docs/envoy/latest/api-v2/api/v2/core/protocol.proto#envoy-api-msg-core-http1protocoloptions-headerkeyformat)
+
+### Regular Expressions (`regex_type`)
+
+If `regex_type` is unset (the default), or is set to any value other than `unsafe`, Ambassador Edge Stack will use the [RE2](https://github.com/google/re2/wiki/Syntax) regular expression engine. This engine is designed to support most regular expressions, but keep bounds on execution time. **RE2 is the recommended regular expression engine.**
+
+If `regex_type` is set to `unsafe`, Ambassador Edge Stack will use the [modified ECMAScript](https://en.cppreference.com/w/cpp/regex/ecmascript) regular expression engine. **This is not recommended** since the modified ECMAScript engine can consume unbounded CPU in some cases (mostly relating to backreferences and lookahead); it is provided for backward compatibility if necessary.
+
+### Overriding Default Ports (`service_port`)
+
+By default, Ambassador Edge Stack listens for HTTP or HTTPS traffic on ports 8080 or 8443 respectively. This value can be overridden by setting the `service_port` in the Ambassador `Module`:
+
+```yaml
+service_port: 4567
+```
+
+This will configure Ambassador Edge Stack to listen for traffic on port 4567 instead of 8080.
+
+### Allow Proxy Protocol (`use_proxy_proto`)
 
 Many load balancers can use the [PROXY protocol](https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt) to convey information about the connection they are proxying. In order to support this in Ambassador Edge Stack, you'll need to set `use_proxy_protocol` to `true`; this is not the default since the PROXY protocol is not compatible with HTTP.
 
-### `xff_num_trusted_hops`
+### Trust Downstream Client IP (`use_remote_address`)
+
+In Ambassador 0.50 and later, the default value for `use_remote_address` is set to `true`. When set to `true`, Ambassador Edge Stack will append to the `X-Forwarded-For` header its IP address so upstream clients of Ambassador Edge Stack can get the full set of IP addresses that have propagated a request.  You may also need to set `externalTrafficPolicy: Local` on your `LoadBalancer` as well to propagate the original source IP address.  See the [Envoy documentation](https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_conn_man/headers) and the [Kubernetes documentation](https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip) for more details.
+
+  **Note well** that if you need to use `x_forwarded_proto_redirect`, you **must** set `use_remote_address` to `false`. Otherwise, unexpected behaviour can occur.
+
+### `X-Forwarded-For` Trusted Hops (`xff_num_trusted_hops`)
 
 The value of `xff_num_trusted_hops` indicates the number of trusted proxies in front of Ambassador Edge Stack. The default setting is 0 which tells Envoy to use the immediate downstream connection's IP address as the trusted client address. The trusted client address is used to populate the `remote_address` field used for rate limiting and can affect which IP address Envoy will set as `X-Envoy-External-Address`.
 

--- a/docs/topics/running/ambassador.md
+++ b/docs/topics/running/ambassador.md
@@ -36,6 +36,7 @@ spec:
 | `envoy_log_format` | Defines the envoy log line format. See [this page](https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/access_log) for a complete list of operators. | See [this page](https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#default-format-string) for the standard log format. |
 | `envoy_log_path` | Defines the path of log envoy will use. By default this is standard output. | `envoy_log_path: /dev/fd/1` |
 | `envoy_log_type` | Defines the type of log envoy will use, currently only support json or text. | `envoy_log_type: text` |
+| `envoy_validation_timeout` | Defines the timeout, in seconds, for validating a new Envoy configuration. The default is 10; a value of 0 disables Envoy configuration validation. Most installations will not need to use this setting. | `envoy_validation_timeout: 30` |
 | `listener_idle_timeout_ms` | Controls how Envoy configures the tcp idle timeout on the http listener. Default is 1 hour. | `listener_idle_timeout_ms: 30000` |
 | `lua_scripts` | Run a custom lua script on every request. see below for more details. | None |
 | `proper_case` | Should we enable upper casing for response headers? For more information, see [the Envoy docs](https://www.envoyproxy.io/docs/envoy/latest/api-v2/api/v2/core/protocol.proto#envoy-api-msg-core-http1protocoloptions-headerkeyformat). | `proper_case: false` |

--- a/docs/topics/using/timeouts.md
+++ b/docs/topics/using/timeouts.md
@@ -16,7 +16,7 @@ Ambassador Edge Stack enables you to control timeouts in several different ways.
 
 ## Connect Timeout: `connect_timeout_ms`
 
-`connect_timeout_ms` sets the connection-level timeout for Ambassador Edge Stack to an upstream service at the network layer.  This timeout runs until Ambassador can verify that a TCP connection has been established.  This timeout cannot be disabled. The default is 3000ms.
+`connect_timeout_ms` sets the connection-level timeout for Ambassador Edge Stack to an upstream service at the network layer.  This timeout runs until Ambassador can verify that a TCP connection has been established, including the TLS handshake.  This timeout cannot be disabled. The default is 3000ms.
 
 ## Module Only
 


### PR DESCRIPTION
This started out as a minor insert of an example into Modules + timeouts page and turned into a formatting update for the Modules page.

Modules is now split into 2 categories:
1) Global mapping config examples
2) Config table enumeration/examples

Part 2 is ordered by appearance in the table, and each header follows the same format of "Title (`table_entry`)".

I added `diagnostics` to the table and moved it into the config table example since I thought it fit there better than where it was.  I also condensed the Liveness and Readiness probes into 1 entry, instead of having them split apart across the document.