### PR TITLE
Add processor dependency management

### DIFF
--- a/python/ambassador/fetch/dependency.py
+++ b/python/ambassador/fetch/dependency.py
@@ -1,0 +1,168 @@
+from typing import Any, Collection, Iterator, Mapping, MutableSet, Optional, Protocol, Sequence, Type, TypeVar
+
+from collections import defaultdict
+import dataclasses
+
+from .k8sobject import KubernetesObject
+
+
+class Dependency (Protocol):
+    """
+    Dependencies link information provided by processors of a given Watt
+    invocation to other processors that need the processed result. This results
+    in an ordering of keys so that processors can be dependent on each other
+    without direct knowledge of where data is coming from.
+    """
+
+    def watt_key(self) -> str: ...
+
+
+class ServiceDependency (Dependency):
+    """
+    A dependency that exposes information about the Kubernetes service for
+    Ambassador itself.
+    """
+
+    ambassador_service: Optional[KubernetesObject]
+
+    def __init__(self) -> None:
+        self.ambassador_service = None
+
+    def watt_key(self) -> str:
+        return 'service'
+
+
+class SecretDependency (Dependency):
+    """
+    A dependency that is satisfied once secret information has been mapped and
+    emitted.
+    """
+
+    def watt_key(self) -> str:
+        return 'secret'
+
+
+D = TypeVar('D', bound=Dependency)
+
+
+class DependencyMapping (Protocol):
+
+    def __contains__(self, key: Type[D]) -> bool: ...
+    def __getitem__(self, key: Type[D]) -> D: ...
+
+
+class DependencyInjector:
+    """
+    Each processor instance is provided with a dependency injector that allows
+    it to declare what dependencies it provides as part of its processing and
+    what dependencies it wants to do its processing.
+
+    Note that dependencies need not be fulfilled; for example, nothing may
+    provide information about the Ambassador service or the list of valid
+    ingress classes. Processors should be prepared to deal with the absence of
+    valid data when they run.
+    """
+
+    wants: MutableSet[Type[Dependency]]
+    provides: MutableSet[Type[Dependency]]
+    deps: DependencyMapping
+
+    def __init__(self, deps: DependencyMapping) -> None:
+        self.wants = set()
+        self.provides = set()
+        self.deps = deps
+
+    def want(self, cls: Type[D]) -> D:
+        self.wants.add(cls)
+        return self.deps[cls]
+
+    def provide(self, cls: Type[D]) -> D:
+        self.provides.add(cls)
+        return self.deps[cls]
+
+
+class DependencyGraph:
+    """
+    Once dependency relationships are known, this class provides the ability to
+    link them holistically and traverse them in topological order. It is most
+    useful in the context of the sorted_watt_keys() method of the
+    DependencyManager.
+    """
+
+    @dataclasses.dataclass
+    class Vertex:
+        out: MutableSet[Any]
+        in_count: int
+
+    vertices: Mapping[Any, Vertex]
+
+    def __init__(self) -> None:
+        self.vertices = defaultdict(lambda: DependencyGraph.Vertex(out=set(), in_count=0))
+
+    def connect(self, a: Any, b: Any) -> None:
+        if b not in self.vertices[a].out:
+            self.vertices[a].out.add(b)
+            self.vertices[b].in_count += 1
+
+    def traverse(self) -> Iterator[Any]:
+        """
+        Returns the items in this graph in topological order.
+        """
+
+        if len(self.vertices) == 0:
+            return
+
+        # This method implements Kahn's algorithm. See
+        # https://en.wikipedia.org/wiki/Topological_sorting#Kahn's_algorithm for
+        # more information.
+
+        # Create a copy of the counts of each inbound edge so we can mutate
+        # them.
+        in_counts = {obj: vertex.in_count for obj, vertex in self.vertices.items()}
+
+        # Find the roots of the graph.
+        queue = [obj for obj, in_count in in_counts.items() if in_count == 0]
+
+        # No roots of a graph with at least one vertex indicates a cycle.
+        if len(queue) == 0:
+            raise ValueError('cyclic')
+
+        while len(queue) > 0:
+            cur = queue.pop(0)
+            yield cur
+
+            for obj in self.vertices[cur].out:
+                in_counts[obj] -= 1
+                if in_counts[obj] == 0:
+                    queue.append(obj)
+
+        assert sum(in_counts.values()) == 0, 'Traversal did not reach every vertex exactly once'
+
+
+class DependencyManager:
+    """
+    A manager that provides access to a set of dependencies for arbitrary object
+    instances and the ability to compute a sorted list of Watt keys that
+    represent the processing order for the dependencies.
+    """
+
+    deps: DependencyMapping
+    injectors: Mapping[Any, DependencyInjector]
+
+    def __init__(self, deps: Collection[D]) -> None:
+        self.deps = {dep.__class__: dep for dep in deps}
+        self.injectors = defaultdict(lambda: DependencyInjector(self.deps))
+
+    def for_instance(self, obj: Any) -> DependencyInjector:
+        return self.injectors[obj]
+
+    def sorted_watt_keys(self) -> Sequence[str]:
+        g = DependencyGraph()
+
+        for obj, injector in self.injectors.items():
+            for cls in injector.provides:
+                g.connect(obj, cls)
+            for cls in injector.wants:
+                g.connect(cls, obj)
+
+        return [self.deps[obj].watt_key() for obj in g.traverse() if obj in self.deps]

