### PR TITLE
[v1.11] Code block titles

### DIFF
--- a/docs/howtos/basic-auth.md
+++ b/docs/howtos/basic-auth.md
@@ -76,7 +76,7 @@ Note that the cluster does not yet contain any Ambassador AuthService definition
 
 The YAML above is published at getambassador.io, so if you like, you can just do
 
-```shell
+```
 kubectl apply -f https://www.getambassador.io/yaml/demo/demo-auth.yaml
 ```
 
@@ -84,7 +84,7 @@ to spin everything up. (Of course, you can also use a local file, if you prefer.
 
 Wait for the pod to be running before continuing. The output of `kubectl get pods` should look something like
 
-```console
+```
 $ kubectl get pods
 NAME                            READY     STATUS    RESTARTS   AGE
 example-auth-6c5855b98d-24clp   1/1       Running   0          4m
@@ -116,7 +116,7 @@ If the auth service uses a framework like [Gorilla Toolkit](http://www.gorillato
 
 You can apply this file from getambassador.io with
 
-```shell
+```
 kubectl apply -f https://www.getambassador.io/yaml/demo/demo-auth-enable.yaml
 ```
 
@@ -128,13 +128,13 @@ Note that the cluster does not yet contain any Ambassador AuthService definition
 
 If we `curl` to a protected URL:
 
-```shell
+```
 $ curl -Lv $AMBASSADORURL/backend/get-quote/
 ```
 
 We get a 401 since we haven't authenticated.
 
-```shell
+```
 * TCP_NODELAY set
 * Connected to 54.165.128.189 (54.165.128.189) port 32281 (#0)
 > GET /backend/get-quote/ HTTP/1.1
@@ -153,7 +153,7 @@ We get a 401 since we haven't authenticated.
 
 If we authenticate to the service, we will get a quote successfully:
 
-```shell
+```
 $ curl -Lv -u username:password $AMBASSADORURL/backend/get-quote/
 
 * TCP_NODELAY set

--- a/docs/howtos/cert-manager.md
+++ b/docs/howtos/cert-manager.md
@@ -13,18 +13,18 @@ Creating and managing certificates in Kubernetes is made simple with Jetstack's 
 There are many different ways to [install cert-manager](https://docs.cert-manager.io/en/latest/getting-started/install.html). For simplicity, we will use Helm v3.
 
 1. Create the cert-manager CRDs.
-    ```shell
+    ```
     kubectl apply -f https://github.com/jetstack/cert-manager/releases/latest/download/cert-manager.crds.yaml
     ```
 
 2. Add the `jetstack` Helm repository.
-    ```shell
+    ```
     helm repo add jetstack https://charts.jetstack.io && helm repo update
     ```
 
 3. Install cert-manager.
 
-    ```shell
+    ```
     kubectl create ns cert-manager
     helm install cert-manager --namespace cert-manager jetstack/cert-manager
     ```
@@ -106,7 +106,7 @@ The DNS-01 challenge verifies domain ownership by proving you have control over 
 
 5. Verify the secret is created.
 
-    ```shell
+    ```
     $ kubectl get secrets -n ambassador
     NAME                     TYPE                                  DATA      AGE
     ambassador-certs         kubernetes.io/tls                     2         1h
@@ -162,7 +162,7 @@ The HTTP-01 challenge verifies ownership of the domain by sending a request for 
 
     After applying both of these YAML manifests, you will notice that cert-manager has spun up a temporary pod named `cm-acme-http-solver-xxxx` but no certificate has been issued. Check the cert-manager logs and you will see a log message that looks like this:
 
-    ```shell
+    ```
     $ kubectl logs cert-manager-756d6d885d-v7gmg
     ...
     Preparing certificate default/ambassador-certs with issuer
@@ -208,7 +208,7 @@ The HTTP-01 challenge verifies ownership of the domain by sending a request for 
 
 5. Verify the secret is created:
 
-    ```shell
+    ```
     $ kubectl get secrets
     NAME                     TYPE                                  DATA      AGE
     ambassador-certs         kubernetes.io/tls                     2         1h

--- a/docs/howtos/client-cert-validation.md
+++ b/docs/howtos/client-cert-validation.md
@@ -49,7 +49,7 @@ certificates.
 
 2. Create a secret to hold the client CA certificate.
 
-   ```shell
+   ```
    kubectl create secret generic client-cacert --from-file=tls.crt=cert.pem
    ```
 

--- a/docs/howtos/consul.md
+++ b/docs/howtos/consul.md
@@ -94,7 +94,7 @@ You'll now register a demo application with Consul, and show how Ambassador Edge
 
 2. Verify the QOTM pod has been registered with Consul. You can verify the QOTM pod is registered correctly by accessing the Consul UI.
 
-   ```shell
+   ```
    kubectl port-forward service/consul-ui 8500:80
    ```
 
@@ -123,7 +123,7 @@ Save the above YAML to a file named `qotm-mapping.yaml`, and use `kubectl apply 
 
 4. Send a request to the `qotm-consul` API.
 
-   ```shell
+   ```
    curl -L http://$AMBASSADOR_IP/qotm-consul/
 
    {"hostname":"qotm-749c675c6c-hq58f","ok":true,"quote":"The last sentence you read is often sensible nonsense.","time":"2019-03-29T22:21:42.197663","version":"1.7"}

--- a/docs/howtos/ext-filters.md
+++ b/docs/howtos/ext-filters.md
@@ -72,7 +72,7 @@ Note that the cluster does not yet contain any Ambassador AuthService definition
 
 The YAML above is published at getambassador.io, so if you like, you can just do
 
-```shell
+```
 kubectl apply -f https://www.getambassador.io/yaml/demo/demo-auth.yaml
 ```
 
