### PR TITLE
Include CRD status updates

### DIFF
--- a/pkg/apiext/internal/inject.go
+++ b/pkg/apiext/internal/inject.go
@@ -136,9 +136,13 @@ func updateCRD(
 	}
 	dlog.Infof(ctx, "Configuring conversion for %q", crd.ObjectMeta.Name)
 	crd.Spec.Conversion = conversionConfig
-	_, err := crdsClient.Update(ctx, &crd, k8sTypesMetaV1.UpdateOptions{})
-	if err != nil && !k8sErrors.IsConflict(err) {
+	if _, err := crdsClient.Update(ctx, &crd, k8sTypesMetaV1.UpdateOptions{}); err != nil && !k8sErrors.IsConflict(err) {
 		return err
 	}
+
+	if _, err := crdsClient.UpdateStatus(ctx, &crd, k8sTypesMetaV1.UpdateOptions{}); err != nil && !k8sErrors.IsConflict(err) {
+		return err
+	}
+
 	return nil
 }


### PR DESCRIPTION
## Description

CRD conversion did not previously update status (as it currently only handles updates to the spec); as a result, any updates to status data were completely lost. This adds an additional call to `UpdateStatus` in order to preserve status changes.

## Related Issues

N/A

## Testing

Manually tested using CRDs without `Status` and CRDs with `Status`; tested multiple, chained updates to ensure `Status` values were changing as expected. All test cases functioned as expected under all scenarios.

## Checklist

- [ ] **Does my change need to be backported to a previous release?**
- [ ] **I made sure to update `CHANGELOG.md`.**
- [x] **This is unlikely to impact how Ambassador performs at scale.**
- [x] **My change is adequately tested.**
- [ ] **I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.**
- [x] **The changes in this PR have been reviewed for security concerns and adherence to security best practices.**
