### PR TITLE
gold file generation: emit kubectl stderr, so it's easier to debug

### DIFF
--- a/builder/copy-gold.sh
+++ b/builder/copy-gold.sh
@@ -9,7 +9,7 @@ copy_gold () {
 	local pod="$1"
 	local namespace="${2:-default}"
 
-	if kubectl cp -n $namespace $pod:/tmp/ambassador "$GOLDDIR/${pod}-tmp" >/dev/null 2>&1; then
+	if kubectl cp -n $namespace $pod:/tmp/ambassador "$GOLDDIR/${pod}-tmp" >/dev/null; then
 		rm -rf "$GOLDDIR/$pod"
 		mv "$GOLDDIR/${pod}-tmp" "$GOLDDIR/${pod}"
 		printf "                                                                \r"


### PR DESCRIPTION
## Description
I was regenerating gold files as part of another PR, but all the gold file copies failed. This stops the gold file generator from hiding stderr, so it's easier to troubleshoot.

In my case, the problem is that gold file generation doesn't honor `DEV_KUBECONFIG`, and auth was failing against the (different) cluster described in my normal `KUBECONFIG`. It feels like fixing that is as easy as adding `KUBECONFIG=$DEV_KUBECONFIG` to the `kubectl` invocation here, but I wasn't sure if there were any other workflows that depend on the existing behavior.