@@ -80,7 +80,7 @@ to spin everything up. (Of course, you can also use a local file, if you prefer.
 
 Wait for the pod to be running before continuing. The output of `kubectl get pods` should look something like
 
-```console
+```
 $ kubectl get pods
 NAME                            READY     STATUS    RESTARTS   AGE
 example-auth-6c5855b98d-24clp   1/1       Running   0          4m
@@ -147,13 +147,13 @@ If the auth service uses a framework like [Gorilla Toolkit](http://www.gorillato
 
 If we `curl` to a protected URL:
 
-```shell
+```
 $ curl -Lv $AMBASSADORURL/backend/get-quote/
 ```
 
 We get a 401 since we haven't authenticated.
 
-```shell
+```
 * TCP_NODELAY set
 * Connected to 54.165.128.189 (54.165.128.189) port 32281 (#0)
 > GET /backend/get-quote/ HTTP/1.1
@@ -172,7 +172,7 @@ We get a 401 since we haven't authenticated.
 
 If we authenticate to the service, we will get a quote successfully:
 
-```shell
+```
 $ curl -Lv -u username:password $AMBASSADORURL/backend/get-quote/
 
 * TCP_NODELAY set

--- a/docs/howtos/grpc.md
+++ b/docs/howtos/grpc.md
@@ -39,7 +39,7 @@ EXPOSE 50051
 
 Create the container and test it:
 
-```shell
+```
 $ docker build -t <docker_reg>/grpc_example
 $ docker run -p 50051:50051 <docker_reg>/grpc_example
 ```
@@ -48,14 +48,14 @@ Where `<docker_reg>` is your Docker user or registry.
 
 Switch to another terminal and from the same directory, run the `greeter_client`. The output should be the same as running it outside of the container.
 
-```shell
+```
 $ docker run -p 50051:50051 <docker_reg>/grpc_example
 Greeter client received: Hello, you!
 ```
 
 Once you verify the container works, push it to your Docker registry:
 
-```shell
+```
 $ docker push <docker_reg>/grpc_example
 ```
 
@@ -157,7 +157,7 @@ The Host is declared here because we are using gRPC without TLS.  Since Ambassad
 
 Once you have the YAML file and the correct Docker registry, deploy it to your cluster with `kubectl`.
 
-```shell
+```
 $ kubectl apply -f grpc_example.yaml
 ```
 
@@ -165,7 +165,7 @@ $ kubectl apply -f grpc_example.yaml
 
 Make sure to test your Kubernetes deployment before making more advanced changes (like adding TLS). To test any service with Ambassador Edge Stack, we will need the hostname of the running Ambassador Edge Stack service which you can get with:
 
-```shell
+```
 $ kubectl get service ambassador -o wide
 ```
 Which should return something similar to:
@@ -188,7 +188,7 @@ You will need to open the `greeter_client.py` and change `localhost:50051` to `$
 
 After making that change, simply run the client again and you will see the gRPC service in your cluster respond:
 
-```shell
+```
 $ python greeter_client.py
 Greeter client received: Hello, you!
 ```

--- a/docs/howtos/istio.md
+++ b/docs/howtos/istio.md
@@ -262,7 +262,7 @@ After applying the updated Ambassador deployment above to your cluster, we need 
 
 We do this with a `TLSContext` using the `istio-certs` secret, which tracks the mTLS certificates provided from the `istio-proxy`.
 
-```bash
+```
 $ kubectl apply -f - <<EOF
 ---
 apiVersion: getambassador.io/v2
@@ -284,7 +284,7 @@ With Istio 1.4 and below, Istio stores it's mTLS certificates as a Kubernetes `S
 
 We can read these certificates from the `istio.default` `Secret` in the Ambassador namespace with a `TLSContext`.
 
-```bash
+```
 $ kubectl apply -f - <<EOF
 ---
 apiVersion: getambassador.io/v2
@@ -313,14 +313,14 @@ Istio's Prometheus deployment is configured using a `ConfigMap`. To add Ambassad
 
    * If you installed Istio with `istioctl`, you can get the YAML that was installed with
 
-      ```bash
+      ```
       istioctl manifest generate > istio.yaml
       ```
       This will export all of the YAML configuration used by Istio to a file named `istio.yaml` so you can update the `ConfigMap` there.
 
    * If you did not install with `istioctl`, you can export the YAML of the current `ConfigMap` in your cluster with `kubectl`:
 
-      ```bash
+      ```
       kubectl get -n istio-system configmap prometheus  -o yaml > prom-cm.yaml
       ```
    
@@ -377,13 +377,13 @@ Istio's Prometheus deployment is configured using a `ConfigMap`. To add Ambassad
 
    The Prometheus pod must be restarted to start with the new configuration. 
 
-   ```bash
+   ```
    kubectl delete pod -n istio-system $(kubectl get pods -n istio-system | grep prometheus | awk '{print $1}')
    ```
 
    After the pod restarts you can port-forward the Prometheus `Service` to access the Prometheus UI.
 
-   ```bash
+   ```
    kubectl port-forward -n istio-system svc/prometheus 9090:9090
    ```
 
@@ -415,7 +415,7 @@ spec:
 
 After applying this configuration with `kubectl apply`, restart the Ambassador pod for the configuration to take effect.
 
-```bash
+```
 kubectl delete po -n ambassador {{AMBASSADOR_POD_NAME}}
 ```
 
@@ -429,7 +429,7 @@ Now we will show how you can use Ambassador to route to services in the Istio se
 
 1. Label the default namespace for [automatic sidecar injection](https://istio.io/docs/setup/additional-setup/sidecar-injection/#automatic-sidecar-injection)
 
-   ```bash
+   ```
    kubectl label namespace default istio-injection=enabled
    ```
 
@@ -437,13 +437,13 @@ Now we will show how you can use Ambassador to route to services in the Istio se
 
 2. Install the quote example service
 
-   ```bash
+   ```
    kubectl apply -n default -f https://getambassador.io/yaml/backends/quote.yaml
    ```
 
    Wait for the pod to start and see that there are two containers: the `quote` application and the `istio-proxy` sidecar.
 
-   ```bash
+   ```
    $ kubectl get po -n default 
 
    NAME                     READY   STATUS    RESTARTS   AGE
@@ -470,7 +470,7 @@ Now we will show how you can use Ambassador to route to services in the Istio se
 
    Simply do that by updating the above `Mapping` with the following one.
 
-   ```bash
+   ```
    $ kubectl apply -f - <<EOF
    apiVersion: getambassador.io/v2
    kind: Mapping
@@ -485,7 +485,7 @@ Now we will show how you can use Ambassador to route to services in the Istio se
 
    Send a request to the quote service using curl:
 
-   ```bash
+   ```
    $ curl -k https://{{AMBASSADOR_HOST}}/backend/
 
    {
@@ -503,7 +503,7 @@ Istio defaults to PERMISSIVE mTLS that does not require authentication between c
 
 1. Configure Istio in [STRICT mTLS](https://istio.io/docs/tasks/security/authentication/authn-policy/#globally-enabling-istio-mutual-tls-in-strict-mode) mode.
 
-   ```bash
+   ```
    $ kubectl apply -f - <<EOF
    apiVersion: security.istio.io/v1beta1
    kind: PeerAuthentication
@@ -521,7 +521,7 @@ Istio defaults to PERMISSIVE mTLS that does not require authentication between c
    We can test this by removing the `tls` configuration from the quote-backend `Mapping`
    and sending a request.
 
-   ```bash
+   ```
    $ kubectl apply -f - <<EOF
    apiVersion: getambassador.io/v2
    kind: Mapping
@@ -544,7 +544,7 @@ Istio defaults to PERMISSIVE mTLS that does not require authentication between c
 
    As we have demonstrated above we can tell Ambassador to use the mTLS certificates from Istio to authenticate with the `istio-proxy` in the quote pod.
 
-   ```bash
+   ```
    $ kubectl apply -f - <<EOF
    ---
    apiVersion: getambassador.io/v2
@@ -560,7 +560,7 @@ Istio defaults to PERMISSIVE mTLS that does not require authentication between c
 
    Now Ambassador will use the Istio mTLS certificates when routing to the `quote` service. 
 
-   ```bash
+   ```
    $ curl -k https://{{AMBASSADOR_HOST}}/backend/
    {
        "server": "bewitched-acai-5jq7q81r",
@@ -577,7 +577,7 @@ The metrics Ambassador adds to the list will appear in the Istio dashboard but w
 
 First, let's start the port-forwarding for Istio's Grafana service:
 
-```sh
+```
 $ kubectl -n istio-system port-forward $(kubectl -n istio-system get pod -l app=grafana -o jsonpath='{.items[0].metadata.name}') 3000:3000 &
 ```
 

--- a/docs/howtos/linkerd2.md
+++ b/docs/howtos/linkerd2.md
@@ -20,7 +20,7 @@ Setting up Linkerd 2 requires to install three components. The first is the CLI 
 
     In a nutshell, these steps boil down to the following:
 
-    ```bash
+    ```
     # install linkerd cli tool
     curl -sL https://run.linkerd.io/install | sh
     # add linkerd to your path
@@ -31,7 +31,7 @@ Setting up Linkerd 2 requires to install three components. The first is the CLI 
 
 2. Now it is time to install Linkerd 2 itself. To do so execute the following command:
 
-    ```bash
+    ```
     linkerd install --ha | kubectl apply -f -
     ```
 
@@ -130,7 +130,7 @@ You'll now register a demo application with Linkerd 2, and show how Ambassador E
 
 3. Verify the QOTM pod has been registered with Linkerd 2. You can verify the QOTM pod is registered correctly by accessing the Linkerd 2 Dashboard.
 
-   ```shell
+   ```
    linkerd dashboard
    ```
 
@@ -157,7 +157,7 @@ to apply this configuration to your Kubernetes cluster. Note that in the above c
 
 1. Send a request to the `qotm-Linkerd2` API.
 
-   ```shell
+   ```
    curl -L http://$AMBASSADOR_IP/qotm-Linkerd2/
 
    {"hostname":"qotm-749c675c6c-hq58f","ok":true,"quote":"The last sentence you read is often sensible nonsense.","time":"2019-03-29T22:21:42.197663","version":"1.7"}
@@ -240,7 +240,7 @@ Allowing the Ambassador installation to serve as a target cluster requires expli
     
     In the `deployment`, you need the `config.linkerd.io/enable-gateway` `annotation`:
     
-    ```bash
+    ```
     kubectl -n ambassador patch deploy ambassador -p='
     spec:
         template:
@@ -255,7 +255,7 @@ Allowing the Ambassador installation to serve as a target cluster requires expli
        - `mc-gateway` needs to be defined as `port` 4143
        - `mc-probe` needs to be defined as `port` 80, `targetPort` 8080 (or wherever Ambassador is listening)
     
-    ```bash
+    ```
     kubectl -n ambassador patch svc ambassador --type='json' -p='[
             {"op":"add","path":"/spec/ports/-", "value":{"name": "mc-gateway", "port": 4143}},
             {"op":"replace","path":"/spec/ports/0", "value":{"name": "mc-probe", "port": 80, "targetPort": 8080}}
@@ -264,7 +264,7 @@ Allowing the Ambassador installation to serve as a target cluster requires expli
     
     Finally, the `service` also needs its own set of `annotation`s:
     
-    ```bash
+    ```
     kubectl -n ambassador patch svc ambassador -p='
     metadata:
         annotations:
@@ -279,7 +279,7 @@ Allowing the Ambassador installation to serve as a target cluster requires expli
 
 4. Configure individual exported services. Adding the following annotations to a service will tell the service to use Ambassador as the gateway:
 
-    ```bash
+    ```
     kubectl -n $namespace patch svc $service -p='
     metadata:
         annotations:
@@ -296,13 +296,13 @@ Allowing the Ambassador installation to serve as a target cluster requires expli
     
     First, check to make that the clusters are correctly linked:
     
-    ```bash
+    ```
     linkerd check --multicluster
     ```
     
     Next, make sure that the Ambassador gateway shows up when listing active gateways:
     
-    ```bash
+    ```
     linkerd multicluster gateways
     ```
     

--- a/docs/howtos/prometheus.md
+++ b/docs/howtos/prometheus.md
@@ -78,7 +78,7 @@ standard YAML files.  Alternatively, you can install it with
    follow the instructions in the README, or simply apply the
    published YAML with `kubectl`.
 
-    ```shell
+    ```
     kubectl apply -f https://raw.githubusercontent.com/coreos/prometheus-operator/master/bundle.yaml
     ```
 
@@ -86,7 +86,7 @@ standard YAML files.  Alternatively, you can install it with
     lower version, you will need to run the following command to
     install the CRDs with the right API version:
 
-    ```shell
+    ```
     curl -sL https://raw.githubusercontent.com/coreos/prometheus-operator/master/bundle.yaml \
       | sed 's|apiVersion: apiextensions.k8s.io/v1|apiVersion: apiextensions.k8s.io/v1beta1|' \
       | sed 's|jsonPath|JSONPath|' \
@@ -97,7 +97,7 @@ standard YAML files.  Alternatively, you can install it with
 
     First, create RBAC resources for your Prometheus instance
 
-    ```shell
+    ```
     kubectl apply -f https://www.getambassador.io/yaml/monitoring/prometheus-rbac.yaml
     ```
 
@@ -406,7 +406,7 @@ connection length, and number of registered services.
 To view the full set of stats available to Prometheus you can access
 the Prometheus UI by running:
 
-```shell
+```
 kubectl port-forward -n monitoring service/prometheus 9090
 ```
 
@@ -434,7 +434,7 @@ Exporter](https://github.com/prometheus/statsd_exporter) to do this.
 
 1. Deploy the StatsD Exporter in the `default` namespace
 
-    ```shell
+    ```
     kubectl apply -f https://www.getambassador.io/yaml/monitoring/statsd-sink.yaml
     ```
 

--- a/docs/howtos/rate-limiting-tutorial.md
+++ b/docs/howtos/rate-limiting-tutorial.md
@@ -166,13 +166,13 @@ Ambassador would also perform multiple requests to `example-rate-limit:5000` if 
 
 If we `curl` to a rate-limited URL:
 
-```shell
+```
 $ curl -Lv -H "x-ambassador-test-allow: probably" $AMBASSADORURL/backend/
 ```
 
 We get a 429, since we are limited.
 
-```shell
+```
 HTTP/1.1 429 Too Many Requests
 content-type: text/html; charset=utf-8
 content-length: 0
@@ -180,7 +180,7 @@ content-length: 0
 
 If we set the correct header value to the service request, we will get a quote successfully:
 
-```shell
+```
 $ curl -Lv -H "x-ambassador-test-allow: true" $AMBASSADORURL/backend/
 
 TCP_NODELAY set

--- a/docs/howtos/sso/uaa.md
+++ b/docs/howtos/sso/uaa.md
@@ -18,7 +18,7 @@
 
 2. Create an OIDC Client:
 
-   ```shell
+   ```
    uaac client add ambassador --name ambassador-client --scope openid --authorized_grant_types authorization_code,refresh_token --redirect_uri {AMBASSADOR_URL}/.ambassador/oauth2/redirection-endpoint --secret CLIENT_SECRET
    ```
 

--- a/docs/howtos/tracing-datadog.md
+++ b/docs/howtos/tracing-datadog.md
@@ -50,7 +50,7 @@ spec:
 
 Use `curl` to generate a few requests to an existing Ambassador Edge Stack mapping. You may need to perform many requests, since only a subset of random requests are sampled and instrumented with traces.
 
-```shell
+```
 $ curl -L $AMBASSADOR_IP/httpbin/ip
 ```
 

--- a/docs/howtos/tracing-zipkin.md
+++ b/docs/howtos/tracing-zipkin.md
@@ -64,7 +64,7 @@ spec:
 
 You can deploy this configuration into your Kubernetes cluster like so:
 
-```shell
+```
 $ kubectl apply -f zipkin.yaml
 ```
 
@@ -74,7 +74,7 @@ $ kubectl apply -f zipkin.yaml
 
 Use `curl` to generate a few requests to an existing Ambassador Edge Stack mapping. You may need to perform many requests since only a subset of random requests are sampled and instrumented with traces.
 
-```shell
+```
 $ curl -L $AMBASSADOR_IP/httpbin/ip
 ```
 
@@ -82,7 +82,7 @@ $ curl -L $AMBASSADOR_IP/httpbin/ip
 
 To test things out, we'll need to access the Zipkin UI. If you're on Kubernetes, get the name of the Zipkin pod:
 
-```shell
+```
 $ kubectl get pods
 NAME                                   READY     STATUS    RESTARTS   AGE
 ambassador-5ffcfc798-c25dc             2/2       Running   0          1d
@@ -92,7 +92,7 @@ zipkin-868b97667c-58v4r                1/1       Running   0          2h
 
 And then use `kubectl port-forward` to access the pod:
 
-```shell
+```
 $ kubectl port-forward zipkin-868b97667c-58v4r 9411
 ```
 
@@ -100,7 +100,7 @@ Open your web browser to `http://localhost:9411` for the Zipkin UI.
 
 If you're on `minikube` you can access the `NodePort` directly, and this ports number can be obtained via the `minikube services list` command. If you are using `Docker for Mac/Windows`, you can use the `kubectl get svc` command to get the same information.
 
-```shell
+```
 $ minikube service list
 |-------------|----------------------|-----------------------------|
 |  NAMESPACE  |         NAME         |             URL             |

--- a/docs/topics/install/aes-operator.md
+++ b/docs/topics/install/aes-operator.md
@@ -32,7 +32,7 @@ Start by installing the operator:
 3. To install the Ambassador Operator CRD in a different namespace, you can specify it in `NS` and
    then run the following command:
 
-    ```shell
+    ```
     $ NS="custom-namespace"
     $ curl -L https://github.com/datawire/ambassador-operator/releases/latest/download/ambassador-operator.yaml | \
         sed -e "s/namespace: ambassador/namespace: $NS/g" | \

--- a/docs/topics/install/docker.md
+++ b/docs/topics/install/docker.md
@@ -37,7 +37,7 @@ Since Ambassador Edge Stack is a comprehensive, self-service edge stack, its pri
 
 in your browser, or from the command line as
 
-```shell
+```
 curl -L 'http://localhost:8080/qotm/?json=true'
 ```
 
@@ -55,13 +55,13 @@ You saw above that access to the diagnostic overview required you to authenticat
 
 in your browser. From the command line, you can see that:
 
-```shell
+```
 curl -Lv 'http://localhost:8080/qotm/quote/5?json=true'
 ```
 
 will return a 401, but
 
-```shell
+```
 curl -Lv -u username:password 'http://localhost:8080/qotm/quote/5?json=true'
 ```
 

--- a/docs/topics/install/helm.md
+++ b/docs/topics/install/helm.md
@@ -8,12 +8,12 @@ The Ambassador Edge Stack Helm chart is hosted by Datawire and published at `htt
 
 Start by adding this repo to your helm client with the following command:
 
-```bash
+```
 helm repo add datawire https://www.getambassador.io
 ```
 
 Both Helm 2 and Helm 3 are supported. To enable CRD creation in Helm 2, the `crd-install` hook is included in the CRD manifests. When installing with Helm 3, the following message will be output to `stderr`:
-```bash
+```
 manifest_sorter.go:175: info: skipping unknown hook: "crd-install"
 ```
 Since this hook is required for Helm 2 support it **IS NOT AN ERROR AND CAN BE SAFELY IGNORED**.

--- a/docs/topics/install/help/aes-acme-challenge.md
+++ b/docs/topics/install/help/aes-acme-challenge.md
@@ -6,7 +6,7 @@ The installer could not verify that Ambassador Edge Stack (AES) is answering que
 
 1. Verify that the load balancer address is reachable from this host
 2. Run the installer again:
-   ```shell
+   ```
    edgectl install
    ```
 

--- a/docs/topics/install/help/aes-crd-manifests.md
+++ b/docs/topics/install/help/aes-crd-manifests.md
@@ -8,7 +8,7 @@ If Internet connectivity is not available, the installer cannot proceed.
 
    Try `curl -ISsf https://www.getambassador.io/` to verify that your computer can reach important websites. Successfully reaching the Internet will show something like
 
-   ```shell
+   ```
    HTTP/2 200
    cache-control: public, max-age=0, must-revalidate
    content-length: 0
@@ -20,14 +20,14 @@ If Internet connectivity is not available, the installer cannot proceed.
 
    A result that looks like
 
-   ```shell
+   ```
    curl: (7) Failed to connect to 167.170.215.127 port 443: Network is unreachable
    ```
 
    indicates that there is something preventing you from reaching the Internet.
 
 2. Run the installer again:
-   ```shell
+   ```
    edgectl install
    ```
 

--- a/docs/topics/install/help/aes-login.md
+++ b/docs/topics/install/help/aes-login.md
@@ -6,7 +6,7 @@ The installer attempted to open the Ambassador Edge Stack (AES) Policy Console f
 
 Run the installer again:
 
-```shell
+```
 edgectl install
 ```
 

--- a/docs/topics/install/help/aes-manifests.md
+++ b/docs/topics/install/help/aes-manifests.md
@@ -8,7 +8,7 @@ If Internet connectivity is not available, the installer cannot proceed.
 
    Try `curl -ISsf https://www.getambassador.io/` to verify that your computer can reach important websites. Successfully reaching the Internet will show something like
 
-   ```shell
+   ```
    HTTP/2 200
    cache-control: public, max-age=0, must-revalidate
    content-length: 0
@@ -20,14 +20,14 @@ If Internet connectivity is not available, the installer cannot proceed.
 
    A result that looks like
 
-   ```shell
+   ```
    curl: (7) Failed to connect to 167.170.215.127 port 443: Network is unreachable
    ```
 
    indicates that there is something preventing you from reaching the Internet.
 
 2. Run the installer again:
-   ```shell
+   ```
    edgectl install
    ```
 

--- a/docs/topics/install/help/certificate-provision.md
+++ b/docs/topics/install/help/certificate-provision.md
@@ -8,7 +8,7 @@ This is an unusual, unexpected failure. Sorry about that!
 
 Please run the installer again:
 
-```shell
+```
 edgectl install
 ```
 

--- a/docs/topics/install/help/dns-name-body.md
+++ b/docs/topics/install/help/dns-name-body.md
@@ -8,7 +8,7 @@ This is likely an intermittent failure of the EdgeStack.me service. Sorry about 
 
 Please run the installer again:
 
-```shell
+```
 edgectl install
 ```
 

--- a/docs/topics/install/help/dns-name-post.md
+++ b/docs/topics/install/help/dns-name-post.md
@@ -8,7 +8,7 @@ This is likely an intermittent failure of the EdgeStack.me service. Sorry about 
 
 Please run the installer again:
 
-```shell
+```
 edgectl install
 ```
 

--- a/docs/topics/install/help/dns-propagation.md
+++ b/docs/topics/install/help/dns-propagation.md
@@ -8,7 +8,7 @@ The EdgeStack.me DNS server is serving a DNS name for you. The associated DNS re
 
 Run the installer again:
 
-```shell
+```
 edgectl install
 ```
 

--- a/docs/topics/install/help/download-error.md
+++ b/docs/topics/install/help/download-error.md
@@ -8,7 +8,7 @@ If Internet connectivity is not available, the installer cannot proceed.
 
    Try `curl -ISsf https://www.getambassador.io/` to verify that your computer can reach important websites. Successfully reaching the Internet will show something like
 
-   ```shell
+   ```
    HTTP/2 200
    cache-control: public, max-age=0, must-revalidate
    content-length: 0
@@ -20,14 +20,14 @@ If Internet connectivity is not available, the installer cannot proceed.
 
    A result that looks like
 
-   ```shell
+   ```
    curl: (7) Failed to connect to 167.170.215.127 port 443: Network is unreachable
    ```
 
    indicates that there is something preventing you from reaching the Internet.
 
 2. Run the installer again:
-   ```shell
+   ```
    edgectl install
    ```
 

--- a/docs/topics/install/help/email-request.md
+++ b/docs/topics/install/help/email-request.md
@@ -8,6 +8,6 @@ For some reason this request failed.
 
 Please run the installer again and enter a valid email address for the installer to send to Let's Encrypt.
 
-```shell
+```
 edgectl install
 ```

--- a/docs/topics/install/help/host-resource-creation.md
+++ b/docs/topics/install/help/host-resource-creation.md
@@ -8,7 +8,7 @@ This is an unusual, unexpected failure. Sorry about that!
 
 Please run the installer again:
 
-```shell
+```
 edgectl install
 ```
 

--- a/docs/topics/install/help/host-retrieval.md
+++ b/docs/topics/install/help/host-retrieval.md
@@ -8,7 +8,7 @@ This is an unusual, unexpected failure. Sorry about that!
 
 Please run the installer again:
 
-```shell
+```
 edgectl install
 ```
 

--- a/docs/topics/install/help/load-balancer.md
+++ b/docs/topics/install/help/load-balancer.md
@@ -7,14 +7,14 @@ The installer could not retrieve an address (DNS name or IP address) for the loa
 * Provisioning a load balancer might be taking longer than expected.
   1. Check whether a load balancer address has appeared:
 
-     ```shell
+     ```
      kubectl get -n ambassador service ambassador -o "go-template={{range .status.loadBalancer.ingress}}{{or .ip .hostname}}{{end}}"
      ```
 
      On most cloud providers, a load balancer will appear within five minutes.
 
   2. Run the installer again:
-     ```shell
+     ```
      edgectl install
      ```
 

--- a/docs/topics/install/help/manifest-parsing.md
+++ b/docs/topics/install/help/manifest-parsing.md
@@ -8,7 +8,7 @@ The installer retrieves information required to install AES over the Internet. S
 
    Try `curl -ISsf https://www.getambassador.io/` to verify that your computer can reach important websites. Successfully reaching the Internet will show something like
 
-   ```shell
+   ```
    HTTP/2 200
    cache-control: public, max-age=0, must-revalidate
    content-length: 0
@@ -20,14 +20,14 @@ The installer retrieves information required to install AES over the Internet. S
 
    A result that looks like
 
-   ```shell
+   ```
    curl: (7) Failed to connect to 167.170.215.127 port 443: Network is unreachable
    ```
 
    indicates that there is something preventing you from reaching the Internet.
 
 2. Run the installer again:
-   ```shell
+   ```
    edgectl install
    ```
 

--- a/docs/topics/install/help/no-kubectl.md
+++ b/docs/topics/install/help/no-kubectl.md
@@ -6,7 +6,7 @@ Installation of Ambassador Edge Stack (AES) requires the `kubectl` command. The 
 
 1. Install `kubectl`: see the [Kubernetes documentation on how to install `kubectl`](https://kubernetes.io/docs/tasks/tools/install-kubectl/).
 2. Run the installer again:
-   ```shell
+   ```
    edgectl install
    ```
 

--- a/docs/topics/install/help/upgrade-no-oss-found.md
+++ b/docs/topics/install/help/upgrade-no-oss-found.md
@@ -13,7 +13,7 @@ The upgrader has not been able to find an existing API Gateway installation.
   The `ambassador` installation should be deployed and with `OSS` flavor.
 
 * Check all the _conditions_ your `AmbassadorInstallation` has passed through with:
-  ```commandline
+  ```
   kubectl get ambassadorinstallations -n ambassador ambassador -o jsonpath='{.status.conditions[?(@.type=="Failed")].message}'
   AuthService(s) exist in the cluster, please remove to upgrade to AES
   ```

--- a/docs/topics/install/index.md
+++ b/docs/topics/install/index.md
@@ -25,7 +25,7 @@ import './index.less'
 1. (1a) [Download the `edgectl` installer](https://metriton.datawire.io/downloads/darwin/edgectl) 	
  or (1b) download it with a curl command:	
 
-    ```shell	
+    ```	
     sudo curl -fL https://metriton.datawire.io/downloads/darwin/edgectl -o /usr/local/bin/edgectl && sudo chmod a+x /usr/local/bin/edgectl	
     ```	
 
@@ -48,7 +48,7 @@ for a domain name, so you can get started right away.
  (1b) download it with a curl	
    command:	
 
-    ```shell	
+    ```	
     sudo curl -fL https://metriton.datawire.io/downloads/linux/edgectl -o /usr/local/bin/edgectl && sudo chmod a+x /usr/local/bin/edgectl	
     ```	
 2. Run the installer with `edgectl install`	

--- a/docs/topics/install/install-ambassador-oss.md
+++ b/docs/topics/install/install-ambassador-oss.md
@@ -28,19 +28,19 @@ The following steps deploy Ambassador in the default namespace.
 
 **Note:** If you're using Google Kubernetes Engine, you'll need to grant permissions to the account that will be setting up the Ambassador API Gateway. To do this, get your official GKE username, and then grant `cluster-admin` role privileges to that username:
 
-```shell
+```
 kubectl create clusterrolebinding my-cluster-admin-binding --clusterrole=cluster-admin --user=$(gcloud info --format="value(config.account)")
 ```
 
 Then, you can deploy the Ambassador API Gateway. Start by installing CRDs required by Ambassador:
 
-```shell
+```
 kubectl apply -f https://www.getambassador.io/yaml/ambassador/ambassador-crds.yaml
 ```
 
 Then, apply the RBAC configuration with:
 
-```shell
+```
 kubectl apply -f https://www.getambassador.io/yaml/ambassador/ambassador-rbac.yaml
 ```
 
@@ -72,7 +72,7 @@ spec:
 
 Deploy this service with `kubectl`:
 
-```shell
+```
 $ kubectl apply -f ambassador-service.yaml
 ```
 
@@ -137,7 +137,7 @@ With Helm 2, you must enable CRD creation with the `crd-install` hook that is
 included in the CRD manifests. When installing with Helm 3, the following
 message will be output to `stderr`:
 
-```bash
+```
 manifest_sorter.go:175: info: skipping unknown hook: "crd-install"
 ```
 

--- a/docs/topics/install/upgrade-to-edge-stack.md
+++ b/docs/topics/install/upgrade-to-edge-stack.md
@@ -17,7 +17,7 @@ First, install `edgectl` by following the instructions
 
 Then, use the following command to upgrade the Ambassador API Gateway installation to Ambassador Edge Stack:
 
-```commandline
+```
 edgectl upgrade
 ```
 

--- a/docs/topics/install/upgrading.md
+++ b/docs/topics/install/upgrading.md
@@ -8,7 +8,7 @@ The steps to upgrade depend on the method that was used to install Ambassador Ed
 * If you installed using the Operator, then you'll need to [use the Operator to perform the upgrade](../aes-operator/#updates-by-the-operator).
 To verify whether the Operator was used to install Ambassador Edge Stack, run the following command
 to see if it returns resources:
-```commandline
+```
 $ kubectl get deployment -n ambassador -l 'app.kubernetes.io/name=ambassador,app.kubernetes.io/managed-by in (amb-oper,amb-oper-manifest,amb-oper-helm,amb-oper-azure)' 
 NAME               READY   UP-TO-DATE   AVAILABLE   AGE
 ambassador         1/1     1            1           ...
@@ -17,7 +17,7 @@ ambassador         1/1     1            1           ...
 * If you installed using the Helm chart or `edgectl install`, then you should
 [upgrade with the help of Helm](../helm/#migrating-to-the-ambassador-edge-stack).
 To verify this, run the following command to see if it returns resources:
-```commandline
+```
 $ kubectl get deployment -n ambassador -l 'app.kubernetes.io/name=ambassador'
 NAME               READY   UP-TO-DATE   AVAILABLE   AGE
 ambassador         1/1     1            1           ...
@@ -25,7 +25,7 @@ ambassador         1/1     1            1           ...
 
 * Finally, if you installed using manifests, simply run the commands in the following section. To verify whether
 manifests were used to install Ambassador Edge Stack, run the following command to see if it returns resources:
-```commandline
+```
 $ kubectl get deployment -n ambassador -l 'product=aes'
 NAME               READY   UP-TO-DATE   AVAILABLE   AGE
 ambassador         1/1     1            1           ...
@@ -39,7 +39,7 @@ the instructions for [upgrading to Ambassador Edge Stack](../upgrade-to-edge-sta
 If you're using the YAML files supplied by Datawire, you'll be able to upgrade simply by repeating
 the following `kubectl apply` command:
 
-```shell
+```
 kubectl apply -f https://www.getambassador.io/yaml/aes-crds.yaml
 kubectl apply -f https://www.getambassador.io/yaml/aes.yaml
 ```

--- a/docs/topics/install/yaml-install.md
+++ b/docs/topics/install/yaml-install.md
@@ -23,7 +23,7 @@ The Ambassador Edge Stack is typically deployed to Kubernetes from the command l
 
 1. In your terminal, run the following command:
 
-    ```bash
+    ```
     kubectl apply -f https://www.getambassador.io/yaml/aes-crds.yaml && \
     kubectl wait --for condition=established --timeout=90s crd -lproduct=aes && \
     kubectl apply -f https://www.getambassador.io/yaml/aes.yaml && \
@@ -32,7 +32,7 @@ The Ambassador Edge Stack is typically deployed to Kubernetes from the command l
 
 2. Determine the IP address or hostname of your cluster by running the following command:
 
-    ```bash
+    ```
     kubectl get -n ambassador service ambassador -o "go-template={{range .status.loadBalancer.ingress}}{{or .ip .hostname}}{{end}}"
     ```
 
@@ -40,7 +40,7 @@ The Ambassador Edge Stack is typically deployed to Kubernetes from the command l
 
     Note: If you are a **Minikube user**, Minikube does not natively support load balancers. Instead, use `minikube service list`. You should see something similar to the following:
 
-    ```bash
+    ```
     (⎈ |minikube:ambassador)$ minikube service list
     |-------------|------------------|--------------------------------|
     |  NAMESPACE  |       NAME       |              URL               |

--- a/docs/topics/running/debugging.md
+++ b/docs/topics/running/debugging.md
@@ -14,7 +14,7 @@ First, check to see if the Edge Policy Console is reachable. If it is successful
 
     The terminal should print something similar to the following:
 
-    ```console
+    ```
     $ kubectl get pods -n ambassador
     NAME                         READY     STATUS    RESTARTS   AGE
     ambassador-85c4cf67b-4pfj2   1/1       Running   0          1m
@@ -26,7 +26,7 @@ First, check to see if the Edge Policy Console is reachable. If it is successful
 
     After a brief period, the terminal will print something similar to the following:
 
-    ```console
+    ```
     $ kubectl get -n ambassador deployments
     NAME         DESIRED   CURRENT   UP-TO-DATE   AVAILABLE   AGE
     ambassador   3         3         3            3           1m
@@ -76,7 +76,7 @@ You can turn on Debug mode in the [Edge Policy Console](../../using/edge-policy-
 
     The terminal will print something similar to the following:
 
-    ```console
+    ```
     $ kubectl get pods -n ambassador
     NAME                         READY     STATUS    RESTARTS   AGE
     ambassador-85c4cf67b-4pfj2   1/1       Running   0          3m
@@ -86,7 +86,7 @@ You can turn on Debug mode in the [Edge Policy Console](../../using/edge-policy-
 
 The terminal will print something similar to the following:
 
-    ```console
+    ```
     $ kubectl logs -n ambassador ambassador-85c4cf67b-4pfj2
     2018-10-10 12:26:50 kubewatch 0.40.0 INFO: generating config with gencount 1 (0 changes)
     /usr/lib/python3.6/site-packages/pkg_resources/__init__.py:1235: UserWarning: /ambassador is writable by group/others and vulnerable to attack when used with get_resource_filename. Consider a more secure location (set with .set_extraction_path or the PYTHON_EGG_CACHE environment variable).
@@ -127,7 +127,7 @@ You can examine the contents of the Ambassador Pod for issues, such as if volume
 
     The terminal will print something similar to the following:
 
-    ```console
+    ```
     /ambassador # cat envoy-2.json
 
     {

--- a/docs/topics/running/scaling.md
+++ b/docs/topics/running/scaling.md
@@ -38,7 +38,7 @@ indication that this has occurred is the pod transitioning momentarily into the 
 state. The only way to actually observe this is if you are lucky enough to be running the following
 command (or have similar monitoring configured) when Ambassador gets `OOMKilled`:
 
-```bash
+```
     kubectl get pods -n ambassador -w
 ```
 
@@ -130,7 +130,7 @@ Ambassador internally tracks a number of key performance indicators. You can ins
 debug endpoint at `localhost:8877/debug`. Note that the `AMBASSADOR_FAST_RECONFIGURE` flag needs to
 be set to `"true"` for this endpoint to be present:
 
-```bash
+```
 $ kubectl exec -n ambassador -it ${POD} curl localhost:8877/debug
 {
   "timers": {

--- a/docs/topics/running/statistics/envoy-statsd.md
+++ b/docs/topics/running/statistics/envoy-statsd.md
@@ -45,7 +45,7 @@ example Graphite setup:
 
 [Graphite]: http://graphite.readthedocs.org/
 
-```shell
+```
 kubectl apply -f statsd-sink/graphite/graphite-statsd-sink.yaml
 ```
 
@@ -54,7 +54,7 @@ Graphite and its related infrastructure.  Graphite's web interface is
 available at `http://statsd-sink/` from within the cluster.  Use port
 forwarding to access the interface from your local machine:
 
-```shell
+```
 SINKPOD=$(kubectl get pod -l service=statsd-sink -o jsonpath="{.items[0].metadata.name}")
 kubectl port-forward $SINKPOD 8080:80
 ```
@@ -184,7 +184,7 @@ Prometheus Operator with Ambassador is available
 Ensure `STATSD_ENABLED` is set to `"true"` and apply the YAML with
 `kubectl`:
 
-```shell
+```
 kubectl apply -f statsd-sink.yaml
 kubectl apply -f prometheus.yaml
 ```
@@ -193,7 +193,7 @@ Wait for a minute after the pods spin up and then access the
 Prometheus dashboard by port-forwarding the Prometheus pod and going
 to `http://localhost:9090/` on a web-browser.
 
-```shell
+```
 kubectl port-forward prometheus-prometheus-0 9090
 ```
 
@@ -241,7 +241,7 @@ apply that YAML:
 
 [`dd-statsd-sink.yaml`]: https://github.com/datawire/ambassador/blob/$branch$/deployments/statsd-sink/datadog/dd-statsd-sink.yaml
 
-```shell
+```
 kubectl apply -f statsd-sink/datadog/dd-statsd-sink.yaml
 ```
 

--- a/docs/topics/using/dev-portal.md
+++ b/docs/topics/using/dev-portal.md
@@ -248,7 +248,7 @@ where:
 
 Check out a local copy of your content repo and from within run the following docker image:
 
-```command-line
+```
 docker run -it --rm --volume $PWD:/content --publish 8877:8877 \
   docker.io/datawire/ambassador_pro:local-devportal-$aproVersion$
 ```

--- a/docs/topics/using/edgectl/edge-control-in-ci.md
+++ b/docs/topics/using/edgectl/edge-control-in-ci.md
@@ -17,17 +17,17 @@ The CI job that performs system tests of `MyService` would look roughly like thi
 2. Perform the usual CI steps (build the microservice and perform unit/local tests).
 3. Set up access to the shared cluster, so that e.g., `kubectl get pods` talks to the right place.
 4. Launch the Edge Control Daemon and connect to the cluster
-   ```shell script
+   ``` script
    sudo edgectl daemon
    edgectl connect --ci
    ```
 5. Add an intercept specific to this test session, e.g., using commit information to construct a unique name
-   ```shell script
+   ``` script
    CI_TAG="MyService-$(git describe --always --tags)"
    edgectl intercept add MyService -n "$CI_TAG" -m "x-ci-tag=$CI_TAG" -t localhost:9000
    ```
 6. Run system tests by sending requests to the application with the appropriate header set
-   ```shell script
+   ``` script
    curl -L -H "x-ci-tag:$CI_TAG" https://my-service-endpoint
    # (or)
    env "TEST_HEADER_VALUE=$CI_TAG" pytest ...
@@ -36,6 +36,6 @@ The CI job that performs system tests of `MyService` would look roughly like thi
    These requests will go to your shared cluster just as any request would, but calls to `MyService` from within the application will be routed back to the modified version running in CI because the intercepted header is set appropriately. All other calls to `MyService` will function as usual, going to the version of `MyService` running in the cluster.
 7. Delete the intercept when the job is done.
    This is not strictly necessary, as the Traffic Manager will clean up automatically after a while, but doing so here keeps diagnostic output (`edgectl intercept list`, etc.) clean.
-   ```shell script
+   ``` script
    edgectl intercept remove "$CI_TAG"
    ```

--- a/docs/topics/using/edgectl/edge-control.md
+++ b/docs/topics/using/edgectl/edge-control.md
@@ -14,7 +14,7 @@ Edge Control is available as a downloadable executable for both Mac OS X and Lin
 
 For MacOS:
 
-```bash
+```
 sudo curl -fL https://metriton.datawire.io/downloads/darwin/edgectl \
   -o /usr/local/bin/edgectl && \
 sudo chmod a+x /usr/local/bin/edgectl
@@ -22,7 +22,7 @@ sudo chmod a+x /usr/local/bin/edgectl
 
 For Linux:
 
-```bash
+```
 sudo curl -fL https://metriton.datawire.io/downloads/linux/edgectl \
   -o /usr/local/bin/edgectl && \
 sudo chmod a+x /usr/local/bin/edgectl
@@ -104,7 +104,7 @@ List the current active intercepts.
 
 Add an intercept. The basic format of this command is:
 
-```bash
+```
   edgectl intercept add DEPLOYMENT -n NAME -t [HOST:]PORT -m HEADER=REGEX ...
 ```
 

--- a/docs/topics/using/edgectl/service-mesh-sp.md
+++ b/docs/topics/using/edgectl/service-mesh-sp.md
@@ -18,7 +18,7 @@ Istio does some complicated networking to ensure that it can transparently inter
 
 The Traffic Manager and Ambassador Injector have this annotation by default. You must manually set this in the `teleproxy` pod that is created after running `edgectl connect` for the first time. You can do this with the following `kubectl` command:
 
-```sh
+```
 kubectl annotation po teleproxy sidecar.istio.io/inject='false'
 ```
 

--- a/docs/topics/using/edgectl/service-preview-install.md
+++ b/docs/topics/using/edgectl/service-preview-install.md
@@ -39,7 +39,7 @@ Services in your cluster opt-in to using Service Preview by injecting the Traffi
 
 Run the following command to let `edgectl` bootstrap your cluster with Ambassador, the Traffic Manager, and Ambassador Injector:
 
-```sh
+```
 $ edgectl install
 ```
 
@@ -49,7 +49,7 @@ Now that you installed the Traffic Manager, you can connect to your cluster usin
 
 First, start the daemon on your local machine to prime your local machine for connecting to your cluster
 
-```sh
+```
 $ sudo edgectl daemon
 
 Launching Edge Control Daemon v1.6.1 (api v1)
@@ -61,7 +61,7 @@ After starting the daemon, you are ready to connect to the Traffic Manager.
 
 Connect your local machine to the cluster with `edgectl`:
 
-```sh
+```
 $ edgectl connect
 
 Connecting to traffic manager in namespace ambassador...
@@ -72,7 +72,7 @@ Connected to context default (https://34.72.18.227)
 
 Verify that you are connected to your cluster:
 
-```sh
+```
 $ edgectl status
 
 Connected
@@ -88,7 +88,7 @@ The Traffic Agent sidecar is required in order to intercept requests to a servic
 
 At the moment, you can see that no sidecars are currently available with `edgectl`:
 
-```sh
+```
 $ edgectl intercept available
 
 No interceptable deployments
@@ -114,7 +114,7 @@ kubectl apply -f https://getambassador.io/yaml/traffic-agent-rbac.yaml
 
 Then, apply the `Hello` service manifest that is annotated to inject the Traffic Agent.
 
-```sh
+```
 kubectl apply -f - <<EOF
 ---
 apiVersion: v1
@@ -236,7 +236,7 @@ Now that you installed the Traffic Manager, you can connect to your cluster usin
 
 First, start the daemon on your local machine to prime your local machine for connecting to your cluster
 
-```sh
+```
 $ sudo edgectl daemon
 
 Launching Edge Control Daemon v1.6.1 (api v1)
@@ -248,7 +248,7 @@ After starting the daemon, you are ready to connect to the Traffic Manager.
 
 Connect your local machine to the cluster with `edgectl`:
 
-```sh
+```
 $ edgectl connect
 
 Connecting to traffic manager in namespace ambassador...
@@ -259,7 +259,7 @@ Connected to context default (https://34.72.18.227)
 
 Verify that you are connected to your cluster:
 
-```sh
+```
 $ edgectl status
 
 Connected
@@ -275,7 +275,7 @@ The Traffic Agent sidecar is required in order to intercept requests to a servic
 
 At the moment, you can see that no sidecars are currently available with `edgectl`:
 
-```sh
+```
 $ edgectl intercept available
 
 No interceptable deployments
@@ -300,7 +300,7 @@ kubectl apply -f https://getambassador.io/yaml/traffic-agent-rbac.yaml
 
 Then, apply the `Hello` service manifest that is annotated to inject the Traffic Agent.
 
-```sh
+```
 kubectl apply -f - <<EOF
 ---
 apiVersion: v1
@@ -407,13 +407,13 @@ servicePreview:
 
 Create the Ambassador namespace if it is not already created:
 
-```sh
+```
 $ kubectl create namespace ambassador
 ```
 
 Upgrade or install your release of the Ambassador Edge Stack with the Traffic Manager and Ambassador Injector
 
-```sh
+```
 $ helm upgrade --install ambassador -n ambassador datawire/ambassador -f values.yaml
 ```
 
@@ -424,7 +424,7 @@ Now that you installed the Traffic Manager, you can connect to your cluster usin
 
 First, start the daemon on your local machine to prime your local machine for connecting to your cluster
 
-```sh
+```
 $ sudo edgectl daemon
 
 Launching Edge Control Daemon v1.6.1 (api v1)
@@ -436,7 +436,7 @@ After starting the daemon, you are ready to connect to the Traffic Manager.
 
 Connect your local machine to the cluster with `edgectl`:
 
-```sh
+```
 $ edgectl connect
 
 Connecting to traffic manager in namespace ambassador...
@@ -447,7 +447,7 @@ Connected to context default (https://34.72.18.227)
 
 Verify that you are connected to your cluster:
 
-```sh
+```
 $ edgectl status
 
 Connected
@@ -463,7 +463,7 @@ The Traffic Agent sidecar is required in order to intercept requests to a servic
 
 At the moment, you can see that no sidecars are currently available with `edgectl`:
 
-```sh
+```
 $ edgectl intercept available
 
 No interceptable deployments
@@ -489,7 +489,7 @@ kubectl apply -f https://getambassador.io/yaml/traffic-agent-rbac.yaml
 
 Then, apply the `Hello` service manifest that is annotated to inject the Traffic Agent.
 
-```sh
+```
 kubectl apply -f - <<EOF
 ---
 apiVersion: v1

--- a/docs/topics/using/intro-mappings.md
+++ b/docs/topics/using/intro-mappings.md
@@ -66,7 +66,7 @@ More detail on each of the available annotations are discussed in subsequent sec
 
 To Ambassador, a `resource` is a group of one or more URLs that all share a common prefix in the URL path. For example:
 
-```shell
+```
 https://ambassador.example.com/resource1/foo
 https://ambassador.example.com/resource1/bar
 https://ambassador.example.com/resource1/baz/zing
@@ -75,7 +75,7 @@ https://ambassador.example.com/resource1/baz/zung
 
 all share the `/resource1/` path prefix, so it can be considered a single resource. On the other hand:
 
-```shell
+```
 https://ambassador.example.com/resource1/foo
 https://ambassador.example.com/resource2/bar
 https://ambassador.example.com/resource3/baz/zing
@@ -88,13 +88,13 @@ Note that the length of the prefix doesn't matter: if you want to use prefixes l
 
 Also note that Ambassador Edge Stack does not actually require the prefix to start and end with `/` -- however, in practice, it's a good idea. Specifying a prefix of
 
-```shell
+```
 /man
 ```
 
 would match all of the following:
 
-```shell
+```
 https://ambassador.example.com/man/foo
 https://ambassador.example.com/mankind
 https://ambassador.example.com/man-it-is/really-hot-today

--- a/docs/topics/using/rewrites.md
+++ b/docs/topics/using/rewrites.md
@@ -73,7 +73,7 @@ http://service1<span style="color:red">/backend-api/</span><span style="color:gr
 
 In some cases, a portion of URL needs to be extracted before making the upstream service URL. For example, suppose that when a request is made to `foo/12345/list`, the target URL must be rewritten as `/bar/12345`. We can do this as follows:
 
-```shell
+```
 prefix: /foo/
 regex_rewrite:
     pattern: '/foo/([0-9]*)/list'

--- a/docs/tutorials/projects.md
+++ b/docs/tutorials/projects.md
@@ -25,7 +25,7 @@ the project functionality is not enabled. If you have performed a
 manual install of Ambassador, you can include this registry and enable
 the project controller by running the following command:
 
-```bash
+```
 kubectl apply -f https://www.getambassador.io/yaml/projects.yaml
 ```
 


### PR DESCRIPTION
Removing the language type from code block markdown wherever the code is a terminal command(s) but something else is specified ("bash," "shell," etc.) since the new code block styling will put that into the title. We want them to consistently be "Terminal" (which it uses if nothing is specified).