### PR TITLE
entrypoint: fix 'occured' -> 'occurred' in watcher.go comment

### DIFF
--- a/cmd/entrypoint/watcher.go
+++ b/cmd/entrypoint/watcher.go
@@ -325,7 +325,7 @@ type SnapshotHolder struct {
 	// XXX: you would expect there to be an analogous snapshot for istio secrets, however the istio
 	// source works by directly munging the k8sSnapshot.
 
-	// The unsentDeltas field tracks the stream of deltas that have occured in between each
+	// The unsentDeltas field tracks the stream of deltas that have occurred in between each
 	// kubernetes snapshot. This is a passthrough of the full stream of deltas reported by kates
 	// which is in turn a facade fo the deltas reported by client-go.
 	unsentDeltas []*kates.Delta


### PR DESCRIPTION
Comment in `cmd/entrypoint/watcher.go` line 328 reads `deltas that have occured`. Fixed to `occurred`. Comment-only change.