### PR TITLE
Fix istio cert rotation bug for issue #4744

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,17 @@ as the Ambassador API Gateway.
 [1.37.1 release notes]: https://www.envoyproxy.io/docs/envoy/latest/version_history/v1.37/v1.37.1
 [1.37.2 release notes]: https://www.envoyproxy.io/docs/envoy/latest/version_history/v1.37/v1.37.2
 
+- Fix: `IR.check_deltas` now forces a complete reconfigure whenever the
+  cache is present but the incoming snapshot has no deltas. Previously,
+  an empty-delta snapshot with a cached entry kept the stale entry around
+  until another delta happened to arrive, which caused the Istio mTLS
+  cert-rotation failure described in [#4744] (the rotated `istio-certs`
+  Secret never produces a delta, since it doesn't map to a K8s resource)
+  (thanks, [Jonathan Bailey]!).
+
+[#4744]: https://github.com/emissary-ingress/emissary/issues/4744
+[Jonathan Bailey]: https://github.com/jonathanelbailey
+
 ## [4.0.1] 26 March 2026
 [4.0.1]: https://github.com/emissary-ingress/emissary/compare/v3.10.0...v4.0.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,9 +27,6 @@ as the Ambassador API Gateway.
   Secret never produces a delta, since it doesn't map to a K8s resource)
   (thanks, [Jonathan Bailey]!).
 
-[#4744]: https://github.com/emissary-ingress/emissary/issues/4744
-[Jonathan Bailey]: https://github.com/jonathanelbailey
-
 ## [4.0.1] 26 March 2026
 [4.0.1]: https://github.com/emissary-ingress/emissary/compare/v3.10.0...v4.0.1
 

--- a/python/ambassador/src/ambassador/fetch/fetcher.py
+++ b/python/ambassador/src/ambassador/fetch/fetcher.py
@@ -250,8 +250,11 @@ class ResourceFetcher:
         try:
             watt_dict = parse_json(serialization)
 
-            # Grab deltas if they're present...
-            self.deltas = watt_dict.get("Deltas", [])
+            # The Go snapshot struct emits `"Deltas": null` for a nil slice (no
+            # `omitempty` on the field), so we can't rely on dict.get's default as it
+            # it only fires on a missing key, not a present-but-null value. The `or []`
+            # coerces null to [].
+            self.deltas = watt_dict.get("Deltas") or []
 
             # ...then it's off to deal with Kubernetes.
             watt_k8s = watt_dict.get("Kubernetes", {})

--- a/python/ambassador/src/ambassador/ir/ir.py
+++ b/python/ambassador/src/ambassador/ir/ir.py
@@ -151,16 +151,14 @@ class IR:
         to_invalidate: List[str] = []
         invalidate_groups_for: List[str] = []
 
-        # OK. If we don't have a cache and there are no deltas, just skip all this crap.
-        if (cache and fetcher.deltas) is not None:
-            # We have a cache and deltas is non null. Start by assuming that we'll need to reset it,
-            # unless there are no deltas at all.
-            reset_cache = len(fetcher.deltas) > 0
-
-            # Yes. We're going to walk over them all and assemble a list
-            # of things to delete and a count of errors while processing our
-            # list.
-
+        # If we don't have a cache, or there are no deltas, there's nothing to do here --
+        # the defaults above (complete reconfigure, reset the cache) are what we want.
+        # Note that fetcher.deltas is always a list: it starts as [] and is reassigned
+        # from watt_dict.get("Deltas", []), so we check truthiness rather than `is not None`.
+        if (cache is not None) and fetcher.deltas:
+            # We have a cache and at least one delta. Walk over all the deltas and
+            # assemble a list of things to delete and a count of errors while processing
+            # our list.
             delta_errors = 0
 
             for delta in fetcher.deltas:
@@ -191,24 +189,15 @@ class IR:
                         # If we're invalidating the Mapping, we need to invalidate its Group.
                         invalidate_groups_for.append(key)
 
-            # OK. If we have things to invalidate, and we have NO ERRORS...
+            # If we have things to invalidate and we have NO ERRORS, we can invalidate
+            # those things incrementally instead of resetting the whole cache.
             if to_invalidate and not delta_errors:
-                # ...then we can invalidate all those things instead of clearing the cache.
                 reset_cache = False
+                config_type = "incremental"
 
                 for key in to_invalidate:
                     logger.debug(f"Delta: invalidating {key}")
                     cache.invalidate(key)
-
-            # When all is said and done, it's an incremental if we don't need to reset
-            # the cache.
-            if not reset_cache:
-                config_type = "incremental"
-
-                # This is _not_ an incremental reconfigure. Reset the cache...
-            else:
-                # OK, we're doing an incremental reconfigure.
-                config_type = "incremental"
 
             cache.dump("Checking incoming deltas (reset_cache %s)", reset_cache)
 

--- a/python/ambassador/src/ambassador/ir/ir.py
+++ b/python/ambassador/src/ambassador/ir/ir.py
@@ -151,56 +151,54 @@ class IR:
         to_invalidate: List[str] = []
         invalidate_groups_for: List[str] = []
 
-        # OK. If we don't have a cache, just skip all this crap.
-        if cache is not None:
-            # We have a cache. Start by assuming that we'll need to reset it,
+        # OK. If we don't have a cache and there are no deltas, just skip all this crap.
+        if (cache and fetcher.deltas) is not None:
+            # We have a cache and deltas is non null. Start by assuming that we'll need to reset it,
             # unless there are no deltas at all.
             reset_cache = len(fetcher.deltas) > 0
 
-            # Next up: are there any deltas?
-            if fetcher.deltas:
-                # Yes. We're going to walk over them all and assemble a list
-                # of things to delete and a count of errors while processing our
-                # list.
+            # Yes. We're going to walk over them all and assemble a list
+            # of things to delete and a count of errors while processing our
+            # list.
 
-                delta_errors = 0
+            delta_errors = 0
 
-                for delta in fetcher.deltas:
-                    logger.debug(f"Delta: {delta}")
+            for delta in fetcher.deltas:
+                logger.debug(f"Delta: {delta}")
 
-                    # The "kind" of a Delta must be a string; assert that to make
-                    # mypy happy.
+                # The "kind" of a Delta must be a string; assert that to make
+                # mypy happy.
 
-                    delta_kind = delta["kind"]
-                    assert isinstance(delta_kind, str)
+                delta_kind = delta["kind"]
+                assert isinstance(delta_kind, str)
 
-                    # Only worry about Mappings and TCPMappings right now.
-                    if (delta_kind == "Mapping") or (delta_kind == "TCPMapping"):
-                        # XXX C'mon, mypy, is this cast really necessary?
-                        metadata = typecast(Dict[str, str], delta.get("metadata", {}))
-                        name = metadata.get("name", "")
-                        namespace = metadata.get("namespace", "")
+                # Only worry about Mappings and TCPMappings right now.
+                if (delta_kind == "Mapping") or (delta_kind == "TCPMapping"):
+                    # XXX C'mon, mypy, is this cast really necessary?
+                    metadata = typecast(Dict[str, str], delta.get("metadata", {}))
+                    name = metadata.get("name", "")
+                    namespace = metadata.get("namespace", "")
 
-                        if not name or not namespace:
-                            # This is an error.
-                            delta_errors += 1
+                    if not name or not namespace:
+                        # This is an error.
+                        delta_errors += 1
 
-                            logger.error(f"Delta object needs name and namespace: {delta}")
-                        else:
-                            key = IRBaseMapping.make_cache_key(delta_kind, name, namespace)
-                            to_invalidate.append(key)
+                        logger.error(f"Delta object needs name and namespace: {delta}")
+                    else:
+                        key = IRBaseMapping.make_cache_key(delta_kind, name, namespace)
+                        to_invalidate.append(key)
 
-                            # If we're invalidating the Mapping, we need to invalidate its Group.
-                            invalidate_groups_for.append(key)
+                        # If we're invalidating the Mapping, we need to invalidate its Group.
+                        invalidate_groups_for.append(key)
 
-                # OK. If we have things to invalidate, and we have NO ERRORS...
-                if to_invalidate and not delta_errors:
-                    # ...then we can invalidate all those things instead of clearing the cache.
-                    reset_cache = False
+            # OK. If we have things to invalidate, and we have NO ERRORS...
+            if to_invalidate and not delta_errors:
+                # ...then we can invalidate all those things instead of clearing the cache.
+                reset_cache = False
 
-                    for key in to_invalidate:
-                        logger.debug(f"Delta: invalidating {key}")
-                        cache.invalidate(key)
+                for key in to_invalidate:
+                    logger.debug(f"Delta: invalidating {key}")
+                    cache.invalidate(key)
 
             # When all is said and done, it's an incremental if we don't need to reset
             # the cache.

--- a/python/ambassador/src/ambassador/ir/ir.py
+++ b/python/ambassador/src/ambassador/ir/ir.py
@@ -151,10 +151,10 @@ class IR:
         to_invalidate: List[str] = []
         invalidate_groups_for: List[str] = []
 
-        # If we don't have a cache, or there are no deltas, there's nothing to do here --
-        # the defaults above (complete reconfigure, reset the cache) are what we want.
-        # Note that fetcher.deltas is always a list: it starts as [] and is reassigned
-        # from watt_dict.get("Deltas", []), so we check truthiness rather than `is not None`.
+        # If we don't have a cache, or there are no deltas, fall through with the
+        # defaults above (complete reconfigure, reset the cache). The `fetcher.deltas`
+        # is always a list here and truthiness handles both the "no cache" and
+        # "empty deltas" cases.
         if (cache is not None) and fetcher.deltas:
             # We have a cache and at least one delta. Walk over all the deltas and
             # assemble a list of things to delete and a count of errors while processing

--- a/python/tests/src/tests/unit/test_cache.py
+++ b/python/tests/src/tests/unit/test_cache.py
@@ -175,9 +175,10 @@ class Builder:
             self.logger, fetcher, self.cache
         )
 
-        # For the tests in this file, we should see cache resets and full reconfigurations
-        # IFF we have no cache.
-
+        # With no cache we always do a complete reconfigure and reset. With a
+        # cache, it's only an incremental reconfigure when we actually have
+        # deltas to invalidate against -- an empty-delta snapshot forces a
+        # complete reconfigure so we flush any stale entries (see #4744).
         if self.cache is None:
             assert (
                 config_type == "complete"
@@ -185,13 +186,25 @@ class Builder:
             assert (
                 reset_cache
             ), "check_deltas with no cache does not want to reset the cache, but it should"
+        elif not fetcher.deltas:
+            assert (
+                config_type == "complete"
+            ), "check_deltas with a cache and no deltas should force a complete reconfigure"
+            assert (
+                reset_cache
+            ), "check_deltas with a cache and no deltas should reset the cache"
         else:
             assert (
                 config_type == "incremental"
-            ), "check_deltas with a cache wants a complete reconfiguration, which it shouldn't"
+            ), "check_deltas with a cache and deltas wants a complete reconfiguration, which it shouldn't"
             assert (
                 not reset_cache
-            ), "check_deltas with a cache wants to reset the cache, which it shouldn't"
+            ), "check_deltas with a cache and deltas wants to reset the cache, which it shouldn't"
+
+        # Mirror diagd: when reset_cache is set, swap in a fresh Cache before
+        # building the IR so we don't carry stale entries into the new config.
+        if reset_cache and self.cache is not None:
+            self.cache = Cache(self.logger)
 
         # Once that's done, compile the IR.
         ir = IR(

--- a/python/tests/src/tests/unit/test_fetch.py
+++ b/python/tests/src/tests/unit/test_fetch.py
@@ -478,5 +478,28 @@ def test_sort(deps: DependencyManager) -> None:
     assert deps.sorted_watt_keys() == ["secret", "service", "ingressclasses"]
 
 
+@pytest.mark.parametrize(
+    "name, payload, expected",
+    [
+        # Regression for #4744: the Go snapshot struct lacks `omitempty` on Deltas,
+        # so a nil slice marshals to `"Deltas": null`. dict.get("Deltas", []) returns
+        # None in that case. For clarity we want it to always return `[]` in all cases.
+        ("null", '{"Kubernetes": {}, "Deltas": null}', []),
+        ("empty-list", '{"Kubernetes": {}, "Deltas": []}', []),
+        ("missing", '{"Kubernetes": {}}', []),
+        (
+            "with-items",
+            '{"Kubernetes": {}, "Deltas": [{"kind":"Mapping","metadata":{"name":"x","namespace":"y"}}]}',
+            [{"kind": "Mapping", "metadata": {"name": "x", "namespace": "y"}}],
+        ),
+    ],
+)
+def test_parse_watt_deltas_is_always_a_list(name, payload, expected):
+    fetcher = ResourceFetcher(logger, Config())
+    fetcher.parse_watt(payload, finalize=False)
+    assert isinstance(fetcher.deltas, list)
+    assert fetcher.deltas == expected
+
+
 if __name__ == "__main__":
     pytest.main(sys.argv)

--- a/python/tests/src/tests/unit/test_ir.py
+++ b/python/tests/src/tests/unit/test_ir.py
@@ -1,6 +1,9 @@
 import logging
 from dataclasses import dataclass
 from typing import Optional
+from unittest.mock import MagicMock
+from unittest.mock import patch
+import pytest
 
 from tests.utils import (
     Compile,
@@ -9,7 +12,13 @@ from tests.utils import (
     default_tcp_listener_manifest,
     default_udp_listener_manifest,
     logger,
+    generate_istio_cert_delta,
+    generate_istio_saved_secret
 )
+
+from ambassador.ir import IR
+from ambassador.config import Config
+from test_acme_privatekey_secrets import MemorySecretHandler
 
 
 def http3_quick_start_manifests():
@@ -66,3 +75,50 @@ class TestIR:
 
             if case.expectedLog is not None:
                 assert case.expectedLog in caplog.text
+
+
+    @pytest.mark.parametrize("name, cache_entry, deltas, expected", [
+        (
+            "cached-secret-with-deltas",
+            generate_istio_saved_secret(),
+            [generate_istio_cert_delta()],
+            {"config_type": "incremental", "reset_cache": True, "invalidate_groups_for": []}
+        ),
+        (
+            "cached-secret-without-deltas",
+            generate_istio_saved_secret(),
+            None,
+            {"config_type": "complete", "reset_cache": True, "invalidate_groups_for": []}
+        ),
+        (
+            "null-cache-with-deltas",
+            None,
+            [generate_istio_cert_delta()],
+            {"config_type": "complete", "reset_cache": True, "invalidate_groups_for": []}
+        ),
+        (
+            "null-cache-without-deltas",
+            None,
+            None,
+            {"config_type": "complete", "reset_cache": True, "invalidate_groups_for": []}
+        )
+        
+        ]
+    )
+    def test_check_deltas(self, name, cache_entry, deltas, expected, caplog):
+        caplog.set_level(logging.DEBUG, logger="ambassador")
+
+        with patch("ambassador.cache.Cache") as cache:
+            cache.return_value = [cache_entry] if cache_entry is not None else None
+            fetcher = MagicMock()
+            fetcher.deltas = deltas
+            aconfig = Config()
+            secret_handler = MemorySecretHandler(logger, "/tmp/unit-test-source-root", "/tmp/unit-test-cache-dir", "0")
+            ir = IR(aconf=aconfig, file_checker=lambda path: True, secret_handler=secret_handler)
+            config_type, reset_cache, invalidate_groups_for = ir.check_deltas(logger=logger, fetcher=fetcher, cache=cache)
+
+            if (cache_entry and deltas) is not None:
+                cache.dump.assert_called()
+                assert config_type == expected["config_type"]
+                assert reset_cache == expected["reset_cache"]
+                assert invalidate_groups_for == expected["invalidate_groups_for"]

--- a/python/tests/src/tests/unit/test_ir.py
+++ b/python/tests/src/tests/unit/test_ir.py
@@ -2,8 +2,11 @@ import logging
 from dataclasses import dataclass
 from typing import Optional
 from unittest.mock import MagicMock
-from unittest.mock import patch
+
 import pytest
+
+from ambassador.ir import IR
+from ambassador.ir.irbasemapping import IRBaseMapping
 
 from tests.utils import (
     Compile,
@@ -11,14 +14,9 @@ from tests.utils import (
     default_listener_manifests,
     default_tcp_listener_manifest,
     default_udp_listener_manifest,
-    logger,
     generate_istio_cert_delta,
-    generate_istio_saved_secret
+    logger,
 )
-
-from ambassador.ir import IR
-from ambassador.config import Config
-from test_acme_privatekey_secrets import MemorySecretHandler
 
 
 def http3_quick_start_manifests():
@@ -77,48 +75,71 @@ class TestIR:
                 assert case.expectedLog in caplog.text
 
 
-    @pytest.mark.parametrize("name, cache_entry, deltas, expected", [
-        (
-            "cached-secret-with-deltas",
-            generate_istio_saved_secret(),
-            [generate_istio_cert_delta()],
-            {"config_type": "incremental", "reset_cache": True, "invalidate_groups_for": []}
-        ),
-        (
-            "cached-secret-without-deltas",
-            generate_istio_saved_secret(),
-            None,
-            {"config_type": "complete", "reset_cache": True, "invalidate_groups_for": []}
-        ),
-        (
-            "null-cache-with-deltas",
-            None,
-            [generate_istio_cert_delta()],
-            {"config_type": "complete", "reset_cache": True, "invalidate_groups_for": []}
-        ),
-        (
-            "null-cache-without-deltas",
-            None,
-            None,
-            {"config_type": "complete", "reset_cache": True, "invalidate_groups_for": []}
-        )
-        
-        ]
+    @pytest.mark.parametrize(
+        "name, has_cache, deltas, expected",
+        [
+            # Regression for #4744: a cache exists but the snapshot had no deltas
+            # (e.g., Istio rotated the mTLS cert and the istio-certs Secret has
+            # no matching K8s resource to emit a delta for). We must force a
+            # complete reconfigure so the stale cache gets cleared.
+            (
+                "cached-no-deltas",
+                True,
+                [],
+                {"config_type": "complete", "reset_cache": True, "invalidate_groups_for": []},
+            ),
+            # Cache exists with a non-Mapping delta (e.g., a Secret update): there's
+            # nothing to invalidate incrementally, so it's still a complete reconfigure.
+            (
+                "cached-non-mapping-delta",
+                True,
+                [generate_istio_cert_delta()],
+                {"config_type": "complete", "reset_cache": True, "invalidate_groups_for": []},
+            ),
+            # Cache exists with a Mapping delta: invalidate incrementally.
+            (
+                "cached-mapping-delta",
+                True,
+                [{"kind": "Mapping", "metadata": {"name": "foo", "namespace": "bar"}}],
+                {
+                    "config_type": "incremental",
+                    "reset_cache": False,
+                    "invalidate_groups_for": [
+                        IRBaseMapping.make_cache_key("Mapping", "foo", "bar"),
+                    ],
+                },
+            ),
+            # No cache: always a complete reconfigure.
+            (
+                "no-cache-with-deltas",
+                False,
+                [generate_istio_cert_delta()],
+                {"config_type": "complete", "reset_cache": True, "invalidate_groups_for": []},
+            ),
+            (
+                "no-cache-no-deltas",
+                False,
+                [],
+                {"config_type": "complete", "reset_cache": True, "invalidate_groups_for": []},
+            ),
+        ],
     )
-    def test_check_deltas(self, name, cache_entry, deltas, expected, caplog):
+    def test_check_deltas(self, name, has_cache, deltas, expected, caplog):
         caplog.set_level(logging.DEBUG, logger="ambassador")
 
-        with patch("ambassador.cache.Cache") as cache:
-            cache.return_value = [cache_entry] if cache_entry is not None else None
-            fetcher = MagicMock()
-            fetcher.deltas = deltas
-            aconfig = Config()
-            secret_handler = MemorySecretHandler(logger, "/tmp/unit-test-source-root", "/tmp/unit-test-cache-dir", "0")
-            ir = IR(aconf=aconfig, file_checker=lambda path: True, secret_handler=secret_handler)
-            config_type, reset_cache, invalidate_groups_for = ir.check_deltas(logger=logger, fetcher=fetcher, cache=cache)
+        fetcher = MagicMock()
+        fetcher.deltas = deltas
+        cache = MagicMock() if has_cache else None
 
-            if (cache_entry and deltas) is not None:
-                cache.dump.assert_called()
-                assert config_type == expected["config_type"]
-                assert reset_cache == expected["reset_cache"]
-                assert invalidate_groups_for == expected["invalidate_groups_for"]
+        config_type, reset_cache, invalidate_groups_for = IR.check_deltas(
+            logger=logger, fetcher=fetcher, cache=cache,
+        )
+
+        assert config_type == expected["config_type"]
+        assert reset_cache == expected["reset_cache"]
+        assert invalidate_groups_for == expected["invalidate_groups_for"]
+
+        # cache.dump is only invoked when we actually walk deltas -- i.e. when
+        # we had both a cache and at least one delta to consider.
+        if has_cache and deltas:
+            cache.dump.assert_called_once()

--- a/python/tests/src/tests/utils.py
+++ b/python/tests/src/tests/utils.py
@@ -14,7 +14,7 @@ from cryptography.hazmat.primitives.asymmetric import dsa, ec, rsa
 from ambassador import IR, Cache, Config, EnvoyConfig
 from ambassador.compile import Compile
 from ambassador.fetch import ResourceFetcher
-from ambassador.utils import NullSecretHandler
+from ambassador.utils import NullSecretHandler, SavedSecret
 
 logger = logging.getLogger("ambassador")
 
@@ -374,3 +374,24 @@ def create_crl_pem_b64(issuerCert, issuerKey, revokedCerts):
 
     crl = crl_builder.sign(private_key=key, algorithm=hashes.SHA256())
     return b64encode(crl.public_bytes(serialization.Encoding.PEM)).decode("utf-8")
+
+
+def generate_istio_cert_delta(delta_type="update"):
+    return {
+                "kind": "Secret",
+                "name": "istio-certs",
+                "namespace": "ambassador",
+                "deltaType": delta_type,
+            }
+
+
+def generate_istio_saved_secret():
+    return SavedSecret(
+        secret_name="test-secret",
+        namespace="default",
+        cert_path="//test-secret-123.crt",
+        key_path="//test-secret-123.key",
+        user_path="//test-secret-123.user",
+        root_cert_path="//test-secret-123.root.crt",
+        cert_data={"tls_crt": "tls_crt", "tls_key": "tls_key", "user_key": "user_key", "root_crt": "root_crt"}
+    )

--- a/python/tests/src/tests/utils.py
+++ b/python/tests/src/tests/utils.py
@@ -14,7 +14,7 @@ from cryptography.hazmat.primitives.asymmetric import dsa, ec, rsa
 from ambassador import IR, Cache, Config, EnvoyConfig
 from ambassador.compile import Compile
 from ambassador.fetch import ResourceFetcher
-from ambassador.utils import NullSecretHandler, SavedSecret
+from ambassador.utils import NullSecretHandler
 
 logger = logging.getLogger("ambassador")
 
@@ -378,20 +378,8 @@ def create_crl_pem_b64(issuerCert, issuerKey, revokedCerts):
 
 def generate_istio_cert_delta(delta_type="update"):
     return {
-                "kind": "Secret",
-                "name": "istio-certs",
-                "namespace": "ambassador",
-                "deltaType": delta_type,
-            }
-
-
-def generate_istio_saved_secret():
-    return SavedSecret(
-        secret_name="test-secret",
-        namespace="default",
-        cert_path="//test-secret-123.crt",
-        key_path="//test-secret-123.key",
-        user_path="//test-secret-123.user",
-        root_cert_path="//test-secret-123.root.crt",
-        cert_data={"tls_crt": "tls_crt", "tls_key": "tls_key", "user_key": "user_key", "root_crt": "root_crt"}
-    )
+        "kind": "Secret",
+        "name": "istio-certs",
+        "namespace": "ambassador",
+        "deltaType": delta_type,
+    }


### PR DESCRIPTION
## Description

This is building off of the existing PR https://github.com/emissary-ingress/emissary/pull/5820, which attempts to address https://github.com/emissary-ingress/emissary/issues/4744. This was originally submitted by @jonathanelbailey. I will include his original post below:

> This PR fixes a known issue when Emissary is configured to connect to an Istio mTLS network. When Emissary's Istio sidecar initiates a cert rotation the istio-certs secret generates a cache entry, but does not generate a delta since the istio-certs cache entry does not map to an actual resource on the Kubernetes cluster. This can eventually resolve itself if a delta is generated that can initiate a change, but other times it results in an unrecoverable error that can cause traffic disruption without custom health checks.

I have included a commit that address the comments from the previous PR so that we can still credit the original author while addressing the questions.

## Related Issues

https://github.com/emissary-ingress/emissary/issues/4744

## Testing

I tested locally with k3d with both `main` and the `peble:fix-istio-cert-rotation-4744` branches:

* Reproduced the bug on a `main` image: emissary crashed with `TypeError: object of type 'NoneType' has no len()` at ir.py:158 on every empty-delta snapshot, never reaching configuration updated
* Verified the fix on a `ppeble:fix-istio-cert-rotation-4744` image built from this branch on the same cluster: 0 `TypeError `/ could not reconfigure events across ~60 min of runtime with SECRET_TTL=1m (cert rotation every ~30 s).

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->
- [x] **Does my change need to be backported to a previous release?** 
No.

- [X] **I made sure to update `CHANGELOG.md`.**

   Remember, the CHANGELOG needs to mention:
  - Any new features
  - Any changes to our included version of Envoy
  - Any non-backward-compatible changes
  - Any deprecations

- [X] **This is unlikely to impact how Ambassador performs at scale.**

   Remember, things that might have an impact at scale include:
  - Any significant changes in memory use that might require adjusting the memory limits
  - Any significant changes in CPU use that might require adjusting the CPU limits
  - Anything that might change how many replicas users should use
  - Changes that impact data-plane latency/scalability

- [X] **My change is adequately tested.**
See testing section above.

- [ ] **I updated `CONTRIBUTING.md` with any special dev tricks I had to use to work on this code efficiently.**
N/A

- [X] **The changes in this PR have been reviewed for security concerns and adherence to security best practices.**
