### PR TITLE
Let ambassador.version override the compiled-in version in busyambassador

### DIFF
--- a/cmd/busyambassador/main.go
+++ b/cmd/busyambassador/main.go
@@ -6,7 +6,11 @@
 package main
 
 import (
+	"bufio"
 	"context"
+	"fmt"
+	"os"
+	"strings"
 
 	"github.com/datawire/ambassador/v2/pkg/busy"
 	"github.com/datawire/ambassador/v2/pkg/environment"
@@ -23,12 +27,88 @@ var Version = "(unknown version)"
 
 func noop(_ context.Context) {}
 
+// Builtin for showing this image's version.
+func showVersion(ctx context.Context, Version string, args ...string) error {
+	fmt.Printf("Version %s\n", Version)
+
+	return nil
+}
+
 func main() {
+	// Allow ambassador.version to override the compiled-in Version.
+	//
+	// "Wait wait wait wait wait," I hear you cry. "Why in the world are you
+	// doing this??" Two reasons:
+	//
+	// 1. ambassador.version is updated during the RC and GA process to always
+	//    contain the Most Polite Version of the version number -- this is the
+	//    ONE thing that should be shown to users.
+	// 2. We do _not_ recompile busyambassador during the RC and GA process, and
+	//    we don't want to: we want to ship the bits we tested, and while we're
+	//    OK with altering a text file after that, recompiling feels weirder. So
+	//    we don't.
+	//
+	// End result: fall back on the compiled-in version, but let ambassador.version
+	// be the primary.
+
+	// THIS IS A CLOSURE CALL, not just an anonymous function definition. Making the
+	// call lets me defer file.Close().
+	func() {
+		file, err := os.Open("/buildroot/ambassador/python/ambassador.version")
+
+		if err != nil {
+			// We DON'T log errors here; we just silently fall back to the
+			// compiled-in version. This is because the code in main() here is
+			// running _wicked_ early, and logging setup happens _after_ this
+			// function.
+			//
+			// XXX Letting the logging setup happen here, instead, would likely
+			// be an improvement.
+			return
+		}
+
+		defer file.Close()
+
+		// Read line by line and hunt for BUILD_VERSION.
+		scanner := bufio.NewScanner(file)
+
+		for scanner.Scan() {
+			line := scanner.Text()
+
+			if strings.HasPrefix(line, "BUILD_VERSION=") {
+				// The BUILD_VERSION line should be e.g.
+				//
+				// BUILD_VERSION="2.0.4-rc.2"
+				//
+				// so... cheat. Split on " and look for the second field.
+				v := strings.Split(line, "\"")
+
+				// If we don't get exactly three fields, though, something
+				// is wrong and we'll give up.
+				if len(v) == 3 {
+					Version = v[1]
+				}
+				// See comments toward the top of this function for why there's no
+				// logging here.
+				// else {
+				// 	fmt.Printf("VERSION OVERRIDE: got %#v ?", v)
+				// }
+			}
+		}
+
+		// Again, see comments toward the top of this function for why there's no
+		// logging here.
+		// if err := scanner.Err(); err != nil {
+		// 	fmt.Printf("VERSION OVERRIDE: scanner error %s", err)
+		// }
+	}()
+
 	busy.Main("busyambassador", "Ambassador", Version, map[string]busy.Command{
 		"ambex":      {Setup: environment.EnvironmentSetupEntrypoint, Run: ambex.Main},
 		"kubestatus": {Setup: environment.EnvironmentSetupEntrypoint, Run: kubestatus.Main},
 		"entrypoint": {Setup: noop, Run: entrypoint.Main},
 		"reproducer": {Setup: noop, Run: reproducer.Main},
 		"agent":      {Setup: environment.EnvironmentSetupEntrypoint, Run: amb_agent.Main},
+		"version":    {Setup: noop, Run: showVersion},
 	})
 }


### PR DESCRIPTION
This will flow into all the busy- binaries, too. There's also now a `busyambassador version` command.

I tested this with `docker run`, editing `ambassador.version` and verifying that valid values worked and invalid values fell back to the compiled-in version.

Signed-off-by: Flynn <flynn@datawire.io>

 - [x] I didn't need to update `CHANGELOG.md`.
 - [x] This is unlikely to impact how Ambassador performs at scale.
 - [x] My change is adequately tested.
 - [x] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
