### PR TITLE
Idle mapping timeout with same value than timeout

### DIFF
--- a/python/ambassador/fetch/knative.py
+++ b/python/ambassador/fetch/knative.py
@@ -78,6 +78,7 @@ class KnativeIngressProcessor (ManagedKubernetesProcessor):
                     'weight': split.get('percent', 100),
                     'prefix': path.get('path', '/'),
                     'timeout_ms': int(durationpy.from_str(path.get('timeout', '15s')).total_seconds() * 1000),
+                    'idle_timeout_ms': int(durationpy.from_str(path.get('timeout', '15s')).total_seconds() * 1000),
                 })
 
         for split_count, (host, split_mapping_spec) in enumerate(itertools.product(hosts, split_mapping_specs)):


### PR DESCRIPTION
## Description

`idle_timeout` mapping is per default 5 minutes. However, there might be some knative uses cases where channel might require more idle time.
This PR sets same `idle_timeout_ms` than `timeout_ms` knative mapping. 

## Related Issues

- #3382  

## Testing
Created a custom aes docker image with `idle_timeout_ms` set on same value we have on `timeout_ms`. I was able to keep idle connections for more than 5 minutes.

## Tasks That Must Be Done
- [ ] Did you update CHANGELOG.md?
  + [ ] Is this a new feature?
  + [ ] Are there any non-backward-compatible changes?
  + [ ] Did the envoy version change?
  + [ ] Are there any deprecations?
  + [ ] Will the changes impact how ambassador performs at scale?
    - [ ] Might an existing production deployment need to change:
      + memory limits?
      + cpu limits?
      + replica counts?
    - [ ] Does the change impact data-plane latency/scalability?
- [ ] Is your change adequately tested?
  + [ ] Was their sufficient test coverage for the area changed?
  + [ ] Do the existing tests capture the requirements for the area changed?
  + [ ] Is the bulk of your code covered by unit tests?
  + [ ] Does at least one end-to-end test cover the integration points your change depends on?
- [ ] Did you update documentation?
- [ ] Were there any special dev tricks you had to use to work on this code efficiently?
  + [ ] Did you add them to DEVELOPING.md?
- [ ] Is this a build change?
  + [ ] If so, did you test on both Mac and Linux?

## Other
* If this is a documentation change for a particular release, please open the pull request against the release branch.
