### PR TITLE
Set up a nightly run to build 2.0.0-wip images.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -118,6 +118,14 @@ commands:
     - run: |
         [[ "$DEV_REGISTRY" == 127.0.0.1:31000 ]] || make push
     - when:
+        condition:
+          not: << parameters.release >>
+        steps:
+        - run:
+            name: "Push dev images"
+            command: |
+              [[ "$DEV_REGISTRY" == 127.0.0.1:31000 ]] || make push-dev
+    - when:
         condition: << parameters.release >>
         steps:
         - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -143,6 +143,21 @@ commands:
     # teardown
     - dirty-check
     - amb-save-workspace
+  "job-push-ci":
+    steps:
+    # setup
+    - amb-linux-install
+    - amb-checkout
+    - amb-skip-if-no-code-changes
+    - amb-config-registry
+    - # main
+      run: make images
+    - run: |
+        [[ "$DEV_REGISTRY" == 127.0.0.1:31000 ]] || make push
+    - run: make push-ci
+    # teardown
+    - dirty-check
+    - amb-save-workspace
   "job-gotest":
     parameters:
       "fast-reconfigure":
@@ -730,6 +745,10 @@ jobs:
     - job-images:
         release: << parameters.release >>
         push_nightly: << parameters.push_nightly >>
+  oss-push-ci:
+    executor: oss-linux
+    steps:
+    - job-push-ci
   oss-gotest:
     executor: oss-linux
     parameters:
@@ -874,7 +893,7 @@ workflows:
         name: "oss-dev-gotest<<# matrix.fast-reconfigure >>-fastreconfigure<</ matrix.fast-reconfigure
           >><<# matrix.legacy-mode >>-legacy<</ matrix.legacy-mode >>"
         matrix:
-          alias: "oss-dev-gotest"
+          alias: "oss-dev-gotest-matrix"
           parameters:
             fast-reconfigure:
             - true
@@ -890,7 +909,7 @@ workflows:
           matrix.fast-reconfigure >><<# matrix.legacy-mode >>-legacy<</ matrix.legacy-mode
           >>"
         matrix:
-          alias: "oss-dev-test"
+          alias: "oss-dev-test-matrix"
           parameters:
             test:
             - "pytest"
@@ -909,6 +928,13 @@ workflows:
             - false
             # If you enable testing with legacy-mode true as well, you'll also need
             # to add some exclusions -- see the Release workflow for more.
+    - oss-push-ci:
+        requires:
+        - "oss-dev-generate"
+        - "oss-dev-lint"
+        - "oss-dev-gotest-matrix"
+        - "oss-dev-test-matrix"
+        name: "oss-dev-push-ci"
   'OSS: Chart Release':
     when:
       or:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,6 +104,9 @@ commands:
       "save_images_to_workspace":
         type: boolean
         default: false
+      "push_nightly":
+        type: boolean
+        default: false
     steps:
     # setup
     - amb-linux-install
@@ -122,6 +125,13 @@ commands:
             command: |
               docker login -u="${DOCKER_RELEASE_USERNAME}" -p="${DOCKER_RELEASE_PASSWORD}" "${RELEASE_REGISTRY%%/*}"
               DEV_KUBECONFIG="-skip-for-release-" make release/bits
+    - when:
+        condition: << parameters.push_nightly >>
+        steps:
+        - run:
+            name: "Push nightly images"
+            command: |
+              make push-nightly
     # teardown
     - dirty-check
     - amb-save-workspace
@@ -703,11 +713,15 @@ jobs:
       release:
         type: boolean
         default: false
+      push_nightly:
+        type: boolean
+        default: false
     executor: oss-linux
     resource_class: large
     steps:
     - job-images:
         release: << parameters.release >>
+        push_nightly: << parameters.push_nightly >>
   oss-gotest:
     executor: oss-linux
     parameters:
@@ -1023,9 +1037,17 @@ workflows:
           branches:
             only:
             - master
+    - schedule:
+        cron: "0 5 * * *"
+        filters:
+          branches:
+            only:
+            - shared/nightly-test
+            # - shared/emissary
     jobs:
     - oss-images:
         name: "oss-nightly-images"
+        push_nightly: true
     - oss-gotest:
         name: "oss-nightly-gotest<<# matrix.fast-reconfigure >>-fastreconfigure<</
           matrix.fast-reconfigure >><<# matrix.legacy-mode >>-legacy<</ matrix.legacy-mode

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -704,7 +704,7 @@ jobs:
         type: boolean
         default: false
     executor: oss-linux
