### PR TITLE
Have a way to promote Emissary builds all the way to "GA"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -984,7 +984,7 @@ workflows:
           matrix.fast-reconfigure >><<# matrix.legacy-mode >>-legacy<</ matrix.legacy-mode
           >>"
         matrix:
-          alias: "oss-dev-test-matrix"
+          alias: "oss-dev-pytest-matrix"
           parameters:
             test:
             - "pytest"
@@ -1012,7 +1012,7 @@ workflows:
           matrix.fast-reconfigure >><<# matrix.legacy-mode >>-legacy<</ matrix.legacy-mode
           >>"
         matrix:
-          alias: "oss-dev-envoy-test"
+          alias: "oss-dev-envoy-test-matrix"
           parameters:
             test:
             - "pytest-envoy"
@@ -1031,6 +1031,16 @@ workflows:
           - test: pytest-envoy-v3
             fast-reconfigure: true
             legacy-mode: true
+    - oss-push-ci:
+        name: oss-dev-push-ci
+        requires:
+        - oss-dev-generate
+        - oss-dev-lint
+        - oss-dev-chart
+        - emissary-dev-chart
+        - oss-dev-gotest-matrix
+        - oss-dev-pytest-matrix
+        - oss-dev-envoy-test-matrix
   'OSS: Chart Release':
     when:
       or:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -142,6 +142,9 @@ commands:
             name: "Push dev images"
             command: |
               [[ "$DEV_REGISTRY" == 127.0.0.1:31000 ]] || make push-dev
+        - run:
+            name: "Clean up dirty chart stuff"
+            command: "make chart-clean                 \n"
     - when:
         condition: << parameters.release >>
         steps:
@@ -157,6 +160,10 @@ commands:
             name: "Push nightly images"
             command: |
               make push-nightly
+        - run:
+            name: "Clean up dirty chart stuff"
+            command: |
+              make chart-clean
     # teardown
     - dirty-check
     - amb-save-workspace

--- a/.circleci/config.yml.d/amb_jobs.yml
+++ b/.circleci/config.yml.d/amb_jobs.yml
@@ -155,6 +155,10 @@ commands:
                 name: "Push dev images"
                 command: |
                   [[ "$DEV_REGISTRY" == 127.0.0.1:31000 ]] || make push-dev
+            - run:
+                name: "Clean up dirty chart stuff"
+                command: |
+                  make chart-clean                 
       - when:
           condition: << parameters.release >>
           steps:
@@ -170,6 +174,10 @@ commands:
                 name: "Push nightly images"
                 command: |
                   make push-nightly
+            - run:
+                name: "Clean up dirty chart stuff"
+                command: |
+                  make chart-clean
 
       # teardown
       - dirty-check

--- a/.circleci/config.yml.d/amb_oss.yml
+++ b/.circleci/config.yml.d/amb_oss.yml
@@ -210,7 +210,7 @@ workflows:
           requires: ["oss-dev-images"]
           name: "oss-dev-<< matrix.test >><<# matrix.fast-reconfigure >>-fastreconfigure<</ matrix.fast-reconfigure >><<# matrix.legacy-mode >>-legacy<</ matrix.legacy-mode >>"
           matrix:
-            alias: "oss-dev-test-matrix"
+            alias: "oss-dev-pytest-matrix"
             parameters:
               test:
                 - "pytest"
@@ -237,7 +237,7 @@ workflows:
           requires: ["oss-dev-images"]
           name: "oss-dev-<< matrix.test >><<# matrix.fast-reconfigure >>-fastreconfigure<</ matrix.fast-reconfigure >><<# matrix.legacy-mode >>-legacy<</ matrix.legacy-mode >>"
           matrix:
-            alias: "oss-dev-envoy-test"
+            alias: "oss-dev-envoy-test-matrix"
             parameters:
               test:
                 - "pytest-envoy"
@@ -259,6 +259,18 @@ workflows:
               - test: pytest-envoy-v3
                 fast-reconfigure: true
                 legacy-mode: true
