### PR TITLE
deps: upgrade to golang 1.19.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,12 @@ it will be removed; but as it won't be user-visible this isn't considered a brea
   Kubernetes Nodes (regardless of whether the installation was migrated from 1.y or was a fresh 2.y
   install); fully supporting `v1` again should resolve these errors.
 
+- Security: Update Golang to release 1.19.4. Two CVE's were annouced in this z patch release.
+  CVE-2022-41720 only affects Windows environments and Emissary-ingress runs in linux. The second
+  one  CVE-2022-41717 only affects HTTP/2 server connections exposed to external clients.
+  Emissary-ingress does  not expose any Golang http servers to outside clients. The data-plane of
+  Envoy is not affected by either of these. 
+
 - Security: Updated Golang to the latest z patch. We are not vulnerable to the CVE-2022-3602 that
   was  released in 1.19.3 and you can read more about it here:
   <https://medium.com/ambassador-api-gateway/ambassador-labs-security-impact-assessment-of-nov-1-openssl-golang-vulnerabilities-f11b5ec37a7e>.

--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -3,7 +3,7 @@ following Free and Open Source software:
 
     Name                                                                                       Version                                      License(s)
     ----                                                                                       -------                                      ----------
-    the Go language standard library ("std")                                                   v1.19.3                                      3-clause BSD license
+    the Go language standard library ("std")                                                   v1.19.4                                      3-clause BSD license
     cloud.google.com/go/compute                                                                v1.2.0                                       Apache License 2.0
     github.com/Azure/go-ansiterm                                                               v0.0.0-20210617225240-d185dfc1b5a1           MIT license
     github.com/Azure/go-autorest                                                               v14.2.0+incompatible                         Apache License 2.0

--- a/docker/base-python/Dockerfile
+++ b/docker/base-python/Dockerfile
@@ -78,7 +78,7 @@ RUN apk --no-cache add \
 # 'python3' versions above.
 RUN pip3 install pip-tools==6.3.1
 
-RUN curl --fail -L https://dl.google.com/go/go1.19.3.linux-amd64.tar.gz | tar -C /usr/local -xzf -
+RUN curl --fail -L https://dl.google.com/go/go1.19.4.linux-amd64.tar.gz | tar -C /usr/local -xzf -
 
 RUN curl --fail -L https://storage.googleapis.com/kubernetes-release/release/v1.23.3/bin/linux/amd64/kubectl -o /usr/bin/kubectl && \
   chmod a+x /usr/bin/kubectl

--- a/docker/test-http/Dockerfile
+++ b/docker/test-http/Dockerfile
@@ -1,7 +1,7 @@
 # The `test-http` image gets built by `pkg/kubeapply` for use by
 # various kubeapply-templated YAML files.
 
-FROM golang:1.19.3
+FROM golang:1.19
 COPY httptest.go /usr/local/bin/httptest.go
 RUN go build -o /usr/local/bin/httptest /usr/local/bin/httptest.go
 ENTRYPOINT ["/usr/local/bin/httptest"]

--- a/docs/releaseNotes.yml
+++ b/docs/releaseNotes.yml
@@ -47,6 +47,15 @@ items:
           installation was migrated from 1.y or was a fresh 2.y install); fully supporting
           <code>v1</code> again should resolve these errors.
 
+      - title: Update Golang to 1.19.4
+        type: security
+        body: >-
+          Update Golang to release 1.19.4. Two CVE's were annouced in this z patch release.
+          CVE-2022-41720 only affects Windows environments and $productName$ runs in linux. The second one 
+          CVE-2022-41717 only affects HTTP/2 server connections exposed to external clients. $productName$ does 
+          not expose any Golang http servers to outside clients. The data-plane of Envoy
+          is not affected by either of these. 
+
       - title: Update Golang to 1.19.3
         type: security
         body: >-


### PR DESCRIPTION
Signed-off-by: Lance Austin <laustin@datawire.io>

## Description

Update Golang to release 1.19.4. Two CVE's were annouced in this z patch release. CVE-2022-41720 only affects Windows environments and $productName$ runs in linux. The second one, CVE-2022-41717 only affects HTTP/2 server connections exposed to external clients.

Emissary-ingress does not expose any Golang http servers to outside clients directly.

The data-plane of Envoy is not affected by either of these since this is a Golang issue.

However, as part of our practice of staying up-to-date with dependencies we will update it accordingly and ensure it is pulled into Edge Stack as well.

## Related Issues

N/A

## Testing

CI is green.

## Checklist

- [x] **I made sure to update `CHANGELOG.md`.**
- [x] **This is unlikely to impact how Ambassador performs at scale.**
- [x] **My change is adequately tested.**
- [ ] **I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.**
- [x] **The changes in this PR have been reviewed for security concerns and adherence to security best practices.**
