### PR TITLE
fix: replace 8 bare except clauses with except Exception

### DIFF
--- a/python/ambassador/diagnostics/envoy_stats.py
+++ b/python/ambassador/diagnostics/envoy_stats.py
@@ -337,7 +337,7 @@ class EnvoyStatsMgr:
 
             try:
                 node[keypath[-1]] = int(value)
-            except:
+            except Exception:
                 continue
 
         # Now dig into clusters a bit more.

--- a/python/ambassador/fetch/ingress.py
+++ b/python/ambassador/fetch/ingress.py
@@ -237,7 +237,7 @@ class IngressProcessor(ManagedKubernetesProcessor):
 
                 try:
                     service_port = int(service_port)
-                except:
+                except Exception:
                     service_port = self._try_resolve_service_port_number(
                         obj.namespace, service_name, service_port
                     )

--- a/python/ambassador/ir/ir.py
+++ b/python/ambassador/ir/ir.py
@@ -689,7 +689,7 @@ class IR:
 
         try:
             agent_port = int(agent_port_str)
-        except:
+        except Exception:
             self.post_error(f"Intercept agent port {agent_port_str} is not valid")
             self.agent_active = False
             return

--- a/python/ambassador/utils.py
+++ b/python/ambassador/utils.py
@@ -196,7 +196,7 @@ class SystemInfo:
 
         try:
             MyHostName = socket.gethostname()
-        except:
+        except Exception:
             pass
 
 

--- a/python/ambassador_diag/diagd.py
+++ b/python/ambassador_diag/diagd.py
@@ -597,7 +597,7 @@ def get_templates_dir():
     try:
         # this will fail when not in a distribution
         res_dir = resource_filename(Requirement.parse("ambassador"), "templates")
-    except:
+    except Exception:
         pass
 
     maybe_dirs = [res_dir, os.path.join(os.path.dirname(__file__), "..", "templates")]
@@ -747,7 +747,7 @@ class Notices:
             local_notices = parse_json(local_data)
         except OSError:
             pass
-        except:
+        except Exception:
             local_notices.append(
                 {"level": "ERROR", "message": "bad local notices: %s" % local_data}
             )
@@ -2231,7 +2231,7 @@ class AmbassadorEventWatcher(threading.Thread):
 
         try:
             v_str = v_encoded.decode("utf-8")
-        except:
+        except Exception:
             pass
 
         self.logger.error(

--- a/python/kat/harness.py
+++ b/python/kat/harness.py
@@ -1048,7 +1048,7 @@ class Runner:
             try:
                 self._setup_k8s(expanded)
                 self._query(expanded_up)
-            except:
+            except Exception:
                 traceback.print_exc()
                 pytest.exit("setup failed")
             finally:


### PR DESCRIPTION
Replace bare `except:` clauses with `except Exception:` for PEP 8 compliance. Bare except catches all exceptions including SystemExit, KeyboardInterrupt, and GeneratorExit, which is rarely intended.