+      - "oss-push-ci":
+          name: oss-dev-push-ci
+          requires:
+            - oss-dev-generate
+            - oss-dev-lint
+            - oss-dev-chart
+            - emissary-dev-chart
+            - oss-dev-gotest-matrix
+            - oss-dev-pytest-matrix
+            - oss-dev-envoy-test-matrix
+
+
   "OSS: Chart Release":
     when: # Don't run this workflow in apro.git
       or:

--- a/builder/builder.mk
+++ b/builder/builder.mk
@@ -434,9 +434,11 @@ push-nightly: docker/$(LCNAME).docker.tag.local docker/$(LCNAME)-ea.docker.tag.l
 				docker push $$tag ;\
 			done ;\
 		done ;\
+		CHART_VERSION_SUFFIX=-nightly.$$today ;\
+		IMAGE_TAG=$${base_version}$${CHART_VERSION_SUFFIX} ;\
 		$(MAKE) \
-			CHART_VERSION_SUFFIX=-nightly.$$today \
-			IMAGE_TAG=$${base_version}-nightly.$${suffix} \
+			CHART_VERSION_SUFFIX="$${CHART_VERSION_SUFFIX}" \
+			IMAGE_TAG="$${IMAGE_TAG}" \
 			IMAGE_REPO="$(DEV_REGISTRY)/$(LCNAME)" \
 			chart-push-ci ; \
 		$(MAKE) update-yaml --always-make; \

