### PR TITLE
Make the releng scripts pass mypy.

### DIFF
--- a/releng/lib/check_artifacts.py
+++ b/releng/lib/check_artifacts.py
@@ -109,37 +109,37 @@ def main(ga_ver: str, ga: bool, include_latest: bool, include_docker: bool = Tru
                     if b != a:
                         subcheck.ok = False
 
-    def do_check_binary(checker: Checker, name: str, txt: bool, private: bool) -> None:
-        with checker.check(name=f'Executable: {name}', clear_on_success=False) as checker:
-            for platform in ['linux/amd64/{}', 'darwin/amd64/{}', 'windows/amd64/{}.exe']:
-                rc_body: Optional[bytes] = None
-                with do_check_s3(checker, f'{name}/{rc_ver}/{platform.format(name)}',
-                                 private=private, bucket=s3_bucket) as (subcheck, body):
-                    if body is not None:
-                        rc_body = body
-                        # TODO: Validate the binary somehow
-                if ga:
-                    with do_check_s3(checker, f'{name}/{ga_ver}/{platform.format(name)}',
-                                     private=private, bucket=s3_bucket) as (subcheck, body):
-                        if body is not None:
-                            assert body == rc_body
-            if txt:
-                if include_latest:
-                    with do_check_s3(checker, f'{name}/latest.txt', private=private, bucket=s3_bucket) as (subcheck, body):
-                        if body is not None:
-                            subcheck.result = body.decode('UTF-8').strip()
-                            if is_private:
-                                assert subcheck.result != rc_ver
-                            else:
-                                assert_eq(subcheck.result, rc_ver)
-                if ga or is_private:
-                    with do_check_s3(checker, f'{name}/stable.txt', private=private, bucket=s3_bucket) as (subcheck, body):
-                        if body is not None:
-                            subcheck.result = body.decode('UTF-8').strip()
-                            if is_private:
-                                assert subcheck.result != ga_ver
-                            else:
-                                assert_eq(subcheck.result, ga_ver)
+    # def do_check_binary(checker: Checker, name: str, txt: bool, private: bool) -> None:
+    #     with checker.check(name=f'Executable: {name}', clear_on_success=False) as checker:
+    #         for platform in ['linux/amd64/{}', 'darwin/amd64/{}', 'windows/amd64/{}.exe']:
+    #             rc_body: Optional[bytes] = None
+    #             with do_check_s3(checker, f'{name}/{rc_ver}/{platform.format(name)}',
+    #                              private=private, bucket=s3_bucket) as (subcheck, body):
+    #                 if body is not None:
+    #                     rc_body = body
+    #                     # TODO: Validate the binary somehow
+    #             if ga:
+    #                 with do_check_s3(checker, f'{name}/{ga_ver}/{platform.format(name)}',
+    #                                  private=private, bucket=s3_bucket) as (subcheck, body):
+    #                     if body is not None:
+    #                         assert body == rc_body
+    #         if txt:
+    #             if include_latest:
+    #                 with do_check_s3(checker, f'{name}/latest.txt', private=private, bucket=s3_bucket) as (subcheck, body):
+    #                     if body is not None:
+    #                         subcheck.result = body.decode('UTF-8').strip()
+    #                         if is_private:
+    #                             assert subcheck.result != rc_ver
+    #                         else:
+    #                             assert_eq(subcheck.result, rc_ver)
+    #             if ga or is_private:
+    #                 with do_check_s3(checker, f'{name}/stable.txt', private=private, bucket=s3_bucket) as (subcheck, body):
+    #                     if body is not None:
+    #                         subcheck.result = body.decode('UTF-8').strip()
+    #                         if is_private:
+    #                             assert subcheck.result != ga_ver
+    #                         else:
+    #                             assert_eq(subcheck.result, ga_ver)
 
     s3_login()
 

--- a/releng/lib/gitutil.py
+++ b/releng/lib/gitutil.py
@@ -1,3 +1,5 @@
+from typing import Optional, Union
+
 import http.client
 import json
 

--- a/releng/lib/uiutil.py
+++ b/releng/lib/uiutil.py
@@ -41,7 +41,7 @@ from . import ansiterm
 _capturing = False
 
 
-def check_command(args) -> int:
+def check_command(args) -> bool:
     p = subprocess.run(args, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
     return p.returncode == 0
 


### PR DESCRIPTION
Make the releng scripts pass `mypy releng`. In particular, `release/start` wouldn't actually run. :slightly_frowning_face:

Signed-off-by: Flynn <flynn@datawire.io>
