### PR TITLE
Support enabling telemetry on gRPC calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ Note that Ambassador Edge Stack `External` Filters already unconditionally use t
 ## Next Release
 
 - Bugfix: Ambassador will no longer mistakenly post notices regarding `regex_rewrite` and `rewrite` directive conflicts in `Mapping`s due to the latter's implicit default value (`/`).
+- Feature: Support configuring the gRPC Statistics Envoy filter to enable telemetry of gRPC calls (see the `grpc_stats` configuration flag)
 
 ## [1.8.1] October 16, 2020
 [1.8.1]: https://github.com/datawire/ambassador/compare/v1.8.0...v1.8.1

--- a/docs/topics/running/ambassador.md
+++ b/docs/topics/running/ambassador.md
@@ -41,6 +41,7 @@ spec:
 | `ip_deny`        | Defines HTTP source IP address ranges to deny; all others will be allowed. `ip_allow` and `ip_deny` may not both be specified. See below for more details. | None |
 | `listener_idle_timeout_ms` | Controls how Envoy configures the tcp idle timeout on the http listener. Default is 1 hour. | `listener_idle_timeout_ms: 30000` |
 | `lua_scripts` | Run a custom lua script on every request. see below for more details. | None |
+| `grpc_stats` | Enables telemetry of gRPC calls using the "gRPC Statistics" Envoy filter. see below for more details. |  |
 | `proper_case` | Should we enable upper casing for response headers? For more information, see [the Envoy docs](https://www.envoyproxy.io/docs/envoy/latest/api-v2/api/v2/core/protocol.proto#envoy-api-msg-core-http1protocoloptions-headerkeyformat). | `proper_case: false` |
 | `regex_max_size` | This field controls the RE2 "program size" which is a rough estimate of how complex a compiled regex is to evaluate. A regex that has a program size greater than the configured value will fail to compile.    | `regex_max_size: 200` |
 | `regex_type` | Set which regular expression engine to use. See the "Regular Expressions" section below. | `regex_type: safe` |
@@ -239,6 +240,27 @@ For more details on the Lua API, see the [Envoy Lua filter documentation](https:
 * They're run on every request/response to every URL
 
 If you need more flexible and configurable options, Ambassador Edge Stack supports a [pluggable Filter system](../../using/filters/).
+
+### gRPC Statistics (`grpc_stats`)
+
+Use the Envoy filter to enable telemetry of gRPC calls. [gRPC Statistics Filter](https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_filters/grpc_stats_filter)
+For configuration parameters, see the [Envoy gRPC Statistics filter documentation](https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/http/grpc_stats/v3/config.proto)
+
+```yaml
+---
+apiVersion: getambassador.io/v2
+kind:  Module
+metadata:
+  name: ambassador
+spec:
+  config:
+    grpc_stats:
+      enable_upstream_stats: true
+      individual_method_stats_allowlist:
+        services:
+          - name: EchoService
+            method_names: [Echo]
+```
 
 ### Header Case (`proper_case`)
 

--- a/python/ambassador/envoy/v2/v2listener.py
+++ b/python/ambassador/envoy/v2/v2listener.py
@@ -212,6 +212,15 @@ def v2filter_grpc_web(irfilter: IRFilter, v2config: 'V2Config'):
         'config': {},
     }
 
+@v2filter.when("ir.grpc_stats")
+def v2filter_grpc_stats(irfilter: IRFilter, v2config: 'V2Config'):
+    del v2config  # silence unused-variable warning
+
+    return {
+        'name': 'envoy.filters.http.grpc_stats',
+        'config': irfilter.config_dict(),
+    }
+
 def auth_cluster_uri(auth: IRAuth, cluster: IRCluster) -> str:
     cluster_context = cluster.get('tls_context')
     scheme = 'https' if cluster_context else 'http'

--- a/python/ambassador/ir/irambassador.py
+++ b/python/ambassador/ir/irambassador.py
@@ -234,6 +234,14 @@ class IRAmbassador (IRResource):
             self.grpc_web.sourced_by(amod)
             ir.save_filter(self.grpc_web)
 
+        if amod and ('grpc_stats' in amod):
+            self.grpc_stats = IRFilter(ir=ir, aconf=aconf,
+                                       kind='ir.grpc_stats',
+                                       name='grpc_stats',
+                                       config=amod.grpc_stats)
+            self.grpc_stats.sourced_by(amod)
+            ir.save_filter(self.grpc_stats)
+
         if amod and ('lua_scripts' in amod):
             self.lua_scripts = IRFilter(ir=ir, aconf=aconf, kind='ir.lua_scripts', name='lua_scripts',
                                         config={'inline_code': amod.lua_scripts})

--- a/python/tests/t_grpc_stats.py
+++ b/python/tests/t_grpc_stats.py
@@ -1,0 +1,161 @@
+from kat.harness import Query
+
+from abstract_tests import AmbassadorTest, EGRPC
+
+class AcceptanceGrpcStatsTest(AmbassadorTest):
+    def init(self):
+        self.target = EGRPC()
+
+    def config(self):
+        yield self, self.format("""
+---
+apiVersion: getambassador.io/v2
+kind: Module
+name: ambassador
+config:
+    grpc_stats:
+        stats_for_all_methods: true
+        enable_upstream_stats: true
+""")
+
+        yield self, self.format("""
+---
+apiVersion: getambassador.io/v2
+kind:  Mapping
+grpc: True
+prefix: /echo.EchoService/
+rewrite: /echo.EchoService/
+name:  {self.target.path.k8s}
+service: {self.target.path.k8s}
+""")
+
+        yield self, self.format("""
+apiVersion: getambassador.io/v2
+kind:  Mapping
+name:  metrics
+prefix: /metrics
+rewrite: /metrics
+service: http://127.0.0.1:8877
+""")
+
+
+    def queries(self):
+        # [0]
+        for i in range(10):
+            yield Query(self.url("echo.EchoService/Echo"),
+                        headers={ "content-type": "application/grpc", "requested-status": "0" },
+                        grpc_type="real",
+                        phase=1)
+
+        for i in range(10):
+            yield Query(self.url("echo.EchoService/Echo"),
+                        headers={ "content-type": "application/grpc", "requested-status": "13" },
+                        grpc_type="real",
+                        phase=1)
+
+        # [1]
+        yield Query(self.url("metrics"), phase=2)
+
+
+    def check(self):
+        # [0]
+        stats = self.results[-1].text
+
+        metrics = [
+            'envoy_cluster_grpc_EchoService_0',
+            'envoy_cluster_grpc_EchoService_13',
+            'envoy_cluster_grpc_EchoService_request_message_count',
+            'envoy_cluster_grpc_EchoService_response_message_count',
+            'envoy_cluster_grpc_EchoService_success',
+            'envoy_cluster_grpc_EchoService_total',
+            # present only when enable_upstream_stats is true
+            'envoy_cluster_grpc_EchoService_upstream_rq_time'
+        ]
+
+        # check if the metrics are there
+        for metric in metrics:
+            assert metric in stats, f'coult not find metric: {metric}'
+
+
+class GrpcStatsTestFilterConfiguration(AmbassadorTest):
+    def init(self):
+        self.target = EGRPC()
+
+    def config(self):
+        yield self, self.format("""
+---
+apiVersion: getambassador.io/v2
+kind: Module
+name: ambassador
+config:
+    grpc_stats:
+        individual_method_stats_allowlist:
+            services:
+                - name: IDontExist
+                  method_names: [Echo]
+""")
+
+        yield self, self.format("""
+---
+apiVersion: getambassador.io/v2
+kind:  Mapping
+grpc: True
+prefix: /echo.EchoService/
+rewrite: /echo.EchoService/
+name:  {self.target.path.k8s}
+service: {self.target.path.k8s}
+""")
+
+        yield self, self.format("""
+apiVersion: getambassador.io/v2
+kind:  Mapping
+name:  metrics
+prefix: /metrics
+rewrite: /metrics
+service: http://127.0.0.1:8877
+""")
+
+
+    def queries(self):
+        # [0]
+        for i in range(10):
+            yield Query(self.url("echo.EchoService/Echo"),
+                        headers={ "content-type": "application/grpc", "requested-status": "0" },
+                        grpc_type="real",
+                        phase=1)
+
+        for i in range(10):
+            yield Query(self.url("echo.EchoService/Echo"),
+                        headers={ "content-type": "application/grpc", "requested-status": "13" },
+                        grpc_type="real",
+                        phase=1)
+
+        # [1]
+        yield Query(self.url("metrics"), phase=2)
+
+
+    def check(self):
+        # [0]
+        stats = self.results[-1].text
+
+        # since the method is not on the allowed list, the metric is generic for all grpc calls
+        metrics = [
+            'envoy_cluster_grpc_0',
+            'envoy_cluster_grpc_13',
+            'envoy_cluster_grpc_request_message_count',
+            'envoy_cluster_grpc_response_message_count',
+            'envoy_cluster_grpc_success',
+            'envoy_cluster_grpc_total',
+        ]
+
+        # these metrics SHOULD NOT be there based on the filter config
+        absent_metrics = [
+            'envoy_cluster_grpc_upstream_rq_time'
+        ]
+
+        # check if the metrics are there
+        for metric in metrics:
+            assert metric in stats, f'coult not find metric: {metric}'
+
+        for absent_metric in absent_metrics:
+            assert absent_metric not in stats, f'metric {metric} should not be present'

--- a/python/tests/t_grpc_stats.py
+++ b/python/tests/t_grpc_stats.py
@@ -14,8 +14,8 @@ kind: Module
 name: ambassador
 config:
     grpc_stats:
-        stats_for_all_methods: true
-        enable_upstream_stats: true
+        all_methods: true
+        upstream_stats: true
 """)
 
         yield self, self.format("""
@@ -72,12 +72,30 @@ service: http://127.0.0.1:8877
             'envoy_cluster_grpc_EchoService_upstream_rq_time'
         ]
 
