### PR TITLE
fix: suppress noisy diagnostics UI warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,10 @@ from the Helm charts.
 - Fix: The diagnostics UI refers to Emissary (instead of Ambassador) and
   links to emissary-ingress.dev's docs.
 
+- Fix: The diagnostics UI no longer treats missing CRD definitions as a
+  warning, and setting `diagnostics.missing_tls_ok: true` on the
+  Ambassador Module suppresses the missing-`TLSContext` warning.
+
 - Fix: Emissary now uses the current `string_match` Envoy HeaderMatcher
   stanza rather than the deprecated `exact_match` stanza.
 

--- a/python/ambassador-diag/src/ambassador_diag/diagd.py
+++ b/python/ambassador-diag/src/ambassador_diag/diagd.py
@@ -138,6 +138,57 @@ ambassador_targets = {
     "module": "https://www.getambassador.io/reference/configuration#modules",
 }
 
+
+# These startup errors remain useful in logs, but they should no longer make the
+# diagnostics UI look unhealthy by default.
+_SUPPRESSED_DIAGNOSTICS_ERROR_PREFIXES = (
+    "Ambassador could not find core CRD definitions.",
+    "Ambassador could not find Resolver type CRD definitions.",
+    "Ambassador could not find the Host CRD definition.",
+    "Ambassador could not find the LogService CRD definition.",
+    "Ambassador could not find the DevPortal CRD definition.",
+)
+
+_SUPPRESSED_MISSING_TLS_NOTICE = (
+    "No TLS termination and no fallback cert -- defaulting to cleartext-only."
+)
+
+
+def _diagnostics_config(ir: Optional[IR]) -> Dict[str, Any]:
+    if not ir:
+        return {}
+
+    amod = getattr(ir, "ambassador_module", None)
+    if not amod:
+        return {}
+
+    diagnostics = getattr(amod, "diagnostics", None)
+    if isinstance(diagnostics, dict):
+        return diagnostics
+
+    return {}
+
+
+def _diagnostics_flag(ir: Optional[IR], key: str, default: bool = False) -> bool:
+    value = _diagnostics_config(ir).get(key, default)
+
+    if isinstance(value, bool):
+        return value
+
+    return parse_bool(str(value))
+
+
+def _suppress_diagnostics_error(err_text: str) -> bool:
+    return err_text.startswith(_SUPPRESSED_DIAGNOSTICS_ERROR_PREFIXES)
+
+
+def _suppress_missing_tls_warning(ir: Optional[IR]) -> bool:
+    return _diagnostics_flag(ir, "missing_tls_ok")
+
+
+def _suppress_diagnostics_notice(ir: Optional[IR], notice_text: str) -> bool:
+    return _suppress_missing_tls_warning(ir) and (notice_text == _SUPPRESSED_MISSING_TLS_NOTICE)
+
 # envoy_targets = {
 #     'route': 'https://envoyproxy.github.io/envoy/configuration/http_conn_man/route_config/route.html',
 #     'cluster': 'https://envoyproxy.github.io/envoy/configuration/cluster_manager/cluster.html',
@@ -1097,7 +1148,12 @@ def collect_errors_and_notices(request, reqid, what: str, diag: Diagnostics) -> 
             err_key = ""
 
         for err in err_list:
-            errors.append((err_key, err["error"]))
+            err_text = err["error"]
+
+            if _suppress_diagnostics_error(err_text):
+                continue
+
+            errors.append((err_key, err_text))
 
     dnotices = ddict.pop("notices", {})
 
@@ -1107,6 +1163,9 @@ def collect_errors_and_notices(request, reqid, what: str, diag: Diagnostics) -> 
 
     for notice_key, notice_list in dnotices.items():
         for notice in notice_list:
+            if _suppress_diagnostics_notice(app.ir, notice):
+                continue
+
             app.notices.post({"level": "NOTICE", "message": "%s: %s" % (notice_key, notice)})
 
     ddict["errors"] = errors
@@ -1859,6 +1918,8 @@ class AmbassadorEventWatcher(threading.Thread):
         if not ir:
             ir = app.ir
 
+        missing_tls_ok = _suppress_missing_tls_warning(ir)
+
         if not ir:
             chime_failures["no config loaded"] = True
             env_good = False
@@ -1872,9 +1933,12 @@ class AmbassadorEventWatcher(threading.Thread):
                         err_key = ""
 
                     for err in err_list:
-                        error_count += 1
                         err_text = err["error"]
 
+                        if _suppress_diagnostics_error(err_text):
+                            continue
+
+                        error_count += 1
                         self.app.logger.info(f"error {err_key} {err_text}")
 
                         if err_text.find("CRD") >= 0:
@@ -1922,6 +1986,8 @@ class AmbassadorEventWatcher(threading.Thread):
                 "TLS",
                 f'{tls_count} TLSContext{" is" if (tls_count == 1) else "s are"} active',
             )
+        elif missing_tls_ok:
+            env_status.OK("TLS", "No TLSContexts are active, but diagnostics.missing_tls_ok allows that")
         else:
             chime_failures["no TLS contexts"] = True
             env_status.failure("TLS", "No TLSContexts are active")

