### PR TITLE
Adding Host warning message where host is used in examples

### DIFF
--- a/docs/howtos/grpc.md
+++ b/docs/howtos/grpc.md
@@ -155,6 +155,21 @@ spec:
 
 The Host is declared here because we are using gRPC without TLS.  Since Ambassador terminates TLS by default, in the Host we add a `requestPolicy` which allows insecure connections. After adding the Ambassador Edge Stack mapping to the service, the rest of the Kubernetes deployment YAML file is pretty straightforward. We need to identify the container image to use, expose the `containerPort` to listen on the same port the Docker container is listening on, and map the service port (80) to the container port (50051).
 
+> **WARNING - Host Configuration:** The `requestPolicy` property of the `Host` `CRD` is applied globally within an Ambassador instance, even if it is applied to only one `Host` when multiple `Host`s are configured. Different `requestPolicy` behaviors cannot be applied to different `Host`s. It is recommended to apply an identical `requestPolicy` to all `Host`s instead of assuming the behavior, to create a more human readable config. 
+> 
+> If you intend to use more than one type of `requestPolicy`, you will need a separate Ambassador instance for each separate type.
+> 
+> If multiple `Host`s are applied, the `requestPolicy` from the `Host` with the first alphabetical `metadata.name` is always the one that is applied. Order does not matter.
+> If a `requestPolicy` is not defined for a `Host`, it's assumed to be `Redirect`, and so even if a host named `a` does not specify it, the default `requestPolicy` of `Redirect` will be applied to all `Host`s in that Ambassador instance.
+>
+> The `insecure-action` can be one of:
+>
+> * `Redirect` (the default): redirect to HTTPS
+> * `Route`: go ahead and route as normal; this will allow handling HTTP requests normally
+> * `Reject`: reject the request with a 400 response
+>
+> For more information, please refer to the [`Host` documentation](../topics/running/host-crd#secure-and-insecure-requests).
+
 Once you have the YAML file and the correct Docker registry, deploy it to your cluster with `kubectl`.
 
 ```

--- a/docs/howtos/grpc.md
+++ b/docs/howtos/grpc.md
@@ -155,13 +155,11 @@ spec:
 
 The Host is declared here because we are using gRPC without TLS.  Since Ambassador terminates TLS by default, in the Host we add a `requestPolicy` which allows insecure connections. After adding the Ambassador Edge Stack mapping to the service, the rest of the Kubernetes deployment YAML file is pretty straightforward. We need to identify the container image to use, expose the `containerPort` to listen on the same port the Docker container is listening on, and map the service port (80) to the container port (50051).
 
-> **WARNING - Host Configuration:** The `requestPolicy` property of the `Host` `CRD` is applied globally within an Ambassador instance, even if it is applied to only one `Host` when multiple `Host`s are configured. Different `requestPolicy` behaviors cannot be applied to different `Host`s. It is recommended to apply an identical `requestPolicy` to all `Host`s instead of assuming the behavior, to create a more human readable config. 
+> **WARNING - Host Configuration:** The `requestPolicy` property of the `Host` `CRD` is applied globally within an Edge Stack instance, even if it is applied to only one `Host` when multiple `Host`s are configured. Different `requestPolicy` behaviors cannot be applied to different `Host`s. It is recommended to apply an identical `requestPolicy` to all `Host`s instead of assuming the behavior, to create a more human readable config. 
 > 
-> If you intend to use more than one type of `requestPolicy`, you will need a separate Ambassador instance for each separate type.
+> If a requestPolicy is not defined for a `Host`, it's assumed to be `Redirect`, so even if a `Host` does not specify it, the default `requestPolicy` of `Redirect` will be applied to all `Host`s in that Edge Stack instance. If the behavior expected out of Edge Stack is anything other than `Redirect`, it must be explicitly enumerated in all Host resources. 
 > 
-> If multiple `Host`s are applied, the `requestPolicy` from the `Host` with the first alphabetical `metadata.name` is always the one that is applied. Order does not matter.
-> If a `requestPolicy` is not defined for a `Host`, it's assumed to be `Redirect`, and so even if a host named `a` does not specify it, the default `requestPolicy` of `Redirect` will be applied to all `Host`s in that Ambassador instance.
->
+> Unexpected behavior can occur when multiple `Host` resources are not using the same value for `requestPolicy`. 
 > The `insecure-action` can be one of:
 >
 > * `Redirect` (the default): redirect to HTTPS

--- a/docs/topics/running/host-crd.md
+++ b/docs/topics/running/host-crd.md
@@ -126,7 +126,12 @@ requestPolicy:
     additionalPort: insecure-port
 ```
 
-> **WARNING:** `requestPolicy` is applied globally, even if it is applied to only one `Host` when multiple `Host`s are configured. Different `requestPolicy` behaviors cannot be applied to different `Host`s. It is recommended to apply an identical `requestPolicy` to all `Host`s instead of assuming the behavior, to create a more human readable config.
+> **WARNING - Host Configuration:** The `requestPolicy` property of the `Host` `CRD` is applied globally within an Ambassador instance, even if it is applied to only one `Host` when multiple `Host`s are configured. Different `requestPolicy` behaviors cannot be applied to different `Host`s. It is recommended to apply an identical `requestPolicy` to all `Host`s instead of assuming the behavior, to create a more human readable config. 
+> 
+> If you intend to use more than one type of `requestPolicy`, you will need a separate Ambassador instance for each separate type.
+> 
+> If multiple `Host`s are applied, the `requestPolicy` from the `Host` with the first alphabetical `metadata.name` is always the one that is applied. Order does not matter.
+> If a `requestPolicy` is not defined for a `Host`, it's assumed to be `Redirect`, and so even if a host named `a` does not specify it, the default `requestPolicy` of `Redirect` will be applied to all `Host`s in that Ambassador instance.
 
 The `insecure-action` can be one of:
 
@@ -172,17 +177,27 @@ It's important to realize that Envoy manages the `X-Forwarded-Proto` header such
 In the definitions below, "L4 LB" refers to a layer 4 load balancer, while "L7
 LB" refers to a layer 7 load balancer.
 
-* [HTTPS-only, TLS terminated at Ambassador, not redirecting cleartext](#https-only-tls-terminated-at-ambassador-not-redirecting-cleartext)
-* [HTTPS-only, TLS terminated at Ambassador, redirecting cleartext from port 8080](#https-only-tls-terminated-at-ambassador-redirecting-cleartext-from-port-8080)
-* [HTTP-only](#http-only)
-* [L4 LB, HTTPS-only, TLS terminated at Ambassador, not redirecting cleartext](#l4-lb-https-only-tls-terminated-at-ambassador-not-redirecting-cleartext)
-* [L4 LB, HTTPS-only, TLS terminated at Ambassador, redirecting cleartext from port 8080](#l4-lb-https-only-tls-terminated-at-ambassador-redirecting-cleartext-from-port-8080)
-* [L4 LB, HTTP-only](#l4-lb-http-only)
-* [L4 LB, TLS terminated at LB, LB speaks cleartext to Ambassador](#l4-lb-tls-terminated-at-lb-lb-speaks-cleartext-to-ambassador)
-* [L4 LB, TLS terminated at LB, LB speaks TLS to Ambassador](#l4-lb-tls-terminated-at-lb-lb-speaks-tls-to-ambassador)
-* [L4 split LB, TLS terminated at Ambassador](#l4-split-lb-tls-terminated-at-ambassador)
-* [L4 split LB, TLS terminated at LB](#l4-split-lb-tls-terminated-at-lb)
-* [L7 LB](#l7-lb)
+- [The `Host` CRD, ACME Support, and External Load Balancer Configuration](#the-host-crd-acme-support-and-external-load-balancer-configuration)
+  - [ACME and TLS Settings](#acme-and-tls-settings)
+    - [ACME Support](#acme-support)
+    - [TLS Configuration](#tls-configuration)
+  - [Secure and Insecure Requests](#secure-and-insecure-requests)
+  - [Load Balancers, the `Host` Resource, and `X-Forwarded-Proto`](#load-balancers-the-host-resource-and-x-forwarded-proto)
+  - [Use Cases and Examples](#use-cases-and-examples)
+    - [HTTPS-only, TLS terminated at Ambassador, not redirecting cleartext](#https-only-tls-terminated-at-ambassador-not-redirecting-cleartext)
+    - [HTTPS-only, TLS terminated at Ambassador, redirecting cleartext from port 8080](#https-only-tls-terminated-at-ambassador-redirecting-cleartext-from-port-8080)
+    - [HTTP-only](#http-only)
+    - [L4 LB, HTTPS-only, TLS terminated at Ambassador, not redirecting cleartext](#l4-lb-https-only-tls-terminated-at-ambassador-not-redirecting-cleartext)
+    - [L4 LB, HTTPS-only, TLS terminated at Ambassador, redirecting cleartext from port 8080](#l4-lb-https-only-tls-terminated-at-ambassador-redirecting-cleartext-from-port-8080)
+    - [L4 LB, HTTP-only](#l4-lb-http-only)
+    - [L4 LB, TLS terminated at LB, LB speaks cleartext to Ambassador](#l4-lb-tls-terminated-at-lb-lb-speaks-cleartext-to-ambassador)
+    - [L4 LB, TLS terminated at LB, LB speaks TLS to Ambassador](#l4-lb-tls-terminated-at-lb-lb-speaks-tls-to-ambassador)
+    - [L4 split LB, TLS terminated at Ambassador](#l4-split-lb-tls-terminated-at-ambassador)
+    - [L4 split LB, TLS terminated at LB](#l4-split-lb-tls-terminated-at-lb)
+    - [L7 LB](#l7-lb)
+  - [Service Preview URLs](#service-preview-urls)
+  - [`Host` Specification](#host-specification)
+    - [CRD Specification](#crd-specification)
 
 ### HTTPS-only, TLS terminated at Ambassador, not redirecting cleartext
 

--- a/docs/topics/running/host-crd.md
+++ b/docs/topics/running/host-crd.md
@@ -126,12 +126,11 @@ requestPolicy:
     additionalPort: insecure-port
 ```
 
-> **WARNING - Host Configuration:** The `requestPolicy` property of the `Host` `CRD` is applied globally within an Ambassador instance, even if it is applied to only one `Host` when multiple `Host`s are configured. Different `requestPolicy` behaviors cannot be applied to different `Host`s. It is recommended to apply an identical `requestPolicy` to all `Host`s instead of assuming the behavior, to create a more human readable config. 
+> **WARNING - Host Configuration:** The `requestPolicy` property of the `Host` `CRD` is applied globally within an Edge Stack instance, even if it is applied to only one `Host` when multiple `Host`s are configured. Different `requestPolicy` behaviors cannot be applied to different `Host`s. It is recommended to apply an identical `requestPolicy` to all `Host`s instead of assuming the behavior, to create a more human readable config. 
 > 
-> If you intend to use more than one type of `requestPolicy`, you will need a separate Ambassador instance for each separate type.
+> If a requestPolicy is not defined for a `Host`, it's assumed to be `Redirect`, so even if a `Host` does not specify it, the default `requestPolicy` of `Redirect` will be applied to all `Host`s in that Edge Stack instance. If the behavior expected out of Edge Stack is anything other than `Redirect`, it must be explicitly enumerated in all Host resources. 
 > 
-> If multiple `Host`s are applied, the `requestPolicy` from the `Host` with the first alphabetical `metadata.name` is always the one that is applied. Order does not matter.
-> If a `requestPolicy` is not defined for a `Host`, it's assumed to be `Redirect`, and so even if a host named `a` does not specify it, the default `requestPolicy` of `Redirect` will be applied to all `Host`s in that Ambassador instance.
+> Unexpected behavior can occur when multiple `Host` resources are not using the same value for `requestPolicy`. 
 
 The `insecure-action` can be one of:
 

--- a/docs/topics/running/tls/cleartext-redirection.md
+++ b/docs/topics/running/tls/cleartext-redirection.md
@@ -38,12 +38,11 @@ spec:
       action: Route
 ```
 
-> **WARNING - Host Configuration:** The `requestPolicy` property of the `Host` `CRD` is applied globally within an Ambassador instance, even if it is applied to only one `Host` when multiple `Host`s are configured. Different `requestPolicy` behaviors cannot be applied to different `Host`s. It is recommended to apply an identical `requestPolicy` to all `Host`s instead of assuming the behavior, to create a more human readable config. 
+> **WARNING - Host Configuration:** The `requestPolicy` property of the `Host` `CRD` is applied globally within an Edge Stack instance, even if it is applied to only one `Host` when multiple `Host`s are configured. Different `requestPolicy` behaviors cannot be applied to different `Host`s. It is recommended to apply an identical `requestPolicy` to all `Host`s instead of assuming the behavior, to create a more human readable config. 
 > 
-> If you intend to use more than one type of `requestPolicy`, you will need a separate Ambassador instance for each separate type.
+> If a requestPolicy is not defined for a `Host`, it's assumed to be `Redirect`, so even if a `Host` does not specify it, the default `requestPolicy` of `Redirect` will be applied to all `Host`s in that Edge Stack instance. If the behavior expected out of Edge Stack is anything other than `Redirect`, it must be explicitly enumerated in all Host resources. 
 > 
-> If multiple `Host`s are applied, the `requestPolicy` from the `Host` with the first alphabetical `metadata.name` is always the one that is applied. Order does not matter.
-> If a `requestPolicy` is not defined for a `Host`, it's assumed to be `Redirect`, and so even if a host named `a` does not specify it, the default `requestPolicy` of `Redirect` will be applied to all `Host`s in that Ambassador instance.
+> Unexpected behavior can occur when multiple `Host` resources are not using the same value for `requestPolicy`. 
 > 
 > For more information, please refer to the [`Host` documentation](../host-crd#secure-and-insecure-requests).
 

--- a/docs/topics/running/tls/cleartext-redirection.md
+++ b/docs/topics/running/tls/cleartext-redirection.md
@@ -38,6 +38,22 @@ spec:
       action: Route
 ```
 
+> **WARNING - Host Configuration:** The `requestPolicy` property of the `Host` `CRD` is applied globally within an Ambassador instance, even if it is applied to only one `Host` when multiple `Host`s are configured. Different `requestPolicy` behaviors cannot be applied to different `Host`s. It is recommended to apply an identical `requestPolicy` to all `Host`s instead of assuming the behavior, to create a more human readable config. 
+> 
+> If you intend to use more than one type of `requestPolicy`, you will need a separate Ambassador instance for each separate type.
+> 
+> If multiple `Host`s are applied, the `requestPolicy` from the `Host` with the first alphabetical `metadata.name` is always the one that is applied. Order does not matter.
+> If a `requestPolicy` is not defined for a `Host`, it's assumed to be `Redirect`, and so even if a host named `a` does not specify it, the default `requestPolicy` of `Redirect` will be applied to all `Host`s in that Ambassador instance.
+> 
+> For more information, please refer to the [`Host` documentation](../host-crd#secure-and-insecure-requests).
+
+The `insecure-action` can be one of:
+
+* `Redirect` (the default): redirect to HTTPS
+* `Route`: go ahead and route as normal; this will allow handling HTTP requests normally
+* `Reject`: reject the request with a 400 response
+
+
 ### HTTPS and Cleartext
 
 Ambassador can also support serving both HTTPS and cleartext traffic from a
@@ -67,6 +83,14 @@ spec:
 With the above configuration, we are tell Ambassador to terminate TLS with the
 certificate in the `example-cert` `Secret` and route cleartext traffic that
 comes in over port `8080`.
+
+> The `additionalPort` element tells Ambassador to listen on the specified `insecure-port` and treat any request arriving on that port as insecure. **By default, `additionalPort` will be set to 8080 for any `Host` using TLS.** To disable this redirection entirely, set `additionalPort` explicitly to `-1`:
+
+```yaml
+requestPolicy:
+  insecure:
+    additionalPort: -1   # This is how to disable the default redirection from 8080.
+```
 
 ## HTTP->HTTPS Redirection
 

--- a/docs/topics/running/tls/index.md
+++ b/docs/topics/running/tls/index.md
@@ -16,6 +16,23 @@ in Ambassador and defines how TLS is managed on that domain. In the Ambassador
 Edge Stack, the simplest configuration of a `Host` will enable TLS with a 
 self-signed certificate and redirect cleartext traffic to HTTPS. 
 
+> **WARNING - Host Configuration:** The `requestPolicy` property of the `Host` `CRD` is applied globally within an Ambassador instance, even if it is applied to only one `Host` when multiple `Host`s are configured. Different `requestPolicy` behaviors cannot be applied to different `Host`s. It is recommended to apply an identical `requestPolicy` to all `Host`s instead of assuming the behavior, to create a more human readable config. 
+> 
+> If you intend to use more than one type of `requestPolicy`, you will need a separate Ambassador instance for each separate type.
+> 
+> If multiple `Host`s are applied, the `requestPolicy` from the `Host` with the first alphabetical `metadata.name` is always the one that is applied. Order does not matter.
+> If a `requestPolicy` is not defined for a `Host`, it's assumed to be `Redirect`, and so even if a host named `a` does not specify it, the default `requestPolicy` of `Redirect` will be applied to all `Host`s in that Ambassador instance.
+>
+> The `insecure-action` can be one of:
+>
+> * `Redirect` (the default): redirect to HTTPS
+> * `Route`: go ahead and route as normal; this will allow handling HTTP requests normally
+> * `Reject`: reject the request with a 400 response
+>
+> The example below does not define a `requestPolicy`; however, this is something to keep in mind as you begin using the `Host` `CRD` in Ambassador.
+>
+> For more information, please refer to the [`Host` documentation](../host-crd#secure-and-insecure-requests).
+
 ### Automatic TLS with ACME
 
 With the Ambassador Edge Stack, the `Host` can be configured to completely 
@@ -74,9 +91,19 @@ The `Host` will configure basic TLS termination settings in Ambassador. If you
 need more advanced TLS options on a domain, such as setting the minimum TLS 
 version, you can do it in one of the following ways.
 
-1. [Create a `TLSContext` with the name `{{HOST}}-context`](#create-a-tlscontext-with-the-name-host-context)
-2. [Link a `TLSContext` to the Host](#link-a-tlscontext-to-the-host)
-3. [Specify TLS configuration in the Host](#specify-tls-configuration-in-the-host)
+- [Transport Layer Security (TLS)](#transport-layer-security-tls)
+  - [`Host`](#host)
+    - [Automatic TLS with ACME](#automatic-tls-with-acme)
+    - [Bring your own certificate](#bring-your-own-certificate)
+    - [`Host` and `TLSContext`](#host-and-tlscontext)
+      - [Create a `TLSContext` with the name `{{HOST}}-context`](#create-a-tlscontext-with-the-name-host-context)
+      - [Link a `TLSContext` to the Host](#link-a-tlscontext-to-the-host)
+      - [Specify TLS configuration in the Host](#specify-tls-configuration-in-the-host)
+  - [TLSContext](#tlscontext)
+    - [`alpn_protocols`](#alpn_protocols)
+      - [HTTP/2 Support](#http2-support)
+    - [TLS Parameters](#tls-parameters)
+  - [TLS `Module` (*Deprecated*)](#tls-module-deprecated)
 
 #### Create a `TLSContext` with the name `{{HOST}}-context`
 

--- a/docs/topics/running/tls/index.md
+++ b/docs/topics/running/tls/index.md
@@ -16,13 +16,12 @@ in Ambassador and defines how TLS is managed on that domain. In the Ambassador
 Edge Stack, the simplest configuration of a `Host` will enable TLS with a 
 self-signed certificate and redirect cleartext traffic to HTTPS. 
 
-> **WARNING - Host Configuration:** The `requestPolicy` property of the `Host` `CRD` is applied globally within an Ambassador instance, even if it is applied to only one `Host` when multiple `Host`s are configured. Different `requestPolicy` behaviors cannot be applied to different `Host`s. It is recommended to apply an identical `requestPolicy` to all `Host`s instead of assuming the behavior, to create a more human readable config. 
+> **WARNING - Host Configuration:** The `requestPolicy` property of the `Host` `CRD` is applied globally within an Edge Stack instance, even if it is applied to only one `Host` when multiple `Host`s are configured. Different `requestPolicy` behaviors cannot be applied to different `Host`s. It is recommended to apply an identical `requestPolicy` to all `Host`s instead of assuming the behavior, to create a more human readable config. 
 > 
-> If you intend to use more than one type of `requestPolicy`, you will need a separate Ambassador instance for each separate type.
+> If a requestPolicy is not defined for a `Host`, it's assumed to be `Redirect`, so even if a `Host` does not specify it, the default `requestPolicy` of `Redirect` will be applied to all `Host`s in that Edge Stack instance. If the behavior expected out of Edge Stack is anything other than `Redirect`, it must be explicitly enumerated in all Host resources. 
 > 
-> If multiple `Host`s are applied, the `requestPolicy` from the `Host` with the first alphabetical `metadata.name` is always the one that is applied. Order does not matter.
-> If a `requestPolicy` is not defined for a `Host`, it's assumed to be `Redirect`, and so even if a host named `a` does not specify it, the default `requestPolicy` of `Redirect` will be applied to all `Host`s in that Ambassador instance.
->
+> Unexpected behavior can occur when multiple `Host` resources are not using the same value for `requestPolicy`. 
+> 
 > The `insecure-action` can be one of:
 >
 > * `Redirect` (the default): redirect to HTTPS


### PR DESCRIPTION
Adding the warning about Host behavior wherever host is used, and adding further clarification about what changes are made to the cluster.

I encountered a user that was using `Host.requestPolicy` which modified the `requestPolicy` for the entire cluster for a user. They did not understand that this change was being applied outside of the `Host` in which they applied the configuration.
The source of the error with `requestPolicy` behavior was not immediately apparent until support asked the user if they had
applied other hosts with a different `requestPolicy`.

The docs state in the warning from this PR that only one `requestPolicy` can be applied to an Ambassador instance, and that all `Host`s should share the same `requestPolicy` configuration.

This is expected behavior; however, we felt that it was a difficult issue for a user to figure out on their own without the assistance of support.  The purpose of this PR is to add clarity to the warning statement, describe in detail what changes are being made to the user's configuration, and copy the warning to other pages that make use of the `Host` `CRD` so that users can be aware of changes that they are making to the configuration of their cluster.

There [is an issue ](https://github.com/datawire/apro/issues/2328) that further addresses the behavior described above.
