### PR TITLE
Add diagnostics.allow_non_local feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,8 @@ Please see the [Envoy documentation](https://www.envoyproxy.io/docs/envoy/latest
 [#3224]: https://github.com/datawire/ambassador/issues/3224
 - Feature: Mapping configuration now supports setting `auth_context_extentions` that allows setting the `check_settings` field in the per route configuration supported by `ext_authz` http filter.
 
+- Feature: Add diagnostics.allow_non_local flag to expose admin UI internally only ([#3074])
+
 ## [1.12.1] March 12, 2021
 [1.12.1]: https://github.com/datawire/ambassador/compare/v1.12.0...v1.12.1
 

--- a/python/tests/t_no_ui_allow_non_local.py
+++ b/python/tests/t_no_ui_allow_non_local.py
@@ -1,0 +1,40 @@
+from kat.harness import Query, EDGE_STACK
+
+from abstract_tests import AmbassadorTest, ServiceType, HTTP
+
+
+class NoUITestAllowNoLocal (AmbassadorTest):
+    # Don't use single_namespace -- we want CRDs, so we want
+    # the cluster-scope RBAC instead of the namespace-scope
+    # RBAC. Our ambassador_id filters out the stuff we want.
+    namespace = "no-ui-namespace-anl"
+    extra_ports = [8877]
+
+    def manifests(self) -> str:
+        return self.format("""
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: no-ui-namespace
+---
+apiVersion: getambassador.io/v2
+kind: Module
+metadata:
+  name: ambassador
+  namespace: no-ui-namespace
+  labels:
+    kat-ambassador-id: {self.ambassador_id}
+spec:
+  ambassador_id: [ {self.ambassador_id} ]
+  config:
+    diagnostics:
+      enabled: false
+      allow_non_local: true
+""") + super().manifests()
+
+    def queries(self):
+        yield(Query(self.url("ambassador/v0/diag/"), expected=404))
+        yield(Query(self.url("edge_stack/admin/"), expected=404))
+        yield Query(self.url("ambassador/v0/diag/", scheme="http", port=8877), expected=200)
+


### PR DESCRIPTION


## Description
This option allows to expose the diag UI to non-local clients, even when
the diag UI is disabled.

## Related Issues
Implements #3074

## Testing
Added a test for this flag

## Tasks That Must Be Done
- [X ] Did you update CHANGELOG.md?
  + [X ] Is this a new feature?
  + [ ] Are there any non-backward-compatible changes?
  + [ ] Did the envoy version change?
  + [ ] Are there any deprecations?
  + [ ] Will the changes impact how ambassador performs at scale?
    - [ ] Might an existing production deployment need to change:
      + memory limits?
      + cpu limits?
      + replica counts?
    - [ ] Does the change impact data-plane latency/scalability?
- [ ] Is your change adequately tested?
  + [ ] Was their sufficient test coverage for the area changed?
  + [ ] Do the existing tests capture the requirements for the area changed?
  + [ ] Is the bulk of your code covered by unit tests?
  + [ ] Does at least one end-to-end test cover the integration points your change depends on?
- [ ] Did you update documentation?
- [ ] Were there any special dev tricks you had to use to work on this code efficiently?
  + [ ] Did you add them to DEVELOPING.md?
- [ ] Is this a build change?
  + [ ] If so, did you test on both Mac and Linux?

## Other
* If this is a documentation change for a particular release, please open the pull request against the release branch.
