### PR TITLE
chore(ci): Allow the release job to run for prerelease tags.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -113,7 +113,7 @@ jobs:
 
   release:
     name: Release
-    if: ${{ (startsWith(github.ref, 'refs/tags/v4.') && !contains(github.ref_name, '-')) || (vars.act =='true' && vars.do_release == 'true') }}
+    if: ${{ startsWith(github.ref, 'refs/tags/v4.') || (vars.act =='true' && vars.do_release == 'true') }}
     secrets: inherit
     uses: ./.github/workflows/release.yaml
     needs:


### PR DESCRIPTION
We will want to create prereleases, so we need to actually run the release workflow for tags that contain a "-".