### PR TITLE
chore: Update prior to renaming dev/v4/main to main

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,7 +6,7 @@ on:
     tags:
       - v4.** # Triggers on any tag like v4.0.0, v4.1.2-rc.1, etc.
     branches:
-      - dev/v4/main
+      - main
 
   pull_request:
     types: # The pull request events to listen for
@@ -14,7 +14,7 @@ on:
       - reopened
       - synchronize
     branches:
-      - dev/v4/main # The base branch that the pull request is targeting
+      - main # The base branch that the pull request is targeting
 
   workflow_dispatch: # Allows manual triggering of the workflow
     inputs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,11 @@ as the Ambassador API Gateway.
 
 ## Emissary v4 Release Notes
 
-## [4.0.0] TBD
-[4.0.0]: https://github.com/emissary-ingress/emissary/compare/v3.10.0...v4.0.0-rc.0
+## [4.0.1] 26 March 2026
+[4.0.1]: https://github.com/emissary-ingress/emissary/compare/v3.10.0...v4.0.1
 
-_These release notes describe Emissary v4.0.0-rc.2._
+_v4.0.0 was never published due to a CI glitch. v4.0.1 is the correct GA
+version of Emissary._
 
 ### Quickstart
 
@@ -44,7 +45,7 @@ from the Helm charts.
   (which should not affect any Emissary users).
 
 - **BREAKING CHANGE**: The Helm chart and Emissary itself now have aligned
-  version numbers (e.g., use chart 4.0.0 to install Emissary 4.0.0).
+  version numbers (e.g., use chart 4.0.1 to install Emissary 4.0.1).
 
 - **BREAKING CHANGE**: Emissary's Helm charts are now available only from
   the GitHub Container Registry (GHCR):

--- a/README.md
+++ b/README.md
@@ -40,11 +40,10 @@ See the full list of [features](https://emissary-ingress.dev/docs/4.0/about/feat
 Branches
 ========
 
-(If you are looking at this list on a branch other than `dev/v4/main`, it
+(If you are looking at this list on a branch other than `main`, it
 is likely to be wrong.)
 
-- [`dev/v4/main`](https://github.com/emissary-ingress/emissary/tree/dev/v4/main): branch for Emissary-ingress 4 development work (:heavy_check_mark: active development)
-   - When Emissary 4.0 ships, this branch will become `main`.
+- [`main`](https://github.com/emissary-ingress/emissary/tree/main): main Emissary-ingress development work (:heavy_check_mark: active development)
 
 - [`master`](https://github.com/emissary-ingress/emissary/tree/master): **frozen** branch for Emissary-ingress 3.10 (:heavy_check_mark: frozen)
 - [`release/v2.5`](https://github.com/emissary-ingress/emissary/tree/release/v2.5): **frozen** branch for Emissary-ingress 2.5 (:heavy_check_mark: frozen)


### PR DESCRIPTION
Now that Emissary 4 has shipped, it's time to rename dev/v4/main to main. This is necessary to do so.

Signed-off-by: Flynn <emissary@flynn.kodachi.com>
