### PR TITLE
Disable prefix_regex for knative default mapping configuration

### DIFF
--- a/python/ambassador/fetch/knative.py
+++ b/python/ambassador/fetch/knative.py
@@ -77,7 +77,7 @@ class KnativeIngressProcessor (ManagedKubernetesProcessor):
                     'add_request_headers': headers,
                     'weight': split.get('percent', 100),
                     'prefix': path.get('path', '/'),
-                    'prefix_regex': True,
+                    'prefix_regex': False,
                     'timeout_ms': int(durationpy.from_str(path.get('timeout', '15s')).total_seconds() * 1000),
                 })
 


### PR DESCRIPTION
## Description
knative latest version does not provide a way to specify `path` value on [knative service](https://knative.dev/docs/reference/api/serving-api/#serving.knative.dev/v1.Service). Then, automated knative ingress render does not have any path reference and having `prefix_regex: true` limits to only one endpoint route: `/`.
Disabling `prefix_regex` will remove that `/` restriction.

## Related Issues
- #3224

## Testing
Created a custom aes docker image with `prefix_regex: False` and I was able to reach internal path services

## Tasks That Must Be Done
- [ ] Did you update CHANGELOG.md?
  + [ ] Is this a new feature?
  + [ ] Are there any non-backward-compatible changes?
  + [ ] Did the envoy version change?
  + [ ] Are there any deprecations?
  + [ ] Will the changes impact how ambassador performs at scale?
    - [ ] Might an existing production deployment need to change:
      + memory limits?
      + cpu limits?
      + replica counts?
    - [ ] Does the change impact data-plane latency/scalability?
- [ ] Is your change adequately tested?
  + [X] Was their sufficient test coverage for the area changed?
  + [ ] Do the existing tests capture the requirements for the area changed?
  + [ ] Is the bulk of your code covered by unit tests?
  + [ ] Does at least one end-to-end test cover the integration points your change depends on?
- [ ] Did you update documentation?
- [ ] Were there any special dev tricks you had to use to work on this code efficiently?
  + [ ] Did you add them to DEVELOPING.md?
- [ ] Is this a build change?
  + [ ] If so, did you test on both Mac and Linux?

## Other
* If this is a documentation change for a particular release, please open the pull request against the release branch.
