### PR TITLE
module: add listener_max_connection_lifetime_ms option

### DIFF
--- a/python/ambassador/envoy/v3/v3listener.py
+++ b/python/ambassador/envoy/v3/v3listener.py
@@ -523,6 +523,15 @@ class V3Listener:
                     "idle_timeout": "%0.3fs" % (float(listener_idle_timeout_ms) / 1000.0)
                 }
 
+        listener_max_connection_lifetime_ms = self.config.ir.ambassador_module.get(
+            "listener_max_connection_lifetime_ms", None
+        )
+        if listener_max_connection_lifetime_ms:
+            common_http_options = base_http_config.setdefault("common_http_protocol_options", {})
+            common_http_options["max_connection_duration"] = "%0.3fs" % (
+                float(listener_max_connection_lifetime_ms) / 1000.0
+            )
+
         if "headers_with_underscores_action" in self.config.ir.ambassador_module:
             if "common_http_protocol_options" in base_http_config:
                 base_http_config["common_http_protocol_options"][

--- a/python/ambassador/ir/ir.py
+++ b/python/ambassador/ir/ir.py
@@ -1160,6 +1160,9 @@ class IR:
         od["listener_idle_timeout_ms"] = self.ambassador_module.get(
             "listener_idle_timeout_ms", None
         )
+        od["listener_max_connection_lifetime_ms"] = self.ambassador_module.get(
+            "listener_max_connection_lifetime_ms", None
+        )
         od["headers_with_underscores_action"] = self.ambassador_module.get(
             "headers_with_underscores_action", None
         )

--- a/python/ambassador/ir/irambassador.py
+++ b/python/ambassador/ir/irambassador.py
@@ -49,6 +49,7 @@ class IRAmbassador(IRResource):
         "headers_with_underscores_action",
         "keepalive",
         "listener_idle_timeout_ms",
+        "listener_max_connection_lifetime_ms",
         "liveness_probe",
         "load_balancer",
         "max_request_headers_kb",
@@ -132,6 +133,7 @@ class IRAmbassador(IRResource):
             envoy_validation_timeout=IRAmbassador.default_validation_timeout,
             enable_ipv4=True,
             listener_idle_timeout_ms=None,
+            listener_max_connection_lifetime_ms=None,
             liveness_probe={"enabled": True},
             readiness_probe={"enabled": True},
             diagnostics={"enabled": True},  # TODO(lukeshu): In getambassador.io/v3alpha2, change

--- a/python/tests/kat/t_listenermaxconnectionlifetime.py
+++ b/python/tests/kat/t_listenermaxconnectionlifetime.py
@@ -1,0 +1,83 @@
+import json
+from typing import Generator, Tuple, Union
+
+from abstract_tests import HTTP, AmbassadorTest, Node, ServiceType
+from kat.harness import Query
+
+
+class ListenerMaxConnectionLifetime(AmbassadorTest):
+    target: ServiceType
+
+    def init(self):
+        self.target = HTTP()
+
+    def config(self) -> Generator[Union[str, Tuple[Node, str]], None, None]:
+        yield self, self.format(
+            """
+---
+apiVersion: getambassador.io/v3alpha1
+kind: Module
+name: ambassador
+ambassador_id: [{self.ambassador_id}]
+config:
+  listener_max_connection_lifetime_ms: 3600000
+"""
+        )
+        yield self, self.format(
+            """
+---
+apiVersion: getambassador.io/v3alpha1
+kind: Mapping
+name:  config__dump
+hostname: "*"
+prefix: /config_dump
+rewrite: /config_dump
+service: http://127.0.0.1:8001
+"""
+        )
+
+    def queries(self):
+        yield Query(self.url("config_dump"), phase=2)
+
+    def check(self):
+        expected_val = "3600s"
+        actual_val = ""
+        assert self.results[0].body
+        body = json.loads(self.results[0].body)
+        for config_obj in body.get("configs"):
+            if config_obj.get("@type") == "type.googleapis.com/envoy.admin.v3.ListenersConfigDump":
+                listeners = config_obj.get("dynamic_listeners")
+                found_max_conn_duration = False
+                for listener_obj in listeners:
+                    listener = listener_obj.get("active_state").get("listener")
+                    filter_chains = listener.get("filter_chains")
+                    for filters in filter_chains:
+                        for filter in filters.get("filters"):
+                            if (
+                                filter.get("name")
+                                == "envoy.filters.network.http_connection_manager"
+                            ):
+                                filter_config = filter.get("typed_config")
+                                common_http_protocol_options = filter_config.get(
+                                    "common_http_protocol_options"
+                                )
+                                if common_http_protocol_options:
+                                    actual_val = common_http_protocol_options.get(
+                                        "max_connection_duration", ""
+                                    )
+                                    if actual_val != "":
+                                        if actual_val == expected_val:
+                                            found_max_conn_duration = True
+                                    else:
+                                        assert (
+                                            False
+                                        ), "Expected to find common_http_protocol_options.max_connection_duration property on listener"
+                                else:
+                                    assert (
+                                        False
+                                    ), "Expected to find common_http_protocol_options property on listener"
+                assert (
+                    found_max_conn_duration
+                ), "Expected common_http_protocol_options.max_connection_duration = {}, Got common_http_protocol_options.max_connection_duration = {}".format(
+                    expected_val, actual_val
+                )

--- a/python/tests/unit/test_listener_common_http_protocol_options.py
+++ b/python/tests/unit/test_listener_common_http_protocol_options.py
@@ -41,11 +41,28 @@ def test_listener_idle_timeout_ms():
 
 
 @pytest.mark.compilertest
+def test_listener_max_connection_lifetime_ms():
+    yaml = module_and_mapping_manifests(["listener_max_connection_lifetime_ms: 3600000"], [])
+    _test_listener_common_http_protocol_options(
+        yaml, expectations={"max_connection_duration": "3600.000s"}
+    )
+
+
+@pytest.mark.compilertest
 def test_all_listener_common_http_protocol_options():
     yaml = module_and_mapping_manifests(
-        ["headers_with_underscores_action: DROP_HEADER", "listener_idle_timeout_ms: 4005"], []
+        [
+            "headers_with_underscores_action: DROP_HEADER",
+            "listener_idle_timeout_ms: 4005",
+            "listener_max_connection_lifetime_ms: 3600005",
+        ],
+        [],
     )
     _test_listener_common_http_protocol_options(
         yaml,
-        expectations={"headers_with_underscores_action": "DROP_HEADER", "idle_timeout": "4.005s"},
+        expectations={
+            "headers_with_underscores_action": "DROP_HEADER",
+            "idle_timeout": "4.005s",
+            "max_connection_duration": "3600.005s",
+        },
     )


### PR DESCRIPTION
## Description

Add listener_max_connection_lifetime_ms, similar to how listener_idle_timeout_ms is implemented. This limit the maximum age of a downstream connections by adding max_connection_duration to the listener's common_http_protocol_options.

This option could already be set on the clusters (upstream connections), but setting it on the downstream connections could be useful in multiple scenarios:

- to periodically rebalance the load between multiple emissary-ingress, especially when most of the clients are using HTTP2/gRPC and connection stick for a really long time.

- when using mTLS (client certificate), to ensure that clients reconnect with their renewed certificate, as Envoy doesn't close the connection when the certificate expires.

## Related Issues

Fix #2900

## Testing

- Added automated tests
- Not yet deployed in a real cluster

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->
- [x] **Does my change need to be backported to a previous release?**
  - No, this is a new feature.

- [ ] **I made sure to update `CHANGELOG.md`.**

   Remember, the CHANGELOG needs to mention:
  - Any new features
  - Any changes to our included version of Envoy
  - Any non-backward-compatible changes
  - Any deprecations

- [x] **This is unlikely to impact how Ambassador performs at scale.**

   Remember, things that might have an impact at scale include:
  - Any significant changes in memory use that might require adjusting the memory limits
  - Any significant changes in CPU use that might require adjusting the CPU limits
  - Anything that might change how many replicas users should use
  - Changes that impact data-plane latency/scalability

- [ ] **My change is adequately tested.**

   Remember when considering testing:
  - Your change needs to be specifically covered by tests.
    - Tests need to cover all the states where your change is relevant: for example, if you add a behavior that can be enabled or disabled, you'll need tests that cover the enabled case and tests that cover the disabled case. It's not sufficient just to test with the behavior enabled.
  - You also need to make sure that the _entire area being changed_ has adequate test coverage.
    - If existing tests don't actually cover the entire area being changed, add tests.
    - This applies even for aspects of the area that you're not changing – check the test coverage, and improve it if needed!
  - We should lean on the bulk of code being covered by unit tests, but...
  - ... an end-to-end test should cover the integration points

- [ ] **I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.**

- [x] **The changes in this PR have been reviewed for security concerns and adherence to security best practices.**