+        # these metrics SHOULD NOT be there based on the filter config
+        absent_metrics = [
+            # since all_methods is true, we should not see the generic metrics
+            'envoy_cluster_grpc_0'
+            'envoy_cluster_grpc_13',
+            'envoy_cluster_grpc_request_message_count',
+            'envoy_cluster_grpc_response_message_count',
+            'envoy_cluster_grpc_success',
+            'envoy_cluster_grpc_total'
+        ]
+
+        # check if the metrics are there
+        for metric in metrics:
+            assert metric in stats, f'coult not find metric: {metric}'
+
+        for absent_metric in absent_metrics:
+            assert absent_metric not in stats, f'metric {metric} should not be present'
+
         # check if the metrics are there
         for metric in metrics:
             assert metric in stats, f'coult not find metric: {metric}'
 
 
-class GrpcStatsTestFilterConfiguration(AmbassadorTest):
+class GrpcStatsTestOnlySelectedServices(AmbassadorTest):
     def init(self):
         self.target = EGRPC()
 
@@ -89,10 +107,11 @@ kind: Module
 name: ambassador
 config:
     grpc_stats:
-        individual_method_stats_allowlist:
-            services:
-                - name: IDontExist
-                  method_names: [Echo]
+        # this will be ignored
+        all_methods: true
+        services:
+            - name: echo.EchoService
+              method_names: [Echo]
 """)
 
         yield self, self.format("""
