### PR TITLE
Add HOST_IP env var to Ambassador deployments

### DIFF
--- a/docs/yaml/aes.yaml
+++ b/docs/yaml/aes.yaml
@@ -316,6 +316,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: HOST_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
         - name: REDIS_URL
           value: ambassador-redis:6379
         - name: AMBASSADOR_URL

--- a/docs/yaml/ambassador/ambassador-knative.yaml
+++ b/docs/yaml/ambassador/ambassador-knative.yaml
@@ -1414,6 +1414,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: HOST_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
         - name: AMBASSADOR_KNATIVE_SUPPORT
           value: "true"
         ports:

--- a/docs/yaml/ambassador/ambassador-knative.yaml.m4
+++ b/docs/yaml/ambassador/ambassador-knative.yaml.m4
@@ -102,6 +102,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: HOST_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
         - name: AMBASSADOR_KNATIVE_SUPPORT
           value: "true"
         ports:

--- a/docs/yaml/ambassador/ambassador-rbac-prometheus.yaml
+++ b/docs/yaml/ambassador/ambassador-rbac-prometheus.yaml
@@ -1431,6 +1431,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: HOST_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
         - name: STATSD_ENABLED
           value: "true"
         - name: STATSD_HOST

--- a/docs/yaml/ambassador/ambassador-rbac-prometheus.yaml.m4
+++ b/docs/yaml/ambassador/ambassador-rbac-prometheus.yaml.m4
@@ -119,6 +119,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: HOST_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
         - name: STATSD_ENABLED
           value: "true"
         - name: STATSD_HOST

--- a/docs/yaml/ambassador/ambassador-rbac.yaml
+++ b/docs/yaml/ambassador/ambassador-rbac.yaml
@@ -96,6 +96,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: HOST_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
         image: docker.io/datawire/ambassador:$version$
         livenessProbe:
           httpGet:

--- a/docs/yaml/oss-migration.yaml
+++ b/docs/yaml/oss-migration.yaml
@@ -148,6 +148,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            - name: HOST_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
             - name: REDIS_URL
               value: ambassador-redis:6379
             - name: AMBASSADOR_URL


### PR DESCRIPTION
    Add HOST_IP env var to Ambassador deployments

    HOST_IP is referenced in a couple locations in our documentation for as
    a resolvable env var that allows Ambassador to dynamically target a
    service running as a `DaemonSet` (like Consul server or DataDog collector).

    This env var is available by default with the YAML deploys but not other
    methods. This commit adds it to the other AES deployments
