### PR TITLE
(1.9 docs) Fix doc-page link parsing

### DIFF
--- a/docs/js/doc-page.js
+++ b/docs/js/doc-page.js
@@ -38,7 +38,10 @@ function getMainDocsUrl(slug) {
 }
 
 // Used to get a flat array of *all* links with their corresponding parents
-function flattenLinks(links, parent) {
+function flattenLinks(links = [], parent) {
+	if (!Array.isArray(links)) {
+		return []
+	}
   return links.reduce((acc, cur) => {
     let link = cur;
     if (parent) {


### PR DESCRIPTION
Starting with 1.9, some `docLinks` from `doc-links.yml` are breaking a function inside `doc-page.js`. This small change should fix it. Will also implement to `master`, but I don't see why apply it to 1.8 and lower.