### PR TITLE
Update READMEs based on new docs location

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -361,20 +361,11 @@ and clear the cache.
 How do I make documentation-only changes?
 -----------------------------------------
 
-The Ambassador documentation lives in the `docs` directory. If you're working
-on documentation for an upcoming feature or fix, make your docs changes along
-with your code changes, and include them all in the same PR.
-
-If you want to make a change that **only** affects the live documentation for
-an already-released version of Ambassador, you'll need to make your changes in
-a branch from the `release` branch for that version, then PR back to the
-`release` branch. For example, if you find a typo while reading the documentation
-for Ambassador 1.4:
-
-- Check out `release/v1.4`
-- Make a branch from it.
-- Fix the typo.
-- Push your branch and PR it back to `release/v1.4`.
+The Ambassador documentation lives at https://github.com/datawire/ambassador-docs.
+If you're working on documentation for an upcoming feature or fix, make your
+changes in the `pre-release` folder in that repository. If you want to make a
+change that affects the live documentation for an already-released version of
+Ambassador, make your changes in the corresponding version folder.
 
 How do I get the source code for a release?
 -------------------------------------------
@@ -398,9 +389,10 @@ How do I make a contribution?
    - If you're using a branch name that starts with your username, `git rebase` is also OK and no one from Datawire will scream at you for force-pushing.
    - Please do **not** rebase any branch that does **not** start with your username.
 
-3. **Code changes must include relevant documentation updates.**
-   - Make changes in the `docs` directory as necessary, and commit them to your
-     branch so that they can be incorporated when the feature is merged into `master`.
+3. **Code changes must have associated documentation updates.**
+   - Make changes in https://github.com/datawire/ambassador-docs as necessary,
+   and include a reference to those changes the pull request for your code
+   changes.
 
 4. **Code changes must include passing tests.**
    - See `python/tests/README.md` for more here.
@@ -646,57 +638,6 @@ Developing Ambassador (Datawire-only advice)
 At the moment, these techniques will only work internally to Datawire. Mostly
 this is because they require credentials to access internal resources at the
 moment, though in several cases we're working to fix that.
-
-How do I test my documentation work?
-------------------------------------
-
-*This will currently only work within Datawire.*
-
-After you've made some documentation changes, run
-
-```
-bash ambassador/scripts/doc-setup
-```
-
-to do all the Javascript work needed to get a local documentation server
-running. You can point a web browser to `http://localhost:8000` to view docs
-with your changes.
-
-After running `ambassador/scripts/doc-setup`, if you need to make further changes, run
-
-```
-bash ambassador/scripts/doc-sync
-```
-
-to push your changes to the local webserver. They should appear immediately
-(you may have to reload the page in your browser).
-
-How do I share a preview of my documentation work with others?
---------------------------------------------------------------
-
-*This will currently only work within Datawire.*
-
-After running `ambassador/scripts/doc-setup`, run
-
-```
-bash ambassador/scripts/doc-publish
-```
-
-to push a preview to the `getambassador-preview` Netlify site.
-Find the Netlify preview URL in the output and hand it off to others.
-
-How do I update the getambassador-preview site with my documentation for others to use?
----------------------------------------------------------------------------------------
-
-*This will currently only work within Datawire.*
-
-After running `ambassador/scripts/doc-setup`, run
-
-```
-bash ambassador/scripts/doc-publish --prod
-```
-
-to update the live `getambassador-preview` Netlify site.
 
 How do I build ambassador on Windows using WSL?
 -----------------------------------------------

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -36,26 +36,19 @@ and the CI will be green.
 6. While the blog post is being written, switch to a new branch for the release.
    - `git checkout -b rel/0.84.0` (or whatever version). **Do not name this branch "release/...".**
 
-7. Next, sync up docs.
-   - `make pull-docs` to pull updates from the docs repo
-   - Handle conflicts as needed.
-   - Commit any conflict-resolution changes to your release branch.
-
-8. After the docs are synced, use `make release-prep` to update `CHANGELOG.md` and `docs/versions.yml`.
+7. Use `make release-prep` to update `CHANGELOG.md`.
    - This will prompt you for the release notes, so retrieve them from your previous file (maybe `~/temp-list.txt`).
      The release notes are pasted in at a prompt (during the make), not read from a file, so you will need them
      accessible to select-and-copy (suggestion: open your previous file in another window).
    - It will _commit_, but not _push_, the updated files. Make sure the diffs it shows you look correct!
-      - It is *critical* to update `docs/versions.yml` so that everyone gets the new version.
    - Do a manual `git push` on your branch.
 
-9. Now for the time-critical bit.
+8. Now for the time-critical bit.
    - Tag your branch with a GA tag like `v0.77.0` and let CI do its thing. **This version tag must start with a 'v'.**
    - CI will retag the latest RC image as the GA image.
 
-10. _After the CI run finishes_:
+9. _After the CI run finishes_:
    - Submit, and land, a PR for your branch.
-   - `make push-docs` from `master` _after the retag_ to push new docs out to the website.
    - Go to https://github.com/datawire/ambassador/releases and create a new release.
       - `make release-prep` should've output the text to paste into the release description.
 
@@ -63,7 +56,7 @@ and the CI will be green.
 
    **Note also** that even though the version _tag_ starts with a 'v', the version _number_ displayed by the diag UI will _not_ start with a 'v'.**
 
-11. Submit a PR into the `helm/charts` repo to update things in `stable/ambassador`:
+10. Submit a PR into the `helm/charts` repo to update things in `stable/ambassador`:
    - in `Chart.yaml`, update `appVersion` with the new Ambassador version, and bump `version`.
    - in `README.md`, update the default value of `image.tag`.
    - in `values.yaml`, update `tag`.
