### PR TITLE
Handle secrets in a separate processor

### DIFF
--- a/python/ambassador/fetch/secret.py
+++ b/python/ambassador/fetch/secret.py
@@ -1,0 +1,69 @@
+from typing import FrozenSet
+
+from ..config import Config
+
+from .k8sobject import KubernetesGVK, KubernetesObject
+from .k8sprocessor import ManagedKubernetesProcessor
+from .resource import NormalizedResource
+
+
+class SecretProcessor (ManagedKubernetesProcessor):
+    """
+    A Kubernetes object processor that emits Ambassador secrets from Kubernetes secrets.
+    """
+
+    KNOWN_TYPES = [
+        'Opaque',
+        'kubernetes.io/tls',
+        'istio.io/key-and-cert',
+    ]
+
+    KNOWN_DATA_KEYS = [
+        'tls.crt',
+        'tls.key',
+        'user.key',
+        'cert-chain.pem',
+        'key.pem',
+        'root-cert.pem',
+    ]
+
+    def kinds(self) -> FrozenSet[KubernetesGVK]:
+        return frozenset([KubernetesGVK('v1', 'Secret')])
+
+    def _admit(self, obj: KubernetesObject) -> bool:
+        if not Config.certs_single_namespace:
+            return True
+
+        return super()._admit(obj)
+
+    def _process(self, obj: KubernetesObject) -> None:
+        secret_type = obj.get('type')
+        if secret_type not in self.KNOWN_TYPES:
+            self.logger.debug("ignoring K8s Secret with unknown type %s" % secret_type)
+            return
+
+        data = obj.get('data')
+        if not data:
+            self.logger.debug("ignoring K8s Secret with no data")
+            return
+
+        if not any(key in data for key in self.KNOWN_DATA_KEYS):
+            # Uh. WTFO?
+            self.logger.debug(f'ignoring K8s Secret {obj.name}.{obj.namespace} with no keys')
+            return
+
+        spec = {
+            'ambassador_id': Config.ambassador_id,
+            'secret_type': secret_type,
+        }
+
+        for key, value in data.items():
+            spec[key.replace('.', '_')] = value
+
+        self.manager.emit(NormalizedResource.from_data(
+            'Secret',
+            obj.name,
+            namespace=obj.namespace,
+            labels=obj.labels,
+            spec=spec,
+        ))

--- a/python/ambassador/fetch/service.py
+++ b/python/ambassador/fetch/service.py
@@ -383,8 +383,8 @@ class ServiceProcessor (ManagedKubernetesProcessor):
                 spec['helm_chart'] = self.services.helm_chart
 
             self.manager.emit(NormalizedResource.from_data(
-                kind='Service',
-                name=k8s_svc.name,
+                'Service',
+                k8s_svc.name,
                 namespace=k8s_svc.namespace,
                 labels=k8s_svc.labels,
                 spec=spec,


### PR DESCRIPTION
## Description
This is the penultimate change to clean up the Python CRD fetching/processing code (after this will be another PR to handle ingresses). It moves `v1/Secret` handling to a separate processor class. It does not change any existing functionality.

## Testing
The automated test suite passes against this change.

## Tasks That Must Be Done
- [ ] Did you update CHANGELOG.md?
- [ ] Did you add or update tests?
- [ ] Did you update documentation?
- [ ] Were there any special dev tricks you had to use to work on this code efficiently?
  + [ ] Did you add them to DEVELOPING.md?
- [ ] Is this a build change?
  + [ ] If so, did you test on both Mac and Linux?
