### PR TITLE
Add note about enabling X-FORWARDED-PROTO redirect

### DIFF
--- a/docs/topics/running/tls/cleartext-redirection.md
+++ b/docs/topics/running/tls/cleartext-redirection.md
@@ -127,7 +127,9 @@ to Ambassador. A couple of options are
 
    `X-Forwarded-Proto` is set by the load balancer or proxy and trusted by
    Envoy. Envoy will trust the value of `X-Forwarded-For` even if the request
-   comes in over cleartext.
+   comes in over cleartext. 
+   [X-FORWARDED-PROTO redirects](../../using/redirects.md)
+   must be enabled in your Ambassador config for this to work.
 
 ## tl;dr
 
@@ -148,3 +150,5 @@ spec:
       action: Redirect     # Configures Ambassador to redirect cleartext
       additionalPort: 8080 # Optional: The redirect port. Defaults to 8080
 ```
+
+If you're using a L7 Load Balancer to terminate TLS, make sure to [enable X-FORWARDED-PROTO redirects](../../using/redirects.md).

--- a/docs/topics/running/tls/cleartext-redirection.md
+++ b/docs/topics/running/tls/cleartext-redirection.md
@@ -128,7 +128,7 @@ to Ambassador. A couple of options are
    `X-Forwarded-Proto` is set by the load balancer or proxy and trusted by
    Envoy. Envoy will trust the value of `X-Forwarded-For` even if the request
    comes in over cleartext. 
-   [X-FORWARDED-PROTO redirects](../../using/redirects.md)
+   [X-FORWARDED-PROTO redirects](../../using/redirects#x-forwarded-proto-redirect)
    must be enabled in your Ambassador config for this to work.
 
 ## tl;dr
@@ -151,4 +151,4 @@ spec:
       additionalPort: 8080 # Optional: The redirect port. Defaults to 8080
 ```
 
-If you're using a L7 Load Balancer to terminate TLS, make sure to [enable X-FORWARDED-PROTO redirects](../../using/redirects.md).
+If you're using a L7 Load Balancer to terminate TLS, make sure to [enable X-FORWARDED-PROTO redirects](../../using/redirects#x-forwarded-proto-redirect).


### PR DESCRIPTION
## Description

I've just started using Ambassador on a GKE cluster and was mostly following [your documentation](https://www.getambassador.io/docs/latest/topics/running/ambassador-with-gke/), which is great.

I was having some issues getting the HTTP->HTTPS redirection to work properly - I got into a situation where even HTTPS traffic was returning a 301, so an infinite redirect loop. I've found that enabling X-FORWARDED-PROTO redirects (as per [this other doc](https://www.getambassador.io/docs/latest/topics/using/redirects/#x-forwarded-proto-redirect)) solved the issue for me, so thought it could be made clearer in the documentation above.

Hope it helps!

(removed everything else as this is a documentation PR)