@@ -80,7 +73,7 @@ and the CI will be green.
       - open a PR
     - Once your PR is merged, _delete the feature branch without merging it back to origin/master_.
 
-12. Update the getambassador.io website by submitting a PR to the `datawire/getambassador.io` repo.
+11. Update the getambassador.io website by submitting a PR to the `datawire/getambassador.io` repo.
    - `src/releaseInfo.js` is the only file you should need to touch:
       - `ReleaseType` comes from Marketing, usually "Feature Release", "Maintenance Release", or "Security Update"
       - `CurrentVersion` is e.g. "0.78.0" -- no leading 'v' here
@@ -88,107 +81,5 @@ and the CI will be green.
    - Make your edits, submit a PR, get it merged. Done.
       - If you want to test before submitting, use `yarn install && yarn start` and point a web browser to `localhost:8000`
 
-   Submit a PR to the Ambassador website repository to update the version on the homepage.
+   Submit a PR to the Ambassador website repository to update the version on the homepage. Details can be found there on specifically how to do that.
 
----
-
-### Host a release branch on getambassador.io
-
-getambassador.io can host multiple versions of ambassador documentation. As a matter of policy, only the documentation for major and minor releases is hosted, documentation changes for patch releases are expected to be folded in the associated minor release.
-
-#### Introduction
-
-Whenever a new release is cut in ambassador, a release branch is created for that release. Generally these release branches are named as `release/v<release version>`.
-A major and a minor release branch is expected to be long lived, protected and it contains the documentation for that particular branch under `/docs/` directory.
-
-To host these different versions of documentation on the website, the following machinery is set up.
-
-In getambassador.io.git repository:
-
-- The release branches are exposed via git submodules under /submodules/ directory.
-```
-submodules/
-├── 1.3 <--- links to `release/v1.3` branch
-├── 1.4 <--- links to `release/v1.4` branch
-├── 1.5 <--- links to `release/v1.5` branch
-├── latest <--- links to `release/v1.5` branch
-└── pre-release <--- links to `master` branch
-```
-- All markdown files under `/docs-structure/` directory make their way to the getambassador.io website with the _exact_ path as they are in.
-```
-docs-structure/
-├── docs <--- This is where we want to expose the /docs/ directory from our release branches
-├── edgestack.me
-├── kat
-├── libraries.md
-├── README.md
-└── yaml -> ../submodules/latest/docs/yaml/
-```
-- Now that we have all release branches under `/submodules/`, we further link their `/docs/` directories under `/docs-structure/docs/`.
-```
-docs-structure/docs/
-├── 1.3 -> ../../submodules/1.3/docs
-├── 1.4 -> ../../submodules/1.4/docs
-├── 1.5 -> ../../submodules/1.5/docs
-├── latest -> ../../submodules/1.5/docs
-└── pre-release -> ../../submodules/pre-release/docs
-```
-
-This is how our docs are laid out.
-
-In ambassador.git, the CI is configured to update the submodules in getambassador.io.git on every documentation update to the release branches (and the master branch), which deploys to the website.
-
-#### How to host a new release branch.
-
-After a new major/minor release is cut, this is how to host it on the website.
-For example, let's suppose version 1.6 of ambassador needs to be hosted.
-
-##### In ambassador.git,
-
-- In the branch `release/v1.6`,
-  - In `docs/js/doc-links.yml`, make sure the links are pointed at `/docs/latest/...`
-  - In `docs/js/doc-page.js`, update the footer branch.
-  ```
-  <DocFooter page={page} branch="release/v1.6" />
-  ```
-
-##### In getambassador.io.git,
-- Add the submodule pointing to `release/v1.6` branch to the `submodules/1.6/` directory
-```
-git submodule add --name ambassador-1.6 --branch release/v1.6 https://github.com/datawire/ambassador.git submodules/1.6/
-```
-- Update `ambassador-latest` submodule to point to `release/v1.6` branch.
-```
-$ cat .gitmodules
-[submodule "ambassador-latest"]
-        path = submodules/latest
-        url = https://github.com/datawire/ambassador.git
-        branch = release/v1.6
-...
-...
-...
-```
-- Now link only the docs in this branch under `/docs-structure/docs/` directory.
-```
-cd docs-structure/docs/
-ln -s ../../submodules/1.6/docs 1.6
-```
-- Add 1.6 dropdown link in `src/components/Header/Header.js` file.
-```js
-              <li>
-                <div className={classnames(styles.Dropdown, !isDocLink((location || {}).pathname) && styles.hidden)}>
-                  <button className={classnames(styles.DropdownButton, styles.DocsDropdownColor)}>{ docsVersion((location || {}).pathname) } ▾</button>
-                  <div className={styles.DropdownContent}>
-                    <Link to="/docs/latest/">Pre-release</Link>
-                    <Link to="/docs/latest/">Latest</Link>
-                    <Link to="/docs/1.6/">1.6</Link>
-                    <Link to="/docs/1.5/">1.5</Link>
-                    <Link to="/docs/1.4/">1.4</Link>
-                    <Link to="/docs/1.3/">1.3</Link>
-                  </div>
-                </div>
-              </li>
-```
-
-##### Note:
-Now the website must display v1.6 docs under getambassador.io/docs/1.6/ and getambassador.io/docs/latest/. Make sure everything looks right.


### PR DESCRIPTION
This pull request updates README.md and DEVELOPING.md to reflect our documentation sources having been moved to ambassador-docs.git.