### PR TITLE
Added clarifications and corrections

### DIFF
--- a/docs/howtos/prometheus.md
+++ b/docs/howtos/prometheus.md
@@ -290,6 +290,10 @@ To deploy Grafana behind Ambassador Edge Stack: replace
 `{{AMBASSADOR_IP}}` with the IP address or DNS name of your Ambassador
 Edge Stack service, copy the YAML below, and apply it with `kubectl`:
 
+**Note:** If you forgot how to get the value of your `AMBASSADOR_IP` or 
+have not set-up DNS, you can get the IP by using the `kubectl get services -n ambassador` 
+command, and select the External-IP of your Ambassador LoadBalancer service. 
+
 ```yaml
 ---
 kind: Deployment
@@ -325,7 +329,7 @@ spec:
               protocol: TCP
           env:
             - name: GF_SERVER_ROOT_URL
-              value: {{ SCHEME }}://{{ AMBASSADOR_HOST }}/grafana
+              value: {{ SCHEME }}://{{ AMBASSADOR_IP }}/grafana
             - name: GRAFANA_PORT
               value: '3000'
             - name: GF_AUTH_BASIC_ENABLED
@@ -370,6 +374,10 @@ spec:
 Now, create a service and `Mapping` to expose Grafana behind
 Ambassador Edge Stack:
 
+**Note:** Don't forget to replace `{{GRAFANA_NAMESPACE}}` with the
+namespace you deployed Grafana to. In our example we used the default namespace,
+so for this example you would change it to `grafana.default` or just `grafana`.
+
 ```yaml
 ---
 apiVersion: getambassador.io/v2
@@ -384,10 +392,22 @@ spec:
 Now, access Grafana by going to `{AMBASSADOR_IP}/grafana/` and logging
 in with `username: admin` : `password: admin`.
 
