### PR TITLE
Make sure oss-chart-changelog can't ever be empty.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -797,6 +797,7 @@ jobs:
   oss-chart-changelog:
     executor: oss-linux
     steps:
+    - run: "true" # Always run a no-op step so that this config has non-zero steps even for the "wrong" repo or branch
     - when:
         condition:
           and:

--- a/.circleci/config.yml.d/amb_oss.yml
+++ b/.circleci/config.yml.d/amb_oss.yml
@@ -97,6 +97,7 @@ jobs:
   "oss-chart-changelog":
     executor: oss-linux
     steps:
+      - run: "true" # Always run a no-op step so that this config has non-zero steps even for the "wrong" repo or branch
       - when:
           condition:
             and:


### PR DESCRIPTION
`oss-chart-changelog` isn't meant to run on `master`, so we need to make sure that it has a no-op step for when its condition doesn't fire.
