### PR TITLE
Use a resource processor for ingresses and ingress classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,8 +75,10 @@ Please see the [Envoy documentation](https://www.envoyproxy.io/docs/envoy/latest
 - Bugfix: Make sure that `labels` specifying headers with extra attributes are correctly supported again ([#3137])
 - Bugfix: Support Consul services when the `ConsulResolver` and the `Mapping` aren't in the same namespace, and legacy mode is not enabled.
 - Feature: Ambassador now reads the ENVOY_CONCURRENCY environment variable to optionally set the [--concurrency](https://www.envoyproxy.io/docs/envoy/latest/operations/cli#cmdoption-concurrency) command line option when launching Envoy. This controls the number of worker threads used to serve requests and can be used to fine-tune system resource usage.
+- Bugfix: Fix failure to start when one or more IngressClasses are present in a cluster ([#3142]).
 
 [#3137]: https://github.com/datawire/ambassador/issues/3137
+[#3142]: https://github.com/datawire/ambassador/issues/3142
 
 ## [1.10.0] January 04, 2021
 [1.10.0]: https://github.com/datawire/ambassador/compare/v1.9.1...v1.10.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,7 @@ Please see the [Envoy documentation](https://www.envoyproxy.io/docs/envoy/latest
 - Bugfix: Support Consul services when the `ConsulResolver` and the `Mapping` aren't in the same namespace, and legacy mode is not enabled.
 - Feature: Ambassador now reads the ENVOY_CONCURRENCY environment variable to optionally set the [--concurrency](https://www.envoyproxy.io/docs/envoy/latest/operations/cli#cmdoption-concurrency) command line option when launching Envoy. This controls the number of worker threads used to serve requests and can be used to fine-tune system resource usage.
 - Bugfix: Fix failure to start when one or more IngressClasses are present in a cluster ([#3142]).
+- Bugfix: Prevent potential reconcile loop when updating the status of an Ingress.
 
 [#3137]: https://github.com/datawire/ambassador/issues/3137
 [#3142]: https://github.com/datawire/ambassador/issues/3142

--- a/builder/sync-excludes.txt
+++ b/builder/sync-excludes.txt
@@ -11,6 +11,7 @@ __pycache__
 .pytest_cache
 .mypy_cache
 .dmypy.json
+.coverage
 go.sum
 
 bin/

--- a/python/ambassador/config/config.py
+++ b/python/ambassador/config/config.py
@@ -148,8 +148,6 @@ class Config:
 
         self.logger.debug("SCHEMA DIR    %s" % os.path.abspath(self.schema_dir_path))
         self.k8s_status_updates: Dict[str, Tuple[str, str, Optional[Dict[str, Any]]]] = {}  # Tuple is (name, namespace, status_json)
-        self.k8s_ingresses: Dict[str, Any] = {}
-        self.k8s_ingress_classes: Dict[str, Any] = {}
         self.pod_labels: Dict[str, str] = {}
         self._reset()
 

--- a/python/ambassador/fetch/dependency.py
+++ b/python/ambassador/fetch/dependency.py
@@ -1,0 +1,128 @@
+from typing import Any, Collection, Iterator, Mapping, MutableSet, Optional, Protocol, Sequence, Type, TypeVar
+
+from collections import defaultdict
+import copy
+import dataclasses
+
+from .k8sobject import KubernetesObject
+
+
+class Dependency (Protocol):
+
+    def watt_key(self) -> str: ...
+
+
+class ServiceDependency (Dependency):
+
+    ambassador_service: Optional[KubernetesObject]
+
+    def watt_key(self) -> str:
+        return 'service'
+
+
+class SecretDependency (Dependency):
+
+    def watt_key(self) -> str:
+        return 'secret'
+
+
+class IngressClassesDependency (Dependency):
+
+    ingress_classes: MutableSet[str]
+
+    def __init__(self):
+        self.ingress_classes = set()
+
+    def watt_key(self) -> str:
+        return 'ingressclasses'
+
+
+D = TypeVar('D', bound=Dependency)
+
+
+class DependencyMapping (Protocol):
+
+    def __contains__(self, key: Type[D]) -> bool: ...
+    def __getitem__(self, key: Type[D]) -> D: ...
+
+
+class DependencyInjector:
+
+    wants: MutableSet[Type[Dependency]]
+    provides: MutableSet[Type[Dependency]]
+    deps: DependencyMapping
+
+    def __init__(self, deps: DependencyMapping) -> None:
+        self.wants = set()
+        self.provides = set()
+        self.deps = deps
+
+    def want(self, cls: Type[D]) -> D:
+        self.wants.add(cls)
+        return self.deps[cls]
+
+    def provide(self, cls: Type[D]) -> D:
+        self.provides.add(cls)
+        return self.deps[cls]
+
+
+class DependencyGraph:
+
+    @dataclasses.dataclass
+    class Vertex:
+        out: MutableSet[Any]
+        in_count: int
+
+    vertices: Mapping[Any, Vertex]
+
+    def __init__(self) -> None:
+        self.vertices = defaultdict(lambda: DependencyGraph.Vertex(out=set(), in_count=0))
+
+    def connect(self, a: Any, b: Any) -> None:
+        if b not in self.vertices[a].out:
+            self.vertices[a].out.add(b)
+            self.vertices[b].in_count += 1
+
+    def traverse(self) -> Iterator[Any]:
+        """
+        Returns the items in this graph in topological order.
+        """
+
+        in_counts = {obj: vertex.in_count for obj, vertex in self.vertices.items()}
+
+        # Find the roots of the graph.
+        queue = [obj for obj, in_count in in_counts.items() if in_count == 0]
+        while len(queue) > 0:
+            cur = queue.pop(0)
+            yield cur
+
+            for obj in self.vertices[cur].out:
+                in_counts[obj] -= 1
+                if in_counts[obj] == 0:
+                    queue.append(obj)
+        else:
+            raise ValueError('cyclic')
+
+
+class DependencyManager:
+
+    deps: DependencyMapping
+    injectors: Mapping[Any, DependencyInjector]
+
+    def __init__(self, deps: Collection[D]) -> None:
+        self.deps = {dep.__class__: dep for dep in deps}
+        self.injectors = defaultdict(lambda: DependencyInjector(self.deps))
+
+    def for_instance(self, obj: Any) -> DependencyInjector:
+        return self.injectors[obj]
+
+    def sorted_watt_keys(self) -> Sequence[Dependency]:
+        g = DependencyGraph()
+
+        for obj, injector in self.injectors.items():
+            for cls in injector.provides:
+                g.connect(obj, cls)
+            for cls in injector.wants:
+                g.connect(cls, obj)
+
+        return [self.deps[obj].watt_key() for obj in g.traverse() if obj in self.deps]

--- a/python/ambassador/fetch/dependency.py
+++ b/python/ambassador/fetch/dependency.py
@@ -127,6 +127,12 @@ class DependencyGraph:
         if len(self.vertices) == 0:
             return
 
+        # This method implements Kahn's algorithm. See
+        # https://en.wikipedia.org/wiki/Topological_sorting#Kahn's_algorithm for
+        # more information.
+
+        # Create a copy of the counts of each inbound edge so we can mutate
+        # them.
         in_counts = {obj: vertex.in_count for obj, vertex in self.vertices.items()}
 
         # Find the roots of the graph.
@@ -144,6 +150,8 @@ class DependencyGraph:
                 in_counts[obj] -= 1
                 if in_counts[obj] == 0:
                     queue.append(obj)
+
+        assert sum(in_counts.values()) == 0, 'Traversal did not reach every vertex exactly once'
 
 
 class DependencyManager:

--- a/python/ambassador/fetch/ingress.py
+++ b/python/ambassador/fetch/ingress.py
@@ -1,0 +1,220 @@
+from typing import ClassVar
+
+from ..config import Config
+
+from .dependency import IngressClassesDependency, SecretDependency, ServiceDependency
+from .k8sobject import KubernetesObject
+from .k8sprocessor import ManagedKubernetesProcessor
+from .resource import NormalizedResource, ResourceManager
+
+
+class IngressClassProcessor (ManagedKubernetesProcessor):
+
+    CONTROLLER: ClassVar[str] = 'getambassador.io/ingress-controller'
+
+    ingress_classes_dep: IngressClassesDependency
+
+    def __init__(self, manager: ResourceManager) -> None:
+        super().__init__(manager)
+
+        self.ingress_classes_dep = self.deps.provide(IngressClassesDependency)
+
+    def _process(self, obj: KubernetesObject) -> None:
+        # We only want to deal with IngressClasses that belong to "spec.controller: getambassador.io/ingress-controller"
+        if obj.spec.get('controller', '').lower() != self.CONTROLLER:
+            self.logger.debug(f'ignoring IngressClass {obj.name} without controller - getambassador.io/ingress-controller')
+            return
+
+        if obj.ambassador_id != Config.ambassador_id:
+            self.logger.debug(f'IngressClass {obj.name} does not have Ambassador ID {Config.ambassador_id}, ignoring...')
+            return
+
+        # TODO: Do we intend to use this parameter in any way?
+        # `parameters` is of type TypedLocalObjectReference,
+        # meaning it links to another k8s resource in the same namespace.
+        # https://godoc.org/k8s.io/api/core/v1#TypedLocalObjectReference
+        #
+        # In this case, the resource referenced by TypedLocalObjectReference
+        # should not be namespaced, as IngressClass is a non-namespaced resource.
+        #
+        # It was designed to reference a CRD for this specific ingress-controller
+        # implementation... although usage is optional and not prescribed.
+        ingress_parameters = obj.spec.get('parameters', {})
+
+        self.logger.debug(f'Handling IngressClass {obj.name} with parameters {ingress_parameters}...')
+        self.aconf.incr_count('k8s_ingress_class')
+
+        # Don't emit this directly. We use it when we handle ingresses below. If
+        # we want to use the parameters, we should add them to this dependency
+        # type.
+        self.ingress_classes_dep.ingress_classes.add(obj.name)
+
+
+class IngressProcessor (ManagedKubernetesProcessor):
+
+    service_dep: ServiceDependency
+    ingress_classes_dep: IngressClassesDependency
+
+    def __init__(self, manager: ResourceManager) -> None:
+        super().__init__(manager)
+
+        self.deps.want(SecretDependency)
+        self.service_dep = self.deps.want(ServiceDependency)
+        self.ingress_classes_dep = self.deps.want(IngressClassesDependency)
+
+    def _process(self, obj: KubernetesObject) -> None:
+        ingress_class_name = obj.spec.get('ingressClassName', '')
+
+        has_ingress_class = ingress_class_name in self.ingress_classes_dep.ingress_classes
+        has_ambassador_ingress_class_annotation = obj.annotations.get('kubernetes.io/ingress.class', '').lower() == 'ambassador'
+
+        # check the Ingress resource has either:
+        #  - a `kubernetes.io/ingress.class: "ambassador"` annotation
+        #  - a `spec.ingressClassName` that references an IngressClass with
+        #      `spec.controller: getambassador.io/ingress-controller`
+        #
+        # also worth noting, the kube-apiserver might assign the `spec.ingressClassName` if unspecified
+        # and only 1 IngressClass has the following annotation:
+        #   annotations:
+        #     ingressclass.kubernetes.io/is-default-class: "true"
+        if not (has_ingress_class or has_ambassador_ingress_class_annotation):
+            self.logger.debug(f'ignoring Ingress {obj.name} without annotation (kubernetes.io/ingress.class: "ambassador") or IngressClass controller (getambassador.io/ingress-controller)')
+            return
+
+        # We don't want to deal with non-matching Ambassador IDs
+        if obj.ambassador_id != Config.ambassador_id:
+            self.logger.debug(f"Ingress {obj.name} does not have Ambassador ID {Config.ambassador_id}, ignoring...")
+            return
+
+        self.logger.debug(f"Handling Ingress {obj.name}...")
+        self.aconf.incr_count('k8s_ingress')
+
+        ingress_tls = obj.spec.get('tls', [])
+        for tls_count, tls in enumerate(ingress_tls):
+
+            tls_secret = tls.get('secretName', None)
+            if tls_secret is not None:
+
+                for host_count, host in enumerate(tls.get('hosts', ['*'])):
+                    tls_unique_identifier = f"{obj.name}-{tls_count}-{host_count}"
+
+                    spec = {
+                        'ambassador_id': [obj.ambassador_id],
+                        'hostname': host,
+                        'acmeProvider': {
+                            'authority': 'none'
+                        },
+                        'tlsSecret': {
+                            'name': tls_secret
+                        },
+                        'requestPolicy': {
+                            'insecure': {
+                                'action': 'Route'
+                            }
+                        }
+                    }
+
+                    ingress_host = NormalizedResource.from_data(
+                        'Host',
+                        tls_unique_identifier,
+                        namespace=obj.namespace,
+                        labels=obj.labels,
+                        spec=spec,
+                    )
+
+                    self.logger.debug(f"Generated Host from ingress {obj.name}: {ingress_host}")
+                    self.manager.emit(ingress_host)
+
+        # parse ingress.spec.defaultBackend
+        # using ingress.spec.backend as a fallback, for older versions of the Ingress resource.
+        default_backend = obj.spec.get('defaultBackend', obj.spec.get('backend', {}))
+        db_service_name = default_backend.get('serviceName', None)
+        db_service_port = default_backend.get('servicePort', None)
+        if db_service_name is not None and db_service_port is not None:
+            db_mapping_identifier = f"{obj.name}-default-backend"
+
+            default_backend_mapping = NormalizedResource.from_data(
+                'Mapping',
+                db_mapping_identifier,
+                namespace=obj.namespace,
+                labels=obj.labels,
+                spec={
+                    'ambassador_id': obj.ambassador_id,
+                    'prefix': '/',
+                    'service': f'{db_service_name}.{obj.namespace}:{db_service_port}'
+                },
+            )
+
+            self.logger.debug(f"Generated mapping from Ingress {obj.name}: {default_backend_mapping}")
+            self.manager.emit(default_backend_mapping)
+
+        # parse ingress.spec.rules
+        ingress_rules = obj.spec.get('rules', [])
+        for rule_count, rule in enumerate(ingress_rules):
+            rule_http = rule.get('http', {})
+
+            rule_host = rule.get('host', None)
+
+            http_paths = rule_http.get('paths', [])
+            for path_count, path in enumerate(http_paths):
+                path_backend = path.get('backend', {})
+                path_type = path.get('pathType', 'ImplementationSpecific')
+
+                service_name = path_backend.get('serviceName', None)
+                service_port = path_backend.get('servicePort', None)
+                path_location = path.get('path', '/')
+
+                if not service_name or not service_port or not path_location:
+                    continue
+
+                unique_suffix = f"{rule_count}-{path_count}"
+                mapping_identifier = f"{obj.name}-{unique_suffix}"
+
+                # For cases where `pathType: Exact`,
+                # otherwise `Prefix` and `ImplementationSpecific` are handled as regular Mapping prefixes
+                is_exact_prefix = True if path_type == 'Exact' else False
+
+                spec = {
+                    'ambassador_id': obj.ambassador_id,
+                    'prefix': path_location,
+                    'prefix_exact': is_exact_prefix,
+                    'precedence': 1 if is_exact_prefix else 0,  # Make sure exact paths are evaluated before prefix
+                    'service': f'{service_name}.{obj.namespace}:{service_port}'
+                }
+
+                if rule_host is not None:
+                    if rule_host.startswith('*.'):
+                        # Ingress allow specifying hosts with a single wildcard as the first label in the hostname.
+                        # Transform the rule_host into a host_regex:
+                        # *.star.com  becomes  ^[a-z0-9]([-a-z0-9]*[a-z0-9])?\.star\.com$
+                        spec['host'] = rule_host\
+                            .replace('.', '\\.')\
+                            .replace('*', '^[a-z0-9]([-a-z0-9]*[a-z0-9])?', 1) + '$'
+                        spec['host_regex'] = True
+                    else:
+                        spec['host'] = rule_host
+
+                path_mapping = NormalizedResource.from_data(
+                    'Mapping',
+                    mapping_identifier,
+                    namespace=obj.namespace,
+                    labels=obj.labels,
+                    spec=spec,
+                )
+
+                self.logger.debug(f"Generated mapping from Ingress {obj.name}: {path_mapping}")
+                self.manager.emit(path_mapping)
+
+        # let's make arrangements to update Ingress' status now
+        if not self.service_dep.ambassador_service:
+            self.logger.error(f"Unable to update Ingress {obj.name}'s status, could not find Ambassador service")
+        else:
+            status = self.service_dep.ambassador_service.status
+
+            if status:
+                status_update = (obj.gvk.kind, obj.namespace, status)
+                self.logger.debug(f"Updating Ingress {obj.name} status to {status_update}")
+                self.aconf.k8s_status_updates[f'{obj.name}.{obj.namespace}'] = status_update
+
+        # Let's see if our Ingress resource has Ambassador annotations on it
+        self.manager.emit_annotated(NormalizedResource.from_kubernetes_object_annotation(obj))

--- a/python/ambassador/fetch/k8sprocessor.py
+++ b/python/ambassador/fetch/k8sprocessor.py
@@ -5,6 +5,7 @@ import logging
 
 from ..config import Config
 
+from .dependency import DependencyInjector
 from .k8sobject import KubernetesGVK, KubernetesObjectScope, KubernetesObjectKey, KubernetesObject
 from .resource import ResourceManager
 
@@ -70,6 +71,10 @@ class ManagedKubernetesProcessor (KubernetesProcessor):
     @property
     def logger(self) -> logging.Logger:
         return self.manager.logger
+
+    @property
+    def deps(self) -> DependencyInjector:
+        return self.manager.deps.for_instance(self)
 
 
 class AggregateKubernetesProcessor (KubernetesProcessor):

--- a/python/ambassador/fetch/resource.py
+++ b/python/ambassador/fetch/resource.py
@@ -8,6 +8,7 @@ import logging
 from ..config import ACResource, Config
 from ..utils import dump_yaml, parse_yaml, dump_json
 
+from .dependency import DependencyManager
 from .k8sobject import KubernetesObjectScope, KubernetesObject
 from .location import LocationManager
 
@@ -103,15 +104,15 @@ class ResourceManager:
 
     logger: logging.Logger
     aconf: Config
+    deps: DependencyManager
     locations: LocationManager
-    ambassador_service: Optional[KubernetesObject]
     elements: List[ACResource]
 
-    def __init__(self, logger: logging.Logger, aconf: Config):
+    def __init__(self, logger: logging.Logger, aconf: Config, deps: DependencyManager):
         self.logger = logger
         self.aconf = aconf
+        self.deps = deps
         self.locations = LocationManager()
-        self.ambassador_service = None
         self.elements = []
 
     @property

--- a/python/ambassador/fetch/secret.py
+++ b/python/ambassador/fetch/secret.py
@@ -2,9 +2,10 @@ from typing import FrozenSet
 
 from ..config import Config
 
+from .dependency import SecretDependency
 from .k8sobject import KubernetesGVK, KubernetesObject
 from .k8sprocessor import ManagedKubernetesProcessor
-from .resource import NormalizedResource
+from .resource import NormalizedResource, ResourceManager
 
 
 class SecretProcessor (ManagedKubernetesProcessor):
@@ -26,6 +27,11 @@ class SecretProcessor (ManagedKubernetesProcessor):
         'key.pem',
         'root-cert.pem',
     ]
+
+    def __init__(self, manager: ResourceManager) -> None:
+        super().__init__(manager)
+
+        self.deps.provide(SecretDependency)
 
     def kinds(self) -> FrozenSet[KubernetesGVK]:
         return frozenset([KubernetesGVK('v1', 'Secret')])

--- a/python/ambassador/ir/ir.py
+++ b/python/ambassador/ir/ir.py
@@ -1005,8 +1005,8 @@ class IR:
         od['cluster_ingress_count'] = 0  # Provided for backward compatibility only.
         od['knative_ingress_count'] = self.aconf.get_count('knative_ingress')
 
-        od['k8s_ingress_count'] = len(self.aconf.k8s_ingresses)
-        od['k8s_ingress_class_count'] = len(self.aconf.k8s_ingress_classes)
+        od['k8s_ingress_count'] = self.aconf.get_count('k8s_ingress')
+        od['k8s_ingress_class_count'] = self.aconf.get_count('k8s_ingress_class')
 
         extauth = False
         extauth_proto: Optional[str] = None

--- a/python/tests/t_ingress.py
+++ b/python/tests/t_ingress.py
@@ -5,7 +5,7 @@ import pytest
 import subprocess
 import time
 
-from kat.harness import Query
+from kat.harness import Query, is_ingress_class_compatible
 from abstract_tests import AmbassadorTest, HTTP, ServiceType
 from kat.utils import namespace_manifest
 
@@ -341,3 +341,100 @@ spec:
             ingress_out, _ = ingress_run.communicate()
             ingress_json = json.loads(ingress_out)
             assert ingress_json['status'] == self.status_update, f"Expected Ingress status to be {self.status_update}, got {ingress_json['status']} instead"
+
+
+class IngressStatusTestWithIngressClass(AmbassadorTest):
+    status_update = {
+        "loadBalancer": {
+            "ingress": [{
+                "ip": "42.42.42.42"
+            }]
+        }
+    }
+
+    def init(self):
+        self.target = HTTP()
+
+        if not is_ingress_class_compatible():
+            self.xfail = 'IngressClass is not supported in this cluster'
+
+    def manifests(self) -> str:
+        return """
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: {self.name.k8s}-ext
+rules:
+- apiGroups: ["networking.k8s.io"]
+  resources: ["ingressclasses"]
+  verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: {self.name.k8s}-ext
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {self.name.k8s}-ext
+subjects:
+- kind: ServiceAccount
+  name: {self.path.k8s}
+  namespace: {self.namespace}
+---
+apiVersion: networking.k8s.io/v1beta1
+kind: IngressClass
+metadata:
+  annotations:
+    getambassador.io/ambassador-id: {self.ambassador_id}
+  name: {self.name.k8s}
+spec:
+  controller: getambassador.io/ingress-controller
+---
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+    getambassador.io/ambassador-id: {self.ambassador_id}
+  name: {self.name.k8s}
+spec:
+  ingressClassName: {self.name.k8s}
+  rules:
+  - http:
+      paths:
+      - backend:
+          serviceName: {self.target.path.k8s}
+          servicePort: 80
+        path: /{self.name}/
+""" + super().manifests()
+
+    def queries(self):
+        if sys.platform != 'darwin':
+            text = json.dumps(self.status_update)
+
+            update_cmd = ['kubestatus', 'Service', '-n', 'default', '-f', f'metadata.name={self.name.k8s}', '-u', '/dev/fd/0']
+            subprocess.run(update_cmd, input=text.encode('utf-8'), timeout=10)
+            # If you run these tests individually, the time between running kubestatus
+            # and the ingress resource actually getting updated is longer than the
+            # time spent waiting for resources to be ready, so this test will fail (most of the time)
+            time.sleep(1)
+
+            yield Query(self.url(self.name + "/"))
+            yield Query(self.url(f'need-normalization/../{self.name}/'))
+
+    def check(self):
+        if sys.platform == 'darwin':
+            pytest.xfail('not supported on Darwin')
+
+        for r in self.results:
+            if r.backend:
+                assert r.backend.name == self.target.path.k8s, (r.backend.name, self.target.path.k8s)
+                assert r.backend.request.headers['x-envoy-original-path'][0] == f'/{self.name}/'
+
+        # check for Ingress IP here
+        ingress_cmd = ["kubectl", "get", "-n", "default", "-o", "json", "ingress", self.path.k8s]
+        ingress_run = subprocess.Popen(ingress_cmd, stdout=subprocess.PIPE)
+        ingress_out, _ = ingress_run.communicate()
+        ingress_json = json.loads(ingress_out)
+        assert ingress_json['status'] == self.status_update, f"Expected Ingress status to be {self.status_update}, got {ingress_json['status']} instead"

--- a/python/tests/test_fetch.py
+++ b/python/tests/test_fetch.py
@@ -13,6 +13,7 @@ logger = logging.getLogger("ambassador")
 
 from ambassador import Config
 from ambassador.fetch import ResourceFetcher
+from ambassador.fetch.dependency import DependencyManager, ServiceDependency
 from ambassador.fetch.location import LocationManager
 from ambassador.fetch.resource import NormalizedResource, ResourceManager
 from ambassador.fetch.k8sobject import (
@@ -221,7 +222,7 @@ class TestAmbassadorProcessor:
 
     def test_mapping(self):
         aconf = Config()
-        mgr = ResourceManager(logger, aconf)
+        mgr = ResourceManager(logger, aconf, DependencyManager([]))
 
         assert AmbassadorProcessor(mgr).try_process(valid_mapping)
         assert len(mgr.elements) == 1
@@ -241,7 +242,7 @@ class TestAmbassadorProcessor:
 
     def test_mapping_v1(self):
         aconf = Config()
-        mgr = ResourceManager(logger, aconf)
+        mgr = ResourceManager(logger, aconf, DependencyManager([]))
 
         assert AmbassadorProcessor(mgr).try_process(valid_mapping_v1)
         assert len(mgr.elements) == 1
@@ -316,7 +317,9 @@ class TestCountingKubernetesProcessor:
 class TestServiceAnnotations:
 
     def setup(self):
-        self.manager = ResourceManager(logger, Config())
+        self.manager = ResourceManager(logger, Config(), DependencyManager([
+            ServiceDependency(),
+        ]))
         self.processor = ServiceProcessor(self.manager)
 
     def test_no_ambassador_annotation(self):

--- a/python/tests/test_knative.py
+++ b/python/tests/test_knative.py
@@ -5,7 +5,7 @@ import time
 
 import pytest
 
-from kat.harness import is_knative
+from kat.harness import is_knative_compatible
 from kat.harness import load_manifest
 from ambassador import Config, IR
 from ambassador.fetch import ResourceFetcher
@@ -153,7 +153,7 @@ def test_knative_counters():
 
 
 def test_knative():
-    if is_knative():
+    if is_knative_compatible():
         knative_test = KnativeTesting()
         knative_test.test_knative()
     else:


### PR DESCRIPTION
## Description
This change moves the handlers for the ingress classes and ingresses in the fetcher to their own resource processors. Because of the strange interdependence of the Ambassador service, which must be discovered, ingress classes, and ingresses, we also introduce a dependency handling mechanism that (a) makes it clear where that information is coming from and (b) automatically generates the desired handling order for data coming in from watt.

## Related Issues
* #3142 

## Testing
New tests were added, and this change was tested against the current integration tests in K3d as well.

## Tasks That Must Be Done
- [x] Did you update CHANGELOG.md?
  + [ ] Is this a new feature?
  + [ ] Are there any non-backward-compatible changes?
  + [ ] Did the envoy version change?
  + [ ] Are there any deprecations?
  + [ ] Will the changes impact how ambassador performs at scale?
    - [ ] Might an existing production deployment need to change:
      + memory limits?
      + cpu limits?
      + replica counts?
    - [ ] Does the change impact data-plane latency/scalability?
- [x] Is your change adequately tested?
  + [ ] Was their sufficient test coverage for the area changed?
  + [ ] Do the existing tests capture the requirements for the area changed?
  + [x] Is the bulk of your code covered by unit tests?
  + [x] Does at least one end-to-end test cover the integration points your change depends on?
- [ ] Did you update documentation?
- [ ] Were there any special dev tricks you had to use to work on this code efficiently?
  + [ ] Did you add them to DEVELOPING.md?
- [x] Is this a build change?
  + [ ] If so, did you test on both Mac and Linux?
