### PR TITLE
add support for AWS EKS clusters

### DIFF
--- a/OPENSOURCE.md
+++ b/OPENSOURCE.md
@@ -206,6 +206,8 @@ libraries:
     Werkzeug           1.0.1      3-clause BSD license
     appdirs            1.4.4      MIT license
     attrs              19.3.0     MIT license
+    awscli             1.19.26    Apache License 2.0
+    botocore           1.20.26    Apache License 2.0
     cachetools         4.1.1      MIT license
     certifi            2020.6.20  Mozilla Public License 2.0
     chardet            3.0.4      GNU Lesser General Public License Version 2.1
@@ -217,7 +219,7 @@ libraries:
     decorator          4.4.2      2-clause BSD license
     distlib            0.3.0      Python Software Foundation license
     distro             1.5.0      Apache License 2.0
-    docutils           0.16       2-clause BSD license, GNU General Public License Version 3, Python Software Foundation license, public domain
+    docutils           0.15.2     2-clause BSD license, GNU General Public License Version 3, Python Software Foundation license, public domain
     dpath              2.0.1      MIT license
     durationpy         0.5        MIT license
     expiringdict       1.2.1      Apache License 2.0
@@ -228,6 +230,7 @@ libraries:
     idna               2.7        3-clause BSD license, Python Software Foundation license, Unicode License Agreement for Data Files and Software (2015)
     iniconfig          1.1.1      MIT license
     itsdangerous       1.1.0      3-clause BSD license
+    jmespath           0.10.0     MIT license
     jsonpatch          1.30       3-clause BSD license
     jsonpointer        2.0        3-clause BSD license
     jsonschema         3.2.0      MIT license
@@ -264,6 +267,7 @@ libraries:
     retry              0.9.2      Apache License 2.0
     retrying           1.3.3      Apache License 2.0
     rsa                4.6        Apache License 2.0
+    s3transfer         0.3.4      Apache License 2.0
     semantic-version   2.8.5      2-clause BSD license
     sigtools           2.0.2      MIT license
     six                1.15.0     MIT license
@@ -271,6 +275,6 @@ libraries:
     toml               0.10.2     MIT license
     typed-ast          1.4.1      Apache License 2.0
     typing-extensions  3.7.4.3    Python Software Foundation license
-    urllib3            1.24.3     MIT license
+    urllib3            1.26.3     MIT license
     webencodings       0.5.1      3-clause BSD license
     websocket-client   0.57.0     3-clause BSD license

--- a/builder/builder.mk
+++ b/builder/builder.mk
@@ -370,6 +370,9 @@ pytest-only: sync preflight-cluster | docker/$(LCNAME).docker.push.remote docker
 		-e DOCKER_BUILD_PASSWORD \
 		-e AMBASSADOR_LEGACY_MODE \
 		-e AMBASSADOR_FAST_RECONFIGURE \
+		-e AWS_SECRET_ACCESS_KEY \
+		-e AWS_ACCESS_KEY_ID \
+		-e AWS_SESSION_TOKEN \
 		-it $(shell $(BUILDER)) /buildroot/builder.sh pytest-internal ; test_exit=$$? ; \
 		[ -n "$(TEST_XML_DIR)" ] && docker cp $(shell $(BUILDER)):/tmp/test-data/pytest.xml $(TEST_XML_DIR) ; exit $$test_exit
 .PHONY: pytest-only

