### PR TITLE
Adding ReplicaSet + PodTemplateSpec aliases to kates

### DIFF
--- a/pkg/kates/aliases.go
+++ b/pkg/kates/aliases.go
@@ -88,6 +88,7 @@ type ClusterRoleBinding = rbacv1.ClusterRoleBinding
 
 type Pod = corev1.Pod
 type PodSpec = corev1.PodSpec
+type PodTemplateSpec = corev1.PodTemplateSpec
 type Container = corev1.Container
 type EnvVar = corev1.EnvVar
 type SecurityContext = corev1.SecurityContext
@@ -122,6 +123,7 @@ const ResourceMemory = corev1.ResourceMemory
 type PersistentVolumeClaim = corev1.PersistentVolumeClaim
 
 type Deployment = appsv1.Deployment
+type ReplicaSet = appsv1.ReplicaSet
 
 type CustomResourceDefinition = xv1.CustomResourceDefinition
 


### PR DESCRIPTION
## Description
Telepresence uses the aliases from Ambassador and we are adding support for ReplicaSets so we needed to add two more aliases. If something like this is frowned upon, I can just alias them in Telepresence themselves but thought it made sense to try having them in the 1 source of truth.

## Related Issues
List related issues.

## Testing
A few sentences describing what testing you've done, e.g., manual tests, automated tests, deployed in production, etc.

## Tasks That Must Be Done
- [ ] Did you update CHANGELOG.md? (not sure it needs an update but let me know if it does)
  + [x] Is this a new feature? no
  + [x] Are there any non-backward-compatible changes? no
  + [x] Did the envoy version change? no
  + [x] Are there any deprecations? no
  + [x] Will the changes impact how ambassador performs at scale? no
    - [x] Might an existing production deployment need to change:
      + memory limits?
      + cpu limits?
      + replica counts?
    - [x] Does the change impact data-plane latency/scalability?
- [x] Is your change adequately tested?
  + [x] Was their sufficient test coverage for the area changed?
  + [x] Do the existing tests capture the requirements for the area changed?
  + [x] Is the bulk of your code covered by unit tests?
  + [x] Does at least one end-to-end test cover the integration points your change depends on?
- [x] Did you update documentation?
- [x] Were there any special dev tricks you had to use to work on this code efficiently?
  + [x] Did you add them to DEVELOPING.md?
- [x] Is this a build change?
  + [x] If so, did you test on both Mac and Linux?

## Other
* If this is a documentation change for a particular release, please open the pull request against the release branch.
