### PR TITLE
Add more detail for needing ambassador auth service in AES for external filters to work

### DIFF
--- a/docs/topics/running/services/auth-service.md
+++ b/docs/topics/running/services/auth-service.md
@@ -4,7 +4,7 @@ The Ambassador API Gateway provides a highly flexible mechanism for authenticati
 
 All requests are validated by the `AuthService` (unless the `Mapping` applied to the request sets `bypass_auth`).  It is not possible to combine multiple `AuthService`s.  While it is possible to create multiple `AuthService` resources, they will be load-balanced between each resource in a round-robin fashion. This is useful for canarying an `AuthService` change, but is not useful for deploying multiple distinct `AuthService`s.  In order to combine multiple external services (either having multiple services apply to the same request, or selecting between different services for the different requests), instead of using an `AuthService`, use [Ambassador Edge Stack `External Filter`](../../../using/filters/).
 
-Because of the limitations described above, **the Ambassador Edge Stack does not support `AuthService` resources, and you should instead use an [`External` `Filter`](../../../using/filters/external),** which is mostly a drop-in replacement for an `AuthService`.
+Because of the limitations described above, **the Ambassador Edge Stack does not support `AuthService` resources, and you should instead use an [`External` `Filter`](../../../using/filters/external),** which is mostly a drop-in replacement for an `AuthService`. Note at AES deploys its own AuthService, which External Filter relies on. You must be sure the AES AuthService exists before External Filters will work.
 
 ## Configure an External AuthService
 

--- a/docs/topics/running/services/auth-service.md
+++ b/docs/topics/running/services/auth-service.md
@@ -4,7 +4,7 @@ The Ambassador API Gateway provides a highly flexible mechanism for authenticati
 
 All requests are validated by the `AuthService` (unless the `Mapping` applied to the request sets `bypass_auth`).  It is not possible to combine multiple `AuthService`s.  While it is possible to create multiple `AuthService` resources, they will be load-balanced between each resource in a round-robin fashion. This is useful for canarying an `AuthService` change, but is not useful for deploying multiple distinct `AuthService`s.  In order to combine multiple external services (either having multiple services apply to the same request, or selecting between different services for the different requests), instead of using an `AuthService`, use [Ambassador Edge Stack `External Filter`](../../../using/filters/).
 
-Because of the limitations described above, **the Ambassador Edge Stack does not support `AuthService` resources, and you should instead use an [`External` `Filter`](../../../using/filters/external),** which is mostly a drop-in replacement for an `AuthService`. Note at AES deploys its own AuthService, which External Filter relies on. You must be sure the AES AuthService exists before External Filters will work.
+Because of the limitations described above, **the Ambassador Edge Stack does not support `AuthService` resources, and you should instead use an [`External` `Filter`](../../../using/filters/external),** which is mostly a drop-in replacement for an `AuthService`. The External Filter relies on the AES AuthService. Make sure the AES AuthService is deployed before configuring External filters.
 
 ## Configure an External AuthService
 


### PR DESCRIPTION
## Description
I ran into an issue when upgrading to AES where the docs had said not to use AuthService and to use External Filters. Because of this, I had turned off the AuthService flag in the helm chart but I didn't realize that External Filters relies on this internal AuthService that ambassador provides. This makes that dependency more clear.

## Related Issues
#2831 