-    resource_class: xlarge
+    resource_class: large
     steps:
     - job-images:
         release: << parameters.release >>
@@ -723,7 +723,7 @@ jobs:
         legacy-mode: << parameters.legacy-mode >>
   oss-test:
     executor: oss-linux
-    resource_class: large
+    resource_class: xlarge
     parameters:
       test:
         type: enum

--- a/.circleci/config.yml.d/amb_jobs.yml
+++ b/.circleci/config.yml.d/amb_jobs.yml
@@ -129,6 +129,14 @@ commands:
       - run: |
           [[ "$DEV_REGISTRY" == 127.0.0.1:31000 ]] || make push
       - when:
+          condition:
+            not: << parameters.release >>
+          steps:
+            - run: 
+                name: "Push dev images"
+                command: |
+                  [[ "$DEV_REGISTRY" == 127.0.0.1:31000 ]] || make push-dev
+      - when:
           condition: << parameters.release >>
           steps:
             - run:

--- a/.circleci/config.yml.d/amb_jobs.yml
+++ b/.circleci/config.yml.d/amb_jobs.yml
@@ -114,6 +114,9 @@ commands:
       "save_images_to_workspace":
         type: boolean
         default: false
+      "push_nightly":
+        type: boolean
+        default: false
     steps:
       # setup
       - amb-linux-install
@@ -133,6 +136,13 @@ commands:
                 command: |
                   docker login -u="${DOCKER_RELEASE_USERNAME}" -p="${DOCKER_RELEASE_PASSWORD}" "${RELEASE_REGISTRY%%/*}"
                   DEV_KUBECONFIG="-skip-for-release-" make release/bits
+      - when:
+          condition: << parameters.push_nightly >>
+          steps:
+            - run:
+                name: "Push nightly images"
+                command: |
+                  make push-nightly
 
       # teardown
       - dirty-check

--- a/.circleci/config.yml.d/amb_jobs.yml
+++ b/.circleci/config.yml.d/amb_jobs.yml
@@ -156,6 +156,24 @@ commands:
       - dirty-check
       - amb-save-workspace
 
+  "job-push-ci":
+    steps:
+      # setup
+      - amb-linux-install
+      - amb-checkout
+      - amb-skip-if-no-code-changes
+      - amb-config-registry
+
+      # main
+      - run: make images
+      - run: |
+          [[ "$DEV_REGISTRY" == 127.0.0.1:31000 ]] || make push
+      - run: make push-ci
+
+      # teardown
+      - dirty-check
+      - amb-save-workspace
+
   "job-gotest":
     parameters:
       "fast-reconfigure":

--- a/.circleci/config.yml.d/amb_oss.yml
+++ b/.circleci/config.yml.d/amb_oss.yml
@@ -18,7 +18,7 @@ jobs:
         type: boolean
         default: false
     executor: oss-linux
-    resource_class: xlarge
+    resource_class: large
     steps:
       - job-images:
           release: << parameters.release >>
@@ -39,7 +39,7 @@ jobs:
 
   "oss-test":
     executor: oss-linux
-    resource_class: large
+    resource_class: xlarge
     parameters:
       "test":
         type: enum
@@ -61,10 +61,12 @@ jobs:
           test: << parameters.test >>
           fast-reconfigure: << parameters.fast-reconfigure >>
           legacy-mode: << parameters.legacy-mode >>
+
   "oss-chart":
     executor: oss-linux
     steps:
       - job-chart
+
   "oss-chart-publish":
     executor: oss-linux
     steps:

--- a/.circleci/config.yml.d/amb_oss.yml
+++ b/.circleci/config.yml.d/amb_oss.yml
@@ -27,6 +27,11 @@ jobs:
           release: << parameters.release >>
           push_nightly: << parameters.push_nightly >>
 
+  "oss-push-ci":
+    executor: oss-linux
+    steps: 
+      - job-push-ci
+
   "oss-gotest":
     executor: oss-linux
     parameters:
@@ -150,7 +155,7 @@ workflows:
       - "oss-gotest":
           name: "oss-dev-gotest<<# matrix.fast-reconfigure >>-fastreconfigure<</ matrix.fast-reconfigure >><<# matrix.legacy-mode >>-legacy<</ matrix.legacy-mode >>"
           matrix:
-            alias: "oss-dev-gotest"
+            alias: "oss-dev-gotest-matrix"
             parameters:
               fast-reconfigure:
                 - true
