### PR TITLE
Updated error response doc (RELEASE BRANCH)

### DIFF
--- a/docs/js/doc-links.yml
+++ b/docs/js/doc-links.yml
@@ -133,6 +133,8 @@
       items:
         - title: The Ambassador Module
           link: /docs/latest/topics/running/ambassador
+        - title: Custom Error Responses
+          items: /docs/latest/topics/running/custom-error-responses
         - title: Deploying Ambassador
           items:
             - title: Deployment Architecture
@@ -145,8 +147,6 @@
               link: /docs/latest/topics/running/running
             - title: The Ambassador Container
               link: /docs/latest/topics/running/environment
-        - title: Error Response Overrides
-          link: /docs/latest/topics/running/error-response-overrides
         - title: Gzip Compression
           link: /docs/latest/topics/running/gzip
         - title: Host CRD, ACME Support, and External Load Balancer Configuration

--- a/docs/topics/running/custom-error-responses.md
+++ b/docs/topics/running/custom-error-responses.md
@@ -4,7 +4,7 @@ Custom error responses set overrides for HTTP response statuses generated either
 by Ambassador or upstream services. 
 
 They can be configured either on the Ambassador
-[`Module`](ambassador)
+[`Module`](../ambassador)
 or on a [`Mapping`](../../using/intro-mappings/), the schema is identical. See
 below for more information on [rule precedence](#rule-precedence).
 


### PR DESCRIPTION
Fixed a broken link, confirmed it's good now by testing with Gatsby locally. I'm getting the hang of a workflow that should let me better test in the future.
Also changed the title in the ToC to match the title on the page itself and what was published on the release announcement blog. I renamed the file as well to match, I thought about not doing this in case it broke links anywhere but I couldn't find any published links in the blog or elsewhere and OCD wouldn't allow leaving the old file name.