### PR TITLE
Convert Knative Ingress paths from prefix match to path match

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,7 +67,11 @@ Please see the [Envoy documentation](https://www.envoyproxy.io/docs/envoy/latest
 
 ## Next Release
 
-(no changes yet)
+### Ambasssador API Gateway + Ambassador Edge Stack
+
+- Bugfix: Make Knative paths match on prefix instead of the entire path to better align to the Knative specification ([#3224]).
+
+[#3224]: https://github.com/datawire/ambassador/issues/3224
 
 ## [1.12.0] March 08, 2021
 [1.12.0]: https://github.com/datawire/ambassador/compare/v1.11.2...v1.12.0

--- a/python/ambassador/fetch/knative.py
+++ b/python/ambassador/fetch/knative.py
@@ -77,7 +77,6 @@ class KnativeIngressProcessor (ManagedKubernetesProcessor):
                     'add_request_headers': headers,
                     'weight': split.get('percent', 100),
                     'prefix': path.get('path', '/'),
-                    'prefix_regex': True,
                     'timeout_ms': int(durationpy.from_str(path.get('timeout', '15s')).total_seconds() * 1000),
                 })
 


### PR DESCRIPTION
## Description
This change makes the paths specified in each Knative Ingress rule prefix-matching. The previous behavior required the path pattern to match the entire actual path. With a default of `/`, this in particular meant that any path other than the root would not match, which explicitly deviates from the "catch all" requirement in the Knative spec.

## Related Issues
* #3224 

## Testing
This change passes existing automated tests, although it could probably use a test of its own as well.

## Tasks That Must Be Done
- [x] Did you update CHANGELOG.md?
  + [ ] Is this a new feature?
  + [ ] Are there any non-backward-compatible changes?
  + [ ] Did the envoy version change?
  + [ ] Are there any deprecations?
  + [ ] Will the changes impact how ambassador performs at scale?
    - [ ] Might an existing production deployment need to change:
      + memory limits?
      + cpu limits?
      + replica counts?
    - [ ] Does the change impact data-plane latency/scalability?
- [ ] Is your change adequately tested?
  + [ ] Was their sufficient test coverage for the area changed?
  + [ ] Do the existing tests capture the requirements for the area changed?
  + [x] Is the bulk of your code covered by unit tests?
  + [x] Does at least one end-to-end test cover the integration points your change depends on?
- [ ] Did you update documentation?
- [ ] Were there any special dev tricks you had to use to work on this code efficiently?
  + [ ] Did you add them to DEVELOPING.md?
- [ ] Is this a build change?
  + [ ] If so, did you test on both Mac and Linux?
