### PR TITLE
support for check-settings for per route configs for the external aut…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@ Please see the [Envoy documentation](https://www.envoyproxy.io/docs/envoy/latest
 - Bugfix: Make Knative paths match on prefix instead of the entire path to better align to the Knative specification ([#3224]).
 
 [#3224]: https://github.com/datawire/ambassador/issues/3224
+- Feature: Mapping configuration now supports setting `auth_context_extentions` that allows setting the `check_settings` field in the per route configuration supported by `ext_authz` http filter.
 
 ## [1.12.0] March 08, 2021
 [1.12.0]: https://github.com/datawire/ambassador/compare/v1.11.2...v1.12.0

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Sanitize the environment a bit.
-unexport ENV      # bad configuration mechansim
-unexport BASH_ENV # bad configuration mechansim, but CircleCI insists on it
+unexport ENV      # bad configuration mechanism
+unexport BASH_ENV # bad configuration mechanism, but CircleCI insists on it
 unexport CDPATH   # should not be exported, but some people do
 unexport IFS      # should not be exported, but some people do
 

--- a/cmd/kat-server/services/grpc-auth.go
+++ b/cmd/kat-server/services/grpc-auth.go
@@ -92,6 +92,16 @@ func (g *GRPCAUTH) Check(ctx context.Context, r *pb.CheckRequest) (*pb.CheckResp
 		rheader["body"] = rbody
 	}
 
+	rContextExtensions := r.GetAttributes().GetContextExtensions()
+	if rContextExtensions != nil {
+		val, err := json.Marshal(rContextExtensions)
+		if err != nil {
+			val = []byte(fmt.Sprintf("Error: %v", err))
+		}
+
+		rs.AddHeader(false, "x-request-context-extensions", string(val))
+	}
+
 	// Sets requested HTTP status.
 	rs.SetStatus(rheader["requested-status"])
 

--- a/docs/yaml/ambassador/ambassador-crds.yaml
+++ b/docs/yaml/ambassador/ambassador-crds.yaml
@@ -761,6 +761,10 @@ spec:
               oneOf:
               - type: string
               - type: array
+            auth_context_extensions:
+              additionalProperties:
+                type: string
+              type: object
             auto_host_rewrite:
               type: boolean
             bypass_auth:

--- a/docs/yaml/ambassador/ambassador-knative.yaml
+++ b/docs/yaml/ambassador/ambassador-knative.yaml
@@ -822,6 +822,10 @@ spec:
               oneOf:
               - type: string
               - type: array
+            auth_context_extensions:
+              additionalProperties:
+                type: string
+              type: object
             auto_host_rewrite:
               type: boolean
             bypass_auth:

--- a/docs/yaml/ambassador/ambassador-rbac-prometheus.yaml
+++ b/docs/yaml/ambassador/ambassador-rbac-prometheus.yaml
@@ -825,6 +825,10 @@ spec:
               oneOf:
               - type: string
               - type: array
+            auth_context_extensions:
+              additionalProperties:
+                type: string
+              type: object
             auto_host_rewrite:
               type: boolean
             bypass_auth:

--- a/pkg/api/getambassador.io/v2/mapping_types.go
+++ b/pkg/api/getambassador.io/v2/mapping_types.go
@@ -107,8 +107,9 @@ type MappingSpec struct {
 	//    - spdy/3.1
 	AllowUpgrade []string `json:"allow_upgrade,omitempty"`
 
-	Weight     *int  `json:"weight,omitempty"`
-	BypassAuth *bool `json:"bypass_auth,omitempty"`
+	Weight                *int              `json:"weight,omitempty"`
+	BypassAuth            *bool             `json:"bypass_auth,omitempty"`
+	AuthContextExtensions map[string]string `json:"auth_context_extensions,omitempty"`
 	// If true, bypasses any `error_response_overrides` set on the Ambassador module.
 	BypassErrorResponseOverrides *bool `json:"bypass_error_response_overrides,omitempty"`
 	// Error response overrides for this Mapping. Replaces all of the `error_response_overrides`

--- a/pkg/api/getambassador.io/v2/zz_generated.deepcopy.go
+++ b/pkg/api/getambassador.io/v2/zz_generated.deepcopy.go
@@ -1774,6 +1774,13 @@ func (in *MappingSpec) DeepCopyInto(out *MappingSpec) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.AuthContextExtensions != nil {
+		in, out := &in.AuthContextExtensions, &out.AuthContextExtensions
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	if in.BypassErrorResponseOverrides != nil {
 		in, out := &in.BypassErrorResponseOverrides, &out.BypassErrorResponseOverrides
 		*out = new(bool)

--- a/python/ambassador/envoy/v2/v2route.py
+++ b/python/ambassador/envoy/v2/v2route.py
@@ -180,6 +180,14 @@ class V2Route(Cacheable):
                 '@type': 'type.googleapis.com/envoy.config.filter.http.ext_authz.v2.ExtAuthzPerRoute',
                 'disabled': True,
             }
+        else:
+            # Additional ext_auth configuration only makes sense when not bypassing auth.
+            auth_context_extensions = mapping.get('auth_context_extensions', False)
+            if auth_context_extensions:
+                typed_per_filter_config['envoy.filters.http.ext_authz'] = {
+                    '@type': 'type.googleapis.com/envoy.config.filter.http.ext_authz.v2.ExtAuthzPerRoute',
+                    'check_settings': {'context_extensions': auth_context_extensions}
+                }
 
         if len(typed_per_filter_config) > 0:
             self['typed_per_filter_config'] = typed_per_filter_config

--- a/python/ambassador/ir/irhttpmapping.py
+++ b/python/ambassador/ir/irhttpmapping.py
@@ -77,6 +77,7 @@ class IRHTTPMapping (IRBaseMapping):
         # Do not include add_request_headers and add_response_headers
         "auto_host_rewrite": False,
         "bypass_auth": False,
+        "auth_context_extensions": False,
         "bypass_error_response_overrides": False,
         "case_sensitive": False,
         "circuit_breakers": False,

--- a/python/schemas/v2/Mapping.schema
+++ b/python/schemas/v2/Mapping.schema
@@ -155,6 +155,7 @@
         },
         "weight": { "type": "integer" },
         "bypass_auth": { "type": "boolean" },
+        "auth_context_extensions": {"$ref": "#/definitions/mapStrStr"}
         "bypass_error_response_overrides": { "type": "boolean" },
         "error_response_overrides": {
             "type": "array",

--- a/python/schemas/v2/Mapping.schema
+++ b/python/schemas/v2/Mapping.schema
@@ -155,7 +155,7 @@
         },
         "weight": { "type": "integer" },
         "bypass_auth": { "type": "boolean" },
-        "auth_context_extensions": {"$ref": "#/definitions/mapStrStr"}
+        "auth_context_extensions": {"$ref": "#/definitions/mapStrStr"},
         "bypass_error_response_overrides": { "type": "boolean" },
         "error_response_overrides": {
             "type": "array",

--- a/python/tests/gold/authenticationgrpctest/snapshots/econf.json
+++ b/python/tests/gold/authenticationgrpctest/snapshots/econf.json
@@ -257,6 +257,72 @@
                                   "name": "x-forwarded-proto"
                                 }
                               ],
+                              "prefix": "/context-extensions/",
+                              "runtime_fraction": {
+                                "default_value": {
+                                  "denominator": "HUNDRED",
+                                  "numerator": 100
+                                },
+                                "runtime_key": "routing.traffic_shift.cluster_authenticationgrpctest_http_default"
+                              }
+                            },
+                            "route": {
+                              "cluster": "cluster_authenticationgrpctest_http_default",
+                              "prefix_rewrite": "/",
+                              "priority": null,
+                              "timeout": "3.000s"
+                            },
+                            "typed_per_filter_config": {
+                              "envoy.filters.http.ext_authz": {
+                                "@type": "type.googleapis.com/envoy.config.filter.http.ext_authz.v2.ExtAuthzPerRoute",
+                                "check_settings": {
+                                  "context_extensions": {
+                                    "first": "first element",
+                                    "second": "second element"
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          {
+                            "match": {
+                              "case_sensitive": true,
+                              "prefix": "/context-extensions/",
+                              "runtime_fraction": {
+                                "default_value": {
+                                  "denominator": "HUNDRED",
+                                  "numerator": 100
+                                },
+                                "runtime_key": "routing.traffic_shift.cluster_authenticationgrpctest_http_default"
+                              }
+                            },
+                            "route": {
+                              "cluster": "cluster_authenticationgrpctest_http_default",
+                              "prefix_rewrite": "/",
+                              "priority": null,
+                              "timeout": "3.000s"
+                            },
+                            "typed_per_filter_config": {
+                              "envoy.filters.http.ext_authz": {
+                                "@type": "type.googleapis.com/envoy.config.filter.http.ext_authz.v2.ExtAuthzPerRoute",
+                                "check_settings": {
+                                  "context_extensions": {
+                                    "first": "first element",
+                                    "second": "second element"
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          {
+                            "match": {
+                              "case_sensitive": true,
+                              "headers": [
+                                {
+                                  "exact_match": "https",
+                                  "name": "x-forwarded-proto"
+                                }
+                              ],
                               "prefix": "/ambassador/v0/",
                               "runtime_fraction": {
                                 "default_value": {

--- a/python/tests/gold/authenticationgrpctest/snapshots/econf.json
+++ b/python/tests/gold/authenticationgrpctest/snapshots/econf.json
@@ -257,6 +257,72 @@
                                   "name": "x-forwarded-proto"
                                 }
                               ],
+                              "prefix": "/context-extensions-crd/",
+                              "runtime_fraction": {
+                                "default_value": {
+                                  "denominator": "HUNDRED",
+                                  "numerator": 100
+                                },
+                                "runtime_key": "routing.traffic_shift.cluster_authenticationgrpctest_http_default"
+                              }
+                            },
+                            "route": {
+                              "cluster": "cluster_authenticationgrpctest_http_default",
+                              "prefix_rewrite": "/",
+                              "priority": null,
+                              "timeout": "3.000s"
+                            },
+                            "typed_per_filter_config": {
+                              "envoy.filters.http.ext_authz": {
+                                "@type": "type.googleapis.com/envoy.config.filter.http.ext_authz.v2.ExtAuthzPerRoute",
+                                "check_settings": {
+                                  "context_extensions": {
+                                    "context": "auth-context-name",
+                                    "data": "auth-data"
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          {
+                            "match": {
+                              "case_sensitive": true,
+                              "prefix": "/context-extensions-crd/",
+                              "runtime_fraction": {
+                                "default_value": {
+                                  "denominator": "HUNDRED",
+                                  "numerator": 100
+                                },
+                                "runtime_key": "routing.traffic_shift.cluster_authenticationgrpctest_http_default"
+                              }
+                            },
+                            "route": {
+                              "cluster": "cluster_authenticationgrpctest_http_default",
+                              "prefix_rewrite": "/",
+                              "priority": null,
+                              "timeout": "3.000s"
+                            },
+                            "typed_per_filter_config": {
+                              "envoy.filters.http.ext_authz": {
+                                "@type": "type.googleapis.com/envoy.config.filter.http.ext_authz.v2.ExtAuthzPerRoute",
+                                "check_settings": {
+                                  "context_extensions": {
+                                    "context": "auth-context-name",
+                                    "data": "auth-data"
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          {
+                            "match": {
+                              "case_sensitive": true,
+                              "headers": [
+                                {
+                                  "exact_match": "https",
+                                  "name": "x-forwarded-proto"
+                                }
+                              ],
                               "prefix": "/context-extensions/",
                               "runtime_fraction": {
                                 "default_value": {

--- a/python/tests/manifests/crds.yaml
+++ b/python/tests/manifests/crds.yaml
@@ -700,6 +700,8 @@ spec:
               oneOf:
               - type: string
               - type: array
+            auth_context_extensions:
+              type: object
             auto_host_rewrite:
               type: boolean
             bypass_auth:


### PR DESCRIPTION
…h filter

## Description
Allow the setting of check_settings in the per filter config for the extAuth filter.

## Related Issues

## Testing
Added to the t_extauth.py file to test the configuration.  Ran all the tests against a K8s cluster and refreshed the python cache.


## Tasks That Must Be Done
- [X] Did you update CHANGELOG.md?
  + [x] Is this a new feature?
  + [x] Are there any non-backward-compatible changes? No
  + [x] Did the envoy version change? No
  + [x] Are there any deprecations? No
  + [x] Will the changes impact how ambassador performs at scale? No
    - [x] Might an existing production deployment need to change: No
      + memory limits?
      + cpu limits?
      + replica counts?
    - [x] Does the change impact data-plane latency/scalability? No
- [ ] Is your change adequately tested?
  + [ ] Was their sufficient test coverage for the area changed?
  + [ ] Do the existing tests capture the requirements for the area changed?
  + [ ] Is the bulk of your code covered by unit tests?
  + [ ] Does at least one end-to-end test cover the integration points your change depends on?
- [ ] Did you update documentation? 
- [x] Were there any special dev tricks you had to use to work on this code efficiently? No
  + [ ] Did you add them to DEVELOPING.md?
- [] Is this a build change? No
  + [ ] If so, did you test on both Mac and Linux?

## Other

