### PR TITLE
Move ingress handling to a resource processor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,7 +67,10 @@ Please see the [Envoy documentation](https://www.envoyproxy.io/docs/envoy/latest
 
 ## Next Release
 
+### Ambasssador API Gateway + Ambassador Edge Stack
+
 - Bugfix: Fix an issue that caused Dev Portal to sporadically respond with upstream connect timeout when loading content
+- Bugfix: Prevent potential reconcile loop when updating the status of an Ingress.
 
 ## [1.11.1] February 04, 2021
 [1.11.1]: https://github.com/datawire/ambassador/compare/v1.11.0...v1.11.1

--- a/python/ambassador/config/config.py
+++ b/python/ambassador/config/config.py
@@ -148,8 +148,6 @@ class Config:
 
         self.logger.debug("SCHEMA DIR    %s" % os.path.abspath(self.schema_dir_path))
         self.k8s_status_updates: Dict[str, Tuple[str, str, Optional[Dict[str, Any]]]] = {}  # Tuple is (name, namespace, status_json)
-        self.k8s_ingresses: Dict[str, Any] = {}
-        self.k8s_ingress_classes: Dict[str, Any] = {}
         self.pod_labels: Dict[str, str] = {}
         self._reset()
 

--- a/python/ambassador/fetch/dependency.py
+++ b/python/ambassador/fetch/dependency.py
@@ -42,6 +42,21 @@ class SecretDependency (Dependency):
         return 'secret'
 
 
+class IngressClassesDependency (Dependency):
+    """
+    A dependency that provides the list of ingress classes that are valid (i.e.,
+    have the proper controller) for this cluster.
+    """
+
+    ingress_classes: MutableSet[str]
+
+    def __init__(self):
+        self.ingress_classes = set()
+
+    def watt_key(self) -> str:
+        return 'ingressclasses'
+
+
 D = TypeVar('D', bound=Dependency)
 
 

--- a/python/ambassador/fetch/fetcher.py
+++ b/python/ambassador/fetch/fetcher.py
@@ -9,7 +9,7 @@ import re
 from ..config import ACResource, Config
 from ..utils import parse_yaml, parse_json, dump_json
 
-from .dependency import DependencyManager, SecretDependency, ServiceDependency
+from .dependency import DependencyManager, IngressClassesDependency, SecretDependency, ServiceDependency
 from .resource import NormalizedResource, ResourceManager
 from .k8sobject import KubernetesGVK, KubernetesObject
 from .k8sprocessor import (
@@ -20,11 +20,11 @@ from .k8sprocessor import (
 )
 from .ambassador import AmbassadorProcessor
 from .secret import SecretProcessor
+from .ingress import IngressClassProcessor, IngressProcessor
 from .service import ServiceProcessor
 from .knative import KnativeIngressProcessor
 
 AnyDict = Dict[str, Any]
-HandlerResult = Optional[Tuple[str, List[AnyDict]]]
 
 # XXX ALL OF THE BELOW COMMENT IS PROBABLY OUT OF DATE. (Flynn, 2019-10-29)
 #
@@ -65,20 +65,20 @@ class ResourceFetcher:
         self.manager = ResourceManager(self.logger, self.aconf, DependencyManager([
             ServiceDependency(),
             SecretDependency(),
+            IngressClassesDependency(),
         ]))
 
         self.k8s_processor = DeduplicatingKubernetesProcessor(AggregateKubernetesProcessor([
             CountingKubernetesProcessor(self.aconf, KubernetesGVK.for_knative_networking('Ingress'), 'knative_ingress'),
             AmbassadorProcessor(self.manager),
             SecretProcessor(self.manager),
+            IngressClassProcessor(self.manager),
+            IngressProcessor(self.manager),
             ServiceProcessor(self.manager, watch_only=watch_only),
             KnativeIngressProcessor(self.manager),
         ]))
 
         self.alerted_about_labels = False
-
-        # For deduplicating objects coming in from watt
-        self.k8s_parsed: Dict[str, bool] = {}
 
         # Deltas, for managing the cache.
         self.deltas: List[Dict[str, Union[str, Dict[str, str]]]] = []
@@ -156,38 +156,26 @@ class ResourceFetcher:
         if finalize:
             self.finalize()
 
-    def parse_yaml(self, serialization: str, k8s=False, rkey: Optional[str]=None,
-                   filename: Optional[str]=None, finalize: bool=True, metadata_labels: Optional[Dict[str, str]]=None) -> None:
+    def parse_yaml(self, serialization: str, k8s=False, rkey: Optional[str] = None,
+                   filename: Optional[str] = None, finalize: bool = True) -> None:
         # self.logger.info(f"RF YAML: {serialization}")
 
         # Expand environment variables allowing interpolation in manifests.
         serialization = os.path.expandvars(serialization)
 
-        try:
-            # UGH. This parse_yaml is the one we imported from utils. XXX This needs to be fixed.
-            objects = parse_yaml(serialization)
-            self.parse_object(objects=objects, k8s=k8s, rkey=rkey, filename=filename)
-        except yaml.error.YAMLError as e:
-            self.aconf.post_error("%s: could not parse YAML: %s" % (self.location, e))
+        if not filename:
+            filename = self.manager.locations.current.filename
 
-        if finalize:
-            self.finalize()
-
-    def parse_json(self, serialization: str, k8s=False, rkey: Optional[str]=None,
-                   filename: Optional[str]=None, finalize: bool=True) -> None:
-        # self.logger.debug("%s: parsing %d byte%s of YAML:\n%s" %
-        #                   (self.location, len(serialization), "" if (len(serialization) == 1) else "s",
-        #                    serialization))
-
-        # Expand environment variables allowing interpolation in manifests.
-        serialization = os.path.expandvars(serialization)
-
-        try:
-            # This parse_json is the one we imported from utils. XXX This (also?) needs to be fixed.
-            objects = parse_json(serialization)
-            self.parse_object(objects=objects, k8s=k8s, rkey=rkey, filename=filename)
-        except json.decoder.JSONDecodeError as e:
-            self.aconf.post_error("%s: could not parse YAML: %s" % (self.location, e))
+        with self.manager.locations.push(filename=filename):
+            try:
+                # UGH. This parse_yaml is the one we imported from utils. XXX This needs to be fixed.
+                for obj in parse_yaml(serialization):
+                    if k8s:
+                        self.handle_k8s(obj)
+                    else:
+                        self.manager.emit(NormalizedResource(obj, rkey=rkey))
+            except yaml.error.YAMLError as e:
+                self.aconf.post_error("%s: could not parse YAML: %s" % (self.location, e))
 
         if finalize:
             self.finalize()
@@ -265,7 +253,7 @@ class ResourceFetcher:
 
             # These objects have to be processed first, in order, as they depend
             # on each other.
-            watt_k8s_keys = list(self.manager.deps.sorted_watt_keys()) + ['ingressclasses', 'ingresses']
+            watt_k8s_keys = list(self.manager.deps.sorted_watt_keys())
 
             # Then we add everything else to be processed.
             watt_k8s_keys += watt_k8s.keys()
@@ -282,12 +270,7 @@ class ResourceFetcher:
             consul_endpoints = watt_consul.get('Endpoints', {})
 
             for consul_rkey, consul_object in consul_endpoints.items():
-                result = self.handle_consul_service(consul_rkey, consul_object)
-
-                if result:
-                    rkey, parsed_objects = result
-
-                    self.parse_object(parsed_objects, k8s=False, rkey=rkey)
+                self.handle_consul_service(consul_rkey, consul_object)
         except json.decoder.JSONDecodeError as e:
             self.aconf.post_error("%s: could not parse WATT: %s" % (self.location, e))
 
@@ -315,16 +298,8 @@ class ResourceFetcher:
                 self.aconf.pod_labels[pod_label_kv[0][0]] = pod_label_kv[0][1]
         self.logger.debug(f"Parsed pod labels: {self.aconf.pod_labels}")
 
-    def check_k8s_dup(self, kind: str, namespace: Optional[str], name: str) -> bool:
-        key = f"{kind}/{name}.{namespace}"
-
-        if key in self.k8s_parsed:
-            # self.logger.debug(f"dropping K8s dup {key}")
-            return False
-
-        # self.logger.info(f"remembering K8s {key}")
-        self.k8s_parsed[key] = True
-        return True
+    def sorted(self, key=lambda x: x.rkey):  # returns an iterator, probably
+        return sorted(self.elements, key=key)
 
     def handle_k8s(self, raw_obj: dict) -> None:
         # self.logger.debug("handle_k8s obj %s" % dump_json(obj, pretty=True))
@@ -337,341 +312,12 @@ class ResourceFetcher:
             return
 
         with self.manager.locations.push_reset():
-            if self.k8s_processor.try_process(obj):
-                # Nothing else to do.
-                return
-
-        handler_name = f'handle_k8s_{obj.kind.lower()}'
-        # self.logger.debug(f"looking for handler {handler_name} for K8s {kind} {name}")
-        handler = getattr(self, handler_name, None)
-
-        if not handler:
-            self.logger.debug(f"{self.location}: skipping K8s {obj.gvk}")
-            return
-
-        # Using obj.key.namespace instead of obj.namespace does not throw an
-        # AttributeError if the object is cluster-scoped, instead returning
-        # None. This is important because check_k8s_dup wants to work with
-        # namespace- or cluster-scoped objects equivalently, so representing the
-        # type as Optional[str] makes the most sense.
-        if not self.check_k8s_dup(obj.kind, obj.key.namespace, obj.name):
-            return
-
-        result = handler(raw_obj)
-
-        if result:
-            rkey, parsed_objects = result
-
-            self.parse_object(parsed_objects, k8s=False, rkey=rkey)
-
-    def parse_object(self, objects, k8s=False, rkey: Optional[str] = None, filename: Optional[str] = None):
-        if not filename:
-            filename = self.manager.locations.current.filename
-
-        self.manager.locations.push(filename=filename)
-
-        # self.logger.debug("PARSE_OBJECT: incoming %d" % len(objects))
-
-        for obj in objects:
-            # self.logger.debug("PARSE_OBJECT: checking %s" % obj)
-
-            if k8s:
-                self.handle_k8s(obj)
-            else:
-                # if not obj:
-                #     self.logger.debug("%s: empty object from %s" % (self.location, serialization))
-
-                self.manager.emit(NormalizedResource(obj, rkey=rkey))
-
-        self.manager.locations.pop()
-
-    def sorted(self, key=lambda x: x.rkey):  # returns an iterator, probably
-        return sorted(self.elements, key=key)
-
-    def handle_k8s_ingressclass(self, k8s_object: AnyDict) -> HandlerResult:
-        metadata = k8s_object.get('metadata', None)
-        ingress_class_name = metadata.get('name') if metadata else None
-        ingress_class_spec = k8s_object.get('spec', None)
-
-        # Important: IngressClass is not namespaced!
-        resource_identifier = f'{ingress_class_name}'
-
-        skip = False
-        if not metadata:
-            self.logger.debug('ignoring K8s IngressClass with no metadata')
-            skip = True
-        if not ingress_class_name:
-            self.logger.debug('ignoring K8s IngressClass with no name')
-            skip = True
-        if not ingress_class_spec:
-            self.logger.debug('ignoring K8s IngressClass with no spec')
-            skip = True
-
-        # We only want to deal with IngressClasses that belong to "spec.controller: getambassador.io/ingress-controller"
-        if ingress_class_spec.get('controller', '').lower() != 'getambassador.io/ingress-controller':
-            self.logger.debug(f'ignoring IngressClass {ingress_class_name} without controller - getambassador.io/ingress-controller')
-            skip = True
-
-        if skip:
-            return None
-
-        annotations = metadata.get('annotations', {})
-        ambassador_id = annotations.get('getambassador.io/ambassador-id', 'default')
-
-        # We don't want to deal with non-matching Ambassador IDs
-        if ambassador_id != Config.ambassador_id:
-            self.logger.debug(f'IngressClass {ingress_class_name} does not have Ambassador ID {Config.ambassador_id}, ignoring...')
-            return None
-
-        # TODO: Do we intend to use this parameter in any way?
-        # `parameters` is of type TypedLocalObjectReference,
-        # meaning it links to another k8s resource in the same namespace.
-        # https://godoc.org/k8s.io/api/core/v1#TypedLocalObjectReference
-        #
-        # In this case, the resource referenced by TypedLocalObjectReference
-        # should not be namespaced, as IngressClass is a non-namespaced resource.
-        #
-        # It was designed to reference a CRD for this specific ingress-controller
-        # implementation... although usage is optional and not prescribed.
-        ingress_parameters = ingress_class_spec.get('parameters', {})
-
-        self.logger.debug(f'Handling IngressClass {ingress_class_name} with parameters {ingress_parameters}...')
-
-        # Don't return this as we won't handle IngressClass downstream.
-        # Instead, save it in self.aconf.k8s_ingress_classes for reference in handle_k8s_ingress
-        self.aconf.k8s_ingress_classes[resource_identifier] = ingress_parameters
-
-        return None
-
-    def handle_k8s_ingress(self, k8s_object: AnyDict) -> HandlerResult:
-        if 'metadata' not in k8s_object:
-            self.logger.debug("ignoring K8s Ingress with no metadata")
-            return None
-
-        metadata = k8s_object['metadata']
-
-        if 'name' not in metadata:
-            self.logger.debug("ignoring K8s Ingress with no name")
-            return None
-
-        ingress_name = metadata['name']
-
-        if 'spec' not in k8s_object:
-            self.logger.debug(f"ignoring K8s Ingress {ingress_name} with no spec")
-            return None
-
-        ingress_spec = k8s_object['spec']
-        ingress_namespace = metadata.get('namespace') or 'default'
-
-        metadata_labels: Optional[Dict[str, str]] = metadata.get('labels')
-
-        resource_identifier = f'{ingress_name}.{ingress_namespace}'
-
-        # we don't need an ingress without ingress class set to ambassador
-        annotations = metadata.get('annotations', {})
-        ingress_class_name = ingress_spec.get('ingressClassName', '')
-
-        ingress_class = self.aconf.k8s_ingress_classes.get(ingress_class_name, None)
-        has_ambassador_ingress_class_annotation = annotations.get('kubernetes.io/ingress.class', '').lower() == 'ambassador'
-
-        # check the Ingress resource has either:
-        #  - a `kubernetes.io/ingress.class: "ambassador"` annotation
-        #  - a `spec.ingressClassName` that references an IngressClass with
-        #      `spec.controller: getambassador.io/ingress-controller`
-        #
-        # also worth noting, the kube-apiserver might assign the `spec.ingressClassName` if unspecified
-        # and only 1 IngressClass has the following annotation:
-        #   annotations:
-        #     ingressclass.kubernetes.io/is-default-class: "true"
-        if (not has_ambassador_ingress_class_annotation) and (ingress_class is None):
-            self.logger.debug(f'ignoring Ingress {ingress_name} without annotation (kubernetes.io/ingress.class: "ambassador") or IngressClass controller (getambassador.io/ingress-controller)')
-            return None
-
-        # Let's see if our Ingress resource has Ambassador annotations on it
-        annotations = metadata.get('annotations', {})
-        ambassador_annotations = annotations.get('getambassador.io/config', None)
-
-        parsed_ambassador_annotations = None
-        if ambassador_annotations is not None:
-            self.manager.locations.mark_annotated()
-
-            try:
-                parsed_ambassador_annotations = parse_yaml(ambassador_annotations)
-            except yaml.error.YAMLError as e:
-                self.logger.debug("could not parse YAML: %s" % e)
-
-        ambassador_id = annotations.get('getambassador.io/ambassador-id', 'default')
-
-        # We don't want to deal with non-matching Ambassador IDs
-        if ambassador_id != Config.ambassador_id:
-            self.logger.debug(f"Ingress {ingress_name} does not have Ambassador ID {Config.ambassador_id}, ignoring...")
-            return None
-
-        self.logger.debug(f"Handling Ingress {ingress_name}...")
-        # We will translate the Ingress resource into Hosts and Mappings,
-        # but keep a reference to the k8s resource in aconf for debugging and stats
-        self.aconf.k8s_ingresses[resource_identifier] = k8s_object
-
-        ingress_tls = ingress_spec.get('tls', [])
-        for tls_count, tls in enumerate(ingress_tls):
-
-            tls_secret = tls.get('secretName', None)
-            if tls_secret is not None:
-
-                for host_count, host in enumerate(tls.get('hosts', ['*'])):
-                    tls_unique_identifier = f"{ingress_name}-{tls_count}-{host_count}"
-
-                    ingress_host: Dict[str, Any] = {
-                        'apiVersion': 'getambassador.io/v2',
-                        'kind': 'Host',
-                        'metadata': {
-                            'name': tls_unique_identifier,
-                            'namespace': ingress_namespace
-                        },
-                        'spec': {
-                            'ambassador_id': [ambassador_id],
-                            'hostname': host,
-                            'acmeProvider': {
-                                'authority': 'none'
-                            },
-                            'tlsSecret': {
-                                'name': tls_secret
-                            },
-                            'requestPolicy': {
-                                'insecure': {
-                                    'action': 'Route'
-                                }
-                            }
-                        }
-                    }
-
-                    if metadata_labels:
-                        ingress_host['metadata']['labels'] = metadata_labels
-
-                    self.logger.debug(f"Generated Host from ingress {ingress_name}: {ingress_host}")
-                    self.handle_k8s(ingress_host)
-
-        # parse ingress.spec.defaultBackend
-        # using ingress.spec.backend as a fallback, for older versions of the Ingress resource.
-        default_backend = ingress_spec.get('defaultBackend', ingress_spec.get('backend', {}))
-        db_service_name = default_backend.get('serviceName', None)
-        db_service_port = default_backend.get('servicePort', None)
-        if db_service_name is not None and db_service_port is not None:
-            db_mapping_identifier = f"{ingress_name}-default-backend"
-
-            default_backend_mapping: AnyDict = {
-                'apiVersion': 'getambassador.io/v2',
-                'kind': 'Mapping',
-                'metadata': {
-                    'name': db_mapping_identifier,
-                    'namespace': ingress_namespace
-                },
-                'spec': {
-                    'ambassador_id': ambassador_id,
-                    'prefix': '/',
-                    'service': f'{db_service_name}.{ingress_namespace}:{db_service_port}'
-                }
-            }
-
-            if metadata_labels:
-                default_backend_mapping['metadata']['labels'] = metadata_labels
-
-            self.logger.debug(f"Generated mapping from Ingress {ingress_name}: {default_backend_mapping}")
-            self.handle_k8s(default_backend_mapping)
-
-        # parse ingress.spec.rules
-        ingress_rules = ingress_spec.get('rules', [])
-        for rule_count, rule in enumerate(ingress_rules):
-            rule_http = rule.get('http', {})
-
-            rule_host = rule.get('host', None)
-
-            http_paths = rule_http.get('paths', [])
-            for path_count, path in enumerate(http_paths):
-                path_backend = path.get('backend', {})
-                path_type = path.get('pathType', 'ImplementationSpecific')
-
-                service_name = path_backend.get('serviceName', None)
-                service_port = path_backend.get('servicePort', None)
-                path_location = path.get('path', '/')
-
-                if not service_name or not service_port or not path_location:
-                    continue
-
-                unique_suffix = f"{rule_count}-{path_count}"
-                mapping_identifier = f"{ingress_name}-{unique_suffix}"
-
-                # For cases where `pathType: Exact`,
-                # otherwise `Prefix` and `ImplementationSpecific` are handled as regular Mapping prefixes
-                is_exact_prefix = True if path_type == 'Exact' else False
-
-                path_mapping: Dict[str, Any] = {
-                    'apiVersion': 'getambassador.io/v2',
-                    'kind': 'Mapping',
-                    'metadata': {
-                        'name': mapping_identifier,
-                        'namespace': ingress_namespace
-                    },
-                    'spec': {
-                        'ambassador_id': ambassador_id,
-                        'prefix': path_location,
-                        'prefix_exact': is_exact_prefix,
-                        'precedence': 1 if is_exact_prefix else 0,  # Make sure exact paths are evaluated before prefix
-                        'service': f'{service_name}.{ingress_namespace}:{service_port}'
-                    }
-                }
-
-                if metadata_labels:
-                    path_mapping['metadata']['labels'] = metadata_labels
-
-                if rule_host is not None:
-                    if rule_host.startswith('*.'):
-                        # Ingress allow specifying hosts with a single wildcard as the first label in the hostname.
-                        # Transform the rule_host into a host_regex:
-                        # *.star.com  becomes  ^[a-z0-9]([-a-z0-9]*[a-z0-9])?\.star\.com$
-                        path_mapping['spec']['host'] = rule_host\
-                            .replace('.', '\\.')\
-                            .replace('*', '^[a-z0-9]([-a-z0-9]*[a-z0-9])?', 1) + '$'
-                        path_mapping['spec']['host_regex'] = True
-                    else:
-                        path_mapping['spec']['host'] = rule_host
-
-                self.logger.debug(f"Generated mapping from Ingress {ingress_name}: {path_mapping}")
-                self.handle_k8s(path_mapping)
-
-        # let's make arrangements to update Ingress' status now
-        service_dep = self.manager.deps.for_instance(self).want(ServiceDependency)
-        if not service_dep.ambassador_service:
-            self.logger.error(f"Unable to update Ingress {ingress_name}'s status, could not find Ambassador service")
-        else:
-            ingress_status = service_dep.ambassador_service.status
-
-            if ingress_status:
-                kind = k8s_object.get('kind')
-                assert(kind)
-
-                ingress_status_update = (kind, ingress_namespace, ingress_status)
-                self.logger.debug(f"Updating Ingress {ingress_name} status to {ingress_status_update}")
-                self.aconf.k8s_status_updates[f'{ingress_name}.{ingress_namespace}'] = ingress_status_update
-
-        if parsed_ambassador_annotations is not None:
-            # Copy metadata_labels to parsed annotations, if need be.
-            if metadata_labels:
-                for p in parsed_ambassador_annotations:
-                    if p.get('metadata_labels') is None:
-                        p['metadata_labels'] = metadata_labels
-
-            # Force validation for all of these objects.
-            for p in parsed_ambassador_annotations:
-                p['_force_validation'] = True
-
-            return resource_identifier, parsed_ambassador_annotations
-
-        return None
+            if not self.k8s_processor.try_process(obj):
+                self.logger.debug(f"{self.location}: skipping K8s {obj.gvk}")
 
     # Handler for Consul services
     def handle_consul_service(self,
-                              consul_rkey: str, consul_object: AnyDict) -> HandlerResult:
+                              consul_rkey: str, consul_object: AnyDict) -> None:
         # resource_identifier = f'consul-{consul_rkey}'
 
         endpoints = consul_object.get('Endpoints', [])
@@ -680,7 +326,7 @@ class ResourceFetcher:
         if len(endpoints) < 1:
             # Bzzt.
             self.logger.debug(f"ignoring Consul service {name} with no Endpoints")
-            return None
+            return
 
         # We can turn this directly into an Ambassador Service resource, since Consul keeps
         # services and endpoints together (as it should!!).
@@ -719,8 +365,6 @@ class ResourceFetcher:
             spec=spec,
             rkey=f"consul-{name}-{spec['datacenter']}",
         ))
