### PR TITLE
.github/actions: Don't allow surprise .Y version upgrades for Python

### DIFF
--- a/.github/actions/execute-go-tests/action.yml
+++ b/.github/actions/execute-go-tests/action.yml
@@ -9,8 +9,8 @@ runs:
       name: Set Unique Test prefix (gotests-legacy-mode.${{ matrix.gotest-settings.legacy-mode }}-fast-reconfigure.${{ matrix.gotest-settings.fast-reconfigure }})
     - uses: actions/setup-python@v2
       with:
-        python-version: '^3.9.5'
-      name: "Install Python (^3.9.5)"
+        python-version: '~3.9.5'
+      name: "Install Python (~3.9.5)"
     - run: python --version
       shell: bash
       name: "Check python installed"

--- a/.github/actions/execute-pytest-unit/action.yml
+++ b/.github/actions/execute-pytest-unit/action.yml
@@ -14,8 +14,8 @@ runs:
       name: "Configure system file and inotify maximums (1600000/4096)"
     - uses: actions/setup-python@v2
       with:
-        python-version: '^3.9.5'
-      name: "Install Python (^3.9.5)"
+        python-version: '~3.9.5'
+      name: "Install Python (~3.9.5)"
     - run: python --version
       shell: bash
       name: "Check python installed"

--- a/.github/actions/execute-pytests/action.yml
+++ b/.github/actions/execute-pytests/action.yml
@@ -17,8 +17,8 @@ runs:
       name: "Configure system file and inotify maximums (1600000/4096)"
     - uses: actions/setup-python@v2
       with:
-        python-version: '^3.9.5'
-      name: "Install Python (^3.9.5)"
+        python-version: '~3.9.5'
+      name: "Install Python (~3.9.5)"
     - run: python --version
       shell: bash
       name: "Check python installed"


### PR DESCRIPTION
## Description

Python 3.10 just came out, and it broke the build.  We'd been saying
"^3.9.5" which means "any 3.y.z that is >= 3.9.5".  Instead change it to
"~3.9.5" which means "any 3.9.z that is >= 3.9.5".

## Related Issues

Well, my other PRs are failing, and this is fixing that.

## Testing
CI should cover it... this should be un-borking CI.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [x] I made sure to update `CHANGELOG.md`. - no applicable changes
   
   Remember, the CHANGELOG needs to mention:
    + Any new features
    + Any changes to our included version of Envoy
    + Any non-backward-compatible changes
    + Any deprecations
 
 - [x] This is unlikely to impact how Ambassador performs at scale. - shouldn't be a runtime change
 
   Remember, things that might have an impact at scale include:
    + Any significant changes in memory use that might require adjusting the memory limits
    + Any significant changes in CPU use that might require adjusting the CPU limits
    + Anything that might change how many replicas users should use
    + Changes that impact data-plane latency/scalability
 
 - [x] My change is adequately tested. - CI should cover it
 
   Remember when considering testing:
    + LEGACY MODE TESTS DO NOT RUN FOR EVERY PR. If your change is affected by legacy mode, you need
      to run legacy-mode tests manually (set `AMBASSADOR_LEGACY_MODE=true` and run the tests).
      (This will be fixed soon.)
    + Your change needs to be specifically covered by tests.
       + Tests need to cover all the states where your change is relevant: for example, if you add a behavior that can be enabled or disabled, you'll need tests that cover the enabled case and tests that cover the disabled case. It's not sufficient just to test with the behavior enabled.
    + You also need to make sure that the _entire area being changed_ has adequate test coverage.
       + If existing tests don't actually cover the entire area being changed, add tests.
       + This applies even for aspects of the area that you're not changing – check the test coverage, and improve it if needed!
    + We should lean on the bulk of code being covered by unit tests, but...
    + ... an end-to-end test should cover the integration points
 
 - [x] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently. - no tricks
