### PR TITLE
Add documentation for running SP with Istio

### DIFF
--- a/docs/topics/using/edgectl/service-preview-reference.md
+++ b/docs/topics/using/edgectl/service-preview-reference.md
@@ -685,7 +685,7 @@ spec:
 
 ## Service Mesh Support
 
-Much like a service mesh, the Service Preview `traffic-agent` runs as a sidecar to the container running your application. Luckily, due to the magic of service mesh Pod networking, Service Preview will run alongside a service mesh without any changes needed to be made on your part.
+The Service Preview `traffic-agent` runs as a sidecar to the container running your application. Luckily, due to the magic of service mesh Pod networking, Service Preview will run alongside a service mesh without any changes needed to be made on your part.
 
 Below is some information on how Service Preview runs alongside different service mesh implementations.
 

--- a/docs/topics/using/edgectl/service-preview-reference.md
+++ b/docs/topics/using/edgectl/service-preview-reference.md
@@ -709,7 +709,7 @@ kubectl annotation po teleproxy sidecar.istio.io/inject='false'
 
 The `traffic-agent` is powered by Envoy proxy. Envoy, by default, does not like to run on the same host as other Envoy proxies. Since Istio is also powered by Envoy, you need to ensure that the `traffic-agent` knows how to run in the same pod as the `istio-proxy`.
 
-This is easily done by setting `AMBASSADOR_ENVOY_BASE_ID: 1` in the `traffic-agent` environment. Make sure this is set when injecting the `traffic-agent`.
+This is easily done by setting `AMBASSADOR_ENVOY_BASE_ID: "1"` in the `traffic-agent` environment. Make sure this is set when injecting the `traffic-agent`.
 
 > **IMPORTANT**
 > At the moment, the Ambassador Injector does not automatically set `AMBASSADOR_ENVOY_BASE_ID`. You will need to manually inject the `traffic-agent` when intercepting a service in your Istio mesh.

--- a/docs/yaml/ambassador-injector.yaml
+++ b/docs/yaml/ambassador-injector.yaml
@@ -45,6 +45,9 @@ spec:
       labels:
         app.kubernetes.io/name: ambassador-injector
         app.kubernetes.io/instance: ambassador
+      annotations:
+        consul.hashicorp.com/connect-inject: 'false'
+        sidecar.istio.io/inject: 'false'
     spec:
       containers:
         - name: webhook

--- a/docs/yaml/traffic-manager.yaml
+++ b/docs/yaml/traffic-manager.yaml
@@ -62,6 +62,9 @@ spec:
     metadata:
       labels:
         app: telepresence-proxy
+      annotations:
+        consul.hashicorp.com/connect-inject: 'false'
+        sidecar.istio.io/inject: 'false'
     spec:
       containers:
       - name: telepresence-proxy


### PR DESCRIPTION
Service preview can intercept request to services in an Istio mesh. 

There are some configuration changes that need to be made to support this. 

1. The `istio-proxy` **must not** run alongside service preview components

2. The `traffic-agent` **must** set `AMBASSADOR_ENVOY_BASE_ID: "1"` so it can
run in the same pod as the `istio-proxy`.
