### PR TITLE
fix single namespace rbac

### DIFF
--- a/charts/ambassador/CHANGELOG.md
+++ b/charts/ambassador/CHANGELOG.md
@@ -3,6 +3,10 @@
 This file documents all notable changes to Ambassador Helm Chart. The release
 numbering uses [semantic versioning](http://semver.org).
 
+## Next Release
+
+- Bugfix: Don't change the Role name when running in singleNamespace mode.
+
 ## v6.7.1
 
 - Update Ambassador chart image to version v1.13.1: [CHANGELOG](https://github.com/datawire/ambassador/blob/master/CHANGELOG.md)

--- a/charts/ambassador/ci/08-single-namespace-values.yaml
+++ b/charts/ambassador/ci/08-single-namespace-values.yaml
@@ -4,11 +4,5 @@ service:
 deploymentStrategy:
   type: Recreate
 
-## This does not work. Waiting on fix for APro code watching for all namespaces
-##
-
-# scope:
-#   singleNamespace: true
-
-env:
-  AMBASSADOR_SINGLE_NAMESPACE: true
+scope:
+  singleNamespace: true

--- a/charts/ambassador/templates/rbac.yaml
+++ b/charts/ambassador/templates/rbac.yaml
@@ -51,14 +51,14 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1beta1
 {{- if .Values.scope.singleNamespace }}
 kind: Role
+metadata:
+  name: {{ include "ambassador.rbacName" . }}
+  namespace: {{ include "ambassador.namespace" . }}
 {{- else }}
 kind: ClusterRole
-{{- end }}
 metadata:
   name: {{ include "ambassador.rbacName" . }}-watch
-  {{- if .Values.scope.singleNamespace }}
-  namespace: {{ include "ambassador.namespace" . }}
-  {{- end }}
+{{- end }}
   labels:
     {{- if ne .Values.deploymentTool "getambassador.io" }}
     app.kubernetes.io/name: {{ include "ambassador.name" . }}
@@ -191,7 +191,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: {{ include "ambassador.rbacName" . }}-watch
+  name: {{ include "ambassador.rbacName" . }}
 subjects:
   - name: {{ include "ambassador.serviceAccountName" . }}
     namespace: {{ include "ambassador.namespace" . }}


### PR DESCRIPTION
## Description

This broke helm upgrades because you can't change the name of a `roleRef`. It gives me great sadness that Roles don't support aggregation as cluster roles do :/

Should fix https://github.com/datawire/ambassador/issues/3363

## Related Issues
List related issues.

## Testing
A few sentences describing what testing you've done, e.g., manual tests, automated tests, deployed in production, etc.

## Tasks That Must Be Done
- [x] Did you update CHANGELOG.md?
  + [ ] Is this a new feature?
  + [ ] Are there any non-backward-compatible changes?
  + [ ] Did the envoy version change?
  + [ ] Are there any deprecations?
  + [ ] Will the changes impact how ambassador performs at scale?
    - [ ] Might an existing production deployment need to change:
      + memory limits?
      + cpu limits?
      + replica counts?
    - [ ] Does the change impact data-plane latency/scalability?
- [x] Is your change adequately tested?
  + [ ] Was their sufficient test coverage for the area changed?
  + [x] Do the existing tests capture the requirements for the area changed?
  + [ ] Is the bulk of your code covered by unit tests?
  + [ ] Does at least one end-to-end test cover the integration points your change depends on?
- [ ] Did you update documentation?
- [ ] Were there any special dev tricks you had to use to work on this code efficiently?
  + [ ] Did you add them to DEVELOPING.md?
- [ ] Is this a build change?
  + [ ] If so, did you test on both Mac and Linux?

## Other
* If this is a documentation change for a particular release, please open the pull request against the release branch.
