### PR TITLE
diagd: Add POST endpoints to change loglevel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@ Please see the [Envoy documentation](https://www.envoyproxy.io/docs/envoy/latest
 [#3224]: https://github.com/datawire/ambassador/issues/3224
 
 - Feature: Add diagnostics.allow_non_local flag to expose admin UI internally only ([#3074])
+- Change: Move endpoint to change log level from GET+params to POST request
 
 ## [1.12.2] March 29, 2021
 [1.12.2]: https://github.com/datawire/ambassador/compare/v1.12.1...v1.12.2

--- a/python/templates/system-info.html
+++ b/python/templates/system-info.html
@@ -46,14 +46,18 @@
         <tbody>
           <tr>
             <td width="50%" align="center">
-              <a href="/ambassador/v0/diag/?loglevel=debug">
-                <button type="button" class="btn btn-warning">Set Debug On</button>
-              </a>
+              <form action="/ambassador/v0/diag/loglevel" method="POST">
+                <input type="hidden" name="loglevel" value="debug" />
+                <input type="hidden" name="redirect_url" value="{{request.path}}" />
+                <button type="submit" class="btn btn-warning">Set Debug On</button>
+              </form>
             </td>
             <td width="50%" align="center">
-              <a href="/ambassador/v0/diag/?loglevel=warning">
-                <button type="button" class="btn btn-warning">Set Debug Off</button>
-              </a>
+              <form action="/ambassador/v0/diag/loglevel" method="POST">
+                <input type="hidden" name="loglevel" value="warning" />
+                <input type="hidden" name="redirect_url" value="{{request.path}}" />
+                <button type="submit" class="btn btn-warning">Set Debug Off</button>
+              </form>
             </td>
           </tr>
         </tbody>


### PR DESCRIPTION
## Description
Right now, log levels are changed by reloading the same url adding get
parameters.
It is more usual to use POST requests for endpoints updating state of
data on the server side.
This commit is adding an endpoint to change the loglevel using post.

## Related Issues
List related issues.

## Testing
A few sentences describing what testing you've done, e.g., manual tests, automated tests, deployed in production, etc.

## Tasks That Must Be Done
- [X] Did you update CHANGELOG.md?
  + [ ] Is this a new feature?
  + [ ] Are there any non-backward-compatible changes?
  + [ ] Did the envoy version change?
  + [ ] Are there any deprecations?
  + [ ] Will the changes impact how ambassador performs at scale?
    - [ ] Might an existing production deployment need to change:
      + memory limits?
      + cpu limits?
      + replica counts?
    - [ ] Does the change impact data-plane latency/scalability?
- [ ] Is your change adequately tested?
  + [ ] Was their sufficient test coverage for the area changed?
  + [ ] Do the existing tests capture the requirements for the area changed?
  + [ ] Is the bulk of your code covered by unit tests?
  + [ ] Does at least one end-to-end test cover the integration points your change depends on?
- [ ] Did you update documentation?
- [ ] Were there any special dev tricks you had to use to work on this code efficiently?
  + [ ] Did you add them to DEVELOPING.md?
- [ ] Is this a build change?
  + [ ] If so, did you test on both Mac and Linux?

## Other
* If this is a documentation change for a particular release, please open the pull request against the release branch.
