### PR TITLE
move/massage some toybox scripts, tie in manifests/helm to GA release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1040,6 +1040,23 @@ workflows:
             only: /^chart\-v[0-9]+\.[0-9]+\.[0-9]+$/
           branches:
             ignore: /.*/
+  'OSS: Manifests Release':
+    when:
+      or:
+      - equal:
+        - "https://github.com/datawire/ambassador"
+        - << pipeline.project.git_url >>
+      - equal:
+        - "https://github.com/datawire/ambassador-private"
+        - << pipeline.project.git_url >>
+    jobs:
+    - oss-manifest-publish:
+        name: "oss-rc-manifests-publish"
+        filters:
+          tags:
+            only: /^chart\-v[0-9]+\.[0-9]+\.[0-9]+$/
+          branches:
+            ignore: /.*/
   'OSS: Release':
     when:
       or:
@@ -1067,15 +1084,6 @@ workflows:
             ignore: /.*/
     - oss-lint:
         name: "oss-release-lint"
-        filters:
-          tags:
-            only: /^v[0-9]+\.[0-9]+\.[0-9]+-(rc|ea)\.[0-9]+$/
-          branches:
-            ignore: /.*/
-    - oss-manifest-publish:
-        name: "oss-rc-manifests-publish"
-        requires:
-        - "oss-release-generate"
         filters:
           tags:
             only: /^v[0-9]+\.[0-9]+\.[0-9]+-(rc|ea)\.[0-9]+$/

--- a/.circleci/config.yml.d/amb_oss.yml
+++ b/.circleci/config.yml.d/amb_oss.yml
@@ -255,7 +255,6 @@ workflows:
                 fast-reconfigure: true
                 legacy-mode: true
 
-
   "OSS: Chart Release":
     when: # Don't run this workflow in apro.git
       or:
@@ -265,6 +264,15 @@ workflows:
       - "oss-chart-publish":
           <<: *filter-chart-release-only
           name: "oss-release-chart"
+  "OSS: Manifests Release":
+    when: # Don't run this workflow in apro.git
+      or:
+      - equal: [ "https://github.com/datawire/ambassador", << pipeline.project.git_url >> ]
+      - equal: [ "https://github.com/datawire/ambassador-private", << pipeline.project.git_url >> ]
+    jobs:
+      - "oss-manifest-publish":
+          <<: *filter-chart-release-only
+          name: "oss-rc-manifests-publish"
 
   "OSS: Release":
     when: # Don't run this workflow in apro.git
@@ -285,10 +293,6 @@ workflows:
       - "oss-lint":
           <<: *filter-prerelease-only
           name: "oss-release-lint"
