### PR TITLE
Fix failure to start when one or more IngressClasses are present in a cluster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,8 +75,10 @@ Please see the [Envoy documentation](https://www.envoyproxy.io/docs/envoy/latest
 - Bugfix: Make sure that `labels` specifying headers with extra attributes are correctly supported again ([#3137])
 - Bugfix: Support Consul services when the `ConsulResolver` and the `Mapping` aren't in the same namespace, and legacy mode is not enabled.
 - Feature: Ambassador now reads the ENVOY_CONCURRENCY environment variable to optionally set the [--concurrency](https://www.envoyproxy.io/docs/envoy/latest/operations/cli#cmdoption-concurrency) command line option when launching Envoy. This controls the number of worker threads used to serve requests and can be used to fine-tune system resource usage.
+- Bugfix: Fix failure to start when one or more IngressClasses are present in a cluster ([#3142]).
 
 [#3137]: https://github.com/datawire/ambassador/issues/3137
+[#3142]: https://github.com/datawire/ambassador/issues/3142
 
 ## [1.10.0] January 04, 2021
 [1.10.0]: https://github.com/datawire/ambassador/compare/v1.9.1...v1.10.0

--- a/builder/sync-excludes.txt
+++ b/builder/sync-excludes.txt
@@ -11,6 +11,7 @@ __pycache__
 .pytest_cache
 .mypy_cache
 .dmypy.json
+.coverage
 go.sum
 
 bin/

--- a/python/ambassador/fetch/fetcher.py
+++ b/python/ambassador/fetch/fetcher.py
@@ -247,7 +247,7 @@ class ResourceFetcher:
                     # Can't work with this at _all_.
                     self.logger.error(f"skipping invalid object with no kind: {obj}")
                     continue
-            
+
                 # We can't use watt_k8s.setdefault() here because many keys have
                 # explicit null values -- they'll need to be turned into empty lists
                 # and re-saved, and setdefault() won't do that for an explicit null.
@@ -345,7 +345,12 @@ class ResourceFetcher:
             self.logger.debug(f"{self.location}: skipping K8s {obj.gvk}")
             return
 
-        if not self.check_k8s_dup(obj.kind, obj.namespace, obj.name):
+        # Using obj.key.namespace instead of obj.namespace does not throw an
+        # AttributeError if the object is cluster-scoped, instead returning
+        # None. This is important because check_k8s_dup wants to work with
+        # namespace- or cluster-scoped objects equivalently, so representing the
+        # type as Optional[str] makes the most sense.
+        if not self.check_k8s_dup(obj.kind, obj.key.namespace, obj.name):
             return
 
         result = handler(raw_obj)

--- a/python/tests/t_ingress.py
+++ b/python/tests/t_ingress.py
@@ -5,7 +5,7 @@ import pytest
 import subprocess
 import time
 
-from kat.harness import Query
+from kat.harness import Query, is_ingress_class_compatible
 from abstract_tests import AmbassadorTest, HTTP, ServiceType
 from kat.utils import namespace_manifest
 
@@ -341,3 +341,100 @@ spec:
             ingress_out, _ = ingress_run.communicate()
             ingress_json = json.loads(ingress_out)
             assert ingress_json['status'] == self.status_update, f"Expected Ingress status to be {self.status_update}, got {ingress_json['status']} instead"
+
+
+class IngressStatusTestWithIngressClass(AmbassadorTest):
+    status_update = {
+        "loadBalancer": {
+            "ingress": [{
+                "ip": "42.42.42.42"
+            }]
+        }
+    }
+
+    def init(self):
+        self.target = HTTP()
+
+        if not is_ingress_class_compatible():
+            self.xfail = 'IngressClass is not supported in this cluster'
+
+    def manifests(self) -> str:
+        return """
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: {self.name.k8s}-ext
+rules:
+- apiGroups: ["networking.k8s.io"]
+  resources: ["ingressclasses"]
+  verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: {self.name.k8s}-ext
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {self.name.k8s}-ext
+subjects:
+- kind: ServiceAccount
+  name: {self.path.k8s}
+  namespace: {self.namespace}
+---
+apiVersion: networking.k8s.io/v1beta1
+kind: IngressClass
+metadata:
+  annotations:
+    getambassador.io/ambassador-id: {self.ambassador_id}
+  name: {self.name.k8s}
+spec:
+  controller: getambassador.io/ingress-controller
+---
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+    getambassador.io/ambassador-id: {self.ambassador_id}
+  name: {self.name.k8s}
+spec:
+  ingressClassName: {self.name.k8s}
+  rules:
+  - http:
+      paths:
+      - backend:
+          serviceName: {self.target.path.k8s}
+          servicePort: 80
+        path: /{self.name}/
+""" + super().manifests()
+
+    def queries(self):
+        if sys.platform != 'darwin':
+            text = json.dumps(self.status_update)
+
+            update_cmd = ['kubestatus', 'Service', '-n', 'default', '-f', f'metadata.name={self.name.k8s}', '-u', '/dev/fd/0']
+            subprocess.run(update_cmd, input=text.encode('utf-8'), timeout=10)
+            # If you run these tests individually, the time between running kubestatus
+            # and the ingress resource actually getting updated is longer than the
+            # time spent waiting for resources to be ready, so this test will fail (most of the time)
+            time.sleep(1)
+
+            yield Query(self.url(self.name + "/"))
+            yield Query(self.url(f'need-normalization/../{self.name}/'))
+
+    def check(self):
+        if sys.platform == 'darwin':
+            pytest.xfail('not supported on Darwin')
+
+        for r in self.results:
+            if r.backend:
+                assert r.backend.name == self.target.path.k8s, (r.backend.name, self.target.path.k8s)
+                assert r.backend.request.headers['x-envoy-original-path'][0] == f'/{self.name}/'
+
+        # check for Ingress IP here
+        ingress_cmd = ["kubectl", "get", "-n", "default", "-o", "json", "ingress", self.path.k8s]
+        ingress_run = subprocess.Popen(ingress_cmd, stdout=subprocess.PIPE)
+        ingress_out, _ = ingress_run.communicate()
+        ingress_json = json.loads(ingress_out)
+        assert ingress_json['status'] == self.status_update, f"Expected Ingress status to be {self.status_update}, got {ingress_json['status']} instead"

--- a/python/tests/test_knative.py
+++ b/python/tests/test_knative.py
@@ -5,7 +5,7 @@ import time
 
 import pytest
 
-from kat.harness import is_knative
+from kat.harness import is_knative_compatible
 from kat.harness import load_manifest
 from ambassador import Config, IR
 from ambassador.fetch import ResourceFetcher
@@ -153,7 +153,7 @@ def test_knative_counters():
 
 
 def test_knative():
-    if is_knative():
+    if is_knative_compatible():
         knative_test = KnativeTesting()
         knative_test.test_knative()
     else:


### PR DESCRIPTION
## Description
This is a subset of the changes in #3143 that only fixes the original issue reported. It includes the test and a quick change to the fetcher to prevent the crash.

## Related Issues
* Fixes #3142 

## Testing
The automated tests pass, and the new test (that doesn't currently run in OSS CI) passes using a newer version of Kubernetes in K3s.

## Tasks That Must Be Done
- [x] Did you update CHANGELOG.md?
  + [ ] Is this a new feature?
  + [ ] Are there any non-backward-compatible changes?
  + [ ] Did the envoy version change?
  + [ ] Are there any deprecations?
  + [ ] Will the changes impact how ambassador performs at scale?
    - [ ] Might an existing production deployment need to change:
      + memory limits?
      + cpu limits?
      + replica counts?
    - [ ] Does the change impact data-plane latency/scalability?
- [x] Is your change adequately tested?
  + [ ] Was their sufficient test coverage for the area changed?
  + [ ] Do the existing tests capture the requirements for the area changed?
  + [ ] Is the bulk of your code covered by unit tests?
  + [x] Does at least one end-to-end test cover the integration points your change depends on?
- [ ] Did you update documentation?
- [ ] Were there any special dev tricks you had to use to work on this code efficiently?
  + [ ] Did you add them to DEVELOPING.md?
- [ ] Is this a build change?
  + [ ] If so, did you test on both Mac and Linux?
