### PR TITLE
Node 14 + CHANGELOG

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -292,7 +292,7 @@ commands:
   website-setup:
     steps:
     - install-node:
-        version: "11"
+        version: "14"
     - install-yarn
     - install-python:
         executor-key: "202008-01"
@@ -319,7 +319,7 @@ commands:
     parameters:
       version:
         type: string
-        default: "10"
+        default: "14"
     steps:
     - run:
         name: "Install Node << parameters.version >>"

--- a/.circleci/config.yml.d/docs.yml
+++ b/.circleci/config.yml.d/docs.yml
@@ -9,7 +9,7 @@ commands:
   "website-setup":
     steps:
       - install-node:
-          version: "11"
+          version: "14"
       - install-yarn
       - install-python:
           executor-key: "202008-01"

--- a/.circleci/config.yml.d/generic_util.yml
+++ b/.circleci/config.yml.d/generic_util.yml
@@ -22,7 +22,7 @@ commands:
     parameters:
       "version":
         type: string
-        default: "10"
+        default: "14"
     steps:
       - run:
           name: "Install Node << parameters.version >>"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ as well as additional capabilities including:
   support, and a fully customizable developer portal.
 
 Note: The Ambassador Edge Stack is free for all users, and includes all the functionality
-of the Ambassador API Gateway in addition to the additional capabilities mentioned above. 
+of the Ambassador API Gateway in addition to the additional capabilities mentioned above.
 Due to popular demand, we’re offering a free tier of our core features as part of the
 Ambassador Edge Stack, designed for startups.
 
@@ -67,7 +67,7 @@ Please see the [Envoy documentation](https://www.envoyproxy.io/docs/envoy/latest
 
 ## Next Release
 
-(no changes yet)
+- Bugfix: Fix an issue that caused Dev Portal to sporadically respond with upstream connect timeout when loading content
 
 ## [1.11.0] January 26, 2021
 [1.11.0]: https://github.com/datawire/ambassador/compare/v1.10.0...v1.11.0


### PR DESCRIPTION
Switch to Node 14, and bring over a CHANGELOG update from Ambassador Labs.