### PR TITLE
Set traced ingress listeners to INBOUND

### DIFF
--- a/python/ambassador/src/ambassador/envoy/v3/v3listener.py
+++ b/python/ambassador/src/ambassador/envoy/v3/v3listener.py
@@ -588,7 +588,7 @@ class V3Listener:
             base_http_config["generate_request_id"] = True
 
             base_http_config["tracing"] = {}
-            self.traffic_direction = "OUTBOUND"
+            self.traffic_direction = "INBOUND"
 
             custom_tags = self.config.ir.tracing.get("custom_tags", [])
             if custom_tags:

--- a/python/tests/src/tests/unit/test_listener.py
+++ b/python/tests/src/tests/unit/test_listener.py
@@ -10,7 +10,13 @@ from ambassador.config import Config
 from ambassador.envoy import EnvoyConfig
 from ambassador.fetch import ResourceFetcher
 from ambassador.utils import EmptySecretHandler
-from tests.utils import Compile, default_http3_listener_manifest, econf_compile, logger
+from tests.utils import (
+    Compile,
+    default_http3_listener_manifest,
+    default_listener_manifests,
+    econf_compile,
+    logger,
+)
 
 
 def _ensure_alt_svc_header_injected(listener, expectedAltSvc):
@@ -311,6 +317,40 @@ spec:
         assert len(udp_filter_chains) == 1
 
         _verify_no_added_response_headers(udp_listener)
+
+    @pytest.mark.compilertest
+    def test_traced_listeners_are_inbound(self):
+        yaml = (
+            default_listener_manifests()
+            + """
+---
+apiVersion: getambassador.io/v3alpha1
+kind: TracingService
+metadata:
+  name: otel-tracing
+  namespace: ambassador
+spec:
+  service: otel-collector.opentelemetry.svc.cluster.local:4317
+  driver: opentelemetry
+  config:
+    service_name: emissary-ingress
+"""
+        )
+
+        econf = econf_compile(yaml)
+        traced_listeners = []
+
+        for listener in econf["static_resources"]["listeners"]:
+            if any(
+                "tracing" in filter_chain["filters"][0]["typed_config"]
+                for filter_chain in listener["filter_chains"]
+            ):
+                traced_listeners.append(listener)
+
+        assert len(traced_listeners) == 2
+
+        for listener in traced_listeners:
+            assert listener["traffic_direction"] == "INBOUND"
 
     @pytest.mark.compilertest
     def test_listener_filterchain_vhost_generation(self):


### PR DESCRIPTION
## Description

This change fixes the listener metadata emitted when tracing is enabled on Emissary-managed ingress listeners.

Today, traced HTTP listeners are generated with `traffic_direction: OUTBOUND`. In Envoy, that causes spans created from those listeners to be treated as client-side spans, which is incorrect for ingress traffic. This patch changes traced ingress listeners to use `traffic_direction: INBOUND` instead, so the generated spans reflect the actual role of the listener.

The change is intentionally small and scoped to listener generation. A targeted unit test was added to cover traced listeners explicitly and to guard against this regression going forward.

## Related Issues

- Fixes #5907

## Testing

I verified the change with focused and broader automated test coverage.

Focused validation:
- `uv run --group dev pytest --tb=short python/tests/src/tests/unit/test_listener.py -k traced_listeners_are_inbound`
- Re-ran the targeted tracing listener test after the final cleanup pass

Area validation:
- `uv run --group dev pytest --tb=short python/tests/src/tests/unit/test_listener.py`

Broader regression validation:
- `uv run --group dev pytest --tb=short python/tests/src/tests/unit`

Linting:
- `uv run --group dev ruff check python/ambassador/src/ambassador/envoy/v3/v3listener.py python/tests/src/tests/unit/test_listener.py`
- `make lint`

Note:
- On this workstation, `make lint` needed to be run with a local Python 3.13 shim for the chart-lint step because the pinned `yamale` tool crashes under host Python 3.14. This was only a local verification detail; no repository files were changed to work around it.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->
- [ ] **Does my change need to be backported to a previous release?**
  - No backport versions were discussed in the issue thread while preparing this fix.

- [ ] **I made sure to update `CHANGELOG.md`.**

   This change does not add a feature, change the bundled Envoy version, introduce a deprecation, or create a backward-incompatible behavior change. I did not update `CHANGELOG.md`.

- [x] **This is unlikely to impact how Ambassador performs at scale.**

   This only changes the emitted listener `traffic_direction` value for traced ingress listeners. It does not change routing, allocation patterns, concurrency, replica guidance, or request processing cost in the data plane.

- [x] **My change is adequately tested.**

   The fix is covered by a new targeted unit test for traced listeners, and the full Python unit test suite was also run to verify the surrounding listener-generation behavior did not regress.

- [ ] **I updated `CONTRIBUTING.md` with any special dev tricks I had to use to work on this code efficiently.**

   No reusable project-specific development trick was introduced by this change.

- [x] **The changes in this PR have been reviewed for security concerns and adherence to security best practices.**

   This change only adjusts listener tracing metadata and adds test coverage. It does not expand privileges, alter authn/authz behavior, or introduce new network-facing configuration surfaces.