-Import the [provided dashboard](https://grafana.com/dashboards/10434)
-by clicking the plus sign in the left side-bar, clicking `New
-Dashboard` in the top left, selecting `Import Dashboard`, and entering
-the dashboard ID(10434).
+Before you can import the Ambassador dashboard. You need to add a data source.
+From the Grafana home page, select `Create your first data source`. Now,
+select 'Prometheus'. In the URL section, type in `http://prometheus.default:9090`.
+We deployed prometheus to the default namespace in our example, but if you 
+deployed it to a different namespace, make sure to replace `default` with your
+namespace. Press `Save & Test` to confirm that the data source works.
+
+Import the [provided dashboard](https://grafana.com/grafana/dashboards/4698)
+by clicking the plus sign in the left side-bar, clicking `Import` in the top left, and entering the dashboard ID(4698).
+
+From here, select the Prometheus data source we created from the `Prometheus` drop
+down menu, and select import to finish adding the dashboard.
+
+In the dashboard we just added, you should now be able to view graphs in the
+`Ambassador Metrics Endpoint` tab.
+
 
 ## Viewing Stats/Metrics
 
@@ -407,7 +427,7 @@ To view the full set of stats available to Prometheus you can access
 the Prometheus UI by running:
 
 ```shell
-kubectl port-forward -n monitoring service/prometheus 9090
+kubectl port-forward service/prometheus 9090
 ```
 
 and going to `http://localhost:9090/` from a web browser

--- a/docs/howtos/prometheus.md
+++ b/docs/howtos/prometheus.md
@@ -400,7 +400,7 @@ deployed it to a different namespace, make sure to replace `default` with your
 namespace. Press `Save & Test` to confirm that the data source works.
 
 Import the [provided dashboard](https://grafana.com/grafana/dashboards/13758)
-by clicking the plus sign in the left side-bar, clicking `Import` in the top left, and entering the dashboard ID(4698).
+by clicking the plus sign in the left side-bar, clicking `Import` in the top left, and entering the dashboard ID(13758).
 
 From here, select the Prometheus data source we created from the `Prometheus` drop
 down menu, and select import to finish adding the dashboard.

--- a/docs/howtos/prometheus.md
+++ b/docs/howtos/prometheus.md
@@ -277,7 +277,7 @@ points.  Grafana allows you to create dynamic dashboards for monitoring
 your ingress traffic stats collected from Prometheus.
 
 We have published a [sample
-dashboard](https://grafana.com/grafana/dashboards/4698) you can use
+dashboard](https://grafana.com/grafana/dashboards/13758) you can use
 for monitoring your ingress traffic.  Since the stats from the
 `/metrics` and `/stats` endpoints are different, you will see a
 section in the dashboard for each use case.
@@ -399,7 +399,7 @@ We deployed prometheus to the default namespace in our example, but if you
 deployed it to a different namespace, make sure to replace `default` with your
 namespace. Press `Save & Test` to confirm that the data source works.
 
-Import the [provided dashboard](https://grafana.com/grafana/dashboards/4698)
+Import the [provided dashboard](https://grafana.com/grafana/dashboards/13758)
 by clicking the plus sign in the left side-bar, clicking `Import` in the top left, and entering the dashboard ID(4698).
 
 From here, select the Prometheus data source we created from the `Prometheus` drop
@@ -504,3 +504,11 @@ spec:
   endpoints:
   - port: prometheus-metrics
 ```
+
+#### Dashboard
+
+Now that you have metrics scraping from StatsD You can use add [this version of
+the dashboard](https://grafana.com/grafana/dashboards/4698) (ID: 4698) configured to work 
+with metrics scraped from StatsD orthe metrics Endpoint. You can configure it the
+same way as the previous dashboard. Adding the prometheus data source is also required, 
+so if you did not add that yet, make sure to configure it before adding the dashboard. 

--- a/docs/howtos/prometheus.md
+++ b/docs/howtos/prometheus.md
@@ -507,8 +507,8 @@ spec:
 
 #### Dashboard
 
-Now that you have metrics scraping from StatsD You can use add [this version of
+Now that you have metrics scraping from StatsD You can use [this version of
 the dashboard](https://grafana.com/grafana/dashboards/4698) (ID: 4698) configured to work 
-with metrics scraped from StatsD orthe metrics Endpoint. You can configure it the
+with metrics scraped from StatsD or the metrics Endpoint. You can configure it the
 same way as the previous dashboard. Adding the prometheus data source is also required, 
 so if you did not add that yet, make sure to configure it before adding the dashboard. 

--- a/docs/topics/running/statistics/8877-metrics.md
+++ b/docs/topics/running/statistics/8877-metrics.md
@@ -57,11 +57,10 @@ with Prometheus and Grafana](../../../../howtos/prometheus).
 
 #### Sample dashboard
 
-We provide a [sample Grafana dashboard][`8877-metrics-grafana.json`]
+We provide a [sample Grafana dashboard](https://grafana.com/dashboards/10434)
 that displays information collected by Prometheus from the
 `:8877/metrics` endpoint.
 
-[`8877-metrics-grafana.json`]: https://raw.githubusercontent.com/datawire/ambassador/$branch$/docs/topics/running/statistics/8877-metrics-grafana.json
 
 #### Just Envoy information
 

--- a/docs/topics/running/statistics/8877-metrics.md
+++ b/docs/topics/running/statistics/8877-metrics.md
@@ -57,7 +57,7 @@ with Prometheus and Grafana](../../../../howtos/prometheus).
 
 #### Sample dashboard
 
-We provide a [sample Grafana dashboard](https://grafana.com/dashboards/10434)
+We provide a [sample Grafana dashboard](https://grafana.com/dashboards/13758)
 that displays information collected by Prometheus from the
 `:8877/metrics` endpoint.
 


### PR DESCRIPTION
## Description
Updated the Prometheus / Grafana documentation to fix a few small issues as well as providing additional detail on a few steps in the guide.

## Changes
Changed AMBASSADOR_HOST to AMBASSADOR_IP to align with its usage in the configuration.
Provided details on obtaining the AMBASSADOR_IP in case of confusion about what IP we are referring to.
Removed the namespace from the port-forward command as we never created that namespace.
Add reminder to change the {{ GRAFANA_NAMESPACE }} as we did with the Ambassador IP 
Update references to the provided Grafana dashboard to the most recent version
Provide steps to add a data source to Grafana which is a required first step before deploying the dashboard
