### PR TITLE
Don't allow mixing host_redirect and non-host_redirect Mappings in the same group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ Note that Ambassador Edge Stack `External` Filters already unconditionally use t
 - Bugfix: The /metrics endpoint will no longer break if invoked before configuration is complete
 - Bugfix: Ambassador will no longer mistakenly post notices regarding `regex_rewrite` and `rewrite` directive conflicts in `Mapping`s due to the latter's implicit default value (`/`).
 - Feature: Support configuring the gRPC Statistics Envoy filter to enable telemetry of gRPC calls (see the `grpc_stats` configuration flag)
+- Bugfix: Prevent mixing `Mapping`s with `host_redirect` set with `Mapping`s that don't in the same group.
 
 ## [1.8.1] October 16, 2020
 [1.8.1]: https://github.com/datawire/ambassador/compare/v1.8.0...v1.8.1

--- a/python/ambassador/envoy/v2/v2route.py
+++ b/python/ambassador/envoy/v2/v2route.py
@@ -96,7 +96,11 @@ class V2Route(Cacheable):
         }
 
         if len(mapping) > 0:
-            runtime_fraction['runtime_key'] = f'routing.traffic_shift.{mapping.cluster.envoy_name}'
+            if not 'cluster' in mapping:
+                config.ir.logger.error("%s: Mapping %s has no cluster? %s", mapping.rkey, route_prefix, mapping.as_json())
+                self['_failed'] = True
+            else:
+                runtime_fraction['runtime_key'] = f'routing.traffic_shift.{mapping.cluster.envoy_name}'
 
         match = {
             'case_sensitive': case_sensitive,
@@ -361,8 +365,10 @@ class V2Route(Cacheable):
             for mapping in irgroup.mappings:
                 key = f"Route-{irgroup.group_id}-{mapping.cache_key}"
 
-                route = config.save_element('route', irgroup, cls.get_route(config, key, irgroup, mapping))
-                config.routes.append(route)
+                route = cls.get_route(config, key, irgroup, mapping)
+
+                if not route.get('_failed', False):
+                    config.routes.append(config.save_element('route', irgroup, route))
 
     @staticmethod
     def generate_headers(config: 'V2Config', mapping_group: IRHTTPMappingGroup) -> List[dict]:

--- a/python/ambassador/ir/irhttpmappinggroup.py
+++ b/python/ambassador/ir/irhttpmappinggroup.py
@@ -177,11 +177,20 @@ class IRHTTPMappingGroup (IRBaseMappingGroup):
                 # All good. Save it.
                 self.host_redirect = mapping
         else:
-            # Neither shadow nor host_redirect: save it.
-            self.mappings.append(mapping)
+            # Neither shadow nor host_redirect are set in the Mapping. 
+            # 
+            # XXX At the moment, we do not do the right thing with the case where some Mappings
+            # in a group have host_redirect and some do not, so make sure that that can't happen.
 
-            if mapping.route_weight > self.group_weight:
-                self.group_weight = mapping.route_weight
+            if self.host_redirect:
+                aconf.post_error("cannot accept %s without host_redirect after %s with host_redirect" %
+                                 (mapping.name, typecast(IRBaseMapping, self.host_redirect).name))
+            else:
+                # All good. Save this mapping.
+                self.mappings.append(mapping)
+
+                if mapping.route_weight > self.group_weight:
+                    self.group_weight = mapping.route_weight
 
         self.referenced_by(mapping)
 


### PR DESCRIPTION
If an `IRHTTPMappingGroup` has some `Mapping`s with `host_redirect` set, and some without, Bad Things Happen™: notably, Ambassador could crash with a Python exception on a missing `IRCluster` if the `host_redirect` `Mapping` is processed first. This change disallows that situation.

(In a future release, we should probably support doing canaries that span `host_redirect` and non-`host_redirect` `Mapping`s.)

This was tested using a `snapshot.yaml` that exhibited this bug. Unit test coming soon.