### PR TITLE
[Docs] Fixed a broken link on the install page

### DIFF
--- a/.circleci/amb-images-save-workspace
+++ b/.circleci/amb-images-save-workspace
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
-set -x
+set -ex
+
+if ! test -e docker/container.txt; then
+	# There will be nothing to do
+	exit 0
+fi
 
 # Save the images
 go run "${0%-workspace}-images.go"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,6 +52,7 @@ commands:
     # setup
     - amb-linux-install
     - amb-checkout
+    - amb-images-save-workspace # in case skip-if-only-changes
     - skip-if-only-changes:
         to: docs/
     - amb-config-registry

--- a/.circleci/config.yml.d/amb_jobs.yml
+++ b/.circleci/config.yml.d/amb_jobs.yml
@@ -58,6 +58,7 @@ commands:
       # setup
       - amb-linux-install
       - amb-checkout
+      - amb-images-save-workspace # in case skip-if-only-changes
       - skip-if-only-changes:
           to: docs/
       - amb-config-registry

--- a/docs/topics/install/index.md
+++ b/docs/topics/install/index.md
@@ -96,7 +96,7 @@ Operator, [follow the Ambassador Edge Stack Operator instructions](aes-operator)
 ## Install on Bare Metal
 If you don't have a load balancer in front of your Kubernetes, the Bare Metal 
 installation mechanism can still be used to expose the Ambassador Edge Stack. 
-We've got [instructions for bare metal installations] including exposing 
+We've got [instructions for bare metal installations](bare-metal) including exposing 
 the Ambassador Edge Stack via a NodePort or the host network.
 <p id="index-installUpgrade"></p><br/>
 


### PR DESCRIPTION
On the install page, the link for bare-metal installation instructions was missing.  I just readded it.

Tested with the doc-preview script