### PR TITLE
Revive push-ci from, y'know, CI.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -984,7 +984,7 @@ workflows:
           matrix.fast-reconfigure >><<# matrix.legacy-mode >>-legacy<</ matrix.legacy-mode
           >>"
         matrix:
-          alias: "oss-dev-test-matrix"
+          alias: "oss-dev-pytest-matrix"
           parameters:
             test:
             - "pytest"
@@ -1012,7 +1012,7 @@ workflows:
           matrix.fast-reconfigure >><<# matrix.legacy-mode >>-legacy<</ matrix.legacy-mode
           >>"
         matrix:
-          alias: "oss-dev-envoy-test"
+          alias: "oss-dev-envoy-test-matrix"
           parameters:
             test:
             - "pytest-envoy"
@@ -1031,6 +1031,16 @@ workflows:
           - test: pytest-envoy-v3
             fast-reconfigure: true
             legacy-mode: true
+    - oss-push-ci:
+        name: oss-dev-push-ci
+        requires:
+        - oss-dev-generate
+        - oss-dev-lint
+        - oss-dev-chart
+        - emissary-dev-chart
+        - oss-dev-gotest-matrix
+        - oss-dev-pytest-matrix
+        - oss-dev-envoy-test-matrix
   'OSS: Chart Release':
     when:
       or:

--- a/.circleci/config.yml.d/amb_oss.yml
+++ b/.circleci/config.yml.d/amb_oss.yml
@@ -210,7 +210,7 @@ workflows:
           requires: ["oss-dev-images"]
           name: "oss-dev-<< matrix.test >><<# matrix.fast-reconfigure >>-fastreconfigure<</ matrix.fast-reconfigure >><<# matrix.legacy-mode >>-legacy<</ matrix.legacy-mode >>"
           matrix:
-            alias: "oss-dev-test-matrix"
+            alias: "oss-dev-pytest-matrix"
             parameters:
               test:
                 - "pytest"
@@ -237,7 +237,7 @@ workflows:
           requires: ["oss-dev-images"]
           name: "oss-dev-<< matrix.test >><<# matrix.fast-reconfigure >>-fastreconfigure<</ matrix.fast-reconfigure >><<# matrix.legacy-mode >>-legacy<</ matrix.legacy-mode >>"
           matrix:
-            alias: "oss-dev-envoy-test"
+            alias: "oss-dev-envoy-test-matrix"
             parameters:
               test:
                 - "pytest-envoy"
@@ -259,6 +259,18 @@ workflows:
               - test: pytest-envoy-v3
                 fast-reconfigure: true
                 legacy-mode: true
+      - "oss-push-ci":
+          name: oss-dev-push-ci
+          requires:
+            - oss-dev-generate
+            - oss-dev-lint
+            - oss-dev-chart
+            - emissary-dev-chart
+            - oss-dev-gotest-matrix
+            - oss-dev-pytest-matrix
+            - oss-dev-envoy-test-matrix
+
+
   "OSS: Chart Release":
     when: # Don't run this workflow in apro.git
       or:


### PR DESCRIPTION
Go ahead and run `push-ci` when the `oss-dev` tests pass.