--- a/builder/builder.sh
+++ b/builder/builder.sh
@@ -254,6 +254,9 @@ bootstrap() {
             ${BUILDER_DOCKER_EXTRA} \
             --env=BUILDER_NAME="${BUILDER_NAME}" \
             --env=GOPRIVATE="${GOPRIVATE}" \
+            --env=AWS_SECRET_ACCESS_KEY \
+            --env=AWS_ACCESS_KEY_ID \
+            --env=AWS_SESSION_TOKEN \
             --entrypoint=tail ${BUILDER_NAME}.local/builder -f /dev/null > /dev/null
         echo_off
 

--- a/builder/requirements.in
+++ b/builder/requirements.in
@@ -24,3 +24,4 @@ pexpect
 pytest
 pytest-cov
 retry
+awscli

--- a/builder/requirements.txt
+++ b/builder/requirements.txt
@@ -5,14 +5,17 @@
 #    pip-compile --allow-unsafe
 #
 attrs==19.3.0             # via clize, jsonschema, pytest
+awscli==1.19.26           # via -r requirements.in
+botocore==1.20.26         # via awscli, s3transfer
 cachetools==4.1.1         # via google-auth
 certifi==2020.6.20        # via kubernetes, requests
 chardet==3.0.4            # via requests
 click==7.1.2              # via -r requirements.in, flask
 clize==4.1.1              # via -r requirements.in
+colorama==0.4.3           # via awscli
 coverage==5.3             # via pytest-cov
 decorator==4.4.2          # via retry
-docutils==0.16            # via clize
+docutils==0.15.2          # via awscli, clize
 dpath==2.0.1              # via -r requirements.in
 durationpy==0.5           # via -r requirements.in
 expiringdict==1.2.1       # via -r requirements.in
@@ -25,6 +28,7 @@ idna==2.7                 # via requests
 iniconfig==1.1.1          # via pytest
 itsdangerous==1.1.0       # via flask
 jinja2==2.11.2            # via flask
+jmespath==0.10.0          # via botocore
 jsonpatch==1.30           # via -r requirements.in
 jsonpointer==2.0          # via jsonpatch
 jsonschema==3.2.0         # via -r requirements.in
@@ -48,12 +52,13 @@ pyparsing==2.4.7          # via packaging
 pyrsistent==0.17.3        # via jsonschema
 pytest-cov==2.10.1        # via -r requirements.in
 pytest==6.1.2             # via -r requirements.in, pytest-cov
-python-dateutil==2.8.1    # via kubernetes
-pyyaml==5.3.1             # via -r requirements.in, kubernetes
+python-dateutil==2.8.1    # via botocore, kubernetes
+pyyaml==5.3.1             # via -r requirements.in, awscli, kubernetes
 requests-oauthlib==1.3.0  # via kubernetes
 requests==2.25.1          # via -r requirements.in, kubernetes, requests-oauthlib
 retry==0.9.2              # via -r requirements.in
-rsa==4.6                  # via google-auth
+rsa==4.6                  # via awscli, google-auth
+s3transfer==0.3.4         # via awscli
 semantic-version==2.8.5   # via -r requirements.in
 sigtools==2.0.2           # via clize
 six==1.15.0               # via clize, google-auth, jsonschema, kubernetes, packaging, protobuf, python-dateutil, sigtools, websocket-client
@@ -61,7 +66,7 @@ smmap==3.0.4              # via gitdb
 toml==0.10.2              # via pytest
 typed-ast==1.4.1          # via mypy
 typing-extensions==3.7.4.3  # via mypy
-urllib3==1.24.3           # via kubernetes, requests
+urllib3==1.26.3           # via botocore, kubernetes, requests
 websocket-client==0.57.0  # via kubernetes
 werkzeug==1.0.1           # via flask
 

--- a/cmd/py-mkopensource/main.go
+++ b/cmd/py-mkopensource/main.go
@@ -78,8 +78,8 @@ func parseLicenses(name, version, license string) map[License]struct{} {
 
 		// These are packages with non-trivial strings to parse, and
 		// it's easier to just hard-code it.
-		{"docutils", "0.16", "public domain, Python, 2-Clause BSD, GPL 3 (see COPYING.txt)"}: {PublicDomain, PSF, BSD2, GPL3},
-		{"packaging", "20.4", "BSD-2-Clause or Apache-2.0"}:                                  {BSD2, Apache2},
+		{"docutils", "0.15.2", "public domain, Python, 2-Clause BSD, GPL 3 (see COPYING.txt)"}: {PublicDomain, PSF, BSD2, GPL3},
+		{"packaging", "20.4", "BSD-2-Clause or Apache-2.0"}:                                    {BSD2, Apache2},
 	}[tuple{name, version, license}]
 	if ok {
 		ret := make(map[License]struct{}, len(override))


### PR DESCRIPTION
## Description
This adds support for AWS EKS clusters when running tests. Their `KUBECONFIG`s define IAM-based auth that needs AWS creds and its CLI.

## Testing
I ran the test suite (partially, limiting the run to a couple of tests) in `envoy` mode against an EKS cluster.
