### PR TITLE
Fix istio cert rotation bug for issue #4744

### DIFF
--- a/python/tests/utils.py
+++ b/python/tests/utils.py
@@ -12,7 +12,8 @@ from OpenSSL import crypto
 from ambassador import IR, Cache, Config, EnvoyConfig
 from ambassador.compile import Compile
 from ambassador.fetch import ResourceFetcher
-from ambassador.utils import NullSecretHandler, parse_bool
+from ambassador.utils import NullSecretHandler, parse_bool, SavedSecret
+
 
 logger = logging.getLogger("ambassador")
 
@@ -376,4 +377,25 @@ def edgestack():
     return pytest.mark.skipif(
         not isEdgeStack,
         reason=f"Skipping because this is an EdgeStack specific case and is tested separately",
+    )
+
+
+def generate_istio_cert_delta(delta_type="update"):
+    return {
+                "kind": "Secret",
+                "name": "istio-certs",
+                "namespace": "ambassador",
+                "deltaType": delta_type,
+            }
+
+
+def generate_istio_saved_secret():
+    return SavedSecret(
+        secret_name="test-secret",
+        namespace="default",
+        cert_path="//test-secret-123.crt",
+        key_path="//test-secret-123.key",
+        user_path="//test-secret-123.user",
+        root_cert_path="//test-secret-123.root.crt",
+        cert_data={"tls_crt": "tls_crt", "tls_key": "tls_key", "user_key": "user_key", "root_crt": "root_crt"}
     )


### PR DESCRIPTION
## Description

This PR fixes a known issue when Emissary is configured to connect to an Istio mTLS network.  When Emissary's Istio sidecar initiates a cert rotation the `istio-certs` secret generates a cache entry, but does not generate a delta since the `istio-certs` cache entry does not map to an actual resource on the Kubernetes cluster.  This can eventually resolve itself if a delta is generated that can initiate a change, but other times it results in an unrecoverable error that can cause traffic disruption without custom health checks.

## Related Issues

https://github.com/emissary-ingress/emissary/issues/4744

## Testing

* Replicated the issue using recommended steps from https://github.com/emissary-ingress/emissary/issues/4744#issuecomment-1406798652
* Using this [test image](https://hub.docker.com/r/jebaile7964/emissary) that includes the fix, the test case could no longer be replicated
* Tested on Istio 1.23.2
* Added parametrized unit tests for improved coverage of this test case


## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->
- [ ] **Does my change need to be backported to a previous release?**
  - What backport versions were discussed with the Maintainers in the Issue?

- [ ] **I made sure to update `CHANGELOG.md`.**

   Remember, the CHANGELOG needs to mention:
  - Any new features
  - Any changes to our included version of Envoy
  - Any non-backward-compatible changes
  - Any deprecations

- [x] **This is unlikely to impact how Ambassador performs at scale.**

   Remember, things that might have an impact at scale include:
  - Any significant changes in memory use that might require adjusting the memory limits
  - Any significant changes in CPU use that might require adjusting the CPU limits
  - Anything that might change how many replicas users should use
  - Changes that impact data-plane latency/scalability

- [ ] **My change is adequately tested.**

   Remember when considering testing:
  - Your change needs to be specifically covered by tests.
    - Tests need to cover all the states where your change is relevant: for example, if you add a behavior that can be enabled or disabled, you'll need tests that cover the enabled case and tests that cover the disabled case. It's not sufficient just to test with the behavior enabled.
  - You also need to make sure that the _entire area being changed_ has adequate test coverage.
    - If existing tests don't actually cover the entire area being changed, add tests.
    - This applies even for aspects of the area that you're not changing – check the test coverage, and improve it if needed!
  - We should lean on the bulk of code being covered by unit tests, but...
  - ... an end-to-end test should cover the integration points

- [ ] **I updated `CONTRIBUTING.md` with any special dev tricks I had to use to work on this code efficiently.**

- [ ] **The changes in this PR have been reviewed for security concerns and adherence to security best practices.**
