### PR TITLE
Guard /metrics from uninitialized ir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ Note that Ambassador Edge Stack `External` Filters already unconditionally use t
 
 ## Next Release
 
+- Bugfix: The /metrics endpoint will no longer break if invoked before configuration is complete
 - Bugfix: Ambassador will no longer mistakenly post notices regarding `regex_rewrite` and `rewrite` directive conflicts in `Mapping`s due to the latter's implicit default value (`/`).
 - Feature: Support configuring the gRPC Statistics Envoy filter to enable telemetry of gRPC calls (see the `grpc_stats` configuration flag)
 

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -685,3 +685,14 @@ bash ambassador/scripts/doc-publish --prod
 ```
 
 to update the live `getambassador-preview` Netlify site.
+
+How do I build ambassador on Windows using WSL?
+-----------------------------------------------
+As the ambassador build sequence requires docker communication via a UNIX socket, using WSL 1 is not possible.
+Not even with a `DOCKER_HOST` environment variable set. As a result, you have to use WSL 2, including using the
+WSL 2 version of docker-for-windows.
+
+Additionally, if your hostname contains an upper-case character, the build script will break. This is based on the
+`NAME` environment variable, which should contain your hostname. You can solve this issue by doing `export NAME=my-lowercase-host-name`.
+If you do this *after* you've already run `make images` once, you will manually have to clean up the docker images
+that have been created using your upper-case host name.

--- a/python/ambassador_diag/diagd.py
+++ b/python/ambassador_diag/diagd.py
@@ -1085,7 +1085,7 @@ def get_prometheus_metrics(*args, **kwargs):
 
     # Extra metrics endpoint
     extra_metrics_content = ''
-    if app.metrics_endpoint and app.ir.edge_stack_allowed:
+    if app.metrics_endpoint and app.ir and app.ir.edge_stack_allowed:
         try:
             response = requests.get(app.metrics_endpoint)
             if response.status_code == 200:


### PR DESCRIPTION
## Description
A missed check causes 1.8.1 to throw an exception. This value is None, for unknown reasons. Other endpoints have this check, so it felt easy to add it here as well.

## Related Issues
https://github.com/datawire/ambassador/issues/3037

## Testing
I built this locally using `make images`, but I did *not* run the tests, as I don't have a cluster that the build can make indiscriminant changes to at the moment. 
Simple testing consisted of deploying the images to our environment and verifying that the exception was not present anymore, which it was not.
This solves *one* of the problems in the linked issue, but it does not have any impact on the other problem, the cluster reconfiguration, which remains.

## Tasks That Must Be Done
- [x] Did you update CHANGELOG.md?
- [ ] Did you add or update tests?
- [X] Did you update documentation?
- [X] Were there any special dev tricks you had to use to work on this code efficiently?
  + [X] Did you add them to DEVELOPING.md?
- [ ] Is this a build change?
  + [ ] If so, did you test on both Mac and Linux?