@@ -163,7 +168,7 @@ workflows:
           requires: ["oss-dev-images"]
           name: "oss-dev-<< matrix.test >><<# matrix.fast-reconfigure >>-fastreconfigure<</ matrix.fast-reconfigure >><<# matrix.legacy-mode >>-legacy<</ matrix.legacy-mode >>"
           matrix:
-            alias: "oss-dev-test"
+            alias: "oss-dev-test-matrix"
             parameters:
               test:
                 - "pytest"
@@ -181,6 +186,10 @@ workflows:
                 - false
                 # If you enable testing with legacy-mode true as well, you'll also need
                 # to add some exclusions -- see the Release workflow for more.
+      - "oss-push-ci":
+          requires: [ "oss-dev-generate", "oss-dev-lint", "oss-dev-gotest-matrix", "oss-dev-test-matrix" ]
+          name: "oss-dev-push-ci"
+
   "OSS: Chart Release":
     when: # Don't run this workflow in apro.git
       or:

--- a/.circleci/config.yml.d/amb_oss.yml
+++ b/.circleci/config.yml.d/amb_oss.yml
@@ -17,11 +17,15 @@ jobs:
       "release":
         type: boolean
         default: false
+      "push_nightly":
+        type: boolean
+        default: false
     executor: oss-linux
     resource_class: large
     steps:
       - job-images:
           release: << parameters.release >>
+          push_nightly: << parameters.push_nightly >>
 
   "oss-gotest":
     executor: oss-linux
@@ -280,10 +284,19 @@ workflows:
             branches:
               only:
                 - master
+      - schedule:
+          # Time is in UTC: 1AM EDT every day
+          cron: "0 5 * * *"
+          filters:
+            branches:
+              only:
+                - shared/nightly-test
+                # - shared/emissary
     jobs:
       # build+push
       - "oss-images":
           name: "oss-nightly-images"
+          push_nightly: true
       - "oss-gotest":
           name: "oss-nightly-gotest<<# matrix.fast-reconfigure >>-fastreconfigure<</ matrix.fast-reconfigure >><<# matrix.legacy-mode >>-legacy<</ matrix.legacy-mode >>"
           matrix:

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ venv
 __pycache__
 .pytest_cache
 .mypy_cache
+.envrc
 
 # local files
 *.local

--- a/builder/Dockerfile-ea
+++ b/builder/Dockerfile-ea
@@ -1,0 +1,14 @@
+########################################
+# The ambassador-ea image is the early access image: it's the "normal"
+# ambassador image with several extra options turned on.
+
+# It's VERY IMPORTANT to set base_ambassador correctly! We override it
+# in the Makefile, but default it to the ambassador stage so maybe we
+# have a chance of this Dockerfile working out of the box.
+
+ARG base_ambassador="ambassador"
+
+FROM ${base_ambassador} as ambassador-ea
+
+ENV AMBASSADOR_FAST_RECONFIGURE=true
+ENV AMBASSADOR_ENVOY_API_VERSION=V3

--- a/builder/builder.mk
+++ b/builder/builder.mk
@@ -373,6 +373,26 @@ push: docker/kat-client.docker.push.remote
 push: docker/kat-server.docker.push.remote
 .PHONY: push
 
+push-nightly: docker/$(LCNAME).docker.tag.local docker/$(LCNAME)-ea.docker.tag.local
+	@set -e; { \
+		if [ -n "$(IS_DIRTY)" ]; then \
+			echo "push-with-datestamp: tree must be clean" >&2 ;\
+			exit 1 ;\
+		fi; \
+		now=$$(date +"%Y%m%dT%H%M%S") ;\
+		today=$$(date +"%Y%m%d") ;\
+		base_version=$$(echo $(BUILD_VERSION) | cut -d- -f1) ;\
+		for image in $(LCNAME) $(LCNAME)-ea; do \
+			for suffix in "$$now" "$$today"; do \
+				tag="$(DEV_REGISTRY)/$$image:$${base_version}-nightly.$${suffix}" ;\
+				echo "pushing $$image as $$tag..." ;\
+				docker tag $$(cat docker/$$image.docker) $$tag && \
+				docker push $$tag ;\
+			done ;\
+		done ;\
+	}
+.PHONY: push-nightly
+
 export KUBECONFIG_ERR=$(RED)ERROR: please set the $(BLU)DEV_KUBECONFIG$(RED) make/env variable to the cluster\n       you would like to use for development. Note this cluster must have access\n       to $(BLU)DEV_REGISTRY$(RED) (currently $(BLD)$(DEV_REGISTRY)$(END)$(RED))$(END)
 export KUBECTL_ERR=$(RED)ERROR: preflight kubectl check failed$(END)
 