-
-        return None
 
     def finalize(self) -> None:
         self.k8s_processor.finalize()

--- a/python/ambassador/fetch/ingress.py
+++ b/python/ambassador/fetch/ingress.py
@@ -1,0 +1,241 @@
+from typing import ClassVar, FrozenSet
+
+from ..config import Config
+
+from .dependency import IngressClassesDependency, SecretDependency, ServiceDependency
+from .k8sobject import KubernetesGVK, KubernetesObject
+from .k8sprocessor import ManagedKubernetesProcessor
+from .resource import NormalizedResource, ResourceManager
+
+
+class IngressClassProcessor (ManagedKubernetesProcessor):
+
+    CONTROLLER: ClassVar[str] = 'getambassador.io/ingress-controller'
+
+    ingress_classes_dep: IngressClassesDependency
+
+    def __init__(self, manager: ResourceManager) -> None:
+        super().__init__(manager)
+
+        self.ingress_classes_dep = self.deps.provide(IngressClassesDependency)
+
+    def kinds(self) -> FrozenSet[KubernetesGVK]:
+        return frozenset([
+            KubernetesGVK('networking.k8s.io/v1beta1', 'IngressClass'),
+            KubernetesGVK('networking.k8s.io/v1', 'IngressClass'),
+        ])
+
+    def _process(self, obj: KubernetesObject) -> None:
+        # We only want to deal with IngressClasses that belong to "spec.controller: getambassador.io/ingress-controller"
+        if obj.spec.get('controller', '').lower() != self.CONTROLLER:
+            self.logger.debug(f'ignoring IngressClass {obj.name} without controller - getambassador.io/ingress-controller')
+            return
+
+        if obj.ambassador_id != Config.ambassador_id:
+            self.logger.debug(f'IngressClass {obj.name} does not have Ambassador ID {Config.ambassador_id}, ignoring...')
+            return
+
+        # TODO: Do we intend to use this parameter in any way?
+        # `parameters` is of type TypedLocalObjectReference,
+        # meaning it links to another k8s resource in the same namespace.
+        # https://godoc.org/k8s.io/api/core/v1#TypedLocalObjectReference
+        #
+        # In this case, the resource referenced by TypedLocalObjectReference
+        # should not be namespaced, as IngressClass is a non-namespaced resource.
+        #
+        # It was designed to reference a CRD for this specific ingress-controller
+        # implementation... although usage is optional and not prescribed.
+        ingress_parameters = obj.spec.get('parameters', {})
+
+        self.logger.debug(f'Handling IngressClass {obj.name} with parameters {ingress_parameters}...')
+        self.aconf.incr_count('k8s_ingress_class')
+
+        # Don't emit this directly. We use it when we handle ingresses below. If
+        # we want to use the parameters, we should add them to this dependency
+        # type.
+        self.ingress_classes_dep.ingress_classes.add(obj.name)
+
+
+class IngressProcessor (ManagedKubernetesProcessor):
+
+    service_dep: ServiceDependency
+    ingress_classes_dep: IngressClassesDependency
+
+    def __init__(self, manager: ResourceManager) -> None:
+        super().__init__(manager)
+
+        self.deps.want(SecretDependency)
+        self.service_dep = self.deps.want(ServiceDependency)
+        self.ingress_classes_dep = self.deps.want(IngressClassesDependency)
+
+    def kinds(self) -> FrozenSet[KubernetesGVK]:
+        return frozenset([
+            KubernetesGVK('extensions/v1beta1', 'Ingress'),
+            KubernetesGVK('networking.k8s.io/v1beta1', 'Ingress'),
+            KubernetesGVK('networking.k8s.io/v1', 'Ingress'),
+        ])
+
+    def _update_status(self, obj: KubernetesObject) -> None:
+        service_status = None
+
+        if not self.service_dep.ambassador_service or not self.service_dep.ambassador_service.name:
+            self.logger.error(f"Unable to set Ingress {obj.name}'s load balancer, could not find Ambassador service")
+        else:
+            service_status = self.service_dep.ambassador_service.status
+
+        if obj.status != service_status:
+            if service_status:
+                status_update = (obj.gvk.kind, obj.namespace, service_status)
+                self.logger.debug(f"Updating Ingress {obj.name} status to {status_update}")
+                self.aconf.k8s_status_updates[f'{obj.name}.{obj.namespace}'] = status_update
+        else:
+            self.logger.debug(f"Not reconciling Ingress {obj.name}: observed and current statuses are in sync")
+
+    def _process(self, obj: KubernetesObject) -> None:
+        ingress_class_name = obj.spec.get('ingressClassName', '')
+
+        has_ingress_class = ingress_class_name in self.ingress_classes_dep.ingress_classes
+        has_ambassador_ingress_class_annotation = obj.annotations.get('kubernetes.io/ingress.class', '').lower() == 'ambassador'
+
+        # check the Ingress resource has either:
+        #  - a `kubernetes.io/ingress.class: "ambassador"` annotation
+        #  - a `spec.ingressClassName` that references an IngressClass with
+        #      `spec.controller: getambassador.io/ingress-controller`
+        #
+        # also worth noting, the kube-apiserver might assign the `spec.ingressClassName` if unspecified
+        # and only 1 IngressClass has the following annotation:
+        #   annotations:
+        #     ingressclass.kubernetes.io/is-default-class: "true"
+        if not (has_ingress_class or has_ambassador_ingress_class_annotation):
+            self.logger.debug(f'ignoring Ingress {obj.name} without annotation (kubernetes.io/ingress.class: "ambassador") or IngressClass controller (getambassador.io/ingress-controller)')
+            return
+
+        # We don't want to deal with non-matching Ambassador IDs
+        if obj.ambassador_id != Config.ambassador_id:
+            self.logger.debug(f"Ingress {obj.name} does not have Ambassador ID {Config.ambassador_id}, ignoring...")
+            return
+
+        self.logger.debug(f"Handling Ingress {obj.name}...")
+        self.aconf.incr_count('k8s_ingress')
+
+        ingress_tls = obj.spec.get('tls', [])
+        for tls_count, tls in enumerate(ingress_tls):
+
+            tls_secret = tls.get('secretName', None)
+            if tls_secret is not None:
+
+                for host_count, host in enumerate(tls.get('hosts', ['*'])):
+                    tls_unique_identifier = f"{obj.name}-{tls_count}-{host_count}"
+
+                    spec = {
+                        'ambassador_id': [obj.ambassador_id],
+                        'hostname': host,
+                        'acmeProvider': {
+                            'authority': 'none'
+                        },
+                        'tlsSecret': {
+                            'name': tls_secret
+                        },
+                        'requestPolicy': {
+                            'insecure': {
+                                'action': 'Route'
+                            }
+                        }
+                    }
+
+                    ingress_host = NormalizedResource.from_data(
+                        'Host',
+                        tls_unique_identifier,
+                        namespace=obj.namespace,
+                        labels=obj.labels,
+                        spec=spec,
+                    )
+
+                    self.logger.debug(f"Generated Host from ingress {obj.name}: {ingress_host}")
+                    self.manager.emit(ingress_host)
+
+        # parse ingress.spec.defaultBackend
+        # using ingress.spec.backend as a fallback, for older versions of the Ingress resource.
+        default_backend = obj.spec.get('defaultBackend', obj.spec.get('backend', {}))
+        db_service_name = default_backend.get('serviceName', None)
+        db_service_port = default_backend.get('servicePort', None)
+        if db_service_name is not None and db_service_port is not None:
+            db_mapping_identifier = f"{obj.name}-default-backend"
+
+            default_backend_mapping = NormalizedResource.from_data(
+                'Mapping',
+                db_mapping_identifier,
+                namespace=obj.namespace,
+                labels=obj.labels,
+                spec={
+                    'ambassador_id': obj.ambassador_id,
+                    'prefix': '/',
+                    'service': f'{db_service_name}.{obj.namespace}:{db_service_port}'
+                },
+            )
+
+            self.logger.debug(f"Generated mapping from Ingress {obj.name}: {default_backend_mapping}")
+            self.manager.emit(default_backend_mapping)
+
+        # parse ingress.spec.rules
+        ingress_rules = obj.spec.get('rules', [])
+        for rule_count, rule in enumerate(ingress_rules):
+            rule_http = rule.get('http', {})
+
+            rule_host = rule.get('host', None)
+
+            http_paths = rule_http.get('paths', [])
+            for path_count, path in enumerate(http_paths):
+                path_backend = path.get('backend', {})
+                path_type = path.get('pathType', 'ImplementationSpecific')
+
+                service_name = path_backend.get('serviceName', None)
+                service_port = path_backend.get('servicePort', None)
+                path_location = path.get('path', '/')
+
+                if not service_name or not service_port or not path_location:
+                    continue
+
+                unique_suffix = f"{rule_count}-{path_count}"
+                mapping_identifier = f"{obj.name}-{unique_suffix}"
+
+                # For cases where `pathType: Exact`,
+                # otherwise `Prefix` and `ImplementationSpecific` are handled as regular Mapping prefixes
+                is_exact_prefix = True if path_type == 'Exact' else False
+
+                spec = {
+                    'ambassador_id': obj.ambassador_id,
+                    'prefix': path_location,
+                    'prefix_exact': is_exact_prefix,
+                    'precedence': 1 if is_exact_prefix else 0,  # Make sure exact paths are evaluated before prefix
+                    'service': f'{service_name}.{obj.namespace}:{service_port}'
+                }
+
+                if rule_host is not None:
+                    if rule_host.startswith('*.'):
+                        # Ingress allow specifying hosts with a single wildcard as the first label in the hostname.
+                        # Transform the rule_host into a host_regex:
+                        # *.star.com  becomes  ^[a-z0-9]([-a-z0-9]*[a-z0-9])?\.star\.com$
+                        spec['host'] = rule_host\
+                            .replace('.', '\\.')\
+                            .replace('*', '^[a-z0-9]([-a-z0-9]*[a-z0-9])?', 1) + '$'
+                        spec['host_regex'] = True
+                    else:
+                        spec['host'] = rule_host
+
+                path_mapping = NormalizedResource.from_data(
+                    'Mapping',
+                    mapping_identifier,
+                    namespace=obj.namespace,
+                    labels=obj.labels,
+                    spec=spec,
+                )
+
+                self.logger.debug(f"Generated mapping from Ingress {obj.name}: {path_mapping}")
+                self.manager.emit(path_mapping)
+
+        # let's make arrangements to update Ingress' status now
+        self._update_status(obj)
+
+        # Let's see if our Ingress resource has Ambassador annotations on it
+        self.manager.emit_annotated(NormalizedResource.from_kubernetes_object_annotation(obj))

