### PR TITLE
fix: TLSSecretNamespacing default silently overridden to false

### DIFF
--- a/cmd/entrypoint/secrets.go
+++ b/cmd/entrypoint/secrets.go
@@ -249,7 +249,9 @@ func ReconcileSecrets(ctx context.Context, sh *SnapshotHolder) error {
 				dlog.Errorf(ctx, "error parsing module: %v", err)
 				continue
 			}
-			secretNamespacing = secs.Defaults.TLSSecretNamespacing
+			if secs.Defaults.TLSSecretNamespacing != nil {
+				secretNamespacing = *secs.Defaults.TLSSecretNamespacing
+			}
 			break
 		}
 	}
@@ -425,7 +427,7 @@ func secretRef(namespace, name string, secretNamespacing bool, action func(snaps
 // but... yeah.
 type ModuleSecrets struct {
 	Defaults struct {
-		TLSSecretNamespacing bool `json:"tls_secret_namespacing"`
+		TLSSecretNamespacing *bool `json:"tls_secret_namespacing"`
 	} `json:"defaults"`
 	Upstream struct {
 		Secret string `json:"secret"`


### PR DESCRIPTION
The ModuleSecrets.Defaults.TLSSecretNamespacing field is a bool. When the module config JSON does not include tls_secret_namespacing, Go's zero-value deserialization produces false, overriding the intended true default.

Change to *bool so we can distinguish 'not set' (nil, keep default true) from 'explicitly set to false'.

## Description

A few sentences describing the overall goals of the pull request's commits.

## Related Issues

List related issues.

## Testing

A few sentences describing what testing you've done, e.g., manual tests, automated tests, deployed in production, etc.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->
- [ ] **Does my change need to be backported to a previous release?**
  - What backport versions were discussed with the Maintainers in the Issue?

- [ ] **I made sure to update `CHANGELOG.md`.**

   Remember, the CHANGELOG needs to mention:
  - Any new features
  - Any changes to our included version of Envoy
  - Any non-backward-compatible changes
  - Any deprecations

- [ ] **This is unlikely to impact how Emissary Ingress performs at scale.**

   Remember, things that might have an impact at scale include:
  - Any significant changes in memory use that might require adjusting the memory limits
  - Any significant changes in CPU use that might require adjusting the CPU limits
  - Anything that might change how many replicas users should use
  - Changes that impact data-plane latency/scalability

- [ ] **My change is adequately tested.**

   Remember when considering testing:
  - Your change needs to be specifically covered by tests.
    - Tests need to cover all the states where your change is relevant: for example, if you add a behavior that can be enabled or disabled, you'll need tests that cover the enabled case and tests that cover the disabled case. It's not sufficient just to test with the behavior enabled.
  - You also need to make sure that the _entire area being changed_ has adequate test coverage.
    - If existing tests don't actually cover the entire area being changed, add tests.
    - This applies even for aspects of the area that you're not changing – check the test coverage, and improve it if needed!
  - We should lean on the bulk of code being covered by unit tests, but...
  - ... an end-to-end test should cover the integration points

- [ ] **I updated `CONTRIBUTING.md` with any special dev tricks I had to use to work on this code efficiently.**

- [ ] **The changes in this PR have been reviewed for security concerns and adherence to security best practices.**
