### PR TITLE
fix: check against default value of rewrite before posting notice regarding rewrite, regex_rewrite conflict

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,7 +55,7 @@ Note that Ambassador Edge Stack `External` Filters already unconditionally use t
 
 ## Next Release
 
-(no changes yet)
+- Bugfix: Ambassador will no longer mistakenly post notices regarding `regex_rewrite` and `rewrite` directive conflicts in `Mapping`s due to the latter's implicit default value (`/`).
 
 ## [1.8.1] October 16, 2020
 [1.8.1]: https://github.com/datawire/ambassador/compare/v1.8.0...v1.8.1

--- a/python/ambassador/ir/irhttpmapping.py
+++ b/python/ambassador/ir/irhttpmapping.py
@@ -263,9 +263,9 @@ class IRHTTPMapping (IRBaseMapping):
                 query_parameters.append(KeyValueDecorator(name, value, regex=True))
 
         if 'regex_rewrite' in kwargs:
-            if rewrite:
+            if rewrite and rewrite != "/":
                 self.ir.aconf.post_notice("Cannot specify both rewrite and regex_rewrite: using regex_rewrite and ignoring rewrite")
-                rewrite = ""
+            rewrite = ""
             rewrite_items = kwargs.get('regex_rewrite', {})
             regex_rewrite = {'pattern' : rewrite_items.get('pattern',''),
                              'substitution' : rewrite_items.get('substitution','') }


### PR DESCRIPTION
## Description
minor bugfix to confirm the `rewrite` directive value is not the implicit default `/` before warning of a potentially non-existent `rewrite`, `regex_rewrite` conflict in a `Mapping`

## Related Issues
* using `regex_rewrite` triggers false alarm for conflict with non-existent `rewrite` directive, gives incorrect notice in diagnostics (#3025)

## Testing
I am unable to test at this time but I'd welcome help

## Tasks That Must Be Done
- [x] Did you update CHANGELOG.md?
- [ ] Did you add or update tests?
- [ ] Did you update documentation?
- [ ] Were there any special dev tricks you had to use to work on this code efficiently?
  + [ ] Did you add them to DEVELOPING.md?
- [ ] Is this a build change?
  + [ ] If so, did you test on both Mac and Linux?
