### PR TITLE
Disable Kubernaut in CI

### DIFF
--- a/.ci/kubernaut-claim
+++ b/.ci/kubernaut-claim
@@ -64,6 +64,9 @@ if [ -n "${KUBECEPTION_TOKEN}" ]; then
     exit
 fi
 
+echo "Kubernaut is no longer supported; halting run"
+exit 1
+
 KUBERNAUT_VERSION=2018.10.24-d46c1f1
 
 set -o errexit


### PR DESCRIPTION
We're shutting down Kubernaut, so if there's no Kubeception token, just stop the CI tests. This isn't meant as the long-term solution. 🙂 