@@ -606,6 +626,7 @@ export RELEASE_REGISTRY_ERR=$(RED)ERROR: please set the RELEASE_REGISTRY make/en
 RELEASE_TYPE=$$($(BUILDER) release-type)
 RELEASE_VERSION=$$($(BUILDER) release-version)
 BUILD_VERSION=$$($(BUILDER) version)
+IS_DIRTY=$$($(BUILDER) is-dirty)
 
 # 'rc' is a deprecated alias for 'release/bits', kept around for the
 # moment to avoid pain with needing to update apro.git in lockstep.

--- a/builder/builder.mk
+++ b/builder/builder.mk
@@ -225,6 +225,10 @@ version:
 	@$(BUILDER) version
 .PHONY: version
 
+raw-version:
+	@$(BUILDER) raw-version
+.PHONY: raw-version
+
 compile: sync
 	@$(BUILDER) compile
 .PHONY: compile

--- a/builder/builder.mk
+++ b/builder/builder.mk
@@ -394,6 +394,27 @@ push-dev: docker/$(LCNAME).docker.tag.local docker/$(LCNAME)-ea.docker.tag.local
 	}
 .PHONY: push-dev
 
+push-ci: docker/$(LCNAME).docker.tag.local docker/$(LCNAME)-ea.docker.tag.local
+	@set -e; { \
+		if [ -n "$(IS_DIRTY)" ]; then \
+			echo "push-ci: tree must be clean" >&2 ;\
+			exit 1 ;\
+		fi; \
+		check=$$(echo $(BUILD_VERSION) | grep -c -e -dev || true) ;\
+		if [ $$check -lt 1 ]; then \
+			echo "push-dev: BUILD_VERSION $(BUILD_VERSION) is not a dev version" >&2 ;\
+			exit 1 ;\
+		fi ;\
+		suffix=$$(echo $(BUILD_VERSION) | sed -e 's/-dev\.\([0-9][0-9]*\).*$$/-ci.\1/') ;\
+		for image in $(LCNAME) $(LCNAME)-ea; do \
+			tag="$(DEV_REGISTRY)/$$image:$${suffix}" ;\
+			echo "pushing $$image as $$tag..." ;\
+			docker tag $$(cat docker/$$image.docker) $$tag && \
+			docker push $$tag ;\
+		done ;\
+	}
+.PHONY: push-ci
+
 push-nightly: docker/$(LCNAME).docker.tag.local docker/$(LCNAME)-ea.docker.tag.local
 	@set -e; { \
 		if [ -n "$(IS_DIRTY)" ]; then \

--- a/builder/builder.mk
+++ b/builder/builder.mk
@@ -373,6 +373,27 @@ push: docker/kat-client.docker.push.remote
 push: docker/kat-server.docker.push.remote
 .PHONY: push
 
+push-dev: docker/$(LCNAME).docker.tag.local docker/$(LCNAME)-ea.docker.tag.local
+	@set -e; { \
+		if [ -n "$(IS_DIRTY)" ]; then \
+			echo "push-dev: tree must be clean" >&2 ;\
+			exit 1 ;\
+		fi; \
+		check=$$(echo $(BUILD_VERSION) | grep -c -e -dev || true) ;\
+		if [ $$check -lt 1 ]; then \
+			echo "push-dev: BUILD_VERSION $(BUILD_VERSION) is not a dev version" >&2 ;\
+			exit 1 ;\
+		fi ;\
+		suffix=$$(echo $(BUILD_VERSION) | sed -e 's/\+/-/') ;\
+		for image in $(LCNAME) $(LCNAME)-ea; do \
+			tag="$(DEV_REGISTRY)/$$image:$${suffix}" ;\
+			echo "pushing $$image as $$tag..." ;\
+			docker tag $$(cat docker/$$image.docker) $$tag && \
+			docker push $$tag ;\
+		done ;\
+	}
+.PHONY: push-dev
+
 push-nightly: docker/$(LCNAME).docker.tag.local docker/$(LCNAME)-ea.docker.tag.local
 	@set -e; { \
 		if [ -n "$(IS_DIRTY)" ]; then \

--- a/builder/builder.sh
+++ b/builder/builder.sh
@@ -286,6 +286,22 @@ bootstrap() {
 module_version() {
     echo MODULE="\"$1\""
 
+    # What version is in docs/yaml/version.yaml?
+
+    BASE_VERSION=
+
+    if [ -f docs/yaml/versions.yml ]; then
+        BASE_VERSION=$(grep version: docs/yaml/versions.yml | awk ' { print $2 }')
+    else
+        # We have... nothing.
+        echo "No base version" >&2 
+        exit 1
+    fi
+
+    # EXTRA_VERSION gets added to BASE_VERSION (below). Start it out empty.
+    EXTRA_VERSION=    
+
+    # Get a bunch of git info, starting with the branch.
     echo GIT_BRANCH="\"$(git rev-parse --abbrev-ref HEAD)\""
 
     # The short git commit hash
@@ -298,47 +314,71 @@ module_version() {
         echo GIT_DIRTY="\"\""
         dirty=""
     fi
-    # The _previous_ tag, plus a git delta, like 0.36.0-436-g8b8c5d3
-    echo GIT_DESCRIPTION="\"$(git describe --tags)\""
+    # The _previous_ tag, plus a git delta, like 'v1.13.3-117-g2434c437f'... or, if we're _on_
+    # a tag, just something like 'v1.13.3'.
+    GIT_DESCRIPTION=$(git describe --tags --match 'v*')
+    echo GIT_DESCRIPTION="\"$GIT_DESCRIPTION\""
 
-    # We're going to post-process RELEASE_VERSION below.  But for now
-    # what you need to know is: This block is just going to set it to
-    # the git tag.
-    #
-    # The reason that we give precedence to `CIRCLE_TAG` over `git
-    # describe` is that if there are multiple tags pointing at the
-    # same commit, then it is non-deterministic which tag `git
-    # describe` will choose.  We want to know which one of those tags
-    # actually triggered this CI run, so we give precedence to
-    # CircleCI, since it has information that isn't actually stored in
-    # Git.
-    for VAR in "${CIRCLE_TAG}" "$(git describe --tags --always)"; do
-        if [ -n "${VAR}" ]; then
-            RELEASE_VERSION="${VAR}"
-            break
+    # Do we have a '-' in our GIT_DESCRIPTION?
+    if [[ ${GIT_DESCRIPTION} =~ - ]]; then 
+        # Pull out fields from that.
+        GIT_VERSION=$(echo $GIT_DESCRIPTION | cut -d- -f1)
+        GIT_REST=$(echo $GIT_DESCRIPTION | cut -d- -f2-)
+
+        # If the first character of GIT_REST is alphabetic, we should be looking
+        # at an "-rc" or "-ea" tag or the like, and there should not be another -
+        # in it.
+        if [[ ${GIT_REST} =~ ^[a-z] ]]; then
+            if [[ ${GIT_REST} =~ - ]]; then
+                echo "GIT_VERSION $GIT_VERSION is not understood" >&2
+                exit 1
+            fi
+
+            # Good to go. Remember to put the leading "-" back here.
+            EXTRA_VERSION="-${GIT_REST}"
+        else
+            # GIT_REST should be N-gH, so split it into parts...
+            GIT_COUNT=$(echo $GIT_REST | cut -d- -f1)
+            GIT_HASH=$(echo $GIT_REST | cut -d- -f2)
+
+            # ...and build EXTRA_VERSION from that.
+            EXTRA_VERSION="-dev.${GIT_COUNT}+${GIT_HASH}"
         fi
-    done
+    else
+        # We're on a tag. Does it match our build version?
+        if [ "$GIT_DESCRIPTION" != "v$BASE_VERSION" ]; then
+            echo "Tag $GIT_DESCRIPTION does not match base version $BASE_VERSION" >&2
+            exit 1
+        fi
 
-    # RELEASE_VERSION is an X.Y.Z[-prerelease] (semver) string that we
-    # will upload/release the image as.  It does NOT include a leading 'v'
-    # (trimming the 'v' from the git tag is what the 'patsubst' is for).
-    # If this is an RC or EA, then it includes the '-rc.N' or '-ea.N'
-    # suffix.
-    #
-    # BUILD_VERSION is of the same format, but is the version number that
-    # we build into the image.  Because an image built as a "release
-    # candidate" will ideally get promoted to be the GA image, we trim off
-    # the '-rc.N' suffix.
-    if [[ ${RELEASE_VERSION} =~ ^v[0-9]+.*$ ]]; then
-        RELEASE_VERSION=${RELEASE_VERSION:1}
+        # All good, use no EXTRA_VERSION stuff here -- but set GIT_VERSION just in
+        # case someone wants it?
+        GIT_VERSION=$GIT_DESCRIPTION
     fi
+
+    # RELEASE_VERSION is a semver string that we use for tagging things.
+    # BUILD_VERSION is a semver string that we build into the images.
+    #
+    # Neither of these should have a leading 'v'.
+
+    BUILD_VERSION="${BASE_VERSION}${EXTRA_VERSION}"
+
+    if [[ ${BUILD_VERSION} =~ ^v[0-9]+.*$ ]]; then
+        BUILD_VERSION=${BUILD_VERSION:1}
+    fi
+
+    RELEASE_VERSION=$BUILD_VERSION
 
     if [ -n "${dirty}" ]; then
         RELEASE_VERSION="${RELEASE_VERSION}-dirty"
     fi
 
+    echo GIT_VERSION="\"${GIT_VERSION}\""
+    echo GIT_REST="\"${GIT_REST}\""
+    echo BASE_VERSION="\"${BASE_VERSION}\""
+    echo EXTRA_VERSION="\"${EXTRA_VERSION}\""
     echo RELEASE_VERSION="\"${RELEASE_VERSION}\""
-    echo BUILD_VERSION="\"$(echo "${RELEASE_VERSION}" | sed 's/-rc\.[0-9]*$//')\""
+    echo BUILD_VERSION="\"${BUILD_VERSION}\""
 }
 
 sync() {

--- a/builder/builder.sh
+++ b/builder/builder.sh
@@ -469,6 +469,15 @@ case "${cmd}" in
         eval $(module_version ${BUILDER_NAME})
         echo "${RELEASE_VERSION}"
         ;;
+    is-dirty)
+        shift
+        eval $(module_version ${BUILDER_NAME})
+        echo "${GIT_DIRTY}"
+        ;;
+    raw-version)
+        shift
+        module_version ${BUILDER_NAME}
+        ;;
     version)
         shift
         eval $(module_version ${BUILDER_NAME})

--- a/builder/builder.sh
+++ b/builder/builder.sh
@@ -466,12 +466,12 @@ case "${cmd}" in
         ;;
     release-version)
         shift
-        source <(module_version ${BUILDER_NAME})
+        eval $(module_version ${BUILDER_NAME})
         echo "${RELEASE_VERSION}"
         ;;
     version)
         shift