-      - "oss-manifest-publish":
-          <<: *filter-prerelease-only
-          name: "oss-rc-manifests-publish"
-          requires: ["oss-release-generate"]
       - "oss-gotest":
           <<: *filter-prerelease-only
           name: "oss-release-gotest<<# matrix.fast-reconfigure >>-fastreconfigure<</ matrix.fast-reconfigure >><<# matrix.legacy-mode >>-legacy<</ matrix.legacy-mode >>"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,7 +63,7 @@ Please see the [Envoy documentation](https://www.envoyproxy.io/docs/envoy/latest
 
 ## RELEASE NOTES
 
-## Next Release
+## [2.0.0] (TBD)
 
 ### Emissary Ingress and Ambassador Edge Stack
 

--- a/charts/charts.mk
+++ b/charts/charts.mk
@@ -1,5 +1,6 @@
 AMBASSADOR_CHART = $(OSS_HOME)/charts/ambassador
 EMISSARY_CHART = $(OSS_HOME)/charts/emissary-ingress
+YQ := $(OSS_HOME)/.circleci/yq
 
 define _push_chart
 	CHART_NAME=$(1) $(OSS_HOME)/charts/scripts/push_chart.sh
@@ -7,6 +8,16 @@ endef
 
 define _set_tag_and_repo
 	$(OSS_HOME)/venv/bin/python $(OSS_HOME)/charts/scripts/update_chart_image_values.py $(1) $(2) $(3)
+endef
+
+define _set_tag
+	$(OSS_HOME)/venv/bin/python $(OSS_HOME)/charts/scripts/update_chart_image_values.py $(1) $(2)
+endef
+
+define _docgen
+	if [[ -f $(1)/doc.yaml ]] ; then \
+		chart-doc-gen -d $(1)/doc.yaml -t $(1)/readme.tpl -v $(1)/values.yaml > $(1)/README.md ; \
+	fi
 endef
 
 push-preflight: create-venv
@@ -39,16 +50,40 @@ chart-push-ga: push-preflight
 	done ;
 .PHONY: chart-push-ga
 
+release/chart/tag:
+	@set -e; { \
+		if [ -n "$(IS_DIRTY)" ]; then \
+			echo "release/chart/tag: tree must be clean" >&2 ;\
+			exit 1 ;\
+		fi; \
+		chart_ver=`grep 'version:' $(AMBASSADOR_CHART)/Chart.yaml | awk ' { print $$2 }'` ; \
+		chart_ver=chart-v$${chart_ver} ; \
+		git tag -s -m "Tagging $${chart_ver}" -a $${chart_ver} ; \
+		git push origin $${chart_ver} ; \
+	}
+
+
 release/changelog:
 	@for chart in $(AMBASSADOR_CHART) $(EMISSARY_CHART) ; do \
 		CHART_NAME=`basename $$chart` $(OSS_HOME)/charts/scripts/update_chart_changelog.sh ; \
 	done ;
 .PHONY: release/changelog
 
+release/chart/update-images: doc-gen-preflight
+	@[ -n "${IMAGE_TAG}" ] || (echo "IMAGE_TAG must be set" && exit 1)
+	([[ "${IMAGE_TAG}" =~ .*\.0$$ ]] && $(MAKE) release/chart-bump/minor) || $(MAKE) release/chart-bump/revision
+	for chart in $(AMBASSADOR_CHART) $(EMISSARY_CHART) ; do \
+		$(call _set_tag,$$chart/values.yaml,${IMAGE_TAG}) ; \
+		$(YQ) w -i $$chart/Chart.yaml 'appVersion' ${IMAGE_TAG} ; \
+		IMAGE_TAG="${IMAGE_TAG}" CHART_NAME=`basename $$chart` $(OSS_HOME)/charts/scripts/image_tag_changelog_update.sh ; \
+		CHART_NAME=`basename $$chart` $(OSS_HOME)/charts/scripts/update_chart_changelog.sh ; \
+		$(call _docgen,$$chart) ; \
+	done ;
+
 # Both charts should have same versions for now. Just makes things a bit easier if we publish them together for now
 release/chart-bump/revision:
 	@for chart in $(AMBASSADOR_CHART) $(EMISSARY_CHART) ; do \
-		$(OSS_HOME)/charts/scripts/bump_chart_version.sh revision $$chart/Chart.yaml ; \
+		$(OSS_HOME)/charts/scripts/bump_chart_version.sh patch $$chart/Chart.yaml ; \
 	done ;
 .PHONY: release/chart-bump/revision
 
@@ -63,3 +98,10 @@ chart-clean:
 	git restore $(OSS_HOME)/charts/*/Chart.yaml $(OSS_HOME)/charts/*/values.yaml
 	rm -f $(OSS_HOME)/charts/*/*.tgz $(OSS_HOME)/charts/*/index.yaml $(OSS_HOME)/charts/*/tmp.yaml
 .PHONY: chart-clean
+
+doc-gen-preflight:
+	@if ! command -v chart-doc-gen 2> /dev/null ; then \
+		printf 'chart-doc-gen not installed, see https://github.com/kubepack/chart-doc-gen'; \
+	    false; \
+	fi
+.PHONY: doc-gen-preflight

--- a/charts/emissary-ingress/CHANGELOG.md
+++ b/charts/emissary-ingress/CHANGELOG.md
@@ -3,8 +3,22 @@
 This file documents all notable changes to Ambassador Helm Chart. The release
 numbering uses [semantic versioning](http://semver.org).
 
+Note: some releases may not have any changes. This is okay.
+
+In the interim period where we're still supporting the emissary and ambassador charts,
+we're packaging and versioning the charts together to make things a bit easier. Since the ambassador chart also contains AES resources, some changes to that chart may not be relevant to emissary.
+
 ## Next Release
 
+(no changes yet)
+
+## v6.7.7
+
+(no changes)
+
+## v6.7.6
+
+- Update Ambassador chart image to version 1.13.4: [CHANGELOG](https://github.com/datawire/ambassador/blob/master/CHANGELOG.md)
 - Change: unless image.repository or image.fullImageOverride is explicitly set, the ambassador image used will be templated on .Values.enableAES. If AES is enabled, the chart will use docker.io/datawire/aes, otherwise will use docker.io/datawire/ambassador.
 
 ## v6.7.5

--- a/charts/emissary-ingress/Chart.yaml
+++ b/charts/emissary-ingress/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.13.3
 description: A Helm chart for Emissary Ingress
 name: emissary-ingress
-version: 0.0.2
+version: 6.7.7
 # TODO: change these to whatever the appropriate things are
 icon: https://www.getambassador.io/images/logo.png
 home: https://www.getambassador.io/

--- a/charts/scripts/image_tag_changelog_update.sh
+++ b/charts/scripts/image_tag_changelog_update.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+set -e
+
+CURR_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+[ -d "$CURR_DIR" ] || { echo "FATAL: no current dir (maybe running in zsh?)";  exit 1; }
+TOP_DIR=$CURR_DIR/..
+
+# shellcheck source=common.sh
+source "$CURR_DIR/common.sh"
+
+if [[ -z "${CHART_NAME}" ]] ; then
+    abort "Need to specify the chart you wish to publish"
+fi
+if [[ -z "${IMAGE_TAG}" ]] ; then
+    abort "Need to specify the image tag being updated"
+fi
+
+CHART_DIR="${TOP_DIR}/${CHART_NAME}"
+
+chart_version=$(get_chart_version ${CHART_DIR})
+
+new_changelog=${CHART_DIR}/CHANGELOG.new.md
+ambassador_changelog_link="https://github.com/datawire/ambassador/blob/master/CHANGELOG.md"
+rm ${new_changelog} > /dev/null 2>&1 || true
+buffering=
+while IFS= read -r line ; do
+    if [[ "${line}" =~ "## Next Release" ]] ; then
+        buffering=true
+    elif [[ "${buffering}" ]] && [[ "${line}" != "" ]]; then
+        buffering=
+        echo "- Update Ambassador chart image to version v${IMAGE_TAG}: [CHANGELOG](${ambassador_changelog_link})" >> ${new_changelog}
+        if [[ "${line}" =~ (no changes yet) ]] ; then
+            continue
+        fi
+    fi
+    echo -e "${line}" >> ${new_changelog}
+
+done < ${CHART_DIR}/CHANGELOG.md
+
+mv ${new_changelog} ${CHART_DIR}/CHANGELOG.md
+
+info "Done editing changelog for ${CHART_NAME}!"

--- a/manifests/manifests.mk
+++ b/manifests/manifests.mk
@@ -5,5 +5,5 @@ push-manifests:
 # This should always be safe to run because the manifest yaml should all be generated
 clean-manifests:
 	@git restore $(OSS_HOME)/manifests/*/*.yaml
-	git restore $(OSS_HOME)/docs/yaml
+	@git restore $(OSS_HOME)/docs/yaml
 .PHONY: clean-manifests

--- a/releng/lib/__init__.py
+++ b/releng/lib/__init__.py
@@ -1,0 +1,33 @@
+#!/hint/python3
+
+import re
+import subprocess
+from typing import Any, List
+
+from .gitutil import git_check_clean as git_check_clean  # Stop mypy complaining about implicit reexport
+from .uiutil import run_txtcapture
+from .gitutil import git_add as git_add # Stop mypy complaining about implicit reexport
+
+# These are some regular expressions to validate and parse
+# X.Y.Z[-rc.N] versions.
+re_ga = re.compile(r'^([0-9]+)\.([0-9]+)\.([0-9]+)$')
+vX = 1
+vY = 2
+
+
+def base_version(release_version: str) -> str:
+    """Given 'X.Y.Z[-rc.N]', return 'X.Y'."""
+    return build_version(release_version).rsplit(sep='.', maxsplit=1)[0]
+
+
+def build_version(release_version: str) -> str:
+    """Given 'X.Y.Z[-rc.N]', return 'X.Y.Z'."""
+    return release_version.split('-')[0]
+
+
+def assert_eq(actual: Any, expected: Any) -> None:
+    """`assert_eq(a, b)` is like `assert a == b`, but has a useful error
+    message when they're not equal.
+    """
+    if actual != expected:
+        raise AssertionError(f"wanted '{expected}', got '{actual}'")

--- a/releng/lib/ansiterm.py
+++ b/releng/lib/ansiterm.py
@@ -1,0 +1,97 @@
+#!/hint/python3
+"""Generate terminal "control seqences" for ANSI X3.64 terminals.
+Or rather, ECMA-48 terminals, because ANSI withdrew X3.64 in favor of
+ECMA-48.
+(https://www.ecma-international.org/publications/files/ECMA-ST/Ecma-048.pdf)
+"control sequences" are a subset of "escape codes"; which are so named
+because they start with the ASCII ESC character ("\033").
+If you're going to try to read ECMA-48, be aware the notation they use
+for a byte is "AB/CD" where AB and CD are zero-padded decimal numbers
+that represent 4-bit sequences.  It's easiest to think of them as
+hexadecimal byte; for example, when ECMA-48 says "11/15", think
+"hexadecimal 0xBF".  And then to make sense of that hexadecimal
+number, you'll want to have an ASCII reference table handy.
+This implementation is not complete/exhaustive; it only supports the
+things that we've found it handy to support.
+"""
+
+from typing import List, Union, cast, overload
+
+_number = Union[int, float]
+
+
+@overload
+def cs(params: List[_number], op: str) -> str:
+    ...
+
+
+@overload
+def cs(op: str) -> str:
+    ...
+
+
+def cs(arg1, arg2=None):  # type: ignore
+    """cs returns a formatted 'control sequence' (ECMA-48 §5.4).
+    This only supports text/ASCII ("7-bit") control seqences, and does
+    support binary ("8-bit") control seqeneces.
+    This only supports standard parameters (ECMA-48 §5.4.1.a /
+    §5.4.2), and does NOT support "experimental"/"private" parameters
+    (ECMA-48 §5.4.1.b).
+    """
+    csi = '\033['
+    if arg2:
+        params: List[_number] = arg1
+        op: str = arg2
+    else:
+        params = []
+        op = arg1
+    return csi + (';'.join(str(n).replace('.', ':') for n in params)) + op
+
+
+# The "EL" ("Erase in Line") control seqence (ECMA-48 §8.3.41) with no
+# parameters.
+clear_rest_of_line = cs('K')
+
+# The "ED" ("Erase in Display^H^H^H^H^H^H^HPage") control seqence
+# (ECMA-48 §8.3.39) with no parameters.
+clear_rest_of_screen = cs('J')
+
+
+def cursor_up(lines: int = 1) -> str:
+    """Generate the "CUU" ("CUrsor Up") control sequence (ECMA-48 §8.3.22)."""
+    if lines == 1:
+        return cs('A')
+    return cs([lines], 'A')
+
+
+def _sgr_code(code: int) -> '_SGR':
+    def get(self: '_SGR') -> '_SGR':
+        return _SGR(self.params + [code])
+
+    return cast('_SGR', property(get))
+
+
+class _SGR:
+    def __init__(self, params: List[_number] = []) -> None:
+        self.params = params
+
+    def __str__(self) -> str:
+        return cs(self.params, 'm')
+
+    reset = _sgr_code(0)
+    bold = _sgr_code(1)
+    fg_blk = _sgr_code(30)
+    fg_red = _sgr_code(31)
+    fg_grn = _sgr_code(32)
+    fg_yel = _sgr_code(33)
+    fg_blu = _sgr_code(34)
+    fg_prp = _sgr_code(35)
+    fg_cyn = _sgr_code(36)
+    fg_wht = _sgr_code(37)
+    # 38 is 8bit/24bit color
+    fg_def = _sgr_code(39)
+
+
+# sgr builds "Set Graphics Rendition" control sequences (ECMA-48
+# §8.3.117).
+sgr = _SGR()

--- a/releng/lib/gitutil.py
+++ b/releng/lib/gitutil.py
@@ -1,0 +1,37 @@
+from .uiutil import run
+from .uiutil import run_txtcapture as run_capture
+
+
+def git_add(filename: str) -> None:
+    """
+    Use `git add` to stage a single file.
+    """
+
+    run(['git', 'add', '--', filename])
+
+
+def git_check_clean(allow_staged: bool = False) -> None:
+    """
+    Use `git status --porcelain` to check if the working tree is dirty.
+    If allow_staged is True, allow staged files, but no unstaged changes.
+    """
+
+    out = run_capture(['git', 'status', '--porcelain'])
+    if out:
+        # Can we allow staged changes?
+        if not allow_staged:
+            # Nope. ANY changes are unacceptable, so we can short-circuit
+            # here.
+            raise Exception(out)
+
+        # If here, staged changes are OK, and unstaged changes are not.
+        # In the porcelain output, staged changes start with a change
+        # character followed by a space, and unstaged changes start with a
+        # space followed by a change character. So any lines with a non-space
+        # in the second column are a problem here.
+
+        lines = out.split('\n')
+        problems = [line for line in lines if line[1] != ' ']
+
+        if problems:
+            raise Exception("\n".join(problems))

--- a/releng/lib/uiutil.py
+++ b/releng/lib/uiutil.py
@@ -1,0 +1,354 @@
+#!/hint/python3
+
+import io
+import os
+import re
+import shutil
+import string
+import subprocess
+import sys
+from contextlib import contextmanager
+from traceback import print_exc
+from typing import Callable, Generator, List, Optional, TextIO, Tuple
+
+from . import ansiterm
+
+# run()/run_bincapture()/run_txtcapture() and capture_output() seem like they're
+# re-implementing something that should already exist for us to use.  And
+# indeed, the `run*()` functions are essentially just stdlib `subprocess.run()`
+# and `capture_output()` is essentially just stdlib
+# `contextlib.redirect_stdout()`+`contextlib.redirect_stderr()`.  But the big
+# reason for them to exist here is: `contextlib.redirect_*` and `subprocess`
+# don't play together!  It's infuriating.
+#
+# So we define a global `_capturing` that is set while `capture_output()` is
+# running, and have the `run*()` functions adjust their behavior if it's set.
+# We could more generally do this by wrapping either `subprocess.run()` or
+# `contextlib.redirect_*()`.  If we only ever called the redirect/capture
+# function on a real file with a real file descriptor, it would be hairy, but
+# not _too_ hairy[1].  But we want to call the redirect/capture function with
+# not-a-real-file things like Indent or LineTracker.  So we'd have to get even
+# hairier... we'd have to do a bunch of extra stuff when the output's
+# `.fileno()` raises io.UnsupportedOperation; the same way that Go's
+# `os/exec.Cmd` has to do extra stuff when the output ins't an `*os.File` (and
+# that's one of the big reasons why I've said that Go's "os/exec" is superior to
+# other languages subprocess facilities).  And it's my best judgment that just
+# special-casing it with `_capturing` is the better choice than taking on all
+# the complexity of mimicing Go's brilliance.
+#
+# [1]: https://eli.thegreenplace.net/2015/redirecting-all-kinds-of-stdout-in-python/
+
+_capturing = False
+
+
+def run(args: List[str]) -> None:
+    """run is like "subprocess.run(args)", but with helpful settings and
+    obeys "with capture_output(out)".
+    """
+    if _capturing:
+        try:
+            subprocess.run(args, check=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
+        except subprocess.CalledProcessError as err:
+            raise Exception(f"{err.stdout}{err}") from err
+    else:
+        subprocess.run(args, check=True)
+
+
+def run_txtcapture(args: List[str]) -> str:
+    """run is like "subprocess.run(args, capture_out=True, text=true)",
+    but with helpful settings and obeys "with capture_output(out)".
+    """
+    if _capturing:
+        try:
+            out = subprocess.run(args, check=True, capture_output=True, text=True).stdout
+        except subprocess.CalledProcessError as err:
+            raise Exception(f"{err.stderr}{err}") from err
+    else:
+        out = subprocess.run(args, check=True, stdout=subprocess.PIPE, text=True).stdout
+    if out.endswith("\n"):
+        out = out[:-1]
+    return out
+
+
+@contextmanager
+def capture_output(log: io.StringIO) -> Generator[None, None, None]:
+    """capture_output is like contextlib.redirect_stdout but also
+    redirects stderr, and also does some extra stuff so that we can
+    have run/run_bincapture/run_txtcapture functions that obey it.
+    """
+    global _capturing
+
+    saved_capturing = _capturing
+    saved_stdout = sys.stdout
+    saved_stderr = sys.stderr
+
+    _capturing = True
+    sys.stdout = sys.stderr = log
+    try:
+        yield
+    finally:
+        _capturing = saved_capturing
+        sys.stdout = saved_stdout
+        sys.stderr = saved_stderr
+
+
+def _lex_char_or_cs(text: str) -> Tuple[str, str]:
+    """Look atthe beginning of the given text and trim either a byte, or
+    an ANSI control sequence from the beginning, returning a tuple
+    ("char-or-cs", "remaining-text").  If it looks like the text is a
+    truncated control seqence, then it doesn't trim anything, and
+    returns ("", "original"); signaling that it needs to wait for more
+    input before successfully lexing anything.
+    """
+    if text == '\033':
+        # wait to see if this is a control sequence
+        return '', text
+    i = 1
+    if text.startswith('\033['):
+        try:
+            i = len('\033[')
+            while text[i] not in string.ascii_letters:
+                i += 1
+            i += 1
+        except IndexError:
+            # wait for a complete control sequence
+            return '', text
+    return text[:i], text[i:]
+
+
+class Indent(io.StringIO):
+    """Indent() is like a io.StringIO(), will indent text with the given
+    string.
+    """
+    def __init__(self, indent: str = "", output: Optional[TextIO] = None, columns: Optional[int] = None) -> None:
+        """Arguments:
+          indent: str: The string to indent with.
+          output: Optional[TextIO]: A TextIO to write to, instead of
+                  building an in-memory buffer.
+          columns: Optional[int]: How wide the terminal is; this is
+                   imporant because a line wrap needs to trigger an
+                   indent.  If not given, then 'output.columns' is
+                   used if 'output' is set and has a 'columns'
+                   attribute, otherwise shutil.get_terminal_size() is
+                   used.  Use a value <= 0 to explicitly disable
+                   wrapping.
+        The 'columns' attribute on the resulting object is set to the
+        number of usable colums; "arg_columns - len(indent)".  This
+        allows Indent objects to be nested.
+        Indent understands "\r" and "\n", but not "\t" or ANSI control
+        sequences that move the cursor; it assumes that all ANSI
+        control sequences do not move the cursor.
+        """
+        super().__init__()
+        self._indent = indent
+        self._output = output
+
+        if columns is None:
+            if output and hasattr(output, 'columns'):
+                columns = output.columns  # type: ignore
+            else:
+                columns = shutil.get_terminal_size().columns
+        self.columns = columns - len(self._indent)
+
+    _rest = ""
+    _cur_col = 0
+    # 0: no indent has been printed for this line, and indent will need to be printed unless this is the final trailing NL
+    # 1: an indent needs to be printed for this line IFF there is any more output on it
+    # 2: no indent (currently) needs to be printed for this line
+    _print_indent = 0
+
+    def write(self, text: str) -> int:
+        # This algorithm is based on
+        # https://git.parabola.nu/packages/libretools.git/tree/src/chroot-tools/indent
+        self._rest += text
+
+        while self._rest:
+            c, self._rest = _lex_char_or_cs(self._rest)
+            if c == "":
+                # wait for more input
+                break
+            elif c == "\n":
+                if self._print_indent < 1:
+                    self._write(self._indent)
+                self._write(c)
+                self._print_indent = 0
+                self._cur_col = 0
+            elif c == "\r":
+                self._write(c)
+                self._print_indent = min(self._print_indent, 1)
+                self._cur_col = 0
+            elif c.startswith('\033['):
+                if self._print_indent < 2:
+                    self._write(self._indent)
+                self._write(c)
+                self._print_indent = 2
+            elif self.columns > 0 and self._cur_col >= self.columns:
+                self._rest = "\n" + c + self._rest
+            else:
+                if self._print_indent < 2:
+                    self._write(self._indent)
+                self._write(c)
+                self._print_indent = 2
+                self._cur_col += len(c)
+        return len(text)
+
+    def _write(self, text: str) -> None:
+        if self._output:
+            self._output.write(text)
+        else:
+            super().write(text)
+
+    def flush(self) -> None:
+        if self._output:
+            self._output.flush()
+        else:
+            super().flush()
+
+    def input(self) -> str:
+        """Use "myindent.input()" instead of "input()" in order to nest well
+        with LineTrackers.
+        """
+        if hasattr(self._output, 'input'):
+            text: str = self._output.input()  # type: ignore
+        else:
+            text = input()
+        return text
+
+
+class LineTracker(io.StringIO):
+    """LineTracker() is like a io.StringIO(), but will keep track of which
+    line you're on; starting on line "1".
+    LineTracker understands "\n", and the "cursor-up" (CSI-A) control
+    sequence.  It does not detect wrapped lines; use Indent() to turn
+    those in to hard-wraps that LineTracker understands.
+    """
+    def __init__(self, output: Optional[TextIO] = None) -> None:
+        self._output = output
+        if output and hasattr(output, 'columns'):
+            self.columns = output.columns  # type: ignore
+
+    cur_line = 1
+
+    _rest = ""
+
+    def _handle(self, text: str) -> None:
+        self._rest += text
+        while self._rest:
+            c, self._rest = _lex_char_or_cs(self._rest)
+            if c == "":
+                # wait for more input
+                break
+            elif c == "\n":
+                self.cur_line += 1
+            elif c.startswith("\033[") and c.endswith('A'):
+                lines = int(c[len("\033["):-len('A')] or "1")
+                self.cur_line -= lines
+
+    def input(self) -> str:
+        """Use "mylinetracker.input()" instead of "input()" to avoid the
+        LineTracker not seeing any newlines input by the user.
+        """
+        if hasattr(self._output, 'input'):
+            text: str = self._output.input()  # type: ignore
+        else:
+            text = input()
+        self._handle(text + "\n")
+        return text
+
+    def goto_line(self, line: int) -> None:
+        """goto_line moves the cursor to the beginning of the given line;
+        where line 1 is the line that the LineTracker started on, line
+        0 is the line above that, and line 1 is the line below
+        that.
+        """
+        self.write("\r")
+        if line < self.cur_line:
+            total_lines = shutil.get_terminal_size().lines
+            if (self.cur_line - line) >= total_lines:
+                raise Exception(f"cannot go back {self.cur_line - line} lines (limit={total_lines - 1})")
+            self.write(ansiterm.cursor_up(self.cur_line - line))
+        else:
+            self.write("\n" * (line - self.cur_line))
+
+    def write(self, text: str) -> int:
+        self._handle(text)
+        if self._output:
+            return self._output.write(text)
+        else:
+            return super().write(text)
+
+    def flush(self) -> None:
+        if self._output:
+            self._output.flush()
+        else:
+            super().flush()
+
+
+class Checker:
+    """Checker is a terminal UI widget for printing a series of '[....]'
+    (running) / '[ OK ]' / '[FAIL]' checks where we can diagnostic
+    output while the check is running, and then go back and update the
+    status, and nest checks.
+    """
+
+    ok: bool = True
+
+    @contextmanager
+    def check(self, name: str, clear_on_success: bool = True) -> Generator['CheckResult', None, None]:
+        """check returns a context manager that handles printing a '[....]'  /
+        '[ OK ]' / '[FAIL]' check.  While the check is running, it
+        will stream whatever you write to stdout/stderr.  If
+        clear_on_success is True, then once the check finishes, if the
+        check passed then it will erase that stdout/stderr output,
+        since you probably only want diagnostic output if the check
+        fails.
+        You can provide a (1-line) textual check result that will be
+        shown on both success and failure by writing to "mycheck.result".
+        You may cause a check to fail by either raising an Exception,
+        or by setting "mycheck.ok = False".  If you do neither of these,
+        then the check will be considered to pass.
+        The mycheck.subcheck method returns a context manager for a
+        nested child check.
+        """
+        def line(status: str, rest: Optional[str] = None) -> str:
+            txt = name
+            if rest:
+                txt = f'{txt}: {rest}'
+            return f" {status}{ansiterm.sgr} {txt}"
+
+        output = LineTracker(output=sys.stdout)
+        output.write(line(status=f'{ansiterm.sgr.bold.fg_blu}[....]') + "\n")
+
+        check = CheckResult()
+
+        with capture_output(Indent(output=output, indent="   > ")):
+            try:
+                yield check
+            except Exception as err:
+                if str(err).strip():
+                    print(err)
+                check.ok = False
+
+        end = output.cur_line
+        output.goto_line(1)
+        if check.ok:
+            output.write(line(status=f'{ansiterm.sgr.bold.fg_grn}[ OK ]', rest=check.result))
+        else:
+            output.write(line(status=f'{ansiterm.sgr.bold.fg_red}[FAIL]', rest=check.result))
+        if check.ok and clear_on_success:
+            output.write(ansiterm.clear_rest_of_screen + "\n")
+        else:
+            output.write(ansiterm.clear_rest_of_line)
+            output.goto_line(end)
+
+        self.ok &= check.ok
+
+    # alias for readability
+    subcheck = check
+
+
+class CheckResult(Checker):
+    """A CheckResult is the context manager type returned by
+    "Checker.check".
+    """
+    result: Optional[str] = None

--- a/releng/release-go-changelog-update
+++ b/releng/release-go-changelog-update
@@ -1,5 +1,8 @@
 #!/usr/bin/env python3
-"""Update the directory "tree" for cutting an RC release.  This will
+"""Updates the dates in the changelog to today's date, then
+launch the `git citool` GUI to create a commit of it, and uses
+the `gh` tool to file a pull request.
+To be run after the GA version of emissary has been tagged.
 change the appropriate files, then launch the `git citool` GUI to
 create a commit of it.
 """
@@ -43,7 +46,6 @@ def main(next_ver: str, today: datetime.date, quiet: bool=False, commit: bool = 
         print("Please install the tool and rerun this script:")
         print("https://github.com/cli/cli#installation")
         return 1
-    run(["gh", "auth", "login"])
 
     warning = """
  ==> Warning: FIXME: This script does not have the property that if
@@ -57,7 +59,6 @@ def main(next_ver: str, today: datetime.date, quiet: bool=False, commit: bool = 
 
     # This context manager and check function are pretty much just to produce
     # a nice list of steps...
-
     checker = Checker()
 
     @contextmanager
@@ -65,6 +66,9 @@ def main(next_ver: str, today: datetime.date, quiet: bool=False, commit: bool = 
         with checker.check(name) as subcheck:
             # time.sleep(1)  # it's stupid, but honestly the delay makes the output more readable
             yield subcheck
+    with check("Logging into github"):
+        run(["gh", "auth", "login"])
+
     workbranch = f"rel/{next_ver}/changelog-date-update"
     with check(f"Creating new branch {workbranch}"):
         run(["git", "checkout", "-b", workbranch])

--- a/releng/release-go-changelog-update
+++ b/releng/release-go-changelog-update
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""Update the directory "tree" for cutting an RC release.  This will
+change the appropriate files, then launch the `git citool` GUI to
+create a commit of it.
+"""
+
+import datetime
+import fileinput
+import os.path
+import re
+import sys
+from contextlib import contextmanager
+from typing import Generator
+from shutil import which
+
+from lib import base_version, build_version, git_add, git_check_clean, re_ga, vX, vY
+from lib.uiutil import Checker, CheckResult, run
+from lib.uiutil import run_txtcapture as run_capture
+from lib import ansiterm
+
+
+def main(next_ver: str, today: datetime.date, quiet: bool=False, commit: bool = True) -> int:
+    """This edits several files (the Git directory "tree"), then launches
+    the `git citool` GUI to commit them.  This _should_ be an utterly
+    trivial and readable list of
+        for line in fileinput.FileInput("FILENAME", inplace=True):
+            # edit 'line' as appropriate
+            sys.stdout.write(line)
+        git_add("FILENAME")
+    blocks.  However, the block to edit the CHANGELOG.md file is unfortunately a
+    touch more complex, because it has to deal with parsing the file in to
+    sections and buffering the sections... maybe line-oriented processing wasn't
+    the best choice for that file.
+    """
+
+    if not quiet:
+        print()
+        print(f'Doing basic updates for v{next_ver}...')
+        print()
+
+    if which("gh") is None:
+        print("gh tool is not installed.")
+        print("Please install the tool and rerun this script:")
+        print("https://github.com/cli/cli#installation")
+        return 1
+    run(["gh", "auth", "login"])
+
+    warning = """
+ ==> Warning: FIXME: This script does not have the property that if
+     something goes wrong, you can just restart it; put another way:
+     it does not have the property that each step is idempotent.
+     If something does go wrong, then you'll have to address it, then
+     resume where the script left off by going through the checklist
+     manually (or by commenting out the already-completed steps).
+"""
+    print(f"{ansiterm.sgr.fg_red}{warning}{ansiterm.sgr}")
+
+    # This context manager and check function are pretty much just to produce
+    # a nice list of steps...
+
+    checker = Checker()
+
+    @contextmanager
+    def check(name: str) -> Generator[CheckResult, None, None]:
+        with checker.check(name) as subcheck:
+            # time.sleep(1)  # it's stupid, but honestly the delay makes the output more readable
+            yield subcheck
+    workbranch = f"rel/{next_ver}/changelog-date-update"
+    with check(f"Creating new branch {workbranch}"):
+        run(["git", "checkout", "-b", workbranch])
+
+    with check(f"Updating CHANGELOG.md with date for {next_ver}..."):
+        found = False
+        for line in fileinput.FileInput("CHANGELOG.md", inplace=True):
+            if not found and line.startswith(f"## [{next_ver}]"):
+                line = f"## [{next_ver}] {today.strftime('%B %d, %Y')}\n"
+                found = True
+
+            sys.stdout.write(line)
+
+        if not found:
+            raise Exception(f"Changelog entry for {next_ver} not found. Was releng/start-update-version run?")
+
+        git_add("CHANGELOG.md")
+
+    if checker.ok and commit:
+        with check(f"Committing changes..."):
+            gitdir = run_capture(['git', 'rev-parse', '--git-dir'])
+            with open(os.path.join(gitdir, 'GITGUI_MSG'), 'w') as msgfile:
+                msgfile.write(f"Update for v{next_ver}\n")
+            run(['git', 'citool'])
+            run(["git", "push", "origin", workbranch])
+
+        with check(f"Creating PR for branch {workbranch}"):
+            m = re_ga.match(next_ver)
+            assert m
+            release_branch = f"release/v{m[vX]}.{m[vY]}"
+            # TODO: dont hardcode owners
+            run(["gh", "pr", "create",
+                    "--base", release_branch,
+                    "--title", f"Changelog updates for {next_ver}",
+                    "--body", f"Changelog date updates for {next_ver}",
+                    "--reviewer", "kflynn,rhs,esmet,acookin"])
+
+    if checker.ok:
+        return 0
+    else:
+        return 1
+
+
+if __name__ == '__main__':
+    args = sys.argv[1:]
+
+    quiet = False
+    commit = True
+
+    while args and args[0].startswith("--"):
+        if args[0] == '--quiet':
+            quiet = True
+            args.pop(0)
+        elif args and (args[0] == '--no-commit'):
+            commit = False
+            args.pop(0)
+
+    if len(args) != 1 or not re_ga.match(args[0]):
+        sys.stderr.write(f"Usage: {os.path.basename(sys.argv[0])} X.Y.Z\n")
+        sys.exit(2)
+
+    sys.exit(main(
+        next_ver=args[0],
+        today=datetime.date.today(),
+        quiet=quiet,
+        commit=commit,
+    ))

--- a/releng/release-manifest-image-update
+++ b/releng/release-manifest-image-update
@@ -1,6 +1,10 @@
 #!/usr/bin/env python3
 """Updates all the manifests and helm charts to use a newer ambassador version.
 This must be run with an already pushed GA tag `vX.Y.Z`.
+This creates a branch from vX.Y.Z, updates all the helm chart/manifest files,
+commits, pushes and creates a pull request.
+After that, this will create a `chart-A.B.C` tag, where A.B.C is the version
+in charts/ambassador/Chart.yaml
 """
 
 import datetime
@@ -30,7 +34,6 @@ def main(next_ver: str, today: datetime.date, quiet: bool=False, commit: bool = 
         with checker.check(name) as subcheck:
             # time.sleep(1)  # it's stupid, but honestly the delay makes the output more readable
             yield subcheck
-    run(["gh", "auth", "login"])
 
     warning = """
  ==> Warning: FIXME: This script does not have the property that if
@@ -41,6 +44,9 @@ def main(next_ver: str, today: datetime.date, quiet: bool=False, commit: bool = 
      manually (or by commenting out the already-completed steps).
 """
     print(f"{ansiterm.sgr.fg_red}{warning}{ansiterm.sgr}")
+
+    with check("Authenticating to GitHub"):
+        run(["gh", "auth", "login"])
 
     workbranch = f"rel/v{next_ver}/chart-img-updates"
     with check(f"Creating new branch {workbranch} off of tag v{next_ver}"):

--- a/releng/release-manifest-image-update
+++ b/releng/release-manifest-image-update
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""Updates all the manifests and helm charts to use a newer ambassador version.
+This must be run with an already pushed GA tag `vX.Y.Z`.
+"""
+
+import datetime
+import fileinput
+import os.path
+import re
+import sys
+from contextlib import contextmanager
+from typing import Generator
+from shutil import which
+
+from lib import base_version, build_version, git_add, git_check_clean, re_ga, vX, vY, ansiterm
+from lib.uiutil import Checker, CheckResult, run
+from lib.uiutil import run_txtcapture as run_capture
+
+
+def main(next_ver: str, today: datetime.date, quiet: bool=False, commit: bool = True) -> int:
+    if which("gh") is None:
+        print("gh tool is not installed.")
+        print("Please install the tool and rerun this script:")
+        print("https://github.com/cli/cli#installation")
+        return 1
+    checker = Checker()
+
+    @contextmanager
+    def check(name: str) -> Generator[CheckResult, None, None]:
+        with checker.check(name) as subcheck:
+            # time.sleep(1)  # it's stupid, but honestly the delay makes the output more readable
+            yield subcheck
+    run(["gh", "auth", "login"])
+
+    warning = """
+ ==> Warning: FIXME: This script does not have the property that if
+     something goes wrong, you can just restart it; put another way:
+     it does not have the property that each step is idempotent.
+     If something does go wrong, then you'll have to address it, then
+     resume where the script left off by going through the checklist
+     manually (or by commenting out the already-completed steps).
+"""
+    print(f"{ansiterm.sgr.fg_red}{warning}{ansiterm.sgr}")
+
+    workbranch = f"rel/v{next_ver}/chart-img-updates"
+    with check(f"Creating new branch {workbranch} off of tag v{next_ver}"):
+        run(["git", "fetch", "--tags"])
+        run(["git", "checkout", f"v{next_ver}", "-b", workbranch])
+
+    print('TODO: CHECK THAT IMAGE EXISTS')
+    with check(f"Updating image tag in charts"):
+        run(["make", f"IMAGE_TAG={next_ver}", "release/chart/update-images"])
+        git_add("charts/ambassador")
+        git_add("charts/emissary-ingress")
+    with check(f"Updating manifest yaml"):
+        run(["make", "update-yaml"])
+        git_add("manifests")
+        git_add("docs/yaml")
+    if checker.ok and commit:
+        with check(f"Committing changes..."):
+            gitdir = run_capture(['git', 'rev-parse', '--git-dir'])
+            with open(os.path.join(gitdir, 'GITGUI_MSG'), 'w') as msgfile:
+                msgfile.write(f"Updating and manifest images for v{next_ver}\n")
+            run(['git', 'citool'])
+        with check(f"Creating pull request for chart and manifest changes"):
+            m = re_ga.match(next_ver)
+            assert m
+            release_branch = f"release/v{m[vX]}.{m[vY]}"
+            # TODO: dont hardcode owners
+            run(["gh", "pr", "create",
+                    "--base", release_branch,
+                    "--title", f"Chart and manifest image updates {next_ver}",
+                    "--body", f"Update charts and manifests to use the newly release images for {next_ver}",
+                    "--reviewer", "kflynn,rhs,esmet,acookin"])
+        with check(f"Creating chart tag"):
+            run(["make", "release/chart/tag"])
+    if checker.ok:
+        return 0
+    else:
+        return 1
+
+
+if __name__ == '__main__':
+    args = sys.argv[1:]
+
+    quiet = False
+    commit = True
+
+    while args and args[0].startswith("--"):
+        if args[0] == '--quiet':
+            quiet = True
+            args.pop(0)
+        elif args and (args[0] == '--no-commit'):
+            commit = False
+            args.pop(0)
+
+    if len(args) != 1 or not re_ga.match(args[0]):
+        sys.stderr.write(f"Usage: {os.path.basename(sys.argv[0])} X.Y.Z\n")
+        sys.exit(2)
+
+    sys.exit(main(
+        next_ver=args[0],
+        today=datetime.date.today(),
+        quiet=quiet,
+        commit=commit,
+    ))

--- a/releng/start-sanity-check
+++ b/releng/start-sanity-check
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""Do a sanity check that you're at something that's ready for you to
+cut an RC from; that you're in the right repo, that you're on the
+right branch, that all of the subtrees are up-to-date...
+"""
+
+import os.path
+import sys
+import time
+from contextlib import contextmanager
+from typing import Generator
+
+from lib import assert_eq, git_check_clean, vX, vY, re_ga
+from lib.uiutil import Checker, CheckResult
+from lib.uiutil import run_txtcapture as run_capture
+
+
+def main(next_ver: str, quiet: bool = False) -> int:
+    print(f'Starting work on "v{next_ver}"...')
+    print()
+
+    checker = Checker()
+
+    @contextmanager
+    def check(name: str) -> Generator[CheckResult, None, None]:
+        with checker.check(name) as subcheck:
+            # time.sleep(1)  # it's stupid, but honestly the delay makes the output more readable
+            yield subcheck
+
+    is_private = False
+
+    with check("You're in a clone of git@github.com:datawire/ambassador[-private].git"):
+        url = run_capture(['git', 'remote', 'get-url', '--push', 'origin'])
+        if url.endswith("/"):
+            url = url[:-len("/")]
+        if url.endswith(".git"):
+            url = url[:-len(".git")]
+        if url.endswith("-private"):
+            is_private = True
+            url = url[:-len("-private")]
+        assert_eq(url, "git@github.com:datawire/ambassador")
+
+    with check("You're in the toplevel of the clone"):
+        toplevel = run_capture(['git', 'rev-parse', '--show-toplevel'])
+        if not os.path.samefile(toplevel, '.'):
+            raise Exception(f"Not in {toplevel}")
+
+    with check("You're in a clean checkout"):
+        git_check_clean()
+
+    # Cache the name of our remote...
+    remote_name = 'git@github.com:datawire/ambassador.git' if is_private else 'origin'
+
+    # ...make sure the passed-in version is OK...
+    m = re_ga.match(next_ver)
+    assert m
+
+    # ...and figure out some branch names.
+    release_branch = os.environ.get("RELEASE_BRANCH") or f"release/v{m[vX]}.{m[vY]}"
+    cur_branch = ""
+
+    with check(f"You're on master or {release_branch}"):
+        cur_branch = run_capture(['git', 'rev-parse', '--abbrev-ref', 'HEAD'])
+
+        if (cur_branch != "master") and (cur_branch != release_branch):
+            raise AssertionError(f"You can't start a release from {cur_branch}")
+
+    if checker.ok:
+        with check("You're up-to-date with ambassador.git"):
+            remote_name = 'git@github.com:datawire/ambassador.git' if is_private else 'origin'
+
+            branch_up_to_date(
+                remote=remote_name,
+                branch=cur_branch,
+                update_cmd=f'git pull {remote_name} {cur_branch}',
+            )
+
+        if is_private:
+            with check("You're up-to-date with ambassador-private.git"):
+                branch_up_to_date(
+                    remote='git@github.com:datawire/ambassador-private.git',
+                    branch=cur_branch,
+                    update_cmd=f'git pull git@github.com:datawire/ambassador-private.git {cur_branch}',
+                )
+
+    if checker.ok:
+        if not quiet:
+            print()
+            print("Yep, looks like you're good to proceed to running `rel-01-rc-update-tree`.")
+        return 0
+    else:
+        print()
+        print("Looks like there's something wrong with your tree that you need to address before continuing.")
+        return 1
+
+
+def branch_exists(remote: str, branch: str) -> None:
+    # Allow exceptions to propagate upward
+    run(['git', 'fetch', remote, f'refs/heads/{branch}'])
+
+
+def branch_up_to_date(remote: str, branch: str, update_cmd: str) -> None:
+    run(['git', 'fetch', remote, f'refs/heads/{branch}'])
+    try:
+        run(['git', 'merge-base', '--is-ancestor', 'FETCH_HEAD', 'HEAD'])
+    except Exception as err:
+        print(f"HEAD is not up-to-date with '{remote}' '{branch}':")
+        print("You need to update it with:")
+        print()
+        print(f"    $ {update_cmd}")
+        print()
+        raise
+
+
+subtree_up_to_date = branch_up_to_date
+
+if __name__ == '__main__':
+    args = sys.argv[1:]
+    quiet = False
+
+    if args and (args[0] == '--quiet'):
+        quiet = True
+        args.pop(0)
+
+    if len(args) != 1 or not re_ga.match(args[0]):
+        sys.stderr.write(f"Usage: {os.path.basename(sys.argv[0])} X.Y.Z\n")
+        sys.exit(2)
+
+    sys.exit(main(next_ver=args[0], quiet=quiet))

--- a/releng/start-update-version
+++ b/releng/start-update-version
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
-"""Update the directory "tree" for cutting an RC release.  This will
-change the appropriate files, then launch the `git citool` GUI to
-create a commit of it.
+"""Updates version.yml and CHANGELOG.md for next version, then
+launch the `git citool` GUI to create a commit of it.
 """
 
 import datetime

--- a/releng/start-update-version
+++ b/releng/start-update-version
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""Update the directory "tree" for cutting an RC release.  This will
+change the appropriate files, then launch the `git citool` GUI to
+create a commit of it.
+"""
+
+import datetime
+import fileinput
+import os.path
+import re
+import sys
+from contextlib import contextmanager
+from typing import Generator
+
+from lib import base_version, build_version, git_add, git_check_clean, re_ga
+from lib.uiutil import Checker, CheckResult, run
+from lib.uiutil import run_txtcapture as run_capture
+
+
+def main(next_ver: str, today: datetime.date, quiet: bool=False, commit: bool = True) -> int:
+    """This edits several files (the Git directory "tree"), then launches
+    the `git citool` GUI to commit them.  This _should_ be an utterly
+    trivial and readable list of
+        for line in fileinput.FileInput("FILENAME", inplace=True):
+            # edit 'line' as appropriate
+            sys.stdout.write(line)
+        git_add("FILENAME")
+    blocks.  However, the block to edit the CHANGELOG.md file is unfortunately a
+    touch more complex, because it has to deal with parsing the file in to
+    sections and buffering the sections... maybe line-oriented processing wasn't
+    the best choice for that file.
+    """
+
+    if not quiet:
+        print()
+        print(f'Doing basic updates for v{next_ver}...')
+        print()
+
+    # This context manager and check function are pretty much just to produce
+    # a nice list of steps...
+
+    checker = Checker()
+
+    @contextmanager
+    def check(name: str) -> Generator[CheckResult, None, None]:
+        with checker.check(name) as subcheck:
+            # time.sleep(1)  # it's stupid, but honestly the delay makes the output more readable
+            yield subcheck
+
+    # docs/yaml/versions.yml
+    with check(f"Updating docs/yaml/versions.yml with {next_ver}..."):
+        for line in fileinput.FileInput("docs/yaml/versions.yml", inplace=True):
+            if line.startswith("version:"):
+                line = f"version: {next_ver}\n"
+            sys.stdout.write(line)
+        git_add("docs/yaml/versions.yml")
+
+    changelog_ver_pattern = re.compile(r"^## \[([0-9]+\.[0-9]+\.[0-9]+(?:-rc\.[0-9]+)?)\] \S+ [0-9]+, [0-9]{4}$")
+    with check(f"Updating CHANGELOG.md with {next_ver}..."):
+        in_notes = False
+        buf = ""
+        for line in fileinput.FileInput("CHANGELOG.md", inplace=True):
+            if not in_notes:
+                sys.stdout.write(line)
+                if line.startswith("## RELEASE NOTES"):
+                    in_notes = True
+                continue
+
+            match = changelog_ver_pattern.match(line)
+            if not match:
+                buf += line
+            elif line.startswith(f"## [{next_ver}]"):
+                # Don't do anything, this changelog already has an entry for the next version
+                sys.stdout.write(buf)
+                sys.stdout.write(line)
+                in_notes = False
+            else:
+                prev_ver = match[1]
+                # dope let's get the last version first
+                # this is the beginning of the last version line
+                sys.stdout.write("\n")
+                sys.stdout.write(f"## [{next_ver}] (TBD)\n")
+                sys.stdout.write(
+                        f"[{next_ver}]: https://github.com/datawire/ambassador/compare/v{prev_ver}...v{next_ver}\n")
+                sys.stdout.write("\n")
+                sys.stdout.write("### Emissary Ingress and Ambassador Edge Stack\n")
+                sys.stdout.write("\n")
+                sys.stdout.write("(no changes yet)\n")
+                sys.stdout.write(buf)
+                sys.stdout.write(line)
+                in_notes = False
+
+        git_add("CHANGELOG.md")
+
+    if checker.ok and commit:
+        with check(f"Committing changes..."):
+            gitdir = run_capture(['git', 'rev-parse', '--git-dir'])
+            with open(os.path.join(gitdir, 'GITGUI_MSG'), 'w') as msgfile:
+                msgfile.write(f"Update for v{next_ver}\n")
+            run(['git', 'citool'])
+
+    if checker.ok:
+        return 0
+    else:
+        return 1
+
+
+if __name__ == '__main__':
+    args = sys.argv[1:]
+
+    quiet = False
+    commit = True
+
+    while args and args[0].startswith("--"):
+        if args[0] == '--quiet':
+            quiet = True
+            args.pop(0)
+        elif args and (args[0] == '--no-commit'):
+            commit = False
+            args.pop(0)
+
+    if len(args) != 1 or not re_ga.match(args[0]):
+        sys.stderr.write(f"Usage: {os.path.basename(sys.argv[0])} X.Y.Z\n")
+        sys.exit(2)
+
+    sys.exit(main(
+        next_ver=args[0],
+        today=datetime.date.today(),
+        quiet=quiet,
+        commit=commit,
+    ))


### PR DESCRIPTION
## Description
TODO: i need to add a bunch more comments

This PR changes the release workflow to look something like this (probably best to review with each step):

1. At some point (beginning of cycle or before a patch release), run `make release/start`, which:
    1. Runs `releng/start-sanity-check`
        1. makes sure you're in `git@github.com:datawire/ambassador` and that you're in a clean checkout
        2. either checks out or creates the release/vX.Y branch and makes sure you're up to date with that branch
    2. Runs `releng/start-update-version X.Y.Z`
        1. updates `docs/yaml/versions.yml` to have version: X.Y.Z
        2. puts `## [X.Y.Z] (TBD)` with (no changes) in the changelog
        3. commits changes. 
2. "At some point" there will be a ref that has been tested/smoked and is ready to be promoted to GA. This ref should be checked out and then you can run `make release/go` which:
    1. runs `releng/start-sanity-check` again (see above for details)
    2. creates+pushes the tag. this will trigger `release/promote-oss/to-ga`, probably in CI (see next step)
    3. runs `releng/release-go-changelog-update`
        1. updates the date in the changelog (there is already a `## [X.Y.Z] (TBD)` entry, this just changes it to `## [X.Y.Z] May 25, 2021` e.g.
        2. creates a branch off of release/vX.Y called `rel/X.Y.Z/changelog-date-update` (TODO: actually ensure this branches from the right place)
        3. commits+pushes changelog changes to changelog branch
        4. creates a PR for these changes
3: Run `make RELEASE_VERSION=X.Y.Z release/promote-oss/to-ga`, where X.Y.Z is the tag created in the step above (TODO: CI does this)
    1. takes the dev version from `s3://datawire-static-files/dev-builds/$commit`, pulls the known image from dev version, re-tags it with GA and pushes the new GA image (i didn't change this bit)
4. Once `make release/promote-oss/to-ga` is run, we can now update the manifests with the GA lookin tag by running `make VERSION=X.Y.Z release/manifests`. (Note: At this point, we've already tested everything with the dev versions)
    1. `git checkout vX.Y.Z -b rel/vX.Y.Z/chart-img-updates`
    1. update all the image tag references in the chart (chart.yaml, values.yaml, README, CHANGELOG entry)
    2. bumps the chart versions (either bumps patch or minor depending on the VERSION).
    3. runs `make update-yaml` to generate the yaml from the chart, so the manifests all have the updated version.
    4. commits+pushes to branch
    5. create a PR back to release/vX.Y
    6. Tags the chart off of the HEAD of rel/vX.Y.Z/chart-img-updates. This tag will trigger CI to publish the chart and manifests. (Note: triggering manifest publishing here because we can't trigger jobs off of release/vX.Y branches without needing to touch almost every PR circle config)

## Related Issues
List related issues.

## Testing
A few sentences describing what testing you've done, e.g., manual tests, automated tests, deployed in production, etc.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [ ] I made sure to update `CHANGELOG.md`.
   
   Remember, the CHANGELOG needs to mention:
    + Any new features
    + Any changes to our included version of Envoy
    + Any non-backward-compatible changes
    + Any deprecations
 
 - [ ] This is unlikely to impact how Ambassador performs at scale.
 
   Remember, things that might have an impact at scale include:
    + Any significant changes in memory use that might require adjusting the memory limits
    + Any significant changes in CPU use that might require adjusting the CPU limits
    + Anything that might change how many replicas users should use
    + Changes that impact data-plane latency/scalability
 
 - [ ] My change is adequately tested.
 
   Remember when considering testing:
    + LEGACY MODE TESTS DO NOT RUN FOR EVERY PR. If your change is affected by legacy mode, you need
      to run legacy-mode tests manually (set `AMBASSADOR_LEGACY_MODE=true` and run the tests).
      (This will be fixed soon.)
    + Your change needs to be specifically covered by tests.
       + Tests need to cover all the states where your change is relevant: for example, if you add a behavior that can be enabled or disabled, you'll need tests that cover the enabled case and tests that cover the disabled case. It's not sufficient just to test with the behavior enabled.
    + You also need to make sure that the _entire area being changed_ has adequate test coverage.
       + If existing tests don't actually cover the entire area being changed, add tests.
       + This applies even for aspects of the area that you're not changing – check the test coverage, and improve it if needed!
    + We should lean on the bulk of code being covered by unit tests, but...
    + ... an end-to-end test should cover the integration points
 
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