--- a/python/ambassador/ir/ir.py
+++ b/python/ambassador/ir/ir.py
@@ -1011,8 +1011,8 @@ class IR:
         od['cluster_ingress_count'] = 0  # Provided for backward compatibility only.
         od['knative_ingress_count'] = self.aconf.get_count('knative_ingress')
 
-        od['k8s_ingress_count'] = len(self.aconf.k8s_ingresses)
-        od['k8s_ingress_class_count'] = len(self.aconf.k8s_ingress_classes)
+        od['k8s_ingress_count'] = self.aconf.get_count('k8s_ingress')
+        od['k8s_ingress_class_count'] = self.aconf.get_count('k8s_ingress_class')
 
         extauth = False
         extauth_proto: Optional[str] = None

--- a/python/tests/test_fetch.py
+++ b/python/tests/test_fetch.py
@@ -13,7 +13,7 @@ logger = logging.getLogger("ambassador")
 
 from ambassador import Config
 from ambassador.fetch import ResourceFetcher
-from ambassador.fetch.dependency import DependencyManager, ServiceDependency, SecretDependency
+from ambassador.fetch.dependency import DependencyManager, ServiceDependency, SecretDependency, IngressClassesDependency
 from ambassador.fetch.location import LocationManager
 from ambassador.fetch.resource import NormalizedResource, ResourceManager
 from ambassador.fetch.k8sobject import (
@@ -387,16 +387,20 @@ class TestDependencyManager:
         self.deps = DependencyManager([
             SecretDependency(),
             ServiceDependency(),
+            IngressClassesDependency(),
         ])
 
     def test_cyclic(self):
         a = self.deps.for_instance(object())
         b = self.deps.for_instance(object())
+        c = self.deps.for_instance(object())
 
         a.provide(SecretDependency)
         a.want(ServiceDependency)
         b.provide(ServiceDependency)
-        b.want(SecretDependency)
+        b.want(IngressClassesDependency)
+        c.provide(IngressClassesDependency)
+        c.want(SecretDependency)
 
         with pytest.raises(ValueError):
             self.deps.sorted_watt_keys()
@@ -408,10 +412,11 @@ class TestDependencyManager:
 
         a.want(SecretDependency)
         a.want(ServiceDependency)
+        a.provide(IngressClassesDependency)
         b.provide(SecretDependency)
         c.provide(ServiceDependency)
 
-        assert self.deps.sorted_watt_keys() == ['secret', 'service']
+        assert self.deps.sorted_watt_keys() == ['secret', 'service', 'ingressclasses']
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Description
This change moves the handling of IngressClasses and Ingresses to their own resource processors. Because this was the last Kubernetes type being handled by the fetcher, we also remove the legacy code for handling different types. Going forward, all new Kubernetes object handling will go into a separate processor type.

This change depends on #3156.

## Testing
This change passes the automated test suite. No behavior is changing.

## Tasks That Must Be Done
- [x] Did you update CHANGELOG.md?
  + [ ] Is this a new feature?
  + [ ] Are there any non-backward-compatible changes?
  + [ ] Did the envoy version change?
  + [ ] Are there any deprecations?
  + [ ] Will the changes impact how ambassador performs at scale?
    - [ ] Might an existing production deployment need to change:
      + memory limits?
      + cpu limits?
      + replica counts?
    - [ ] Does the change impact data-plane latency/scalability?
- [x] Is your change adequately tested?
  + [x] Was their sufficient test coverage for the area changed?
  + [x] Do the existing tests capture the requirements for the area changed?
  + [x] Is the bulk of your code covered by unit tests?
  + [x] Does at least one end-to-end test cover the integration points your change depends on?
- [ ] Did you update documentation?
- [ ] Were there any special dev tricks you had to use to work on this code efficiently?
  + [ ] Did you add them to DEVELOPING.md?
- [ ] Is this a build change?
  + [ ] If so, did you test on both Mac and Linux?
