### PR TITLE
Fixing a small typo in the example configuration

### DIFF
--- a/docs/howtos/advanced-rate-limiting.md
+++ b/docs/howtos/advanced-rate-limiting.md
@@ -144,7 +144,7 @@ Suppose, like [Example 2](#example-2-per-user-rate-limiting), you want to ensure
 ---
 apiVersion: getambassador.io/v2
 kind: Module
-matadata:
+metadata:
   name: ambassador
 spec:
   config:


### PR DESCRIPTION
A small typo in the example configuration on the Advanced Rate Limit doc page.