@@ -138,7 +157,96 @@ service: http://127.0.0.1:8877
         # [0]
         stats = self.results[-1].text
 
-        # since the method is not on the allowed list, the metric is generic for all grpc calls
+        metrics = [
+            'envoy_cluster_grpc_EchoService_0',
+            'envoy_cluster_grpc_EchoService_13',
+            'envoy_cluster_grpc_EchoService_request_message_count',
+            'envoy_cluster_grpc_EchoService_response_message_count',
+            'envoy_cluster_grpc_EchoService_success',
+            'envoy_cluster_grpc_EchoService_total',
+        ]
+
+        # these metrics SHOULD NOT be there based on the filter config
+        absent_metrics = [
+            # upstream stats is disabled
+            'envoy_cluster_grpc_upstream_rq_time',
+            # the generic metrics shouldn't be present since all the methods being called are on the allowed list
+            'envoy_cluster_grpc_0'
+            'envoy_cluster_grpc_13',
+            'envoy_cluster_grpc_request_message_count',
+            'envoy_cluster_grpc_response_message_count',
+            'envoy_cluster_grpc_success',
+            'envoy_cluster_grpc_total'
+        ]
+
+        # check if the metrics are there
+        for metric in metrics:
+            assert metric in stats, f'coult not find metric: {metric}'
+
+        for absent_metric in absent_metrics:
+            assert absent_metric not in stats, f'metric {metric} should not be present'
+
+class GrpcStatsTestNoUpstreamAllMethodsFalseInvalidKeys(AmbassadorTest):
+    def init(self):
+        self.target = EGRPC()
+
+    def config(self):
+        yield self, self.format("""
+---
+apiVersion: getambassador.io/v2
+kind: Module
+name: ambassador
+config:
+    grpc_stats:
+        all_methods: false
+        upstream_stats: false
+        i_will_not_break_envoy: true
+""")
+
+        yield self, self.format("""
+---
+apiVersion: getambassador.io/v2
+kind:  Mapping
+grpc: True
+prefix: /echo.EchoService/
+rewrite: /echo.EchoService/
+name:  {self.target.path.k8s}
+service: {self.target.path.k8s}
+""")
+
+        yield self, self.format("""
+apiVersion: getambassador.io/v2
+kind:  Mapping
+name:  metrics
+prefix: /metrics
+rewrite: /metrics
+service: http://127.0.0.1:8877
+""")
+
+
+    def queries(self):
+        # [0]
+        for i in range(10):
+            yield Query(self.url("echo.EchoService/Echo"),
+                        headers={ "content-type": "application/grpc", "requested-status": "0" },
+                        grpc_type="real",
+                        phase=1)
+
+        for i in range(10):
+            yield Query(self.url("echo.EchoService/Echo"),
+                        headers={ "content-type": "application/grpc", "requested-status": "13" },
+                        grpc_type="real",
+                        phase=1)
+
+        # [1]
+        yield Query(self.url("metrics"), phase=2)
+
+
+    def check(self):
+        # [0]
+        stats = self.results[-1].text
+
+        # stat_all_methods is disabled and the list of services is empty, so we should only see generic metrics
         metrics = [
             'envoy_cluster_grpc_0',
             'envoy_cluster_grpc_13',
@@ -150,7 +258,8 @@ service: http://127.0.0.1:8877
 
         # these metrics SHOULD NOT be there based on the filter config
         absent_metrics = [
-            'envoy_cluster_grpc_upstream_rq_time'
+            'envoy_cluster_grpc_upstream_rq_time',
+            'envoy_cluster_grpc_EchoService_0'
         ]
 
         # check if the metrics are there

--- a/python/tests/test_ambassador.py
+++ b/python/tests/test_ambassador.py
@@ -9,6 +9,7 @@ import t_cors
 import t_extauth
 import t_grpc
 import t_grpc_bridge
+import t_grpc_stats
 import t_grpc_web
 import t_gzip
 import t_headerrouting


### PR DESCRIPTION
## Description
Support configuring the gRPC Statistics Envoy filter to enable telemetry on gRPC calls (https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_filters/grpc_stats_filter)

## Testing
There are automated tests for this feature.
To test manually, deploy a grpc service, configure ambassador to enable the grpc stats filter and check the prometheus metrics on `/metrics`

## Tasks That Must Be Done
- [X] Did you update CHANGELOG.md?
- [X] Did you add or update tests?
- [X] Did you update documentation?
- [ ] Were there any special dev tricks you had to use to work on this code efficiently?
  + [ ] Did you add them to DEVELOPING.md?
- [ ] Is this a build change?
  + [ ] If so, did you test on both Mac and Linux?