--- a/python/ambassador/fetch/k8sprocessor.py
+++ b/python/ambassador/fetch/k8sprocessor.py
@@ -5,6 +5,7 @@ import logging
 
 from ..config import Config
 
+from .dependency import DependencyInjector
 from .k8sobject import KubernetesGVK, KubernetesObjectScope, KubernetesObjectKey, KubernetesObject
 from .resource import ResourceManager
 
@@ -70,6 +71,10 @@ class ManagedKubernetesProcessor (KubernetesProcessor):
     @property
     def logger(self) -> logging.Logger:
         return self.manager.logger
+
+    @property
+    def deps(self) -> DependencyInjector:
+        return self.manager.deps.for_instance(self)
 
 
 class AggregateKubernetesProcessor (KubernetesProcessor):

--- a/python/ambassador/fetch/resource.py
+++ b/python/ambassador/fetch/resource.py
@@ -8,6 +8,7 @@ import logging
 from ..config import ACResource, Config
 from ..utils import dump_yaml, parse_yaml, dump_json
 
+from .dependency import DependencyManager
 from .k8sobject import KubernetesObjectScope, KubernetesObject
 from .location import LocationManager
 
@@ -103,15 +104,15 @@ class ResourceManager:
 
     logger: logging.Logger
     aconf: Config
+    deps: DependencyManager
     locations: LocationManager
-    ambassador_service: Optional[KubernetesObject]
     elements: List[ACResource]
 
-    def __init__(self, logger: logging.Logger, aconf: Config):
+    def __init__(self, logger: logging.Logger, aconf: Config, deps: DependencyManager):
         self.logger = logger
         self.aconf = aconf
+        self.deps = deps
         self.locations = LocationManager()
-        self.ambassador_service = None
         self.elements = []
 
     @property

--- a/python/ambassador/fetch/secret.py
+++ b/python/ambassador/fetch/secret.py
@@ -2,9 +2,10 @@ from typing import FrozenSet
 
 from ..config import Config
 
+from .dependency import SecretDependency
 from .k8sobject import KubernetesGVK, KubernetesObject
 from .k8sprocessor import ManagedKubernetesProcessor
-from .resource import NormalizedResource
+from .resource import NormalizedResource, ResourceManager
 
 
 class SecretProcessor (ManagedKubernetesProcessor):
@@ -26,6 +27,11 @@ class SecretProcessor (ManagedKubernetesProcessor):
         'key.pem',
         'root-cert.pem',
     ]
+
+    def __init__(self, manager: ResourceManager) -> None:
+        super().__init__(manager)
+
+        self.deps.provide(SecretDependency)
 
     def kinds(self) -> FrozenSet[KubernetesGVK]:
         return frozenset([KubernetesGVK('v1', 'Secret')])


### PR DESCRIPTION
## Description

This is a subset of #3143.

Frequently, one or more processors will depend on something discovered by another processor to work correctly. This had been implemented by manually keeping track of these dependencies and putting them into a list in the fetcher so that the order would be known in advance. However, this approach is brittle and it's hard to find a good place to store the dependencies that makes sense to every dependent processor.

This change adds support for dependency management, where a processor may provide or want a specific set of data associated with the processing of a given type (expressed as a Watt key). The ordering is then automatically computed by traversing a graph of the dependencies.

Since we've yet to migrate IngressClasses and Ingresses to new processors, there's a bit of rough behavior around them, but the overall approach works as intended.

## Testing

The automated test suite passes with these changes. No changes to behavior are part of this PR.

## Tasks That Must Be Done
- [ ] Did you update CHANGELOG.md?
  + [ ] Is this a new feature?
  + [ ] Are there any non-backward-compatible changes?
  + [ ] Did the envoy version change?
  + [ ] Are there any deprecations?
  + [ ] Will the changes impact how ambassador performs at scale?
    - [ ] Might an existing production deployment need to change:
      + memory limits?
      + cpu limits?
      + replica counts?
    - [ ] Does the change impact data-plane latency/scalability?
- [x] Is your change adequately tested?
  + [x] Was their sufficient test coverage for the area changed?
  + [x] Do the existing tests capture the requirements for the area changed?
  + [x] Is the bulk of your code covered by unit tests?
  + [x] Does at least one end-to-end test cover the integration points your change depends on?
- [ ] Did you update documentation?
- [ ] Were there any special dev tricks you had to use to work on this code efficiently?
  + [ ] Did you add them to DEVELOPING.md?
- [ ] Is this a build change?
  + [ ] If so, did you test on both Mac and Linux?
