### PR TITLE
Tell cocogitto-bot to ignore merge commits and fixup commits

### DIFF
--- a/cog.toml
+++ b/cog.toml
@@ -1,0 +1,3 @@
+# Ignore merges and fixups
+ignore_merge_commits = true
+ignore_fixup_commits = true


### PR DESCRIPTION
Having cocogitto-bot check for conventional commits is helpful, but having it complain about merges and fixups is just annoying.

Signed-off-by: Flynn <emissary@flynn.kodachi.com>