--- a/builder/builder.mk
+++ b/builder/builder.mk
@@ -424,7 +424,7 @@ push-ci: docker/$(LCNAME).docker.tag.local docker/$(LCNAME)-ea.docker.tag.local
 push-nightly: docker/$(LCNAME).docker.tag.local docker/$(LCNAME)-ea.docker.tag.local
 	@set -e; { \
 		if [ -n "$(IS_DIRTY)" ]; then \
-			echo "push-with-datestamp: tree must be clean" >&2 ;\
+			echo "push-nightly: tree must be clean" >&2 ;\
 			exit 1 ;\
 		fi; \
 		now=$$(date +"%Y%m%dT%H%M%S") ;\

--- a/builder/builder.mk
+++ b/builder/builder.mk
@@ -390,6 +390,9 @@ push-dev: docker/$(LCNAME).docker.tag.local docker/$(LCNAME)-ea.docker.tag.local
 			docker tag $$(cat docker/$$image.docker) $$tag && \
 			docker push $$tag ;\
 		done ;\
+		commit=$$(git rev-parse HEAD) ;\
+		printf "$(CYN)==> $(GRN)recording $(BLU)$$commit$(GRN) => $(BLU)$$suffix$(GRN) in S3...$(END)\n" ;\
+		echo "$$suffix" | aws s3 cp - s3://datawire-static-files/dev-builds/$$commit ;\
 		$(MAKE) \
 			CHART_VERSION_SUFFIX=-$$chartsuffix \
 			IMAGE_TAG=$${suffix} \

--- a/builder/builder.mk
+++ b/builder/builder.mk
@@ -383,12 +383,20 @@ push-dev: docker/$(LCNAME).docker.tag.local docker/$(LCNAME)-ea.docker.tag.local
 			exit 1 ;\
 		fi ;\
 		suffix=$$(echo $(BUILD_VERSION) | sed -e 's/\+/-/') ;\
+		chartsuffix=$${suffix#*-} ; \
 		for image in $(LCNAME) $(LCNAME)-ea; do \
 			tag="$(DEV_REGISTRY)/$$image:$${suffix}" ;\
 			printf "$(CYN)==> $(GRN)pushing $(BLU)$$image$(GRN) as $(BLU)$$tag$(GRN)...$(END)\n" ;\
 			docker tag $$(cat docker/$$image.docker) $$tag && \
 			docker push $$tag ;\
 		done ;\
+		$(MAKE) \
+			CHART_VERSION_SUFFIX=-$$chartsuffix \
+			IMAGE_TAG=$${suffix} \
+			IMAGE_REPO="$(DEV_REGISTRY)/$(LCNAME)" \
+			chart-push-ci ; \
+		$(MAKE) update-yaml --always-make; \
+		VERSION_OVERRIDE=$$suffix $(OSS_HOME)/manifests/push_manifests.sh ; \
 	}
 .PHONY: push-dev
 

--- a/builder/builder.mk
+++ b/builder/builder.mk
@@ -383,13 +383,13 @@ push-dev: docker/$(LCNAME).docker.tag.local docker/$(LCNAME)-ea.docker.tag.local
 		fi; \
 		check=$$(echo $(BUILD_VERSION) | grep -c -e -dev || true) ;\
 		if [ $$check -lt 1 ]; then \
-			echo "push-dev: BUILD_VERSION $(BUILD_VERSION) is not a dev version" >&2 ;\
+			printf "$(RED)push-dev: BUILD_VERSION $(BUILD_VERSION) is not a dev version$(END)\n" >&2 ;\
 			exit 1 ;\
 		fi ;\
 		suffix=$$(echo $(BUILD_VERSION) | sed -e 's/\+/-/') ;\
 		for image in $(LCNAME) $(LCNAME)-ea; do \
 			tag="$(DEV_REGISTRY)/$$image:$${suffix}" ;\
-			echo "pushing $$image as $$tag..." ;\
+			printf "$(CYN)==> $(GRN)pushing $(BLU)$$image$(GRN) as $(BLU)$$tag$(GRN)...$(END)\n" ;\
 			docker tag $$(cat docker/$$image.docker) $$tag && \
 			docker push $$tag ;\
 		done ;\
@@ -400,14 +400,14 @@ push-ci: docker/$(LCNAME).docker.tag.local docker/$(LCNAME)-ea.docker.tag.local
 	@set -e; { \
 		check=$$(echo $(BUILD_VERSION) | grep -c -e -dev || true) ;\
 		if [ $$check -lt 1 ]; then \
-			echo "push-dev: BUILD_VERSION $(BUILD_VERSION) is not a dev version" >&2 ;\
+			printf "$(RED)push-ci: BUILD_VERSION $(BUILD_VERSION) is not a dev version$(END)\n" >&2 ;\
 			exit 1 ;\
 		fi ;\
 		suffix=$$(echo $(BUILD_VERSION) | sed -e 's/-dev\.\([0-9][0-9]*\).*$$/-ci.\1/') ;\
 		chartsuffix=$${suffix#*-} ; \
 		for image in $(LCNAME) $(LCNAME)-ea; do \
 			tag="$(DEV_REGISTRY)/$$image:$${suffix}" ;\
-			echo "pushing $$image as $$tag..." ;\
+			printf "$(CYN)==> $(GRN)pushing $(BLU)$$image$(GRN) as $(BLU)$$tag$(GRN)...$(END)\n" ;\
 			docker tag $$(cat docker/$$image.docker) $$tag && \
 			docker push $$tag ;\
 		done ;\
@@ -433,7 +433,7 @@ push-nightly: docker/$(LCNAME).docker.tag.local docker/$(LCNAME)-ea.docker.tag.l
 		for image in $(LCNAME) $(LCNAME)-ea; do \
 			for suffix in "$$now" "$$today"; do \
 				tag="$(DEV_REGISTRY)/$$image:$${base_version}-nightly.$${suffix}" ;\
-				echo "pushing $$image as $$tag..." ;\
+				printf "$(CYN)==> $(GRN)pushing $(BLU)$$image$(GRN) as $(BLU)$$tag$(GRN)...$(END)\n" ;\
 				docker tag $$(cat docker/$$image.docker) $$tag && \
 				docker push $$tag ;\
 			done ;\

--- a/builder/builder.mk
+++ b/builder/builder.mk
@@ -731,6 +731,13 @@ release/promote-oss/.main:
 
 	@printf '  $(CYN)s3://scout-datawire-io/emissary-ingress/$(PROMOTE_CHANNEL)app.json$(END)\n'
 	printf '{"application":"emissary","latest_version":"%s","notices":[]}' "$(RELEASE_VERSION)" | aws s3 cp - s3://scout-datawire-io/emissary-ingress/$(PROMOTE_CHANNEL)app.json
+	$(MAKE) \
+		CHART_VERSION_SUFFIX= \
+		IMAGE_TAG=$(PROMOTE_TO_VERSION) \
+		IMAGE_REPO="$(DEV_REGISTRY)/$(LCNAME)" \
+		chart-push-ga ; \
+	$(MAKE) update-yaml --always-make; \
+	VERSION_OVERRIDE=$$suffix $(OSS_HOME)/manifests/push_manifests.sh
 .PHONY: release/promote-oss/.main
 
 # To be run from a checkout at the tag you are promoting _from_.

--- a/builder/builder.mk
+++ b/builder/builder.mk
@@ -377,10 +377,6 @@ push: docker/kat-server.docker.push.remote
 
 push-dev: docker/$(LCNAME).docker.tag.local docker/$(LCNAME)-ea.docker.tag.local
 	@set -e; { \
-		if [ -n "$(IS_DIRTY)" ]; then \
-			echo "push-dev: tree must be clean" >&2 ;\
-			exit 1 ;\
-		fi; \
 		check=$$(echo $(BUILD_VERSION) | grep -c -e -dev || true) ;\
 		if [ $$check -lt 1 ]; then \
 			printf "$(RED)push-dev: BUILD_VERSION $(BUILD_VERSION) is not a dev version$(END)\n" >&2 ;\

--- a/charts/ambassador/ci/push_chart.sh
+++ b/charts/ambassador/ci/push_chart.sh
@@ -15,6 +15,7 @@ if ! command -v helm 2> /dev/null ; then
     curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3
     chmod 700 get_helm.sh
     ./get_helm.sh --version v3.4.1
+    rm -f get_helm.sh
 fi
 thisversion=$(grep version charts/ambassador/Chart.yaml | awk ' { print $2 }')
 

--- a/charts/ambassador/ci/push_chart.sh
+++ b/charts/ambassador/ci/push_chart.sh
@@ -23,9 +23,11 @@ repo_key=
 if [[ -n "${REPO_KEY}" ]] ; then
     repo_key="${REPO_KEY}"
 elif [[ $version =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] ; then
-    repo_key=ambassador
+    # repo_key=ambassador
+    repo_key=emissary-ingress   # I really don't want this messing with ambassador's stuff now
 else
-    repo_key=ambassador-dev
+    # repo_key=ambassador-dev
+    repo_key=emissary-ingress   # I really don't want this messing with ambassador's stuff now
 fi
 repo_url=https://s3.amazonaws.com/datawire-static-files/${repo_key}/
 

--- a/charts/ambassador/ci/push_chart.sh
+++ b/charts/ambassador/ci/push_chart.sh
@@ -52,7 +52,7 @@ fi
 info "Pushing chart to S3 bucket $AWS_BUCKET"
 for f in "$CHART_PACKAGE" "${TOP_DIR}/index.yaml" ; do
     fname=`basename $f`
-    echo "would have pushed ${repo_key}/$fname"
+    echo "pushing ${repo_key}/$fname"
     aws s3api put-object \
         --bucket "$AWS_BUCKET" \
         --key "${repo_key}/$fname" \

--- a/charts/charts.mk
+++ b/charts/charts.mk
@@ -27,6 +27,19 @@ chart-push-ci:
 		$(call _push_chart,$$chart) ; \
 	done ;
 
+chart-push-ga:
+	@echo ">>> This will dirty your local tree and should only be run in CI"
+	@echo ">>> If running locally, you'll probably want to reset charts/ directory after running this"
+	@[ -z "${CHART_VERSION_SUFFIX}" ] || (echo "CHART_VERSION_SUFFIX must not be set for GA pushes" && exit 1)
+	@[ -n "${IMAGE_TAG}" ] || (echo "IMAGE_TAG must be set" && exit 1)
+	@[ -n "${IMAGE_REPO}" ] || (echo "IMAGE_REPO must be set" && exit 1)
+	@for chart in $(AMBASSADOR_CHART) $(EMISSARY_CHART) ; do \
+		sed -i.bak -E "s/version: ([0-9]+\.[0-9]+\.[0-9]+).*/version: \1/g" $$chart/Chart.yaml && rm $$chart/Chart.yaml.bak ; \
+		$(call _set_tag,$$chart,${IMAGE_TAG}) ; \
+		$(call _set_repo,$$chart,${IMAGE_REPO}) ; \
+		$(call _push_chart,$$chart) ; \
+	done ;
+
 # This is pretty Draconian. Use with care.
 chart-clean:
 	git restore charts/*/Chart.yaml charts/*/values.yaml

--- a/charts/charts.mk
+++ b/charts/charts.mk
@@ -26,3 +26,9 @@ chart-push-ci:
 		$(call _set_repo,$$chart,${IMAGE_REPO}) ; \
 		$(call _push_chart,$$chart) ; \
 	done ;
+
+# This is pretty Draconian. Use with care.
+chart-clean:
+	git restore charts/*/Chart.yaml charts/*/values.yaml
+	rm -f charts/*/*.tgz charts/*/index.yaml charts/*/tmp.yaml
+.PHONY: chart-clean

--- a/charts/emissary-ingress/ci/push_chart.sh
+++ b/charts/emissary-ingress/ci/push_chart.sh
@@ -57,7 +57,7 @@ fi
 info "Pushing chart to S3 bucket $AWS_BUCKET"
 for f in "$CHART_PACKAGE" "${TOP_DIR}/index.yaml" ; do
     fname=`basename $f`
-    echo "would have pushed ${repo_key}/$fname"
+    echo "pushing ${repo_key}/$fname"
     aws s3api put-object \
         --bucket "$AWS_BUCKET" \
         --key "${repo_key}/$fname" \

--- a/charts/emissary-ingress/ci/push_chart.sh
+++ b/charts/emissary-ingress/ci/push_chart.sh
@@ -27,9 +27,11 @@ repo_key=
 if [[ -n "${REPO_KEY}" ]] ; then
     repo_key="${REPO_KEY}"
 elif [[ $version =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] ; then
-    repo_key=ambassador
+    # repo_key=ambassador
+    repo_key=emissary-ingress   # I really don't want this messing with ambassador's stuff now
 else
-    repo_key=ambassador-dev
+    # repo_key=ambassador-dev
+    repo_key=emissary-ingress   # I really don't want this messing with ambassador's stuff now
 fi
 s3url=https://s3.amazonaws.com/datawire-static-files/${repo_key}/
 

--- a/charts/emissary-ingress/ci/push_chart.sh
+++ b/charts/emissary-ingress/ci/push_chart.sh
@@ -20,6 +20,7 @@ if ! command -v helm 2> /dev/null ; then
     curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3
     chmod 700 get_helm.sh
     ./get_helm.sh --version v3.4.1
+    rm -f get_helm.sh
 fi
 thisversion=$(grep version charts/emissary-ingress/Chart.yaml | awk ' { print $2 }')
 repo_key=


### PR DESCRIPTION
Review commit-by-commit. **NOTE WELL**: several paths are deliberately tweaked to be _certain_ that we won't collide with Ambassador. Also, there's a _lot_ of opportunity to factor out common code in here.

Flow:
- Develop as usual.
- PRs build and push dev-versioned images, Helm charts, and YAML.
   - These builds are also recorded in S3 so you can find the dev build corresponding to a given commit.
- To promote to GA, tag with a `vX.Y.Z` tag and, for now, run `make release/promote-oss/to-ga`
   - This will look up the dev build in S3, retag it as "GA" and push, then push Helm and manifests
      - Right now, the "GA" tag looks like `vX.Y.Z-wip` to avoid collisions with real builds.
 
Major caveats:
- The EA images are pushed, but the EA Helm charts are not (yet).
- The paths in S3 and such are hella disorganized, and we need to clean them up.
- CI isn't hooked up on the GA tag, but that's deliberate.
- The whole record-the-dev-version in S3 bugs me; if we keep it we'll need a pruning job.
   - OTOH we can probably ditch the whole `-ci` version thing by keeping the S3 thing.