--- a/python/tests/src/tests/unit/test_diagd.py
+++ b/python/tests/src/tests/unit/test_diagd.py
@@ -1,0 +1,112 @@
+import logging
+from types import SimpleNamespace
+
+import ambassador_diag.diagd as diagd
+
+
+logger = logging.getLogger("ambassador")
+
+
+CRD_ERROR = (
+    "Ambassador could not find core CRD definitions. Please visit "
+    "https://www.getambassador.io/docs/edge-stack/latest/topics/install/upgrade-to-edge-stack/#5-update-and-restart "
+    "for more information. You can continue using Ambassador via Kubernetes annotations, any configuration via CRDs will be ignored..."
+)
+
+TLS_NOTICE = "No TLS termination and no fallback cert -- defaulting to cleartext-only."
+
+
+class FakeNotices:
+    def __init__(self) -> None:
+        self.notices = []
+
+    def post(self, notice) -> None:
+        self.notices.append(notice)
+
+    def prepend(self, notice) -> None:
+        self.notices.insert(0, notice)
+
+
+class FakeDiag:
+    def __init__(self, errors=None, notices=None) -> None:
+        self._errors = errors or {}
+        self._notices = notices or {}
+
+    def as_dict(self):
+        return {"errors": self._errors, "notices": self._notices}
+
+
+def make_ir(*, diagnostics=None, errors=None, notices=None, tls_contexts=None, mapping_count=1):
+    mappings = [{"prefix": "/qotm/", "name": "qotm"} for _ in range(mapping_count)]
+    groups = {"group": SimpleNamespace(mappings=mappings)} if mapping_count else {}
+
+    return SimpleNamespace(
+        ambassador_module=SimpleNamespace(diagnostics=diagnostics or {}),
+        aconf=SimpleNamespace(errors=errors or {}, notices=notices or {}),
+        tls_contexts=tls_contexts or [],
+        groups=groups,
+    )
+
+
+def test_collect_errors_and_notices_filters_suppressed_ui_messages(monkeypatch):
+    fake_app = SimpleNamespace(ir=make_ir(diagnostics={"missing_tls_ok": True}), notices=FakeNotices())
+    monkeypatch.setattr(diagd, "app", fake_app)
+
+    diag = FakeDiag(
+        errors={"-global-": [{"error": CRD_ERROR}, {"error": "real error"}]},
+        notices={"diag": [TLS_NOTICE, "keep this notice"]},
+    )
+
+    result = diagd.collect_errors_and_notices(SimpleNamespace(args={}), "reqid", "overview", diag)
+
+    assert result["errors"] == [("", "real error")]
+    assert fake_app.notices.notices == [{"level": "NOTICE", "message": "diag: keep this notice"}]
+
+
+def test_check_environment_allows_missing_tls_when_configured():
+    watcher = diagd.AmbassadorEventWatcher(SimpleNamespace(logger=logger))
+
+    watcher.check_environment(make_ir(diagnostics={"missing_tls_ok": True}))
+
+    assert watcher.env_good is True
+    assert watcher.failure_list == []
+    assert watcher.env_status.to_dict()["TLS"] == {
+        "status": True,
+        "specifics": [
+            (True, "No TLSContexts are active, but diagnostics.missing_tls_ok allows that")
+        ],
+    }
+
+
+def test_check_environment_ignores_suppressed_crd_errors():
+    watcher = diagd.AmbassadorEventWatcher(SimpleNamespace(logger=logger))
+    ir = make_ir(
+        diagnostics={"missing_tls_ok": True},
+        errors={"-global-": [{"error": CRD_ERROR}]},
+    )
+
+    watcher.check_environment(ir)
+
+    assert watcher.env_good is True
+    assert watcher.failure_list == []
+    assert watcher.env_status.to_dict()["Error check"] == {
+        "status": True,
+        "specifics": [(True, "No errors logged")],
+    }
+
+
+def test_check_environment_still_flags_real_errors():
+    watcher = diagd.AmbassadorEventWatcher(SimpleNamespace(logger=logger))
+    ir = make_ir(
+        diagnostics={"missing_tls_ok": True},
+        errors={"-global-": [{"error": "a real error"}]},
+    )
+
+    watcher.check_environment(ir)
+
+    assert watcher.env_good is False
+    assert watcher.failure_list == []
+    assert watcher.env_status.to_dict()["Error check"] == {
+        "status": False,
+        "specifics": [(False, "1 total error logged")],
+    }


### PR DESCRIPTION
## Description

Suppress the diagnostics UI warnings that were making otherwise-healthy installs look broken:

- filter the noisy missing-CRD messages out of the diagnostics UI while leaving the underlying logged errors intact
- add `diagnostics.missing_tls_ok: true` on the Ambassador Module to suppress the missing-`TLSContext` warning for intentionally cleartext deployments

## Related Issues

Fixes #5923.

## Testing

- `ruff check python/ambassador-diag/src/ambassador_diag/diagd.py python/tests/src/tests/unit/test_diagd.py`
- `/tmp/emissary/.venv/bin/python -m pytest python/tests/src/tests/unit/test_envoy_stats.py python/tests/src/tests/unit/test_diagd.py`

## Checklist

- [ ] **Does my change need to be backported to a previous release?**
  - What backport versions were discussed with the Maintainers in the Issue?
    None were discussed.

- [x] **I made sure to update `CHANGELOG.md`.**

- [x] **This is unlikely to impact how Ambassador performs at scale.**

- [x] **My change is adequately tested.**

- [ ] **I updated `CONTRIBUTING.md` with any special dev tricks I had to use to work on this code efficiently.**

- [x] **The changes in this PR have been reviewed for security concerns and adherence to security best practices.**
