### PR TITLE
Fix "make images"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,10 +9,6 @@ include build-aux/tools.mk
 # to "emissary-test".
 TEST_CLUSTER ?= emissary-test
 
-# To support contributors building project on M1 Macs we will default container builds to run as linux/amd64 rather than
-# the host architecture. Setting the corresponding environment variable allows overriding it if want to work with other architectures.
-BUILD_ARCH ?= linux/amd64
-
 # Bootstrapping the build env
 #
 ifneq ($(MAKECMDGOALS),$(OSS_HOME)/build-aux/go-version.txt)
@@ -38,6 +34,11 @@ ifneq ($(MAKECMDGOALS),$(OSS_HOME)/build-aux/go-version.txt)
 	ARCH := arm64
   endif
   export ARCH
+
+  # By default, we'll build for the same processor architecture as this Makefile
+  # is running on, but you can change this. Unsetting it will build for all amd64
+  # and arm64.
+  BUILD_ARCH ?= linux/$(ARCH)
 
   # This is a bit hackish, at the moment, but let's run with it for now
   # and see how far we get.

--- a/make-gorel.py
+++ b/make-gorel.py
@@ -89,9 +89,16 @@ def main():
     parser.add_argument("--footer", type=str, help="File to print after YAML output")
     args = parser.parse_args()
 
-    # Update default architectures globally
+    # Update default architectures globally. If an architecture includes
+    # the OS as well (e.g. "linux/arm64" instead of just "arm64", strip
+    # that off.
 
-    BuildStyle.ARCHITECTURES = args.arch.split(",")
+    BuildStyle.ARCHITECTURES = []
+    for arch in args.arch.split(","):
+        arch = arch.strip().split("/")[-1]
+        BuildStyle.ARCHITECTURES.append(arch)
+
+    # sys.stderr.write(f"Using architectures: {','.join(BuildStyle.ARCHITECTURES)}\n")
 
     # Rebuild BUILDS with possibly new architectures
     builds = [


### PR DESCRIPTION
Arrange for "make images" without explicitly setting BUILD_ARCH to correctly just build images for your local architecture. (If you want _all_ architectures, set BUILD_ARCH="".)

Signed-off-by: Flynn <emissary@flynn.kodachi.com>