-        source <(module_version ${BUILDER_NAME})
+        eval $(module_version ${BUILDER_NAME})
         echo "${BUILD_VERSION}"
         ;;
     compile)

--- a/docs/yaml/versions.yml
+++ b/docs/yaml/versions.yml
@@ -1,2 +1,2 @@
-version: 1.13.3
+version: 2.0.0
 quoteVersion: 0.4.1


### PR DESCRIPTION
This'll be gaining intelligence as we go, but, here're the highlights:

- Introduce a nightly job for `shared/emissary` to run the new `push-wip` job. 
   - For the moment, it runs on `shared/nightly-test`, for testing.
- The `push-wip` job currently 
   - takes the existing image that we already built,
   - retags and pushes it as `2.0.0-wip.YYYYMMDDTHHMMSS`, and also
   - retags and pushes it as `2.0.0-wip.YYYYMMDD`.
- It does this _before testing_ so that we always have that image.
- The `wip` tag is because c'mon, folks, this is _not_ a real image yet! There's a lot of testing we need to do. (If you're reading this from outside Ambassador Labs, for the love of all that is holy please _do not run this image_ before talking to us!)
- Next step is to teach `push-wip` to also create and tag a `2.0.0-eawip.YYYYMMDD` image.
   - The `eawip` image will have all the interesting knobs that exist turned on.
   - At present, that means that it'll set `AMBASSADOR_FAST_RECONFIGURE=true` and `AMBASSADOR_ENVOY_API_VERSION=V3`.
   - Soon enough it might also include e.g. making the endpoint resolver standard or something. Who knows.
- After that, we'll be teaching `push-wip` to also push the Helm chart, YAML, etc.

Some underlying changes:

- Version information always reads `docs/yaml/versions.yml` now, which implies that
- We'll be updating `docs/yaml/versions.yml` to reflect the next upcoming release very early in the cycle.

Note that this PR currently builds the EA images from `Dockerfile-ea`, which I find a little unsatisfying. Either we should spilt the KAT images out of `Dockerfile` (which I would support), or we should include the EA images in `Dockerfile` (a quick cut at that turned up hassles with needless build args, so I did this the simple way instead).