### PR TITLE
docs: update Prometheus with Helm location

### DIFF
--- a/docs/howtos/prometheus.md
+++ b/docs/howtos/prometheus.md
@@ -184,7 +184,7 @@ Helm.  Alternatively, you can install it with [kubectl
 YAML](#prometheus-operator-with-standard-yaml) if you prefer.
 
 The default [Helm
-Chart](https://github.com/prometheus-community/helm-charts)
+Chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack)
 will install Prometheus and configure it to monitor your Kubernetes
 cluster.
 

--- a/docs/howtos/prometheus.md
+++ b/docs/howtos/prometheus.md
@@ -184,7 +184,7 @@ Helm.  Alternatively, you can install it with [kubectl
 YAML](#prometheus-operator-with-standard-yaml) if you prefer.
 
 The default [Helm
-Chart](https://github.com/helm/charts/tree/master/stable/prometheus-operator)
+Chart](https://github.com/prometheus-community/helm-charts)
 will install Prometheus and configure it to monitor your Kubernetes
 cluster.
 


### PR DESCRIPTION
Update documentation for Prometheus with Helm location

## Description
Further development has moved to [prometheus-community/helm-charts](https://github.com/prometheus-community/helm-charts).

## Related Issues

## Testing

## Tasks That Must Be Done
- [ ] Did you update CHANGELOG.md?
- [ ] Did you add or update tests?
- [ ] Did you update documentation?
- [ ] Were there any special dev tricks you had to use to work on this code efficiently?
  + [ ] Did you add them to DEVELOPING.md?
- [ ] Is this a build change?
  + [ ] If so, did you test on both Mac and Linux?

## Other
* If this is a documentation change for a particular release, please open the pull request against the release branch.
