### PR TITLE
Let reusable workflows request their own permissions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -62,7 +62,8 @@ on:
           Defaults to: ghcr.io/emissary-ingress
 
 permissions:
-  contents: read
+  contents: read  # Required by all reusable workflows
+  # packages: write is only granted to release.yaml via its own permissions block
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -114,6 +115,9 @@ jobs:
   release:
     name: Release
     if: ${{ startsWith(github.ref, 'refs/tags/v4.') || (vars.act =='true' && vars.do_release == 'true') }}
+    permissions:
+      contents: read
+      packages: write  # Override to allow pushing to GHCR
     secrets: inherit
     uses: ./.github/workflows/release.yaml
     needs:


### PR DESCRIPTION
ci.yaml was declaring read-only permissions, and since it was the parent workflow for everything else, this meant that release.yaml couldn't ask for `package: write`. Instead, ci.yaml needs to explicitly grant `package: write` to release.yaml.
