### PR TITLE
add / remove headers before parsing filters

### DIFF
--- a/python/ambassador/envoy/v2/v2route.py
+++ b/python/ambassador/envoy/v2/v2route.py
@@ -139,6 +139,17 @@ class V2Route(Cacheable):
         # `typed_per_filter_config` is used to pass typed configuration to Envoy filters
         typed_per_filter_config = {}
 
+        # add and remove headers before parsing the filters
+        response_headers_to_add = group.get('add_response_headers', None)
+        if response_headers_to_add:
+            self['response_headers_to_add'] = self.generate_headers_to_add(response_headers_to_add)
+
+        response_headers_to_remove = group.get('remove_response_headers', None)
+        if response_headers_to_remove:
+            if type(response_headers_to_remove) != list:
+                response_headers_to_remove = [ response_headers_to_remove ]
+            self['response_headers_to_remove'] = response_headers_to_remove
+
         if mapping.get('bypass_error_response_overrides', False):
             typed_per_filter_config['envoy.filters.http.response_map'] = {
                 '@type': 'type.googleapis.com/envoy.extensions.filters.http.response_map.v3.ResponseMapPerRoute',
@@ -196,21 +207,11 @@ class V2Route(Cacheable):
         if request_headers_to_add:
             self['request_headers_to_add'] = self.generate_headers_to_add(request_headers_to_add)
 
-        response_headers_to_add = group.get('add_response_headers', None)
-        if response_headers_to_add:
-            self['response_headers_to_add'] = self.generate_headers_to_add(response_headers_to_add)
-
         request_headers_to_remove = group.get('remove_request_headers', None)
         if request_headers_to_remove:
             if type(request_headers_to_remove) != list:
                 request_headers_to_remove = [ request_headers_to_remove ]
             self['request_headers_to_remove'] = request_headers_to_remove
-
-        response_headers_to_remove = group.get('remove_response_headers', None)
-        if response_headers_to_remove:
-            if type(response_headers_to_remove) != list:
-                response_headers_to_remove = [ response_headers_to_remove ]
-            self['response_headers_to_remove'] = response_headers_to_remove
 
         host_redirect = group.get('host_redirect', None)
 

--- a/python/ambassador/envoy/v2/v2route.py
+++ b/python/ambassador/envoy/v2/v2route.py
@@ -139,16 +139,10 @@ class V2Route(Cacheable):
         # `typed_per_filter_config` is used to pass typed configuration to Envoy filters
         typed_per_filter_config = {}
 
-        # add and remove headers before parsing the filters
-        response_headers_to_add = group.get('add_response_headers', None)
-        if response_headers_to_add:
-            self['response_headers_to_add'] = self.generate_headers_to_add(response_headers_to_add)
-
-        response_headers_to_remove = group.get('remove_response_headers', None)
-        if response_headers_to_remove:
-            if type(response_headers_to_remove) != list:
-                response_headers_to_remove = [ response_headers_to_remove ]
-            self['response_headers_to_remove'] = response_headers_to_remove
+        # add headers before parsing the filters
+        pre_filter_response_headers_to_add = group.get('add_response_headers', None)
+        if pre_filter_response_headers_to_add:
+            self['pre_filter_response_headers_to_add'] = self.generate_headers_to_add(pre_filter_response_headers_to_add)
 
         if mapping.get('bypass_error_response_overrides', False):
             typed_per_filter_config['envoy.filters.http.response_map'] = {
@@ -202,6 +196,17 @@ class V2Route(Cacheable):
 
         if len(typed_per_filter_config) > 0:
             self['typed_per_filter_config'] = typed_per_filter_config
+
+        # add and remove headers after parsing the filters
+        post_filter_response_headers_to_add = group.get('add_response_headers', None)
+        if post_filter_response_headers_to_add:
+            self['post_filter_response_headers_to_add'] = self.generate_headers_to_add(post_filter_response_headers_to_add)
+
+        response_headers_to_remove = group.get('remove_response_headers', None)
+        if response_headers_to_remove:
+            if type(response_headers_to_remove) != list:
+                response_headers_to_remove = [ response_headers_to_remove ]
+            self['response_headers_to_remove'] = response_headers_to_remove
 
         request_headers_to_add = group.get('add_request_headers', None)
         if request_headers_to_add:


### PR DESCRIPTION
## Description
Parses the [add/remove]_response_headers before parsing any filters.  Does not make any other changes

## Related Issues
https://github.com/datawire/ambassador/issues/3333

## Testing
I was not sure how to test this, was hoping for some help in that regard. 

## Tasks That Must Be Done
- [ ] Did you update CHANGELOG.md?
  + [ ] Is this a new feature?
  + [ ] Are there any non-backward-compatible changes?
  + [ ] Did the envoy version change?
  + [ ] Are there any deprecations?
  + [ ] Will the changes impact how ambassador performs at scale?
    - [ ] Might an existing production deployment need to change:
      + memory limits?
      + cpu limits?
      + replica counts?
    - [ ] Does the change impact data-plane latency/scalability?
- [ ] Is your change adequately tested?
  + [ ] Was their sufficient test coverage for the area changed?
  + [ ] Do the existing tests capture the requirements for the area changed?
  + [ ] Is the bulk of your code covered by unit tests?
  + [ ] Does at least one end-to-end test cover the integration points your change depends on?
- [ ] Did you update documentation?
- [ ] Were there any special dev tricks you had to use to work on this code efficiently?
  + [ ] Did you add them to DEVELOPING.md?
- [ ] Is this a build change?
  + [ ] If so, did you test on both Mac and Linux?

## Other
* If this is a documentation change for a particular release, please open the pull request against the release branch.
