### PR TITLE
Bump Envoy to 1.38.3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ include build-aux/tools.mk
 TEST_CLUSTER ?= emissary-test
 
 # Default Envoy image to use when building Emissary.
-ENVOY_IMAGE ?= envoyproxy/envoy:distroless-v1.37.2
+ENVOY_IMAGE ?= envoyproxy/envoy:distroless-v1.38.3
 
 # Bootstrapping the build env
 #


### PR DESCRIPTION
This _only_ bumps the Envoy version; it doesn't try to make changes to typing for filters or any such, which seems like it'll be necessary to go to Envoy 1.39.

Signed-off-by: Flynn <emissary@flynn.kodachi.com>
