### PR TITLE
Added instructions on building from source, but within a docker container.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ Note that Ambassador Edge Stack `External` Filters already unconditionally use t
 - Bugfix: The /metrics endpoint will no longer break if invoked before configuration is complete
 - Bugfix: Ambassador will no longer mistakenly post notices regarding `regex_rewrite` and `rewrite` directive conflicts in `Mapping`s due to the latter's implicit default value (`/`).
 - Feature: Support configuring the gRPC Statistics Envoy filter to enable telemetry of gRPC calls (see the `grpc_stats` configuration flag)
+- Docs: Added instructions for building ambassador from source, within a docker container.
 
 ## [1.8.1] October 16, 2020
 [1.8.1]: https://github.com/datawire/ambassador/compare/v1.8.0...v1.8.1

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -75,12 +75,26 @@ available along with documentation for what each target does.
 How do I build an ambassador image from source?
 -----------------------------------------------
 
+### On your machine
+
 0. `git clone https://github.com/datawire/ambassador.git && cd ambassador`
 1. `make images` (this will take a while the first time)
 
 The ambassador image will be tagged as `ambassador:latest`. There will
 also be a `kat-server:latest` and a `kat-client:latest` image. These
 two images are only used for testing.
+
+### Within a docker container
+
+0. `docker pull docker:latest`
+1. `docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -it docker:latest sh`
+2. `apk add --update --no-cache bash build-base go curl rsync python3 python2 git`
+3. `git clone https://github.com/datawire/ambassador.git && cd ambassador`
+4. `make images`
+
+Steps 0 and 1 are run on your machine, and 2 - 4 are from within the docker container. The base image is a "Docker in Docker" image, ran with `-v /var/run/docker.sock:/var/run/docker.sock` in order to connect to your local daemon from the docker inside the container. More info on Docker in Docker [here](https://hub.docker.com/_/docker).
+
+The images will be created and tagged as defined above, and will be available in docker on your local machine.
 
 How do I push an ambassador image from source?
 ----------------------------------------------


### PR DESCRIPTION
## Description
There are currently only simple instructions on how to build from source, with no description of the minimum requirements to build ambassador. I've added a quick set of instructions for building ambassador within a docker container.

This can be useful to developers for any number of reasons, including building ambassador without altering packages in their local machines.

## Related Issues
N/A

## Testing
- Manually ran and tested commands to build ambassador from source, within a docker container.

## Tasks That Must Be Done
- [x] Did you update CHANGELOG.md?
- [ ] Did you add or update tests?
- [x] Did you update documentation?
- [x] Were there any special dev tricks you had to use to work on this code efficiently?
  + [x] Did you add them to DEVELOPING.md?
- [ ] Is this a build change?
  + [ ] If so, did you test on both Mac and Linux?

